### PR TITLE
Fixed Manjaro not being detected as arch

### DIFF
--- a/cmd/linux.go
+++ b/cmd/linux.go
@@ -58,6 +58,8 @@ func GetLinuxDistroInfo() *DistroInfo {
 						result.Distribution = Ubuntu
 					case "Arch":
 						result.Distribution = Arch
+					case "ManjaroLinux":
+						result.Distribution = Arch
 					}
 				case "Description":
 					result.Description = value


### PR DESCRIPTION
using lsb_release on Manjaro returns a Distributor ID of ManjaroLinux not Arch so I added ManjaroLinux to the switch statement