### PR TITLE
[v2] Update docs with new assetdir management and add reloaddirs

### DIFF
--- a/v2/cmd/wails/internal/commands/dev/dev.go
+++ b/v2/cmd/wails/internal/commands/dev/dev.go
@@ -309,6 +309,7 @@ func loadAndMergeProjectConfig(cwd string, flags *devFlags) (*project.Project, e
 
 	if flags.assetDir != projectConfig.AssetDirectory {
 		projectConfig.AssetDirectory = filepath.ToSlash(flags.assetDir)
+		shouldSaveConfig = true
 	}
 
 	if flags.assetDir != "" {

--- a/v2/cmd/wails/internal/commands/dev/dev.go
+++ b/v2/cmd/wails/internal/commands/dev/dev.go
@@ -325,6 +325,7 @@ func loadAndMergeProjectConfig(cwd string, flags *devFlags) (*project.Project, e
 
 	if flags.reloadDirs != projectConfig.ReloadDirectories {
 		projectConfig.ReloadDirectories = filepath.ToSlash(flags.reloadDirs)
+		shouldSaveConfig = true
 	}
 
 	if flags.devServerURL == defaultDevServerURL && projectConfig.DevServerURL != defaultDevServerURL && projectConfig.DevServerURL != "" {

--- a/v2/internal/project/project.go
+++ b/v2/internal/project/project.go
@@ -13,9 +13,9 @@ type Project struct {
 
 	/*** Application Data ***/
 	Name           string `json:"name"`
-	AssetDirectory string `json:"assetdir"`
+	AssetDirectory string `json:"assetdir,omitempty"`
 
-	ReloadDirectories string `json:"reloaddirs"`
+	ReloadDirectories string `json:"reloaddirs,omitempty"`
 
 	BuildCommand   string `json:"frontend:build"`
 	InstallCommand string `json:"frontend:install"`

--- a/website/docs/guides/application-development.mdx
+++ b/website/docs/guides/application-development.mdx
@@ -165,7 +165,7 @@ If these 2 keys aren't given, then Wails does absolutely nothing with the fronte
 
 Running `wails dev` will start the built in dev server which will start a file watcher in your project directory. By
 default, if any file changes, wails checks if it was an application file (default: `.go`, configurable with `-e` flag).
-If it was, then it will rebuild your application and relaunch it. If the changed file was in the `assetdir` directory,
+If it was, then it will rebuild your application and relaunch it. If the changed file was in the assets,
 it will issue a reload after a short amount of time.
 
 The dev server uses a technique called "debouncing" which means it doesn't reload straight away,

--- a/website/docs/guides/ides.mdx
+++ b/website/docs/guides/ides.mdx
@@ -46,8 +46,7 @@ The 2 files generated are `tasks.json` and `launch.json`. Below are the files ge
             "program": "${workspaceFolder}/build/bin/myproject.exe",
             "preLaunchTask": "build",
             "cwd": "${workspaceFolder}",
-            "env": {},
-            "args": ["-assetdir", "frontend/src"]
+            "env": {}
         },
     ]
 }

--- a/website/docs/guides/migrating.mdx
+++ b/website/docs/guides/migrating.mdx
@@ -199,7 +199,8 @@ The format of the file is slightly different. Here is a comparison:
 | frontend / serve   |                  | Removed                                             |
 | tags               |                  | Removed                                             |
 |                    | wailsjsdir       | The directory to generate wailsjs modules           |
-|                    | assetdir         | The directory of the compiled frontend assets for `dev` mode |
+|                    | assetdir         | The directory of the compiled frontend assets for `dev` mode. This is normally inferred and could be left empty. |
+|                    | reloaddirs       | Comma separated list of additional directories to watch for changes and to trigger reloads in `dev` mode. This is only needed for some more advanced asset configurations. |
 
 </p>
 

--- a/website/docs/howdoesitwork.mdx
+++ b/website/docs/howdoesitwork.mdx
@@ -106,9 +106,7 @@ As production binaries use the files contained in `embed.FS`, there are no exter
 the application.
 
 When running in development mode using the `wails dev` command, the assets are loaded off disk, and any changes result
-in a "live reload". The location of the assets needs to be passed to the `wails dev` command using the `-assetdir` flag
-and is likely to be the same as the embed path. It is hoped that in the future we can calculate this from the `embed.FS`
-itself.
+in a "live reload". The location of the assets will be inferred from the `embed.FS`.
 
 More details can be found in the [Application Development Guide](/docs/guides/application-development).
 

--- a/website/docs/reference/cli.mdx
+++ b/website/docs/reference/cli.mdx
@@ -146,7 +146,7 @@ Your system is ready for Wails development!
 |  -appargs "args"         | Arguments passed to the application in shell style  | |
 |  -platform "platform"    | Platform/Arch to target | `runtime.GOOS` |
 
-If the `assetdir`, `wailsjsdir`, `debounce` or `devserverurl` flags are provided on the command line, they are saved in
+If the `assetdir`, `reloaddirs`, `wailsjsdir`, `debounce` or `devserverurl` flags are provided on the command line, they are saved in
 `wails.json`, and become the defaults for subsequent invocations.
 
 Example:

--- a/website/docs/reference/cli.mdx
+++ b/website/docs/reference/cli.mdx
@@ -130,10 +130,11 @@ Your system is ready for Wails development!
 
 |  Flag                |  Description                            |  Default                   |
 | :------------------- | :-------------------------------------- | :------------------------- |
-|  -assetdir "./path/to/assets" | The path to your compiled assets  | Value in `wails.json` |
+|  -assetdir "./path/to/assets" | Serve assets from the given directory instead of using the provided asset FS | Value in `wails.json` |
 |  -browser | Opens a browser to `http://localhost:34115` on startup | |
 |  -compiler "compiler"| Use a different go compiler to build, eg go1.15beta1 | go            |
 |  -e                  | Extensions to trigger rebuilds (comma separated)  | go |
+|  -reloaddirs         | Additional directories to trigger reloads (comma separated) | Value in `wails.json` |
 |  -ldflags "flags"    | Additional ldflags to pass to the compiler |                         |
 |  -tags "extra tags"  | Build tags to pass to compiler (quoted and space separated) |        |
 |  -loglevel "loglevel"| Loglevel to use - Trace, Debug, Info, Warning, Error | Debug         |

--- a/website/docs/reference/project-config.mdx
+++ b/website/docs/reference/project-config.mdx
@@ -26,5 +26,5 @@ The project config resides in the `wails.json` file in the project directory. Th
 
 This file is read by the Wails CLI when running `wails build` or `wails dev`.
 
-The `assetdir`, `wailsjsdir`, `debounceMS` and `devserverurl` flags in `wails build/dev` will update the project config
+The `assetdir`, `reloaddirs`, `wailsjsdir`, `debounceMS` and `devserverurl` flags in `wails build/dev` will update the project config
 and thus become defaults for subsequent runs.

--- a/website/docs/reference/project-config.mdx
+++ b/website/docs/reference/project-config.mdx
@@ -9,7 +9,8 @@ The project config resides in the `wails.json` file in the project directory. Th
 ```json
 {
     "name": "[The project name]",
-	"assetdir": "[Relative path to the directory containing the compiled assets]",
+	"assetdir": "[Relative path to the directory containing the compiled assets, this is normally inferred and could be left empty]",
+	"reloaddirs": "[Additional directories to trigger reloads (comma separated), this is only used for some advanced asset configurations]",
 	"frontend:install": "[The command to install node dependencies, run in the frontend directory - often `npm install`]",
 	"frontend:build": "[The command to build the assets, run in the frontend directory - often `npm run build`]",
 	"frontend:dev": "[This command is run in a separate process on `wails dev`. Useful for 3rd party watchers]",


### PR DESCRIPTION
It also contains some minor improvements for updating `wails.json` from `wails dev`.

This is a followup of #1001