### PR TITLE
[V2] []byte type fix.

### DIFF
--- a/v2/internal/binding/generate.go
+++ b/v2/internal/binding/generate.go
@@ -144,6 +144,8 @@ func goTypeToJSDocType(input string) string {
 		return "number"
 	case input == "bool":
 		return "boolean"
+	case input == "[]byte":
+		return "string"
 	case strings.HasPrefix(input, "[]"):
 		arrayType := goTypeToJSDocType(input[2:])
 		return "Array.<" + arrayType + ">"

--- a/v2/internal/binding/generate_test.go
+++ b/v2/internal/binding/generate_test.go
@@ -1,0 +1,87 @@
+package binding
+
+import (
+	"testing"
+)
+
+func Test_goTypeToJSDocType(t *testing.T) {
+
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "string",
+			input: "string",
+			want:  "string",
+		},
+		{
+			name:  "error",
+			input: "error",
+			want:  "Error",
+		},
+		{
+			name:  "int",
+			input: "int",
+			want:  "number",
+		},
+		{
+			name:  "int32",
+			input: "int32",
+			want:  "number",
+		},
+		{
+			name:  "uint",
+			input: "uint",
+			want:  "number",
+		},
+		{
+			name:  "uint32",
+			input: "uint32",
+			want:  "number",
+		},
+		{
+			name:  "float32",
+			input: "float32",
+			want:  "number",
+		},
+		{
+			name:  "float64",
+			input: "float64",
+			want:  "number",
+		},
+		{
+			name:  "bool",
+			input: "bool",
+			want:  "boolean",
+		},
+		{
+			name:  "[]byte",
+			input: "[]byte",
+			want:  "string",
+		},
+		{
+			name:  "[]int",
+			input: "[]int",
+			want:  "Array.<number>",
+		},
+		{
+			name:  "[]bool",
+			input: "[]bool",
+			want:  "Array.<boolean>",
+		},
+		{
+			name:  "anything else",
+			input: "foo",
+			want:  "any",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := goTypeToJSDocType(tt.input); got != tt.want {
+				t.Errorf("goTypeToJSDocType() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
When serializing a []byte type to json, Go actually creates a base64 encoded string, not an array of numbers. This PR updates the generated javascript types to correctly handle this case.