### PR TITLE
Fix crash on Mac save dialog when replacing file

### DIFF
--- a/lib/renderer/webview/webview.h
+++ b/lib/renderer/webview/webview.h
@@ -2431,6 +2431,8 @@ struct webview_priv
         [panel setAllowedFileTypes:fileTypes];
       }
       [panel setTreatsFilePackagesAsDirectories:YES];
+      [panel setNameFieldStringValue:@"Temp"]; // Necessary to prevent crash when replacing files
+      [panel setNameFieldStringValue:@"Untitled"];
       [panel beginSheetModalForWindow:w->priv.window
                     completionHandler:^(NSInteger result) {
                       [NSApp stopModalWithCode:result];


### PR DESCRIPTION
Fix to #614 