### PR TITLE
Bug/shadowed err

### DIFF
--- a/v2/pkg/commands/build/packager_darwin.go
+++ b/v2/pkg/commands/build/packager_darwin.go
@@ -150,7 +150,7 @@ func processApplicationIcon(resourceDir string, iconsDir string) (err error) {
 	// Install default icon if one doesn't exist
 	if !fs.FileExists(appIcon) {
 		// No - Install default icon
-		err := buildassets.RegenerateAppIcon(appIcon)
+		err = buildassets.RegenerateAppIcon(appIcon)
 		if err != nil {
 			return
 		}


### PR DESCRIPTION
small bug I found when building on a mac.

```
 #] go build .
# github.com/wailsapp/wails/v2/pkg/commands/build
../../pkg/commands/build/packager_darwin.go:155:4: err is shadowed during return
```