### PR TITLE
fix: V2 code gen issue

### DIFF
--- a/v2/internal/html/assetbundle.go
+++ b/v2/internal/html/assetbundle.go
@@ -112,6 +112,9 @@ func (a *AssetBundle) processHTML(htmldata string) error {
 					if attr.Key == "as" && attr.Val == "script" {
 						asset.Type = AssetTypes.JS
 					}
+					if attr.Key == "rel" && attr.Val == "modulepreload" {
+						asset.Type = AssetTypes.JS
+					}
 				}
 
 				// Ensure we don't include duplicates


### PR DESCRIPTION
In some bundler enviroments like vite the output on index.html uses link
tag with rel="modulepreload" to load javascript, add support to handle
this files on assetbundle, more info
https://developer.mozilla.org/en-US/docs/Web/HTML/Link_types/modulepreload
this is experimental, so maybe its necessary review what types are supposed to be supported

fix #620