### PR TITLE
[V2] width height fix

### DIFF
--- a/v2/pkg/options/options.go
+++ b/v2/pkg/options/options.go
@@ -1,9 +1,10 @@
 package options
 
 import (
-	"github.com/wailsapp/wails/v2/pkg/options/windows"
 	"log"
 	"runtime"
+
+	"github.com/wailsapp/wails/v2/pkg/options/windows"
 
 	wailsruntime "github.com/wailsapp/wails/v2/internal/runtime"
 	"github.com/wailsapp/wails/v2/pkg/menu"
@@ -63,13 +64,13 @@ func MergeDefaults(appoptions *App) {
 	if appoptions.Width < appoptions.MinWidth {
 		appoptions.Width = appoptions.MinWidth
 	}
-	if appoptions.Width > appoptions.MaxWidth {
+	if appoptions.MaxWidth > 0 && appoptions.Width > appoptions.MaxWidth {
 		appoptions.Width = appoptions.MaxWidth
 	}
 	if appoptions.Height < appoptions.MinHeight {
 		appoptions.Height = appoptions.MinHeight
 	}
-	if appoptions.Height > appoptions.MaxHeight {
+	if appoptions.MaxHeight > 0 && appoptions.Height > appoptions.MaxHeight {
 		appoptions.Height = appoptions.MaxHeight
 	}
 

--- a/v2/pkg/options/options_test.go
+++ b/v2/pkg/options/options_test.go
@@ -1,0 +1,85 @@
+package options
+
+import (
+	"testing"
+)
+
+func TestMergeDefaultsWH(t *testing.T) {
+	tests := []struct {
+		name       string
+		appoptions *App
+		wantWidth  int
+		wantHeight int
+	}{
+		{
+			name:       "No width and height",
+			appoptions: &App{},
+			wantWidth:  Default.Width,
+			wantHeight: Default.Height,
+		},
+		{
+			name: "Basic width and height",
+			appoptions: &App{
+				Width:  800,
+				Height: 600,
+			},
+			wantWidth:  800,
+			wantHeight: 600,
+		},
+		{
+			name: "With MinWidth and MinHeight",
+			appoptions: &App{
+				Width:     200,
+				MinWidth:  800,
+				Height:    100,
+				MinHeight: 600,
+			},
+			wantWidth:  800,
+			wantHeight: 600,
+		},
+		{
+			name: "With MaxWidth and MaxHeight",
+			appoptions: &App{
+				Width:     900,
+				MaxWidth:  800,
+				Height:    700,
+				MaxHeight: 600,
+			},
+			wantWidth:  800,
+			wantHeight: 600,
+		},
+		{
+			name: "With MinWidth more than MaxWidth",
+			appoptions: &App{
+				Width:    900,
+				MinWidth: 900,
+				MaxWidth: 800,
+				Height:   600,
+			},
+			wantWidth:  800,
+			wantHeight: 600,
+		},
+		{
+			name: "With MinHeight more than MaxHeight",
+			appoptions: &App{
+				Width:     800,
+				Height:    700,
+				MinHeight: 900,
+				MaxHeight: 600,
+			},
+			wantWidth:  800,
+			wantHeight: 600,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			MergeDefaults(tt.appoptions)
+			if tt.appoptions.Width != tt.wantWidth {
+				t.Errorf("MergeDefaults().Width =%v, want %v", tt.appoptions.Width, tt.wantWidth)
+			}
+			if tt.appoptions.Height != tt.wantHeight {
+				t.Errorf("MergeDefaults().Height =%v, want %v", tt.appoptions.Height, tt.wantHeight)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Currently if MaxWidth and MaxHeight are left as default, it causes Width and Height to be set to 0. This PR fixes this and adds tests for the width and height behaviour of MergeDefaults.