### PR TITLE
runtime.Store => wails.Store

### DIFF
--- a/cmd/templates/vanilla/frontend/src/main.js
+++ b/cmd/templates/vanilla/frontend/src/main.js
@@ -4,7 +4,7 @@ const runtime = require('@wailsapp/runtime');
 // Main entry point
 function start() {
 
-	var mystore = runtime.Store.New('Counter');
+	var mystore = wails.Store.New('Counter');
 
 	// Ensure the default app div is 100% wide/high
 	var app = document.getElementById('app');
@@ -39,7 +39,7 @@ function start() {
 	mystore.subscribe( (state) => {
 		document.getElementById('counter').innerText = state;
 	});
-	
+
 	mystore.set(0);
 };
 


### PR DESCRIPTION
Was testing the vanilla template locally on my Mac and noticed that I was getting a `runtime.Store` was undefined in the javascript.

This shows up as follows in the debug output on the host and a blank white page shown on the UI.

```
aught Unhandled Error ****}" type=log
DEBU[0000] [IPC] Processing message                      1D=0xc0000b0048
ERRO[0000] **** Caught Unhandled Error ****
DEBU[0000] [IPC] Finished processing message             1D=0xc0000b0048
DEBU[0000] [IPC] Message received                        payload="&{error Message: Script error.}" type=log
DEBU[0000] [IPC] Processing message                      1D=0xc0000b0050
ERRO[0000] Message: Script error.
DEBU[0000] [IPC] Message received                        payload="&{error URL: }" type=log
DEBU[0000] [IPC] Finished processing message             1D=0xc0000b0050
DEBU[0000] [IPC] Processing message                      1D=0xc0000b0058
ERRO[0000] URL:
DEBU[0000] [IPC] Finished processing message             1D=0xc0000b0058
DEBU[0000] [IPC] Message received                        payload="&{error Line No: 0}" type=log
DEBU[0000] [IPC] Processing message                      1D=0xc0000b0060
ERRO[0000] Line No: 0
DEBU[0000] [IPC] Finished processing message             1D=0xc0000b0060
DEBU[0000] [IPC] Message received                        payload="&{error Column No: 0}" type=log
DEBU[0000] [IPC] Processing message                      1D=0xc0000b0068
ERRO[0000] Column No: 0
DEBU[0000] [IPC] Finished processing message             1D=0xc0000b0068
DEBU[0000] [IPC] Message received                        payload="&{error error: null}" type=log
DEBU[0000] [IPC] Processing message                      1D=0xc00051e008
ERRO[0000] error: null
```

Changing the reference to `wails.store` corrected the issue and allowed the GUI to be shown.