### PR TITLE
add the GOLDFLAGS environment variable

### DIFF
--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -569,5 +569,8 @@ func ldFlags(po *ProjectOptions, buildMode string) string {
 			ldflags += " -X github.com/wailsapp/wails/lib/binding.typescriptDefinitionFilename=" + filename
 		}
 	}
+	if len(os.Getenv("GOLDFLAGS")) > 0 {
+		ldflags += " " + strings.ReplaceAll(os.Getenv("GOLDFLAGS"), "\"", "")
+	}
 	return ldflags
 }


### PR DESCRIPTION
example Makefile:

build_n_run: export GOLDFLAGS=-X main.Version=$(GVER) -X main.BuildTime=$(BUILD_TIME)
build_n_run:
        wails build -d -verbose
