### PR TITLE
Drop lsb_release

### DIFF
--- a/cmd/linux.go
+++ b/cmd/linux.go
@@ -49,6 +49,7 @@ func GetLinuxDistroInfo() *DistroInfo {
 	if !os.IsNotExist(err) {
 		// Default value
 		osID := "unknown"
+		osNAME := "Unknown"
 		version := ""
 		// read /etc/os-release
 		osRelease, _ := ioutil.ReadFile("/etc/os-release")
@@ -65,6 +66,8 @@ func GetLinuxDistroInfo() *DistroInfo {
 			switch splitLine[0] {
 			case "ID":
 				osID = strings.Trim(splitLine[1], "\"")
+			case "NAME":
+				osNAME = strings.Trim(splitLine[1], "\"")
 			case "VERSION_ID":
 				version = strings.Trim(splitLine[1], "\"")
 			}
@@ -88,7 +91,7 @@ func GetLinuxDistroInfo() *DistroInfo {
 			result.Distribution = Unknown
 		}
 
-		result.DistributorID = osID
+		result.DistributorID = osNAME
 	}
 	return result
 }

--- a/cmd/linux.go
+++ b/cmd/linux.go
@@ -77,11 +77,11 @@ func GetLinuxDistroInfo() *DistroInfo {
 		result.Release = version
 		result.DiscoveredBy = "os-release"
 		switch osID {
-		case "fedora":
+		case "fedora", "centos":
 			result.Distribution = RedHat
 		case "arch":
 			result.Distribution = Arch
-		case "debian":
+		case "debian", "ubuntu":
 			result.Distribution = Debian
 		case "gentoo":
 			result.Distribution = Gentoo

--- a/cmd/linux.go
+++ b/cmd/linux.go
@@ -33,12 +33,12 @@ const (
 
 // DistroInfo contains all the information relating to a linux distribution
 type DistroInfo struct {
-	Distribution  LinuxDistribution
-	Description   string
-	Release       string
-	Codename      string
-	DistributorID string
-	DiscoveredBy  string
+	Distribution LinuxDistribution
+	Name         string
+	ID           string
+	Description  string
+	Release      string
+	DiscoveredBy string
 }
 
 // GetLinuxDistroInfo returns information about the running linux distribution
@@ -91,7 +91,8 @@ func GetLinuxDistroInfo() *DistroInfo {
 			result.Distribution = Unknown
 		}
 
-		result.DistributorID = osNAME
+		result.ID = osID
+		result.Name = osNAME
 	}
 	return result
 }
@@ -144,16 +145,16 @@ func RpmInstalled(packageName string) (bool, error) {
 // currently unsupported distribution
 func RequestSupportForDistribution(distroInfo *DistroInfo, libraryName string) error {
 	var logger = NewLogger()
-	defaultError := fmt.Errorf("unable to check libraries on distribution '%s'. Please ensure that the '%s' equivalent is installed", distroInfo.DistributorID, libraryName)
+	defaultError := fmt.Errorf("unable to check libraries on distribution '%s'. Please ensure that the '%s' equivalent is installed", distroInfo.Name, libraryName)
 
-	logger.Yellow("Distribution '%s' is not currently supported, but we would love to!", distroInfo.DistributorID)
-	q := fmt.Sprintf("Would you like to submit a request to support distribution '%s'?", distroInfo.DistributorID)
+	logger.Yellow("Distribution '%s' is not currently supported, but we would love to!", distroInfo.Name)
+	q := fmt.Sprintf("Would you like to submit a request to support distribution '%s'?", distroInfo.Name)
 	result := Prompt(q, "yes")
 	if strings.ToLower(result) != "yes" {
 		return defaultError
 	}
 
-	title := fmt.Sprintf("Support Distribution '%s'", distroInfo.DistributorID)
+	title := fmt.Sprintf("Support Distribution '%s'", distroInfo.Name)
 
 	var str strings.Builder
 
@@ -168,16 +169,16 @@ func RequestSupportForDistribution(distroInfo *DistroInfo, libraryName string) e
 	str.WriteString(fmt.Sprintf("| Platform      | %s |\n", runtime.GOOS))
 	str.WriteString(fmt.Sprintf("| Arch          | %s |\n", runtime.GOARCH))
 	str.WriteString(fmt.Sprintf("| GO111MODULE   | %s |\n", gomodule))
-	str.WriteString(fmt.Sprintf("| Distribution ID   | %s |\n", distroInfo.DistributorID))
+	str.WriteString(fmt.Sprintf("| Distribution ID   | %s |\n", distroInfo.ID))
+	str.WriteString(fmt.Sprintf("| Distribution Name   | %s |\n", distroInfo.Name))
 	str.WriteString(fmt.Sprintf("| Distribution Version   | %s |\n", distroInfo.Release))
 	str.WriteString(fmt.Sprintf("| Discovered by   | %s |\n", distroInfo.DiscoveredBy))
 
-	body := fmt.Sprintf("**Description**\nDistribution '%s' is currently unsupported.\n\n**Further Information**\n\n%s\n\n*Please add any extra information here, EG: libraries that are needed to make the distribution work, or commands to install them*", distroInfo.DistributorID, str.String())
+	body := fmt.Sprintf("**Description**\nDistribution '%s' is currently unsupported.\n\n**Further Information**\n\n%s\n\n*Please add any extra information here, EG: libraries that are needed to make the distribution work, or commands to install them*", distroInfo.ID, str.String())
 	fullURL := "https://github.com/wailsapp/wails/issues/new?"
 	params := "title=" + title + "&body=" + body
 
 	fmt.Println("Opening browser to file request.")
 	browser.OpenURL(fullURL + url.PathEscape(params))
 	return nil
-
 }


### PR DESCRIPTION
Since `/etc/os-release` should always exist and `lsb_release` doesn't I removed it.
I changed detection from `NAME=` to `ID=` which should fit this purpose better.
Fixes #171 

I did not test anything this on any distro besides Arch Linux.

Signed-off-by: Chronophylos <nikolai@chronophylos.com>