### PR TITLE
add \r\n for awaitIPC callback

### DIFF
--- a/v2/internal/frontend/assetserver/assetserver_browser_dev.go
+++ b/v2/internal/frontend/assetserver/assetserver_browser_dev.go
@@ -102,7 +102,8 @@ func (a *BrowserAssetServer) Load(filename string) ([]byte, string, error) {
 			var buffer bytes.Buffer
 			buffer.WriteString("window.awaitIPC('" + filename + "', ()=>{")
 			buffer.Write(content)
-			buffer.WriteString("\r\n});")
+			buffer.WriteString(`
+});`)
 			content = buffer.Bytes()
 		}
 	}


### PR DESCRIPTION
if js file last line is comment, it will get error.

like this ↓
//something comment
↓
//something comment});

in order to fix above bug.
add \r\n for awaitIPC callback