### PR TITLE
Fix for #950

### DIFF
--- a/lib/event/manager.go
+++ b/lib/event/manager.go
@@ -55,20 +55,20 @@ func (e *Manager) addEventListener(eventName string, callback func(...interface{
 		return fmt.Errorf("nil callback bassed to addEventListener")
 	}
 
-	// Check event has been registered before
-	if e.listeners[eventName] == nil {
-		e.listeners[eventName] = []*eventListener{}
-	}
-
 	// Create the callback
 	listener := &eventListener{
 		callback: callback,
 		counter:  counter,
 	}
+	e.mu.Lock()
+	// Check event has been registered before
+	if e.listeners[eventName] == nil {
+		e.listeners[eventName] = []*eventListener{}
+	}
 
 	// Register listener
 	e.listeners[eventName] = append(e.listeners[eventName], listener)
-
+	e.mu.Unlock()
 	// All good mate
 	return nil
 }


### PR DESCRIPTION
Locking the event manager before mutating it. The mutex was never locked before accessing the listeners which caused a concurrency error. This should be the only thing needed to fix the error. 