### PR TITLE
Correct help text for enabling Debug log level

### DIFF
--- a/v2/cmd/wails/internal/commands/dev/dev.go
+++ b/v2/cmd/wails/internal/commands/dev/dev.go
@@ -88,7 +88,7 @@ func AddSubcommand(app *clir.Cli, w io.Writer) error {
 	command.StringFlag("wailsjsdir", "Directory to generate the Wails JS modules", &flags.wailsjsdir)
 	command.StringFlag("tags", "tags to pass to Go compiler (quoted and space separated)", &flags.tags)
 	command.IntFlag("v", "Verbosity level (0 - silent, 1 - standard, 2 - verbose)", &flags.verbosity)
-	command.StringFlag("loglevel", "Loglevel to use - Trace, Dev, Info, Warning, Error", &flags.loglevel)
+	command.StringFlag("loglevel", "Loglevel to use - Trace, Debug, Info, Warning, Error", &flags.loglevel)
 	command.BoolFlag("f", "Force build application", &flags.forceBuild)
 	command.IntFlag("debounce", "The amount of time to wait to trigger a reload on change", &flags.debounceMS)
 	command.StringFlag("devserverurl", "The url of the dev server to use", &flags.devServerURL)


### PR DESCRIPTION
Upon viewing the help menu for wails dev (`wails dev -h`), there is a log level called `Dev`.

I notice that both [in documentation](https://github.com/wailsapp/wails/blob/722ecc969bb9bdcee5412e73b34f19506981633f/website/docs/reference/cli.mdx#dev) and [in code](https://github.com/wailsapp/wails/blob/master/v2/pkg/logger/logger.go#L30), the second most log level is called "Debug" so this is a small PR to correct what I assume is a typo.

Trying to use `wails dev -loglevel Dev` throws an error regardless while `Debug` works just fine 🙂

![Screen Shot 2021-10-11 at 1 25 30 PM](https://user-images.githubusercontent.com/14816406/136718669-595f21f2-eed3-41cf-b07b-f419aeda0a03.png)

