### PR TITLE
[v2] Fixed bundling and minification.

### DIFF
--- a/v2/internal/html/asset.go
+++ b/v2/internal/html/asset.go
@@ -57,11 +57,8 @@ func (a *Asset) minifiedData() (string, error) {
 	case AssetTypes.HTML:
 
 		// Escape HTML
-		var re = regexp.MustCompile(`\s{2,}`)
+		var re = regexp.MustCompile(`[\s]+`)
 		result := re.ReplaceAllString(a.Data, ` `)
-		result = strings.ReplaceAll(result, "\n", "")
-		result = strings.ReplaceAll(result, "\r\n", "")
-		result = strings.ReplaceAll(result, "\n", "")
 
 		// Inject wailsloader code
 		result = strings.Replace(result, `</body>`, `<script id='wailsloader'>window.wailsloader = { html: true, runtime: false, userjs: false, usercss: false };var self=document.querySelector('#wailsloader');self.parentNode.removeChild(self);</script></body>`, 1)

--- a/v2/internal/html/asset_test.go
+++ b/v2/internal/html/asset_test.go
@@ -21,7 +21,16 @@ func TestAsset_minifiedData(t *testing.T) {
 				Path: "foo.html",
 				Data: "<link\n  rel=\"stylesheet\"\n href=\"src/foo.css\"\n>\n",
 			},
-			want: "data:text/html;charset=utf-8,%3Clink%20rel=%22stylesheet%22%20href=%22src%2ffoo.css%22%3E",
+			want: "data:text/html;charset=utf-8,%3Clink%20rel=%22stylesheet%22%20href=%22src%2ffoo.css%22%20%3E%20",
+		},
+		{
+			name: "multi-line tag no spaces",
+			fields: fields{
+				Type: AssetTypes.HTML,
+				Path: "foo.html",
+				Data: "<link\nrel=\"stylesheet\"\nhref=\"src/foo.css\"\n>\n",
+			},
+			want: "data:text/html;charset=utf-8,%3Clink%20rel=%22stylesheet%22%20href=%22src%2ffoo.css%22%20%3E%20",
 		},
 	}
 	for _, tt := range tests {

--- a/v2/internal/html/asset_test.go
+++ b/v2/internal/html/asset_test.go
@@ -1,0 +1,44 @@
+package html
+
+import "testing"
+
+func TestAsset_minifiedData(t *testing.T) {
+	type fields struct {
+		Type string
+		Path string
+		Data string
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "multi-line tag",
+			fields: fields{
+				Type: AssetTypes.HTML,
+				Path: "foo.html",
+				Data: "<link\n  rel=\"stylesheet\"\n href=\"src/foo.css\"\n>\n",
+			},
+			want: "data:text/html;charset=utf-8,%3Clink%20rel=%22stylesheet%22%20href=%22src%2ffoo.css%22%3E",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			a := &Asset{
+				Type: tt.fields.Type,
+				Path: tt.fields.Path,
+				Data: tt.fields.Data,
+			}
+			got, err := a.minifiedData()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Asset.minifiedData() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("Asset.minifiedData() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/v2/internal/html/assetbundle.go
+++ b/v2/internal/html/assetbundle.go
@@ -84,7 +84,7 @@ func (a *AssetBundle) processHTML(htmldata string) error {
 		}
 
 		//process the token according to the token type...
-		if tokenType == html.StartTagToken {
+		if tokenType == html.StartTagToken || tokenType == html.SelfClosingTagToken {
 			//get the token
 			token := tokenizer.Token()
 

--- a/v2/internal/html/assetbundle_test.go
+++ b/v2/internal/html/assetbundle_test.go
@@ -1,0 +1,73 @@
+package html
+
+import (
+	"testing"
+)
+
+func TestNewAssetBundle(t *testing.T) {
+	tests := []struct {
+		name       string
+		pathToHTML string
+		wantAssets []string
+		wantErr    bool
+	}{
+		{
+			name:       "basic html",
+			pathToHTML: "testdata/basic.html",
+			wantAssets: []string{
+				AssetTypes.HTML,
+				AssetTypes.FAVICON,
+				AssetTypes.JS,
+				AssetTypes.CSS,
+			},
+			wantErr: false,
+		},
+		{
+			name:       "self closing tags",
+			pathToHTML: "testdata/self_closing.html",
+			wantAssets: []string{
+				AssetTypes.HTML,
+				AssetTypes.FAVICON,
+				AssetTypes.JS,
+				AssetTypes.CSS,
+			},
+			wantErr: false,
+		},
+		{
+			name:       "multi-line tags",
+			pathToHTML: "testdata/self_closing.html",
+			wantAssets: []string{
+				AssetTypes.HTML,
+				AssetTypes.FAVICON,
+				AssetTypes.JS,
+				AssetTypes.CSS,
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := NewAssetBundle(tt.pathToHTML)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("NewAssetBundle() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if len(got.assets) != len(tt.wantAssets) {
+				t.Errorf("NewAssetBundle() len(assets) = %d, want %d",
+					len(got.assets), len(tt.wantAssets))
+			}
+
+			for i := range tt.wantAssets {
+				if i >= len(got.assets) {
+					t.Errorf("NewAssetBundle() missing assets[%d].Type = %s",
+						i, tt.wantAssets[i])
+				} else {
+					if got.assets[i].Type != tt.wantAssets[i] {
+						t.Errorf("NewAssetBundle() assets[%d].Type = %s, want %s",
+							i, got.assets[i].Type, tt.wantAssets[i])
+					}
+				}
+			}
+		})
+	}
+}

--- a/v2/internal/html/testdata/basic.html
+++ b/v2/internal/html/testdata/basic.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/src/favicon.svg"></link>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <script type="text/javascript" src="src/bundle.js"></script>
+    <link rel="stylesheet" href="src/style.css"></link>
+    <title>Vite App</title>
+  </head>
+  <body>
+    <div id="root"></div>
+  </body>
+</html>

--- a/v2/internal/html/testdata/multi_line.html
+++ b/v2/internal/html/testdata/multi_line.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/src/favicon.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <script type="text/javascript" src="src/bundle.js"></script>
+    <link 
+      rel="stylesheet" 
+      href="src/style.css" 
+    />
+    <title>Vite App</title>
+  </head>
+  <body>
+    <div id="root"></div>
+  </body>
+</html>

--- a/v2/internal/html/testdata/self_closing.html
+++ b/v2/internal/html/testdata/self_closing.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/src/favicon.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <script type="text/javascript" src="src/bundle.js"></script>
+    <link rel="stylesheet" href="src/style.css" />
+    <title>Vite App</title>
+  </head>
+  <body>
+    <div id="root"></div>
+  </body>
+</html>

--- a/v2/internal/html/testdata/src/bundle.js
+++ b/v2/internal/html/testdata/src/bundle.js
@@ -1,0 +1,1 @@
+window.alert("I am JS!");

--- a/v2/internal/html/testdata/src/favicon.svg
+++ b/v2/internal/html/testdata/src/favicon.svg
@@ -1,0 +1,8 @@
+<svg version="1.1"
+     baseProfile="full"
+     width="300" height="200"
+     xmlns="http://www.w3.org/2000/svg">
+
+  <rect width="100%" height="100%" fill="blue" />
+
+</svg>

--- a/v2/internal/html/testdata/src/style.css
+++ b/v2/internal/html/testdata/src/style.css
@@ -1,0 +1,3 @@
+.body {
+  background: blue;
+}


### PR DESCRIPTION
I probably should have made this two PRs, but was lazy, sorry. :-/ 

This fixes two issues.

1. Multi-line tags like
```
<link
  rel="foo"
  href="bar"
>
```
currently get minified to something like `<linkrel="foo"href="bar>` which isn't right. To fix this I modified the magnification for html to simply replace any run of whitespace with a single space. It's certainly possible to compress more with more sophistication but given that the initial html load is generally super small probably a premature optimization.

2. The asset building doesn't catch self closing html tags like `<link rel="foo" href="foo" />`. It now works with these too. 

I've added tests for both of these cases.