### PR TITLE
refactor home and config dir to stdlib, update min go ver to 1.13

### DIFF
--- a/.github/workflows/latest-pre.yml
+++ b/.github/workflows/latest-pre.yml
@@ -13,10 +13,10 @@ jobs:
         os: [ubuntu-latest, windows-latest, macOS-latest]
     steps:
 
-    - name: Set up Go 1.12
+    - name: Set up Go 1.13
       uses: actions/setup-go@v1
       with:
-        go-version: 1.12
+        go-version: 1.13
       id: go
 
     - name: Check out code into the Go module directory
@@ -27,6 +27,6 @@ jobs:
         go get -v -d ./...
     - name: Build
       run: go build -v ./cmd/wails
-    
+
     - name: Test
       run: ./wails version

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -13,10 +13,10 @@ jobs:
         os: [ubuntu-latest, windows-latest, macOS-latest]
     steps:
 
-    - name: Set up Go 1.12
+    - name: Set up Go 1.13
       uses: actions/setup-go@v1
       with:
-        go-version: 1.12
+        go-version: 1.13
       id: go
 
     - name: Check out code into the Go module directory
@@ -27,6 +27,6 @@ jobs:
         go get -v -d ./...
     - name: Build
       run: go build -v ./cmd/wails
-    
+
     - name: Test
       run: ./wails version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ on:
     branches:
     - master
     tags:
-    - '!**pre**' 
+    - '!**pre**'
 jobs:
 
   build:
@@ -15,10 +15,10 @@ jobs:
         os: [ubuntu-latest, windows-latest, macOS-latest]
     steps:
 
-    - name: Set up Go 1.12
+    - name: Set up Go 1.13
       uses: actions/setup-go@v1
       with:
-        go-version: 1.12
+        go-version: 1.13
       id: go
 
     - name: Check out code into the Go module directory
@@ -29,6 +29,6 @@ jobs:
         go get -v -d ./...
     - name: Build
       run: go build -v ./cmd/wails
-    
+
     - name: Test
       run: ./wails version

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ The official docs can be found at [https://wails.app](https://wails.app).
 
 Wails uses cgo to bind to the native rendering engines so a number of platform dependent libraries are needed as well as an installation of Go. The basic requirements are:
 
-- Go 1.12
+- Go 1.13
 - npm
 
 ### MacOS

--- a/cmd/system.go
+++ b/cmd/system.go
@@ -5,12 +5,11 @@ import (
 	"fmt"
 	"io/ioutil"
 	"log"
+	"os"
 	"path/filepath"
 	"runtime"
 	"strconv"
 	"time"
-
-	homedir "github.com/mitchellh/go-homedir"
 )
 
 // SystemHelper - Defines everything related to the system
@@ -38,7 +37,7 @@ func NewSystemHelper() *SystemHelper {
 // setSystemDirs calculates the system directories it is interested in
 func (s *SystemHelper) setSystemDirs() {
 	var err error
-	s.homeDir, err = homedir.Dir()
+	s.homeDir, err = os.UserHomeDir()
 	if err != nil {
 		log.Fatal("Cannot find home directory! Please file a bug report!")
 	}
@@ -132,7 +131,7 @@ func (s *SystemHelper) setup() error {
 }
 
 const introText = `
-Wails is a lightweight framework for creating web-like desktop apps in Go. 
+Wails is a lightweight framework for creating web-like desktop apps in Go.
 I'll need to ask you a few questions so I can fill in your project templates and then I will try and see if you have the correct dependencies installed. If you don't have the right tools installed, I'll try and suggest how to install them.
 `
 

--- a/cmd/system.go
+++ b/cmd/system.go
@@ -37,12 +37,13 @@ func NewSystemHelper() *SystemHelper {
 // setSystemDirs calculates the system directories it is interested in
 func (s *SystemHelper) setSystemDirs() {
 	var err error
-	s.homeDir, err = os.UserHomeDir()
+	s.homeDir, err = os.UserConfigDir()
 	if err != nil {
 		log.Fatal("Cannot find home directory! Please file a bug report!")
 	}
+
 	// TODO: A better config system
-	s.wailsSystemDir = filepath.Join(s.homeDir, ".wails")
+	s.wailsSystemDir = filepath.Join(s.homeDir, "wails")
 	s.wailsSystemConfig = filepath.Join(s.wailsSystemDir, s.configFilename)
 }
 

--- a/cmd/wails/8_update.go
+++ b/cmd/wails/8_update.go
@@ -3,9 +3,9 @@ package main
 import (
 	"fmt"
 	"log"
+	"os"
 
 	"github.com/leaanthony/spinner"
-	"github.com/mitchellh/go-homedir"
 	"github.com/wailsapp/wails/cmd"
 )
 
@@ -146,7 +146,7 @@ func updateToVersion(targetVersion *cmd.SemanticVersion, force bool) error {
 	updateSpinner.Start("Installing Wails " + desiredVersion)
 
 	// Run command in non module directory
-	homeDir, err := homedir.Dir()
+	homeDir, err := os.UserHomeDir()
 	if err != nil {
 		log.Fatal("Cannot find home directory! Please file a bug report!")
 	}

--- a/go.mod
+++ b/go.mod
@@ -28,4 +28,4 @@ require (
 	gopkg.in/yaml.v3 v3.0.0-20190709130402-674ba3eaed22
 )
 
-go 1.12
+go 1.13

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,6 @@ require (
 	github.com/leaanthony/spinner v0.5.3
 	github.com/mattn/go-colorable v0.1.1 // indirect
 	github.com/mattn/go-isatty v0.0.7 // indirect
-	github.com/mitchellh/go-homedir v1.1.0
 	github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646 // indirect
 	github.com/pkg/browser v0.0.0-20180916011732-0a3d74bf9ce4
 	github.com/pkg/errors v0.8.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -46,8 +46,6 @@ github.com/mattn/go-isatty v0.0.7 h1:UvyT9uN+3r7yLEYSlJsbQGdsaB/a0DlgWP3pql6iwOc
 github.com/mattn/go-isatty v0.0.7/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
 github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b h1:j7+1HpAFS1zy5+Q4qx1fWh90gTKwiN4QCGoY9TWyyO4=
 github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b/go.mod h1:01TrycV0kFyexm33Z7vhZRXopbI8J3TDReVlkTgMUxE=
-github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
-github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646 h1:zYyBkD/k9seD2A7fsi6Oo2LfFZAehjjQMERAvZLEDnQ=
 github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646/go.mod h1:jpp1/29i3P1S/RLdc7JQKbRpFeM1dOBd8T9ki5s+AY8=
 github.com/pkg/browser v0.0.0-20180916011732-0a3d74bf9ce4 h1:49lOXmGaUpV9Fz3gd7TFZY106KVlPVa5jcYD1gaQf98=

--- a/runtime/filesystem.go
+++ b/runtime/filesystem.go
@@ -1,9 +1,9 @@
 package runtime
 
-import homedir "github.com/mitchellh/go-homedir"
+import "os"
 
 // FileSystem exposes file system utilities to the runtime
-type FileSystem struct {}
+type FileSystem struct{}
 
 // NewFileSystem creates a new FileSystem struct
 func NewFileSystem() *FileSystem {
@@ -12,5 +12,5 @@ func NewFileSystem() *FileSystem {
 
 // HomeDir returns the user's home directory
 func (r *FileSystem) HomeDir() (string, error) {
-	return homedir.Dir()
+	return os.UserHomeDir()
 }


### PR DESCRIPTION
- Remove mitchellh/go-homedir dependency in favor of the stdlib os.UserHomeDir (supported since 1.12)

if we can move the min go version to 1.13, we can introduce the following improvements too:

- Use os.UserConfigDir as configuration path (respects XDG user dirs with fallback on Linux, `%AppData%` on windows and `$HOME/Library/Application Support` on mac)
- Rename the config directory to wails (since its now inside a subdirectory and not on $home)
