### PR TITLE
hack: enable builds on non-Windows

### DIFF
--- a/v2/internal/ffenestri/windows/x64/x64.go
+++ b/v2/internal/ffenestri/windows/x64/x64.go
@@ -1,3 +1,5 @@
+// +build windows
+
 package x64
 
 import _ "embed"

--- a/v2/internal/ffenestri/windows/x64/x64_stub.go
+++ b/v2/internal/ffenestri/windows/x64/x64_stub.go
@@ -1,0 +1,9 @@
+// +build !windows
+
+// This is a stub to define the following even though they don't exist
+// on non-Windows systems.  Note: This is not the right way to handle this.
+package x64
+
+var WebView2 []byte
+
+var WebView2Loader []byte


### PR DESCRIPTION
Howdy!

So I was on a flight and was attempting to get wails to build on my mac.
Ran in to the Windows specific code inside the `base` and just added this small hack to get it to work.

```
 go build
../../internal/ffenestri/windows/x64/x64.go:5:12: pattern webview.dll: no matching files found
```

I do not really want this merged since I think a better solution should be created first.
