### PR TITLE
Fix wails init failing using the Svelte template

### DIFF
--- a/cmd/templates/svelte/frontend/rollup.config.js
+++ b/cmd/templates/svelte/frontend/rollup.config.js
@@ -80,7 +80,6 @@ export default {
 				{
 				  targets: '> 0.25%, not dead, IE 11',
 				  modules: false,
-				  spec: true, 
 				  useBuiltIns: 'usage',
 				  forceAllTransforms: true,
 				  corejs: 3,


### PR DESCRIPTION
As described in #592 , the `spec` option leads to a failing frontend. Removing it fixes this and seems to not break anything.