### PR TITLE
419 encoding issue for notify

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -30,3 +30,4 @@ Wails is what it is because of the time and effort given by these great people. 
   * [Florian Didron](https://github.com/fdidron)
   * [Christopher Murphy](https://github.com/Splode)
   * [Zámbó, Levente](https://github.com/Lyimmi)
+  * [artem](https://github.com/Unix4ever)

--- a/lib/renderer/bridge/bridge.go
+++ b/lib/renderer/bridge/bridge.go
@@ -152,12 +152,19 @@ func (h *Bridge) NotifyEvent(event *messages.EventData) error {
 		// Marshall the data
 		data, err = json.Marshal(event.Data)
 		if err != nil {
-			h.log.Errorf("Cannot unmarshall JSON data in event: %s ", err.Error())
+			h.log.Errorf("Cannot marshal JSON data in event: %s ", err.Error())
 			return err
 		}
 	}
 
-	message := "window.wails._.Notify('" + event.Name + "','" + string(data) + "')"
+	// Double encode data to ensure everything is escaped correctly.
+	data, err = json.Marshal(string(data))
+	if err != nil {
+		h.log.Errorf("Cannot marshal JSON data in event: %s ", err.Error())
+		return err
+	}
+
+	message := "window.wails._.Notify('" + event.Name + "'," + string(data) + ")"
 	dead := []*session{}
 	for _, session := range h.sessions {
 		err := session.evalJS(message, notifyMessage)

--- a/lib/renderer/webview.go
+++ b/lib/renderer/webview.go
@@ -329,7 +329,14 @@ func (w *WebView) NotifyEvent(event *messages.EventData) error {
 		}
 	}
 
-	message := fmt.Sprintf("wails._.Notify('%s','%s')", event.Name, data)
+	// Double encode data to ensure everything is escaped correctly.
+	data, err = json.Marshal(string(data))
+	if err != nil {
+		w.log.Errorf("Cannot marshal JSON data in event: %s ", err.Error())
+		return err
+	}
+
+	message := "window.wails._.Notify('" + event.Name + "'," + string(data) + ")"
 	return w.evalJS(message)
 }
 


### PR DESCRIPTION
This PR supersedes https://github.com/wailsapp/wails/pull/475.

This fixes potential encoding issues with data sent to the Notify endpoints.

Huge thanks and credit to [artem](https://github.com/Unix4ever) for raising this and providing the initial solution.