### PR TITLE
implement gopath handling during cross compilation

### DIFF
--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -18,6 +18,8 @@ import (
 	"github.com/leaanthony/spinner"
 )
 
+const XGO_VERSION = "latest"
+
 var fs = NewFSHelper()
 
 // ValidateFrontendConfig checks if the frontend config is valid
@@ -146,14 +148,20 @@ func BuildDocker(binaryName string, buildMode string, projectOptions *ProjectOpt
 		"-e", "FLAG_RACE=false",
 		"-e", "FLAG_BUILDMODE=default",
 		"-e", "FLAG_TRIMPATH=false",
-		"-e", fmt.Sprintf("TARGETS=%s", projectOptions.Platform+"/"+projectOptions.Architecture),
+		"-e", fmt.Sprintf("TARGETS=%s/%s", projectOptions.Platform, projectOptions.Architecture),
 		"-e", "GOPROXY=",
 		"-e", "GO111MODULE=on",
-		"wailsapp/xgo:latest",
-		".",
 	} {
 		buildCommand.Add(arg)
 	}
+
+	if projectOptions.GoPath != "" {
+		buildCommand.Add("-v")
+		buildCommand.Add(fmt.Sprintf("%s:/go", projectOptions.GoPath))
+	}
+
+	buildCommand.Add(fmt.Sprintf("wailsapp/xgo:%s", XGO_VERSION))
+	buildCommand.Add(".")
 
 	compileMessage := fmt.Sprintf(
 		"Packing + Compiling project for %s/%s using docker image wailsapp/xgo:latest",

--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -18,7 +18,7 @@ import (
 	"github.com/leaanthony/spinner"
 )
 
-const XGO_VERSION = "latest"
+const xgoVersion = "latest"
 
 var fs = NewFSHelper()
 
@@ -92,16 +92,17 @@ func InitializeCrossCompilation(verbose bool) error {
 	}
 
 	var packSpinner *spinner.Spinner
+	msg := fmt.Sprintf("Pulling wailsapp/xgo:%s docker image... (may take a while)", xgoVersion)
 	if !verbose {
-		packSpinner = spinner.New("Pulling wailsapp/xgo:latest docker image... (may take a while)")
+		packSpinner = spinner.New(msg)
 		packSpinner.SetSpinSpeed(50)
 		packSpinner.Start()
 	} else {
-		println("Pulling wailsapp/xgo:latest docker image... (may take a while)")
+		println(msg)
 	}
 
 	err := NewProgramHelper(verbose).RunCommandArray([]string{"docker",
-		"pull", "wailsapp/xgo:latest"})
+		"pull", fmt.Sprintf("wailsapp/xgo:%s", xgoVersion)})
 
 	if err != nil {
 		if packSpinner != nil {
@@ -116,7 +117,7 @@ func InitializeCrossCompilation(verbose bool) error {
 	return nil
 }
 
-// BuildDocker builds the project using the cross compiling wailsapp/xgo:latest container
+// BuildDocker builds the project using the cross compiling wailsapp/xgo:<xgoVersion> container
 func BuildDocker(binaryName string, buildMode string, projectOptions *ProjectOptions) error {
 	var packSpinner *spinner.Spinner
 	if buildMode == BuildModeBridge {
@@ -160,12 +161,12 @@ func BuildDocker(binaryName string, buildMode string, projectOptions *ProjectOpt
 		buildCommand.Add(fmt.Sprintf("%s:/go", projectOptions.GoPath))
 	}
 
-	buildCommand.Add(fmt.Sprintf("wailsapp/xgo:%s", XGO_VERSION))
+	buildCommand.Add(fmt.Sprintf("wailsapp/xgo:%s", xgoVersion))
 	buildCommand.Add(".")
 
 	compileMessage := fmt.Sprintf(
-		"Packing + Compiling project for %s/%s using docker image wailsapp/xgo:latest",
-		projectOptions.Platform, projectOptions.Architecture)
+		"Packing + Compiling project for %s/%s using docker image wailsapp/xgo:%s",
+		projectOptions.Platform, projectOptions.Architecture, xgoVersion)
 
 	if buildMode == BuildModeDebug {
 		compileMessage += " (Debug Mode)"

--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -18,7 +18,7 @@ import (
 	"github.com/leaanthony/spinner"
 )
 
-const xgoVersion = "latest"
+const xgoVersion = "1.0.1"
 
 var fs = NewFSHelper()
 

--- a/cmd/project.go
+++ b/cmd/project.go
@@ -162,6 +162,7 @@ type ProjectOptions struct {
 	Platform               string
 	Architecture           string
 	LdFlags                string
+	GoPath                 string
 }
 
 // Defaults sets the default project template

--- a/cmd/wails/4_build.go
+++ b/cmd/wails/4_build.go
@@ -26,6 +26,7 @@ func init() {
 	var packageApp = false
 	var forceRebuild = false
 	var debugMode = false
+	var gopath = ""
 	var typescriptFilename = ""
 	var verbose = false
 	var platform = ""
@@ -42,7 +43,8 @@ func init() {
 		BoolFlag("d", "Build in Debug mode", &debugMode).
 		BoolFlag("verbose", "Verbose output", &verbose).
 		StringFlag("t", "Generate Typescript definitions to given file (at runtime)", &typescriptFilename).
-		StringFlag("ldflags", "Extra options for -ldflags", &ldflags)
+		StringFlag("ldflags", "Extra options for -ldflags", &ldflags).
+		StringFlag("gopath", "Specify your GOPATH location. Mounted to /go during cross-compilation.", &gopath)
 
 	var b strings.Builder
 	for _, plat := range getSupportedPlatforms() {
@@ -97,6 +99,7 @@ func init() {
 
 		// Add ldflags
 		projectOptions.LdFlags = ldflags
+		projectOptions.GoPath = gopath
 
 		// Validate config
 		// Check if we have a frontend


### PR DESCRIPTION
Allows the developer to specify a `-gopath` path argument during build which is mounted to the docker container at `/go` which is configured as the GOPATH inside the runtime.

Allows the developer to specify a `-gopath` path argument during build which causes the location on your host to be mounted at `/go` inside the cross-compiler container.  
Enabling the `replace github.com/original/library => github.com/tmclane/library` style of substitution where you edit files on the host and they are made available in the cross-compile environment.

Addresses: #460 