### PR TITLE
Fixes TypeScript generated typings

### DIFF
--- a/lib/binding/manager.go
+++ b/lib/binding/manager.go
@@ -115,15 +115,15 @@ func (b *Manager) generateTypescriptDefinitions() error {
 
 	for structname, methodList := range b.structList {
 		structname = strings.SplitN(structname, ".", 2)[1]
-		output.WriteString(fmt.Sprintf("Interface %s {\n", structname))
+		output.WriteString(fmt.Sprintf("interface %s {\n", structname))
 		for _, method := range methodList {
-			output.WriteString(fmt.Sprintf("\t%s: (...args : any[]) => Promise\n", method))
+			output.WriteString(fmt.Sprintf("\t%s(...args : any[]):Promise<any>\n", method))
 		}
 		output.WriteString("}\n")
 	}
 
 	output.WriteString("\n")
-	output.WriteString("Interface Backend {\n")
+	output.WriteString("interface Backend {\n")
 
 	for structname := range b.structList {
 		structname = strings.SplitN(structname, ".", 2)[1]
@@ -136,7 +136,8 @@ declare global {
 	interface Window {
 		backend: Backend;
 	}
-}`
+}
+export {};`
 	output.WriteString(globals)
 
 	b.log.Info("Written Typescript file: " + typescriptDefinitionFilename)


### PR DESCRIPTION
Currently generated typings produce invalid TypeScript code and look  something like this:
```
Interface ServerApi {
	AddNewServer: (...args : any[]) => Promise
	DeleteServer: (...args : any[]) => Promise
	GetExistingServers: (...args : any[]) => Promise
}

Interface Backend {
	ServerApi: ServerApi
}

declare global {
	interface Window {
		backend: Backend;
	}
}
```
First of all, some `export` is required, since augmentations of window aren't allowed otherwise (TS error). 
`interface` keyword should start with a lowercase and `Promise` should have a typed response, even if it's an `any`.

After this small change typings look like this:
```
interface ServerApi {
	AddNewServer(...args : any[]):Promise<any>
	DeleteServer(...args : any[]):Promise<any>
	GetExistingServers(...args : any[]):Promise<any>
}

interface Backend {
	ServerApi: ServerApi
}

declare global {
	interface Window {
		backend: Backend;
	}
}
export {};
```

TypeScript validity can be checked here https://www.typescriptlang.org/play for example