### PR TITLE
fix(bridge): fixed long message emit issue #469

### DIFF
--- a/lib/renderer/bridge/bridge.go
+++ b/lib/renderer/bridge/bridge.go
@@ -157,7 +157,7 @@ func (h *Bridge) NotifyEvent(event *messages.EventData) error {
 		}
 	}
 
-	message := fmt.Sprintf("window.wails._.Notify('%s','%s')", event.Name, data)
+	message := "window.wails._.Notify('" + event.Name + "','" + string(data) + "')"
 	dead := []*session{}
 	for _, session := range h.sessions {
 		err := session.evalJS(message, notifyMessage)


### PR DESCRIPTION
A simple fix for emitting long messages with runtime. As discussed at #469.