### PR TITLE
Added JS case to mimecache

### DIFF
--- a/v2/internal/frontend/assetserver/mimecache.go
+++ b/v2/internal/frontend/assetserver/mimecache.go
@@ -5,8 +5,9 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+
+	"github.com/gabriel-vasile/mimetype"
 )
-import "github.com/gabriel-vasile/mimetype"
 
 var (
 	cache = map[string]string{}
@@ -31,6 +32,10 @@ func GetMimetype(filename string, data []byte) string {
 
 	if filepath.Ext(filename) == ".css" && strings.HasPrefix(result, "text/plain") {
 		result = strings.Replace(result, "text/plain", "text/css", 1)
+	}
+
+	if filepath.Ext(filename) == ".js" && strings.HasPrefix(result, "text/plain") {
+		result = strings.Replace(result, "text/plain", "text/javascript", 1)
 	}
 
 	if result == "" {

--- a/v2/internal/frontend/assetserver/mimecache.go
+++ b/v2/internal/frontend/assetserver/mimecache.go
@@ -35,7 +35,7 @@ func GetMimetype(filename string, data []byte) string {
 	}
 
 	if filepath.Ext(filename) == ".js" && strings.HasPrefix(result, "text/plain") {
-		result = strings.Replace(result, "text/plain", "text/javascript", 1)
+		result = strings.Replace(result, "text/plain", "application/javascript", 1)
 	}
 
 	if result == "" {

--- a/v2/internal/frontend/assetserver/mimecache_test.go
+++ b/v2/internal/frontend/assetserver/mimecache_test.go
@@ -14,7 +14,7 @@ func TestGetMimetype(t *testing.T) {
 	}{
 		// TODO: Add test cases.
 		{"css", args{"test.css", []byte("body{margin:0;padding:0;background-color:#d579b2}#app{font-family:Avenir,Helvetica,Arial,sans-serif;-webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale;text-align:center;color:#2c3e50;background-color:#ededed}#nav{padding:30px}#nav a{font-weight:700;color:#2c\n3e50}#nav a.router-link-exact-active{color:#42b983}.hello[data-v-4e26ad49]{margin:10px 0}")}, "text/css; charset=utf-8"},
-		{"js", args{"test.js", []byte("let foo = 'bar'; console.log(foo);")}, "text/javascript; charset=utf-8"},
+		{"js", args{"test.js", []byte("let foo = 'bar'; console.log(foo);")}, "application/javascript; charset=utf-8"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/v2/internal/frontend/assetserver/mimecache_test.go
+++ b/v2/internal/frontend/assetserver/mimecache_test.go
@@ -14,6 +14,7 @@ func TestGetMimetype(t *testing.T) {
 	}{
 		// TODO: Add test cases.
 		{"css", args{"test.css", []byte("body{margin:0;padding:0;background-color:#d579b2}#app{font-family:Avenir,Helvetica,Arial,sans-serif;-webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale;text-align:center;color:#2c3e50;background-color:#ededed}#nav{padding:30px}#nav a{font-weight:700;color:#2c\n3e50}#nav a.router-link-exact-active{color:#42b983}.hello[data-v-4e26ad49]{margin:10px 0}")}, "text/css; charset=utf-8"},
+		{"js", args{"test.js", []byte("let foo = 'bar'; console.log(foo);")}, "text/javascript; charset=utf-8"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
I was trying to setup a Vite+Vue3-TS application so I could create a template and ran into an issue with the asset server serving JS files as 'text/plain', which results in the following console error: 

`Failed to load module script: Expected a JavaScript module script but the server responded with a MIME type of "text/plain". Strict MIME type checking is enforced for module scripts per HTML spec.`