### PR TITLE
Handle event expirations immediately

### DIFF
--- a/lib/event/manager.go
+++ b/lib/event/manager.go
@@ -49,6 +49,9 @@ func (e *Manager) addEventListener(eventName string, callback func(...interface{
 		return fmt.Errorf("nil callback bassed to addEventListener")
 	}
 
+	// synchronize with other Goroutines before adding an element
+	e.mu.Lock()
+
 	// Check event has been registered before
 	if e.listeners[eventName] == nil {
 		e.listeners[eventName] = []*eventListener{}
@@ -60,8 +63,9 @@ func (e *Manager) addEventListener(eventName string, callback func(...interface{
 		counter:  counter,
 	}
 
-	// Register listener
+	// Register listener and unlock
 	e.listeners[eventName] = append(e.listeners[eventName], listener)
+	e.mu.Unlock()
 
 	// All good mate
 	return nil

--- a/lib/event/manager.go
+++ b/lib/event/manager.go
@@ -12,11 +12,11 @@ import (
 // Manager handles and processes events
 type Manager struct {
 	incomingEvents chan *messages.EventData
-	quitChannel    chan struct{}
 	listeners      map[string][]*eventListener
-	running        bool
 	log            *logger.CustomLogger
+	quitChannel    chan struct{}
 	renderer       interfaces.Renderer // Messages will be dispatched to the frontend
+	running        bool
 	wg             sync.WaitGroup
 }
 
@@ -24,10 +24,10 @@ type Manager struct {
 func NewManager() interfaces.EventManager {
 	return &Manager{
 		incomingEvents: make(chan *messages.EventData, 100),
-		quitChannel:    make(chan struct{}, 1),
 		listeners:      make(map[string][]*eventListener),
-		running:        false,
 		log:            logger.NewCustomLogger("Events"),
+		quitChannel:    make(chan struct{}, 1),
+		running:        false,
 	}
 }
 

--- a/lib/event/manager_test.go
+++ b/lib/event/manager_test.go
@@ -1,0 +1,64 @@
+package event
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/wailsapp/wails/lib/renderer"
+)
+
+func TestLifecycle(t *testing.T) {
+
+	// test fn
+	emptyTest := func(data ...interface{}) {
+		fmt.Println("emptyTest ran")
+	}
+
+	// spin up an instance
+	// HELP - WHAT IS THE RIGHT WAY TO DO THIS?
+	eventManager := NewManager()
+	eventManager.Start(renderer.NewWebView()) // is WebView ok to use?
+
+	// load it with a test event
+	eventManager.On("test", emptyTest) // OK
+
+	// begin tests
+	// eventManager.Emit("test") // NOPE - blows chunks
+
+	// proper Shutdown
+	eventManager.Shutdown()
+}
+
+func TestInstantiation(t *testing.T) {
+	// NewManager should expose certain public functions
+	eventManager := NewManager()
+
+	if reflect.ValueOf(eventManager.Emit).Kind() != reflect.Func {
+		t.Errorf("Emit func is missing from NewManager")
+	}
+
+	if reflect.ValueOf(eventManager.On).Kind() != reflect.Func {
+		t.Errorf("On func is missing from NewManager")
+	}
+
+	if reflect.ValueOf(eventManager.Once).Kind() != reflect.Func {
+		t.Errorf("Once func is missing from NewManager")
+	}
+
+	if reflect.ValueOf(eventManager.OnMultiple).Kind() != reflect.Func {
+		t.Errorf("OnMultiple func is missing from NewManager")
+	}
+
+	if reflect.ValueOf(eventManager.PushEvent).Kind() != reflect.Func {
+		t.Errorf("PushEvent func is missing from NewManager")
+	}
+
+	if reflect.ValueOf(eventManager.Shutdown).Kind() != reflect.Func {
+		t.Errorf("Shutdown func is missing from NewManager")
+	}
+
+	if reflect.ValueOf(eventManager.Start).Kind() != reflect.Func {
+		t.Errorf("Start func is missing from NewManager")
+	}
+}


### PR DESCRIPTION
_Basically, the concept of `expired` has gone away in favor of just dealing with the expiration task immediately. This results in simplified code that doesn't allow expired listeners to pile up in the slices._

Change notes:

1)	`eventListener` struct no longer needs `expired` field because we are taking care of the expiration immediately. Also brought to near top of file instead of being buried in the struct methods.

2)	Code reviewed the entire file to ensure no `expired` logic anywhere else.

3)	Used “clone and truncate” method of slice element removal to handle the expiration immediately. There are references and a playground snippet in the comments to demonstrate this for the uninitiated and to demystify this complexity.

4)	tightened the `mutex` closer to the action for concurrent performance reasons.

5)	alphabetized `struct` fields for quicker locating; same for methods.

6)	added `manager_test.go` to prove this logic out. **NEED HELP GETTING STARTED**. Please see `TestLifecycle` for details. I’d like to write some deep tests but setting up the test instance is giving me fits.
