### PR TITLE
Ensure version in go.mod is up to date

### DIFF
--- a/cmd/gomod.go
+++ b/cmd/gomod.go
@@ -1,0 +1,78 @@
+package cmd
+
+import (
+	"fmt"
+	"path/filepath"
+	"regexp"
+
+	"github.com/Masterminds/semver"
+)
+
+func GetWailsVersion() (*semver.Version, error) {
+	var FS = NewFSHelper()
+	var result *semver.Version
+
+	// Load file
+	var err error
+	goModFile, err := filepath.Abs(filepath.Join(".", "go.mod"))
+	if err != nil {
+		return nil, fmt.Errorf("Unable to load go.mod at %s", goModFile)
+	}
+	goMod, err := FS.LoadAsString(goModFile)
+	if err != nil {
+		return nil, fmt.Errorf("Unable to load go.mod")
+	}
+
+	// Find wails version
+	versionRegexp := regexp.MustCompile(`.*github.com/wailsapp/wails.*(v\d+.\d+.\d+(?:-pre\d+)?)`)
+	versions := versionRegexp.FindStringSubmatch(goMod)
+
+	if len(versions) != 2 {
+		return nil, fmt.Errorf("Unable to determine Wails version")
+	}
+
+	version := versions[1]
+	result, err = semver.NewVersion(version)
+	if err != nil {
+		return nil, fmt.Errorf("Unable to parse Wails version: %s", version)
+	}
+	return result, nil
+
+}
+
+func GetCurrentVersion() (*semver.Version, error) {
+	result, err := semver.NewVersion(Version)
+	if err != nil {
+		return nil, fmt.Errorf("Unable to parse Wails version: %s", Version)
+	}
+	return result, nil
+}
+
+func GoModOutOfSync() (bool, error) {
+	gomodversion, err := GetWailsVersion()
+	if err != nil {
+		return true, err
+	}
+	currentVersion, err := GetCurrentVersion()
+	if err != nil {
+		return true, err
+	}
+	result := !currentVersion.Equal(gomodversion)
+	return result, nil
+}
+
+func UpdateGoModVersion() error {
+	currentVersion, err := GetCurrentVersion()
+	if err != nil {
+		return err
+	}
+	currentVersionString := currentVersion.String()
+
+	requireLine := "-require=github.com/wailsapp/wails@v" + currentVersionString
+
+	// Issue: go mod edit -require=github.com/wailsapp/wails@1.0.2-pre5
+	helper := NewProgramHelper()
+	command := []string{"go", "mod", "edit", requireLine}
+	return helper.RunCommandArray(command)
+
+}

--- a/cmd/wails/15_migrate.go
+++ b/cmd/wails/15_migrate.go
@@ -7,7 +7,6 @@ import (
 	"log"
 	"os"
 	"path/filepath"
-	"regexp"
 	"strings"
 
 	"github.com/Masterminds/semver"
@@ -183,35 +182,13 @@ func checkProjectDirectory() error {
 
 func getWailsVersion() (*semver.Version, error) {
 	checkSpinner.Start("Get Wails Version")
-	var result *semver.Version
 
-	// Load file
-	var err error
-	goModFile, err = filepath.Abs(filepath.Join(".", "go.mod"))
+	result, err := cmd.GetWailsVersion()
+
 	if err != nil {
-		checkSpinner.Error()
-		return nil, fmt.Errorf("Unable to load go.mod at %s", goModFile)
+		checkSpinner.Error(err.Error())
+		return nil, err
 	}
-	goMod, err = migrateFS.LoadAsString(goModFile)
-	if err != nil {
-		checkSpinner.Error()
-		return nil, fmt.Errorf("Unable to load go.mod")
-	}
-
-	// Find wails version
-	versionRegexp := regexp.MustCompile(`.*github.com/wailsapp/wails.*(v\d+.\d+.\d+)`)
-	versions := versionRegexp.FindStringSubmatch(goMod)
-
-	if len(versions) != 2 {
-		return nil, fmt.Errorf("Unable to determine Wails version")
-	}
-
-	version := versions[1]
-	result, err = semver.NewVersion(version)
-	if err != nil {
-		return nil, fmt.Errorf("Unable to parse Wails version: %s", version)
-	}
-	checkSpinner.Success("Found Wails Version: " + version)
 	return result, nil
 
 }

--- a/cmd/wails/4_build.go
+++ b/cmd/wails/4_build.go
@@ -106,6 +106,27 @@ func init() {
 			projectOptions.SetTypescriptDefsFilename(typescriptFilename)
 		}
 
+		// Update go.mod if it is out of sync with current version
+		outofsync, err := cmd.GoModOutOfSync()
+		if err != nil {
+			return err
+		}
+		gomodVersion, err := cmd.GetWailsVersion()
+		if err != nil {
+			return err
+		}
+		if outofsync {
+			syncMessage := fmt.Sprintf("Updating go.mod (Wails version %s => %s)", gomodVersion, cmd.Version)
+			buildSpinner := spinner.NewSpinner(syncMessage)
+			buildSpinner.Start()
+			err := cmd.UpdateGoModVersion()
+			if err != nil {
+				buildSpinner.Error(err.Error())
+				return err
+			}
+			buildSpinner.Success()
+		}
+
 		err = cmd.BuildApplication(projectOptions.BinaryName, forceRebuild, buildMode, packageApp, projectOptions)
 		if err != nil {
 			return err


### PR DESCRIPTION
This PR will add the ability at compile time to update the version of Wails in go.mod. Currently it is possible to have the compiler and runtime versions out of sync, leading to some interesting side effects.