### PR TITLE
[v2] Improve processRequest: Handle errors and behave more like a webserver

### DIFF
--- a/v2/internal/frontend/desktop/darwin/Application.h
+++ b/v2/internal/frontend/desktop/darwin/Application.h
@@ -41,7 +41,7 @@ void Quit(void*);
 const char* GetSize(void *ctx);
 const char* GetPos(void *ctx);
 
-void ProcessURLResponse(void *inctx, const char *url, const char *contentType, void* data, int datalength);
+void ProcessURLResponse(void *inctx, const char *url, int statusCode, const char *contentType, void* data, int datalength);
 
 /* Dialogs */
 

--- a/v2/internal/frontend/desktop/darwin/Application.m
+++ b/v2/internal/frontend/desktop/darwin/Application.m
@@ -51,13 +51,13 @@ WailsContext* Create(const char* title, int width, int height, int frameless, in
     return result;
 }
 
-void ProcessURLResponse(void *inctx, const char *url, const char *contentType, void* data, int datalength) {
+void ProcessURLResponse(void *inctx, const char *url, int statusCode, const char *contentType, void* data, int datalength) {
     WailsContext *ctx = (__bridge WailsContext*) inctx;
     NSString *nsurl = safeInit(url);
     NSString *nsContentType = safeInit(contentType);
     NSData *nsdata = [NSData dataWithBytes:data length:datalength];
     
-    [ctx processURLResponse:nsurl :nsContentType :nsdata];
+    [ctx processURLResponse:nsurl :statusCode :nsContentType :nsdata];
 
     [nsdata release];
 }

--- a/v2/internal/frontend/desktop/darwin/WailsContext.h
+++ b/v2/internal/frontend/desktop/darwin/WailsContext.h
@@ -79,7 +79,7 @@
 - (void) SaveFileDialog :(NSString*)title :(NSString*)defaultFilename :(NSString*)defaultDirectory :(bool)canCreateDirectories :(bool)treatPackagesAsDirectories :(bool)showHiddenFiles :(NSString*)filters;
 
 - (void) loadRequest:(NSString*)url;
-- (void) processURLResponse:(NSString *)url :(NSString *)contentType :(NSData*)data;
+- (void) processURLResponse:(NSString *)url :(int)statusCode :(NSString *)contentType :(NSData*)data;
 - (void) ExecJS:(NSString*)script;
 - (NSScreen*) getCurrentScreen;
 

--- a/v2/internal/frontend/desktop/darwin/WailsContext.m
+++ b/v2/internal/frontend/desktop/darwin/WailsContext.m
@@ -376,12 +376,14 @@
    [self.webview evaluateJavaScript:script completionHandler:nil];
 }
 
-- (void) processURLResponse:(NSString *)url :(NSString *)contentType :(NSData *)data {
+- (void) processURLResponse:(NSString *)url :(int)statusCode :(NSString *)contentType :(NSData *)data {
     id<WKURLSchemeTask> urlSchemeTask = self.urlRequests[url];
     NSURL *nsurl = [NSURL URLWithString:url];
     NSMutableDictionary *headerFields = [NSMutableDictionary new];
-    headerFields[@"content-type"] = contentType;
-    NSHTTPURLResponse *response = [[NSHTTPURLResponse new] initWithURL:nsurl statusCode:200 HTTPVersion:@"HTTP/1.1" headerFields:headerFields];
+    if ( ![contentType isEqualToString:@""] ) {
+        headerFields[@"content-type"] = contentType;
+    }
+    NSHTTPURLResponse *response = [[NSHTTPURLResponse new] initWithURL:nsurl statusCode:statusCode HTTPVersion:@"HTTP/1.1" headerFields:headerFields];
     [urlSchemeTask didReceiveResponse:response];
     [urlSchemeTask didReceiveData:data];
     [urlSchemeTask didFinish];

--- a/v2/internal/frontend/desktop/linux/frontend.go
+++ b/v2/internal/frontend/desktop/linux/frontend.go
@@ -333,7 +333,8 @@ func (f *Frontend) processRequest(request unsafe.Pointer) {
 		// TODO Handle errors
 		return
 	} else if !match {
-		return
+		// This should never happen on linux, because we get only called for wails://
+		panic("Unexpected host for request on wails:// scheme")
 	}
 
 	// Load file from asset store
@@ -341,6 +342,8 @@ func (f *Frontend) processRequest(request unsafe.Pointer) {
 	if err != nil {
 		return
 	}
+
+	// TODO How to return 404/500 errors to webkit?
 
 	cContent := C.CString(string(content))
 	defer C.free(unsafe.Pointer(cContent))


### PR DESCRIPTION
This also fixes that requests remain in "pending" state on
darwin if e.g. a file is not found or an error occurs during
loading of the file.

Fix #1003 