### PR TITLE
133 unsupported platform requests

### DIFF
--- a/cmd/linux.go
+++ b/cmd/linux.go
@@ -5,7 +5,7 @@ import (
 	"io/ioutil"
 	"net/url"
 	"os"
-	"regexp"
+	"runtime"
 	"strings"
 
 	"github.com/pkg/browser"
@@ -32,6 +32,7 @@ type DistroInfo struct {
 	Release       string
 	Codename      string
 	DistributorID string
+	DiscoveredBy  string
 }
 
 // GetLinuxDistroInfo returns information about the running linux distribution
@@ -46,7 +47,7 @@ func GetLinuxDistroInfo() *DistroInfo {
 		if err != nil {
 			return result
 		}
-
+		result.DiscoveredBy = "lsb"
 		for _, line := range strings.Split(stdout, "\n") {
 			if strings.Contains(line, ":") {
 				// Iterate lines a
@@ -61,6 +62,8 @@ func GetLinuxDistroInfo() *DistroInfo {
 						result.Distribution = Ubuntu
 					case "Arch", "ManjaroLinux":
 						result.Distribution = Arch
+						// case "Debian":
+						// 	result.Distribution = Debian
 					}
 				case "Description":
 					result.Description = value
@@ -68,21 +71,37 @@ func GetLinuxDistroInfo() *DistroInfo {
 					result.Release = value
 				case "Codename":
 					result.Codename = value
-
 				}
 			}
 		}
 		// check if /etc/os-release exists
 	} else if _, err := os.Stat("/etc/os-release"); !os.IsNotExist(err) {
+		// Default value
+		osName := "Unknown"
+		version := ""
 		// read /etc/os-release
 		osRelease, _ := ioutil.ReadFile("/etc/os-release")
-		// compile a regex to find NAME=distro
-		re := regexp.MustCompile(`^NAME=(.*)\n`)
-		// extract the distro name
-		osName := string(re.FindSubmatch(osRelease)[1])
-		// strip quotations
-		osName = strings.Trim(osName, "\"")
+		// Split into lines
+		lines := strings.Split(string(osRelease), "\n")
+		// Iterate lines
+		for _, line := range lines {
+			// Split each line by the equals char
+			splitLine := strings.SplitN(line, "=", 2)
+			// Check we have
+			if len(splitLine) != 2 {
+				continue
+			}
+			switch splitLine[0] {
+			case "NAME":
+				osName = strings.Trim(splitLine[1], "\"")
+			case "VERSION_ID":
+				version = strings.Trim(splitLine[1], "\"")
+			}
+
+		}
 		// Check distro name against list of distros
+		result.Release = version
+		result.DiscoveredBy = "os-release"
 		switch osName {
 		case "Fedora":
 			result.Distribution = RedHat
@@ -90,6 +109,11 @@ func GetLinuxDistroInfo() *DistroInfo {
 			result.Distribution = RedHat
 		case "Arch Linux":
 			result.Distribution = Arch
+		// case "Debian GNU/Linux":
+		// 	result.Distribution = Debian
+		default:
+			result.Distribution = Unknown
+			result.DistributorID = osName
 		}
 	}
 	return result
@@ -143,7 +167,24 @@ func RequestSupportForDistribution(distroInfo *DistroInfo, libraryName string) e
 
 	title := fmt.Sprintf("Support Distribution '%s'", distroInfo.DistributorID)
 
-	body := fmt.Sprintf("**Description**\nDistribution '%s' is curently unsupported.\n\n**Further Information**\n\n**Please add any extra information here, EG: libraries that are needed to make the distribution work, or commands to install them", distroInfo.DistributorID)
+	var str strings.Builder
+
+	gomodule, exists := os.LookupEnv("GO111MODULE")
+	if !exists {
+		gomodule = "(Not Set)"
+	}
+
+	str.WriteString("\n| Name   | Value |\n| ----- | ----- |\n")
+	str.WriteString(fmt.Sprintf("| Wails Version | %s |\n", Version))
+	str.WriteString(fmt.Sprintf("| Go Version    | %s |\n", runtime.Version()))
+	str.WriteString(fmt.Sprintf("| Platform      | %s |\n", runtime.GOOS))
+	str.WriteString(fmt.Sprintf("| Arch          | %s |\n", runtime.GOARCH))
+	str.WriteString(fmt.Sprintf("| GO111MODULE   | %s |\n", gomodule))
+	str.WriteString(fmt.Sprintf("| Distribution ID   | %s |\n", distroInfo.DistributorID))
+	str.WriteString(fmt.Sprintf("| Distribution Version   | %s |\n", distroInfo.Release))
+	str.WriteString(fmt.Sprintf("| Discovered by   | %s |\n", distroInfo.DiscoveredBy))
+
+	body := fmt.Sprintf("**Description**\nDistribution '%s' is curently unsupported.\n\n**Further Information**\n\n%s\n\n*Please add any extra information here, EG: libraries that are needed to make the distribution work, or commands to install them*", distroInfo.DistributorID, str.String())
 	fullURL := "https://github.com/wailsapp/wails/issues/new?"
 	params := "title=" + title + "&body=" + body
 

--- a/cmd/system.go
+++ b/cmd/system.go
@@ -307,7 +307,7 @@ func CheckDependencies(logger *Logger) (bool, error) {
 					logger.Green("Library '%s' installed.", library.Name)
 				}
 			default:
-				return false, fmt.Errorf("unable to check libraries on distribution '%s'. Please ensure that the '%s' equivalent is installed", distroInfo.DistributorID, library.Name)
+				return false, RequestSupportForDistribution(distroInfo, library.Name)
 			}
 		}
 	}

--- a/cmd/system.go
+++ b/cmd/system.go
@@ -295,7 +295,6 @@ func CheckDependencies(logger *Logger) (bool, error) {
 					logger.Green("Library '%s' installed.", library.Name)
 				}
 			case RedHat:
-
 				installed, err := RpmInstalled(library.Name)
 				if err != nil {
 					return false, err

--- a/cmd/wails/0_setup.go
+++ b/cmd/wails/0_setup.go
@@ -108,7 +108,7 @@ func checkLibraries() (errors bool, err error) {
 					logger.Green("Library '%s' installed.", library.Name)
 				}
 			default:
-				return false, fmt.Errorf("unable to check libraries on distribution '%s'. Please ensure that the '%s' equivalent is installed", distroInfo.DistributorID, library.Name)
+				return false, cmd.RequestSupportForDistribution(distroInfo, library.Name)
 			}
 		}
 	}


### PR DESCRIPTION
If a distribution is unknown to Wails, the user is prompted if they'd like to submit a ticket to add support for the distribution.