### PR TITLE
Adding workspace to npm which better integrates wails and frontend npm.

### DIFF
--- a/v2/cmd/wails/internal/commands/generate/template/base/package.json
+++ b/v2/cmd/wails/internal/commands/generate/template/base/package.json
@@ -1,12 +1,14 @@
 {
   "private": true,
   "scripts": {
-    "postinstall": "npm run setup && cd frontend && npm install",
+    "install": "go install github.com/wailsapp/wails/v2/cmd/wails@latest",
     "build": "wails build --clean",
     "build:macos": "npm run build -- --platform darwin/universal",
     "build:macos-arm": "npm run build -- --platform darwin/arm64",
     "build:macos-intel": "npm run build -- --platform darwin",
-    "build:windows": "npm run build -- --platform windows/amd64",
-    "setup": "go install github.com/wailsapp/wails/v2/cmd/wails@latest"
-  }
+    "build:windows": "npm run build -- --platform windows/amd64"
+  },
+  "workspaces": [
+    "frontend"
+  ]
 }


### PR DESCRIPTION
Running `npm install` will now run on the top level of a generated project and additionally the "frontend" workspace (we can add plugins for wails to this folder space for auto update, package, sign, publish, etc)

Other commands that use workspaces (including pre/post hooks mostly) and might be helpful to Wails are `docs`, `install`, `rebuild`, `publish`, `pkg`, `pack`, `ci`

For example, during wails build, you could ask for data from the frontend/package.json to get version, title, etc with.

`npm pkg get name version --workspace=frontend`
