### PR TITLE
CMD: LINUX: Arch Linux detection without lsb-release

### DIFF
--- a/cmd/linux.go
+++ b/cmd/linux.go
@@ -77,10 +77,16 @@ func GetLinuxDistroInfo() *DistroInfo {
 		re := regexp.MustCompile(`^NAME=(.*)\n`)
 		// extract the distro name
 		osName := string(re.FindSubmatch(osRelease)[1])
-		// Check distro name against list of RedHat distros
-		if osName == "Fedora" || osName == "CentOS" {
-			//if it matches set result.Distribution to RedHat
+		// strip quotations
+		osName = strings.Trim(osName, "\"")
+		// Check distro name against list of distros
+		switch osName {
+		case "Fedora":
 			result.Distribution = RedHat
+		case "CentOS":
+			result.Distribution = RedHat
+		case "Arch Linux":
+			result.Distribution = Arch
 		}
 	}
 	return result


### PR DESCRIPTION
The existing distribution detection does not work on Arch Linux
without the `lsb-release` package installed. This patch adds
detection using `/etc/os-release` in the same way that f9a1881
uses for Fedora and CentOS detection.

I changed the if statement that Bryn Sinclair used to a case
statement to avoid extra if-else-if statements.

I also needed to add a trim statement to remove the `"` characters
that are present in Arch Linux's `/etc/os-release` file.