### PR TITLE
Add User Application Cache Directory

### DIFF
--- a/runtime/filesystem.go
+++ b/runtime/filesystem.go
@@ -14,3 +14,8 @@ func NewFileSystem() *FileSystem {
 func (r *FileSystem) HomeDir() (string, error) {
 	return os.UserHomeDir()
 }
+
+// UserCacheDir returns the user's application cache directory
+func (r *FileSystem) UserCacheDir() (string, error) {
+	return os.UserCacheDir()
+}


### PR DESCRIPTION
## Summary

I added a small enhancement to the runtime filesystem to enable getting the user's application cache directory.

## Motivation

`os.UserCacheDir` returns the default root directory to use for user-specific cached data. Users should create their own application-specific subdirectory within this one and use that. The Go library call wraps the correct platforms' cache directory to allow an application to have it's data sandboxed and in a place that makes sense. 

This will allow a Wails application to store a local cache sqlite database file or write files/media and other files in directory that is namespaced by the Application.

### Use Cases

- sqlite database file to power application local cache

```
# MacOS
/Users/<your-user-name>/Library/Application Support/<application-name>/data
```

<img width="386" alt="Screenshot 2021-04-21 at 10 25 20" src="https://user-images.githubusercontent.com/4479918/115522167-2a13e480-a28c-11eb-8951-785220d388a8.png">


### Changes

- Allow for the user application cache directory to be available via the runtime filesystem.

