### PR TITLE
[v2] Only call EnableSizable for normal windows

### DIFF
--- a/v2/go.mod
+++ b/v2/go.mod
@@ -27,7 +27,7 @@ require (
 	github.com/leaanthony/idgen v1.0.0
 	github.com/leaanthony/slicer v1.5.0
 	github.com/leaanthony/typescriptify-golang-structs v0.1.7
-	github.com/leaanthony/winc v0.0.0-20220112092814-1608a1744133
+	github.com/leaanthony/winc v0.0.0-20220117090042-fdd739b32c58
 	github.com/leaanthony/winicon v1.0.0
 	github.com/matryer/is v1.4.0
 	github.com/olekukonko/tablewriter v0.0.4
@@ -42,7 +42,7 @@ require (
 	github.com/ztrue/tracerr v0.3.0
 	golang.org/x/mod v0.4.1
 	golang.org/x/net v0.0.0-20210510120150-4163338589ed
-	golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e
+	golang.org/x/sys v0.0.0-20220114195835-da31bd327af9
 	golang.org/x/tools v0.1.0
 	nhooyr.io/websocket v1.8.6
 )

--- a/v2/go.sum
+++ b/v2/go.sum
@@ -128,8 +128,8 @@ github.com/leaanthony/slicer v1.5.0 h1:aHYTN8xbCCLxJmkNKiLB6tgcMARl4eWmH9/F+S/0H
 github.com/leaanthony/slicer v1.5.0/go.mod h1:FwrApmf8gOrpzEWM2J/9Lh79tyq8KTX5AzRtwV7m4AY=
 github.com/leaanthony/typescriptify-golang-structs v0.1.7 h1:yoznzWzyxkO/iWdlpq+aPcuJ5Y/hpjq/lmgMFmpjwl0=
 github.com/leaanthony/typescriptify-golang-structs v0.1.7/go.mod h1:cWtOkiVhMF77e6phAXUcfNwYmMwCJ67Sij24lfvi9Js=
-github.com/leaanthony/winc v0.0.0-20220112092814-1608a1744133 h1:pt0HDBG8mdHbhgQANOUyHQVfzFdMRriU0QEk1dn7WAk=
-github.com/leaanthony/winc v0.0.0-20220112092814-1608a1744133/go.mod h1:KEbMsKoznsebyGHwLk5LqkFOxL5uXSRdvpP4+avmAMs=
+github.com/leaanthony/winc v0.0.0-20220117090042-fdd739b32c58 h1:gIHTuLZmfaiOJAoJiedFs0I1rrYyz3iJfgdtnmG6afY=
+github.com/leaanthony/winc v0.0.0-20220117090042-fdd739b32c58/go.mod h1:OPfk8SNMAKRcSv8Vw1QL0yupmwcRtJyXZUgtMoaHUGc=
 github.com/leaanthony/winicon v1.0.0 h1:ZNt5U5dY71oEoKZ97UVwJRT4e+5xo5o/ieKuHuk8NqQ=
 github.com/leaanthony/winicon v1.0.0/go.mod h1:en5xhijl92aphrJdmRPlh4NI1L6wq3gEm0LpXAPghjU=
 github.com/leodido/go-urn v1.2.0 h1:hpXL4XnriNwQ/ABnpepYM/1vCLWNDfUNts8dX3xTG6Y=
@@ -257,8 +257,8 @@ golang.org/x/sys v0.0.0-20210324051608-47abb6519492/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210514084401-e8d321eab015/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210616045830-e2b7044e8c71/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e h1:fLOSk5Q00efkSvAm+4xcoXD+RRmLmmulPn5I3Y9F2EM=
-golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220114195835-da31bd327af9 h1:XfKQ4OlFl8okEOr5UvAqFRVj8pY/4yfcXrddB8qAbU0=
+golang.org/x/sys v0.0.0-20220114195835-da31bd327af9/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1 h1:v+OssWQX+hTHEmOBgwxdZxK4zHq3yOs8F9J7mk0PY8E=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/v2/internal/frontend/desktop/windows/window.go
+++ b/v2/internal/frontend/desktop/windows/window.go
@@ -55,12 +55,17 @@ func NewWindow(parent winc.Controller, appoptions *options.App) *Window {
 
 	result.SetSize(appoptions.Width, appoptions.Height)
 	result.SetText(appoptions.Title)
-	if appoptions.Frameless == false && !appoptions.Fullscreen {
-		result.EnableMaxButton(!appoptions.DisableResize)
-		result.SetMinSize(appoptions.MinWidth, appoptions.MinHeight)
-		result.SetMaxSize(appoptions.MaxWidth, appoptions.MaxHeight)
+	if appoptions.Frameless == false {
+		if !appoptions.Fullscreen {
+			result.EnableMaxButton(!appoptions.DisableResize)
+			result.SetMinSize(appoptions.MinWidth, appoptions.MinHeight)
+			result.SetMaxSize(appoptions.MaxWidth, appoptions.MaxHeight)
+		}
+		// Only call EnableSizable for normal windows, frameless windows are always not resizable per default and
+		// the resizing for those will be initiated by the frontend see processMessage.
+		// If EnableSizable is enabled for frameless windows, a small white titlebar will be shown.
+		result.EnableSizable(!appoptions.DisableResize)
 	}
-	result.EnableSizable(!appoptions.DisableResize)
 
 	if appoptions.Windows != nil {
 		if appoptions.Windows.WindowIsTranslucent {


### PR DESCRIPTION
Frameless windows are always not resizable per default and
the resizing for those will be initiated by the frontend see
processMessage.

If EnableSizable is enabled for frameless windows, a small white
titlebar will be shown.

Fix #1049