### PR TITLE
[v2] Fix: win window maximise/minimise

### DIFF
--- a/v2/internal/frontend/desktop/windows/frontend.go
+++ b/v2/internal/frontend/desktop/windows/frontend.go
@@ -199,7 +199,11 @@ func (f *Frontend) WindowHide() {
 }
 func (f *Frontend) WindowMaximise() {
 	runtime.LockOSThread()
-	f.mainWindow.Maximise()
+	if f.hasStarted {
+		f.mainWindow.Maximise()
+	} else {
+		f.frontendOptions.WindowStartState = options.Maximised
+	}
 }
 func (f *Frontend) WindowUnmaximise() {
 	runtime.LockOSThread()

--- a/v2/internal/frontend/desktop/windows/frontend.go
+++ b/v2/internal/frontend/desktop/windows/frontend.go
@@ -211,7 +211,11 @@ func (f *Frontend) WindowUnmaximise() {
 }
 func (f *Frontend) WindowMinimise() {
 	runtime.LockOSThread()
-	f.mainWindow.Minimise()
+	if f.hasStarted {
+		f.mainWindow.Minimise()
+	} else {
+		f.frontendOptions.WindowStartState = options.Minimised
+	}
 }
 func (f *Frontend) WindowUnminimise() {
 	runtime.LockOSThread()


### PR DESCRIPTION
-  Fixes #916 
- Tested on Windows 11

### Issue:
Using `WindowStartState:  options.Maximised` in app options is 100% functional BUT manually setting the window state like
```
func (b *App) startup(ctx context.Context) {
	runtime.WindowMaximise(ctx)
}
```
does not work.

### Solution:
Found out the calls to Show in [navigationCompleted](https://github.com/wailsapp/wails/blob/0d402492db8dd36d455d745ed5f7a1a980ab7000/v2/internal/frontend/desktop/windows/frontend.go#L480) were negating the maximize request in startup.

I added a navigationCompleted check in WindowMaximise and WindowMinimise for windows devices. If chromium is not ready when called, the WindowStartState will be modified before startup and ensures we do not mistakenly call a window Show an extra time.

### Alternate solution:
Set the StartHidden option to true in app options & use the following func
```
func (b *App) startup(ctx context.Context) {
	runtime.WindowShow(ctx)
	runtime.WindowMaximise(ctx)
}
```