### PR TITLE
Updated windows window/frontend to fix issue with html select positioning

### DIFF
--- a/v2/internal/frontend/desktop/windows/frontend.go
+++ b/v2/internal/frontend/desktop/windows/frontend.go
@@ -64,6 +64,8 @@ func NewFrontend(ctx context.Context, appoptions *options.App, myLogger *logger.
 		startURL:        "file://wails/",
 	}
 
+	result.frontendOptions.Windows.NotifyParentWindowPositionChanged = result.NotifyParentWindowPositionChanged
+
 	bindingsJSON, err := appBindings.ToJSON()
 	if err != nil {
 		log.Fatal(err)
@@ -528,4 +530,10 @@ func (f *Frontend) navigationCompleted(sender *edge.ICoreWebView2, args *edge.IC
 		f.mainWindow.Show()
 	}
 
+}
+
+func (f *Frontend) NotifyParentWindowPositionChanged() {
+	if f.chromium != nil {
+		f.chromium.NotifyParentWindowPositionChanged()
+	}
 }

--- a/v2/internal/frontend/desktop/windows/frontend.go
+++ b/v2/internal/frontend/desktop/windows/frontend.go
@@ -64,8 +64,6 @@ func NewFrontend(ctx context.Context, appoptions *options.App, myLogger *logger.
 		startURL:        "file://wails/",
 	}
 
-	result.frontendOptions.Windows.NotifyParentWindowPositionChanged = result.NotifyParentWindowPositionChanged
-
 	bindingsJSON, err := appBindings.ToJSON()
 	if err != nil {
 		log.Fatal(err)
@@ -118,6 +116,8 @@ func (f *Frontend) Run(ctx context.Context) error {
 	f.WindowCenter()
 	f.setupChromium()
 
+	f.mainWindow.notifyParentWindowPositionChanged = f.chromium.NotifyParentWindowPositionChanged
+
 	mainWindow.OnSize().Bind(func(arg *winc.Event) {
 		f.chromium.Resize()
 	})
@@ -135,7 +135,6 @@ func (f *Frontend) Run(ctx context.Context) error {
 			f.frontendOptions.OnStartup(f.ctx)
 		}
 	}()
-
 	mainWindow.Run()
 	mainWindow.Close()
 	return nil
@@ -530,10 +529,4 @@ func (f *Frontend) navigationCompleted(sender *edge.ICoreWebView2, args *edge.IC
 		f.mainWindow.Show()
 	}
 
-}
-
-func (f *Frontend) NotifyParentWindowPositionChanged() {
-	if f.chromium != nil {
-		f.chromium.NotifyParentWindowPositionChanged()
-	}
 }

--- a/v2/internal/frontend/desktop/windows/window.go
+++ b/v2/internal/frontend/desktop/windows/window.go
@@ -11,8 +11,9 @@ import (
 
 type Window struct {
 	winc.Form
-	frontendOptions *options.App
-	applicationMenu *menu.Menu
+	frontendOptions                   *options.App
+	applicationMenu                   *menu.Menu
+	notifyParentWindowPositionChanged func() error
 }
 
 func NewWindow(parent winc.Controller, appoptions *options.App) *Window {
@@ -74,7 +75,6 @@ func NewWindow(parent winc.Controller, appoptions *options.App) *Window {
 
 	// Dlg forces display of focus rectangles, as soon as the user starts to type.
 	w32.SendMessage(result.Handle(), w32.WM_CHANGEUISTATE, w32.UIS_INITIALIZE, 0)
-	winc.RegMsgHandler(result)
 
 	result.SetFont(winc.DefaultFont)
 
@@ -86,6 +86,7 @@ func NewWindow(parent winc.Controller, appoptions *options.App) *Window {
 }
 
 func (w *Window) Run() int {
+	winc.RegMsgHandler(w)
 	return winc.RunMainLoop()
 }
 
@@ -94,7 +95,7 @@ func (w *Window) WndProc(msg uint32, wparam, lparam uintptr) uintptr {
 	case w32.WM_NCLBUTTONDOWN:
 		w32.SetFocus(w.Handle())
 	case w32.WM_MOVE, w32.WM_MOVING:
-		w.frontendOptions.Windows.NotifyParentWindowPositionChanged()
+		w.notifyParentWindowPositionChanged()
 	}
 	return w.Form.WndProc(msg, wparam, lparam)
 }

--- a/v2/internal/frontend/desktop/windows/window.go
+++ b/v2/internal/frontend/desktop/windows/window.go
@@ -97,9 +97,9 @@ func (w *Window) WndProc(msg uint32, wparam, lparam uintptr) uintptr {
 	case w32.WM_MOVE, w32.WM_MOVING:
 		if w.notifyParentWindowPositionChanged != nil {
 			w.notifyParentWindowPositionChanged()
-    }
-  }
-  
+		}
+	}
+
 	if w.frontendOptions.Frameless {
 		switch msg {
 		case w32.WM_ACTIVATE:
@@ -135,6 +135,7 @@ func (w *Window) WndProc(msg uint32, wparam, lparam uintptr) uintptr {
 
 				return 0
 			}
+		}
 	}
 	return w.Form.WndProc(msg, wparam, lparam)
 }

--- a/v2/internal/frontend/desktop/windows/window.go
+++ b/v2/internal/frontend/desktop/windows/window.go
@@ -95,7 +95,9 @@ func (w *Window) WndProc(msg uint32, wparam, lparam uintptr) uintptr {
 	case w32.WM_NCLBUTTONDOWN:
 		w32.SetFocus(w.Handle())
 	case w32.WM_MOVE, w32.WM_MOVING:
-		w.notifyParentWindowPositionChanged()
+		if w.notifyParentWindowPositionChanged != nil {
+			w.notifyParentWindowPositionChanged()
+		}
 	}
 	return w.Form.WndProc(msg, wparam, lparam)
 }

--- a/v2/internal/frontend/desktop/windows/window.go
+++ b/v2/internal/frontend/desktop/windows/window.go
@@ -88,3 +88,13 @@ func NewWindow(parent winc.Controller, appoptions *options.App) *Window {
 func (w *Window) Run() int {
 	return winc.RunMainLoop()
 }
+
+func (w *Window) WndProc(msg uint32, wparam, lparam uintptr) uintptr {
+	switch msg {
+	case w32.WM_NCLBUTTONDOWN:
+		w32.SetFocus(w.Handle())
+	case w32.WM_MOVE, w32.WM_MOVING:
+		w.frontendOptions.Windows.NotifyParentWindowPositionChanged()
+	}
+	return w.Form.WndProc(msg, wparam, lparam)
+}

--- a/v2/internal/frontend/desktop/windows/window.go
+++ b/v2/internal/frontend/desktop/windows/window.go
@@ -42,6 +42,7 @@ func NewWindow(parent winc.Controller, appoptions *options.App) *Window {
 
 	winc.RegClassOnlyOnce("wailsWindow")
 	result.SetHandle(winc.CreateWindow("wailsWindow", parent, uint(exStyle), uint(dwStyle)))
+	winc.RegMsgHandler(w)
 	result.SetParent(parent)
 
 	loadIcon := true
@@ -86,7 +87,6 @@ func NewWindow(parent winc.Controller, appoptions *options.App) *Window {
 }
 
 func (w *Window) Run() int {
-	winc.RegMsgHandler(w)
 	return winc.RunMainLoop()
 }
 

--- a/v2/pkg/options/windows/windows.go
+++ b/v2/pkg/options/windows/windows.go
@@ -7,5 +7,6 @@ type Options struct {
 	DisableWindowIcon    bool
 
 	// Draw a border around the window, even if the window is frameless
-	EnableFramelessBorder bool
+	EnableFramelessBorder             bool
+	NotifyParentWindowPositionChanged func()
 }

--- a/v2/pkg/options/windows/windows.go
+++ b/v2/pkg/options/windows/windows.go
@@ -7,6 +7,5 @@ type Options struct {
 	DisableWindowIcon    bool
 
 	// Draw a border around the window, even if the window is frameless
-	EnableFramelessBorder             bool
-	NotifyParentWindowPositionChanged func()
+	EnableFramelessBorder bool
 }


### PR DESCRIPTION
Fixes #1081

Need to wait for the following PR (https://github.com/leaanthony/go-webview2/pull/5) to merge so `go-webview2` exposes the `NotifyParentWindowPositionChanged()` method.

Was not sure how to correctly expose the chromium object to the window object. Do you agree with the proposed fix? Doesn't feel really solid imo

Note: First time creating a public Pull Request, so if I can improve certain parts, please let me know :)