### PR TITLE
Helper NPM scripts for developers working on a Wails GUI project

### DIFF
--- a/v2/cmd/wails/internal/commands/generate/template/base/package.json
+++ b/v2/cmd/wails/internal/commands/generate/template/base/package.json
@@ -1,0 +1,12 @@
+{
+  "private": true,
+  "scripts": {
+    "postinstall": "npm run setup && cd frontend && npm install",
+    "build": "wails build --clean",
+    "build:macos": "npm run build -- --platform darwin/universal",
+    "build:macos-arm": "npm run build -- --platform darwin/arm64",
+    "build:macos-intel": "npm run build -- --platform darwin",
+    "build:windows": "npm run build -- --platform windows/amd64",
+    "setup": "go install github.com/wailsapp/wails/v2/cmd/wails@latest"
+  }
+}


### PR DESCRIPTION
Adds a package.json with basic start / setup npm scripts to assist non golang developers working on an end project.