### PR TITLE
[v2] handle inline javascript in assetbundle.go

### DIFF
--- a/v2/internal/html/assetbundle.go
+++ b/v2/internal/html/assetbundle.go
@@ -137,7 +137,7 @@ func (a *AssetBundle) processHTML(htmldata string) error {
 						break
 					}
 				}
-				if !paths.Contains(asset.Path) {
+				if !paths.Contains(asset.Path) && asset.Path != "" {
 					err := asset.Load(a.basedirectory)
 					if err != nil {
 						return err

--- a/v2/internal/html/assetbundle_test.go
+++ b/v2/internal/html/assetbundle_test.go
@@ -44,6 +44,17 @@ func TestNewAssetBundle(t *testing.T) {
 			},
 			wantErr: false,
 		},
+		{
+			name:       "inline javascript",
+			pathToHTML: "testdata/inline_javascript.html",
+			wantAssets: []string{
+				AssetTypes.HTML,
+				AssetTypes.FAVICON,
+				AssetTypes.JS,
+				AssetTypes.CSS,
+			},
+			wantErr: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/v2/internal/html/testdata/inline_javascript.html
+++ b/v2/internal/html/testdata/inline_javascript.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/src/favicon.svg"></link>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <script type="text/javascript" src="src/bundle.js"></script>
+    <link rel="stylesheet" href="src/style.css"></link>
+    <title>Vite App</title>
+    <script>console.log("test")</script>
+  </head>
+  <body>
+    <div id="root"></div>
+  </body>
+</html>


### PR DESCRIPTION
Think it would be nice to allow inline javacsript.

I've created an app via `create-react-app` and stumbled upon this. Also, I bumped into errors, when none of these conditions were met: https://github.com/wailsapp/wails/blob/v2-alpha/v2/internal/html/assetbundle.go#L97-L118

Think better error reporting might be a good idea so users can remove those `link` tags?