### PR TITLE
[linux] Fix dialogs 

### DIFF
--- a/v2/internal/appng/app_default_darwin.go
+++ b/v2/internal/appng/app_default_darwin.go
@@ -17,16 +17,5 @@ func (a *App) Run() error {
 
 // CreateApp creates the app!
 func CreateApp(_ *options.App) (*App, error) {
-	//	result := w32.MessageBox(0,
-	//		`Wails applications will not build without the correct build tags.
-	//Please use "wails build" or press "OK" to open the documentation on how to use "go build"`,
-	//		"Error",
-	//		w32.MB_ICONERROR|w32.MB_OKCANCEL)
-	//	if result == 1 {
-	//		exec.Command("rundll32", "url.dll,FileProtocolHandler", "https://wails.io").Start()
-	//	}
-
-	err := fmt.Errorf(`Wails applications will not build without the correct build tags.`)
-
-	return nil, err
+	return nil, fmt.Errorf(`Wails applications will not build without the correct build tags.`)
 }

--- a/v2/internal/appng/app_default_linux.go
+++ b/v2/internal/appng/app_default_linux.go
@@ -17,16 +17,5 @@ func (a *App) Run() error {
 
 // CreateApp creates the app!
 func CreateApp(_ *options.App) (*App, error) {
-	//	result := w32.MessageBox(0,
-	//		`Wails applications will not build without the correct build tags.
-	//Please use "wails build" or press "OK" to open the documentation on how to use "go build"`,
-	//		"Error",
-	//		w32.MB_ICONERROR|w32.MB_OKCANCEL)
-	//	if result == 1 {
-	//		exec.Command("rundll32", "url.dll,FileProtocolHandler", "https://wails.io").Start()
-	//	}
-
-	err := fmt.Errorf(`Wails applications will not build without the correct build tags.`)
-
-	return nil, err
+	return nil, fmt.Errorf(`Wails applications will not build without the correct build tags.`)
 }

--- a/v2/internal/appng/app_production.go
+++ b/v2/internal/appng/app_production.go
@@ -78,11 +78,13 @@ func CreateApp(appoptions *options.App) (*App, error) {
 	ctx = context.WithValue(ctx, "events", eventHandler)
 	messageDispatcher := dispatcher.NewDispatcher(myLogger, appBindings, eventHandler)
 
-	appFrontend := desktop.NewFrontend(ctx, appoptions, myLogger, appBindings, messageDispatcher)
-	eventHandler.AddFrontend(appFrontend)
-
+	debug := IsDebug()
+	ctx = context.WithValue(ctx, "debug", debug)
 	// Attach logger to context
 	ctx = context.WithValue(ctx, "logger", myLogger)
+
+	appFrontend := desktop.NewFrontend(ctx, appoptions, myLogger, appBindings, messageDispatcher)
+	eventHandler.AddFrontend(appFrontend)
 
 	result := &App{
 		ctx:              ctx,
@@ -91,12 +93,9 @@ func CreateApp(appoptions *options.App) (*App, error) {
 		menuManager:      menuManager,
 		startupCallback:  appoptions.OnStartup,
 		shutdownCallback: appoptions.OnShutdown,
-		debug:            IsDebug(),
+		debug:            debug,
+		options:          appoptions,
 	}
-
-	result.options = appoptions
-
-	result.ctx = context.WithValue(result.ctx, "debug", result.debug)
 
 	return result, nil
 

--- a/v2/internal/frontend/desktop/linux/calloc.go
+++ b/v2/internal/frontend/desktop/linux/calloc.go
@@ -1,0 +1,32 @@
+package linux
+
+/*
+#include <stdlib.h>
+*/
+import "C"
+import "unsafe"
+
+// Calloc handles alloc/dealloc of C data
+type Calloc struct {
+	pool []unsafe.Pointer
+}
+
+// NewCalloc creates a new allocator
+func NewCalloc() Calloc {
+	return Calloc{}
+}
+
+// String creates a new C string and retains a reference to it
+func (c Calloc) String(in string) *C.char {
+	result := C.CString(in)
+	c.pool = append(c.pool, unsafe.Pointer(result))
+	return result
+}
+
+// Free frees all allocated C memory
+func (c Calloc) Free() {
+	for _, str := range c.pool {
+		C.free(str)
+	}
+	c.pool = []unsafe.Pointer{}
+}

--- a/v2/internal/frontend/desktop/linux/dialog.go
+++ b/v2/internal/frontend/desktop/linux/dialog.go
@@ -3,10 +3,24 @@
 
 package linux
 
-import "github.com/wailsapp/wails/v2/internal/frontend"
+import (
+	"github.com/wailsapp/wails/v2/internal/frontend"
+)
+import "C"
 
-func (f *Frontend) OpenFileDialog(dialogOptions frontend.OpenDialogOptions) (string, error) {
-	panic("implement me")
+var openFileResults = make(chan string)
+
+func (f *Frontend) OpenFileDialog(dialogOptions frontend.OpenDialogOptions) (result string, err error) {
+
+	f.dispatch(func() {
+		println("Before OpenFileDialog")
+		f.mainWindow.OpenFileDialog(dialogOptions)
+		println("After OpenFileDialog")
+	})
+	println("Waiting for result")
+	result = <-openFileResults
+	println("Got result")
+	return
 }
 
 func (f *Frontend) OpenMultipleFilesDialog(dialogOptions frontend.OpenDialogOptions) ([]string, error) {
@@ -23,4 +37,9 @@ func (f *Frontend) SaveFileDialog(dialogOptions frontend.SaveDialogOptions) (str
 
 func (f *Frontend) MessageDialog(dialogOptions frontend.MessageDialogOptions) (string, error) {
 	panic("implement me")
+}
+
+//export processOpenFileResult
+func processOpenFileResult(result *C.char) {
+	openFileResults <- C.GoString(result)
 }

--- a/v2/internal/frontend/desktop/linux/dialog.go
+++ b/v2/internal/frontend/desktop/linux/dialog.go
@@ -38,7 +38,12 @@ func (f *Frontend) OpenMultipleFilesDialog(dialogOptions frontend.OpenDialogOpti
 }
 
 func (f *Frontend) OpenDirectoryDialog(dialogOptions frontend.OpenDialogOptions) (string, error) {
-	panic("implement me")
+	f.mainWindow.OpenFileDialog(dialogOptions, 0, GTK_FILE_CHOOSER_ACTION_SELECT_FOLDER)
+	result := <-openFileResults
+	if len(result) == 1 {
+		return result[0], nil
+	}
+	return "", nil
 }
 
 func (f *Frontend) SaveFileDialog(dialogOptions frontend.SaveDialogOptions) (string, error) {

--- a/v2/internal/frontend/desktop/linux/dialog.go
+++ b/v2/internal/frontend/desktop/linux/dialog.go
@@ -21,6 +21,7 @@ const (
 )
 
 var openFileResults = make(chan []string)
+var messageDialogResult = make(chan string)
 
 func (f *Frontend) OpenFileDialog(dialogOptions frontend.OpenDialogOptions) (result string, err error) {
 	f.mainWindow.OpenFileDialog(dialogOptions, 0, GTK_FILE_CHOOSER_ACTION_OPEN)
@@ -64,7 +65,8 @@ func (f *Frontend) SaveFileDialog(dialogOptions frontend.SaveDialogOptions) (str
 }
 
 func (f *Frontend) MessageDialog(dialogOptions frontend.MessageDialogOptions) (string, error) {
-	panic("implement me")
+	f.mainWindow.MessageDialog(dialogOptions)
+	return <-messageDialogResult, nil
 }
 
 //export processOpenFileResult
@@ -79,4 +81,9 @@ func processOpenFileResult(carray **C.char) {
 		result = append(result, C.GoString(s))
 	}
 	openFileResults <- result
+}
+
+//export processMessageDialogResult
+func processMessageDialogResult(result *C.char) {
+	messageDialogResult <- C.GoString(result)
 }

--- a/v2/internal/frontend/desktop/linux/dialog.go
+++ b/v2/internal/frontend/desktop/linux/dialog.go
@@ -5,19 +5,36 @@ package linux
 
 import (
 	"github.com/wailsapp/wails/v2/internal/frontend"
+	"unsafe"
 )
+
+/*
+#include <stdlib.h>
+#include "gtk/gtk.h"
+*/
 import "C"
 
-var openFileResults = make(chan string)
+const (
+	GTK_FILE_CHOOSER_ACTION_OPEN          C.GtkFileChooserAction = C.GTK_FILE_CHOOSER_ACTION_OPEN
+	GTK_FILE_CHOOSER_ACTION_SAVE          C.GtkFileChooserAction = C.GTK_FILE_CHOOSER_ACTION_SAVE
+	GTK_FILE_CHOOSER_ACTION_SELECT_FOLDER C.GtkFileChooserAction = C.GTK_FILE_CHOOSER_ACTION_SELECT_FOLDER
+)
+
+var openFileResults = make(chan []string)
 
 func (f *Frontend) OpenFileDialog(dialogOptions frontend.OpenDialogOptions) (result string, err error) {
-	f.mainWindow.OpenFileDialog(dialogOptions)
-	result = <-openFileResults
-	return
+	f.mainWindow.OpenFileDialog(dialogOptions, 0, GTK_FILE_CHOOSER_ACTION_OPEN)
+	results := <-openFileResults
+	if len(results) == 1 {
+		return results[0], nil
+	}
+	return "", nil
 }
 
 func (f *Frontend) OpenMultipleFilesDialog(dialogOptions frontend.OpenDialogOptions) ([]string, error) {
-	panic("implement me")
+	f.mainWindow.OpenFileDialog(dialogOptions, 1, GTK_FILE_CHOOSER_ACTION_OPEN)
+	result := <-openFileResults
+	return result, nil
 }
 
 func (f *Frontend) OpenDirectoryDialog(dialogOptions frontend.OpenDialogOptions) (string, error) {
@@ -33,6 +50,15 @@ func (f *Frontend) MessageDialog(dialogOptions frontend.MessageDialogOptions) (s
 }
 
 //export processOpenFileResult
-func processOpenFileResult(result *C.char) {
-	openFileResults <- C.GoString(result)
+func processOpenFileResult(carray **C.char) {
+	// Create a Go slice from the C array
+	var result []string
+	goArray := (*[1024]*C.char)(unsafe.Pointer(carray))[:1024:1024]
+	for _, s := range goArray {
+		if s == nil {
+			break
+		}
+		result = append(result, C.GoString(s))
+	}
+	openFileResults <- result
 }

--- a/v2/internal/frontend/desktop/linux/dialog.go
+++ b/v2/internal/frontend/desktop/linux/dialog.go
@@ -47,7 +47,12 @@ func (f *Frontend) OpenDirectoryDialog(dialogOptions frontend.OpenDialogOptions)
 }
 
 func (f *Frontend) SaveFileDialog(dialogOptions frontend.SaveDialogOptions) (string, error) {
-	panic("implement me")
+	f.mainWindow.OpenFileDialog(dialogOptions, 0, GTK_FILE_CHOOSER_ACTION_SAVE)
+	results := <-openFileResults
+	if len(results) == 1 {
+		return results[0], nil
+	}
+	return "", nil
 }
 
 func (f *Frontend) MessageDialog(dialogOptions frontend.MessageDialogOptions) (string, error) {

--- a/v2/internal/frontend/desktop/linux/dialog.go
+++ b/v2/internal/frontend/desktop/linux/dialog.go
@@ -11,15 +11,8 @@ import "C"
 var openFileResults = make(chan string)
 
 func (f *Frontend) OpenFileDialog(dialogOptions frontend.OpenDialogOptions) (result string, err error) {
-
-	f.dispatch(func() {
-		println("Before OpenFileDialog")
-		f.mainWindow.OpenFileDialog(dialogOptions)
-		println("After OpenFileDialog")
-	})
-	println("Waiting for result")
+	f.mainWindow.OpenFileDialog(dialogOptions)
 	result = <-openFileResults
-	println("Got result")
 	return
 }
 

--- a/v2/internal/frontend/desktop/linux/dialog.go
+++ b/v2/internal/frontend/desktop/linux/dialog.go
@@ -48,13 +48,12 @@ func (f *Frontend) OpenDirectoryDialog(dialogOptions frontend.OpenDialogOptions)
 
 func (f *Frontend) SaveFileDialog(dialogOptions frontend.SaveDialogOptions) (string, error) {
 	options := frontend.OpenDialogOptions{
-		DefaultDirectory: dialogOptions.DefaultDirectory,
-		DefaultFilename: dialogOptions.DefaultFilename,
-		Title: dialogOptions.Title,
-		Filters: dialogOptions.Filters,
-		ShowHiddenFiles: dialogOptions.ShowHiddenFiles,
+		DefaultDirectory:     dialogOptions.DefaultDirectory,
+		DefaultFilename:      dialogOptions.DefaultFilename,
+		Title:                dialogOptions.Title,
+		Filters:              dialogOptions.Filters,
+		ShowHiddenFiles:      dialogOptions.ShowHiddenFiles,
 		CanCreateDirectories: dialogOptions.CanCreateDirectories,
-		TreatPackagesAsDirectories: dialogOptions.TreatPackagesAsDirectories,
 	}
 	f.mainWindow.OpenFileDialog(options, 0, GTK_FILE_CHOOSER_ACTION_SAVE)
 	results := <-openFileResults

--- a/v2/internal/frontend/desktop/linux/dialog.go
+++ b/v2/internal/frontend/desktop/linux/dialog.go
@@ -47,7 +47,16 @@ func (f *Frontend) OpenDirectoryDialog(dialogOptions frontend.OpenDialogOptions)
 }
 
 func (f *Frontend) SaveFileDialog(dialogOptions frontend.SaveDialogOptions) (string, error) {
-	f.mainWindow.OpenFileDialog(dialogOptions, 0, GTK_FILE_CHOOSER_ACTION_SAVE)
+	options := frontend.OpenDialogOptions{
+		DefaultDirectory: dialogOptions.DefaultDirectory,
+		DefaultFilename: dialogOptions.DefaultFilename,
+		Title: dialogOptions.Title,
+		Filters: dialogOptions.Filters,
+		ShowHiddenFiles: dialogOptions.ShowHiddenFiles,
+		CanCreateDirectories: dialogOptions.CanCreateDirectories,
+		TreatPackagesAsDirectories: dialogOptions.TreatPackagesAsDirectories,
+	}
+	f.mainWindow.OpenFileDialog(options, 0, GTK_FILE_CHOOSER_ACTION_SAVE)
 	results := <-openFileResults
 	if len(results) == 1 {
 		return results[0], nil

--- a/v2/internal/frontend/desktop/linux/frontend.go
+++ b/v2/internal/frontend/desktop/linux/frontend.go
@@ -16,7 +16,7 @@ static inline void processDispatchID(gpointer id) {
 }
 
 static void gtkDispatch(int id) {
-	gdk_threads_add_idle((GSourceFunc)processDispatchID, GINT_TO_POINTER(id));
+	g_idle_add((GSourceFunc)processDispatchID, GINT_TO_POINTER(id));
 }
 
 */
@@ -63,7 +63,6 @@ type Frontend struct {
 
 func NewFrontend(ctx context.Context, appoptions *options.App, myLogger *logger.Logger, appBindings *binding.Bindings, dispatcher frontend.Dispatcher) *Frontend {
 
-	println("[NewFrontend] PID:", os.Getpid())
 	// Set GDK_BACKEND=x11 to prevent warnings
 	os.Setenv("GDK_BACKEND", "x11")
 
@@ -303,7 +302,6 @@ var dispatchCallbackLock sync.Mutex
 
 //export callDispatchedMethod
 func callDispatchedMethod(cid C.int) {
-	println("[callDispatchedMethod] PID:", os.Getpid())
 	id := int(cid)
 	fn := dispatchCallbacks[id]
 	if fn != nil {

--- a/v2/internal/frontend/desktop/linux/frontend.go
+++ b/v2/internal/frontend/desktop/linux/frontend.go
@@ -24,7 +24,6 @@ import "C"
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"log"
 	"os"
 	"strconv"
@@ -345,22 +344,22 @@ func (f *Frontend) processRequest(request unsafe.Pointer) {
 	content, mimeType, err := f.assets.Load(file)
 
 	// TODO How to return 404/500 errors to webkit?
-	if err != nil {
-		if os.IsNotExist(err) {
-			f.dispatch(func() {
-				message := C.CString("not found")
-				defer C.free(unsafe.Pointer(message))
-				C.webkit_uri_scheme_request_finish_error(req, C.g_error_new_literal(C.G_FILE_ERROR_NOENT, C.int(404), message))
-			})
-		} else {
-			err = fmt.Errorf("Error processing request %s: %w", uri, err)
-			f.logger.Error(err.Error())
-			message := C.CString("internal server error")
-			defer C.free(unsafe.Pointer(message))
-			C.webkit_uri_scheme_request_finish_error(req, C.g_error_new_literal(C.G_FILE_ERROR_NOENT, C.int(500), message))
-		}
-		return
-	}
+	//if err != nil {
+	//if os.IsNotExist(err) {
+	//	f.dispatch(func() {
+	//		message := C.CString("not found")
+	//		defer C.free(unsafe.Pointer(message))
+	//		C.webkit_uri_scheme_request_finish_error(req, C.g_error_new_literal(C.G_FILE_ERROR_NOENT, C.int(404), message))
+	//	})
+	//} else {
+	//	err = fmt.Errorf("Error processing request %s: %w", uri, err)
+	//	f.logger.Error(err.Error())
+	//	message := C.CString("internal server error")
+	//	defer C.free(unsafe.Pointer(message))
+	//	C.webkit_uri_scheme_request_finish_error(req, C.g_error_new_literal(C.G_FILE_ERROR_NOENT, C.int(500), message))
+	//}
+	//return
+	//}
 
 	cContent := C.CString(string(content))
 	defer C.free(unsafe.Pointer(cContent))

--- a/v2/internal/frontend/desktop/linux/window.go
+++ b/v2/internal/frontend/desktop/linux/window.go
@@ -4,11 +4,10 @@
 package linux
 
 /*
-#cgo linux pkg-config: gtk+-3.0 webkit2gtk-4.0 x11
+#cgo linux pkg-config: gtk+-3.0 webkit2gtk-4.0
 
 #include "gtk/gtk.h"
 #include "webkit2/webkit2.h"
-#include <X11/Xlib.h>
 #include <stdio.h>
 #include <limits.h>
 
@@ -104,11 +103,6 @@ static void sendMessageToBackend(WebKitUserContentManager *contentManager,
 
 ulong setupInvokeSignal(void* contentManager) {
 	return g_signal_connect((WebKitUserContentManager*)contentManager, "script-message-received::external", G_CALLBACK(sendMessageToBackend), NULL);
-}
-
-void initThreads() {
-	printf("init threads\n");
-	XInitThreads();
 }
 
 // These are the x,y & time of the last mouse down event
@@ -418,7 +412,6 @@ func (w *Window) Run() {
 		w.Maximise()
 	}
 
-	C.initThreads()
 	C.gtk_main()
 	w.Destroy()
 }

--- a/v2/internal/frontend/desktop/linux/window.go
+++ b/v2/internal/frontend/desktop/linux/window.go
@@ -4,10 +4,11 @@
 package linux
 
 /*
-#cgo linux pkg-config: gtk+-3.0 webkit2gtk-4.0
+#cgo linux pkg-config: gtk+-3.0 webkit2gtk-4.0 x11
 
 #include "gtk/gtk.h"
 #include "webkit2/webkit2.h"
+#include <X11/Xlib.h>
 #include <stdio.h>
 #include <limits.h>
 
@@ -105,6 +106,11 @@ ulong setupInvokeSignal(void* contentManager) {
 	return g_signal_connect((WebKitUserContentManager*)contentManager, "script-message-received::external", G_CALLBACK(sendMessageToBackend), NULL);
 }
 
+void initThreads() {
+	printf("init threads\n");
+	XInitThreads();
+}
+
 // These are the x,y & time of the last mouse down event
 // It's used for window dragging
 float xroot = 0.0f;
@@ -199,10 +205,37 @@ int executeJS(gpointer data) {
 void ExecuteOnMainThread(JSCallback* jscallback) {
     g_idle_add((GSourceFunc)executeJS, (gpointer)jscallback);
 }
+
+void extern processOpenFileResult(char*);
+
+static void OpenDialog(GtkWindow* window, char *title) {
+	printf("Here\n");
+      GtkWidget *dlg = gtk_file_chooser_dialog_new(title, window, GTK_FILE_CHOOSER_ACTION_OPEN,
+          "_Cancel", GTK_RESPONSE_CANCEL,
+          "_Open", GTK_RESPONSE_ACCEPT,
+			NULL);
+	printf("Here3\n");
+
+	gint response = gtk_dialog_run(GTK_DIALOG(dlg));
+	printf("Here 4\n");
+
+  if (response == GTK_RESPONSE_ACCEPT)
+      {
+	printf("Here 5\n");
+
+        gchar *filename = gtk_file_chooser_get_filename(GTK_FILE_CHOOSER(dlg));
+        processOpenFileResult(filename);
+        g_free(filename);
+      }
+      gtk_widget_destroy(dlg);
+}
+
 */
 import "C"
 import (
+	"github.com/wailsapp/wails/v2/internal/frontend"
 	"github.com/wailsapp/wails/v2/pkg/options"
+	"os"
 	"unsafe"
 )
 
@@ -384,6 +417,8 @@ func (w *Window) Run() {
 	case options.Maximised:
 		w.Maximise()
 	}
+
+	C.initThreads()
 	C.gtk_main()
 	w.Destroy()
 }
@@ -424,4 +459,12 @@ func (w *Window) StartDrag() {
 
 func (w *Window) Quit() {
 	C.gtk_main_quit()
+}
+
+func (w *Window) OpenFileDialog(dialogOptions frontend.OpenDialogOptions) {
+	println("OpenFileDialog PID:", os.Getpid())
+	mem := NewCalloc()
+	title := mem.String(dialogOptions.Title)
+	C.OpenDialog(w.asGTKWindow(), title)
+	mem.Free()
 }

--- a/v2/internal/frontend/desktop/linux/window.go
+++ b/v2/internal/frontend/desktop/linux/window.go
@@ -196,8 +196,8 @@ int executeJS(gpointer data) {
     return G_SOURCE_REMOVE;
 }
 
-void ExecuteOnMainThread(JSCallback* jscallback) {
-    g_idle_add((GSourceFunc)executeJS, (gpointer)jscallback);
+void ExecuteOnMainThread(void* f, JSCallback* jscallback) {
+    g_idle_add((GSourceFunc)f, (gpointer)jscallback);
 }
 
 void extern processOpenFileResult(char*);
@@ -443,7 +443,7 @@ func (w *Window) ExecJS(js string) {
 		webview: w.webview,
 		script: C.CString(js),
 	}
-	C.ExecuteOnMainThread(&jscallback)
+	C.ExecuteOnMainThread(C.executeJS, &jscallback)
 }
 
 func (w *Window) StartDrag() {

--- a/v2/internal/frontend/desktop/linux/window.go
+++ b/v2/internal/frontend/desktop/linux/window.go
@@ -223,7 +223,7 @@ void freeFileFilterArray(GtkFileFilter** filters) {
 
 int opendialog(gpointer data) {
     struct OpenFileDialogOptions *options = data;
-    GtkWidget *dlgWidget = gtk_file_chooser_dialog_new(options->title, options->webview, GTK_FILE_CHOOSER_ACTION_OPEN,
+    GtkWidget *dlgWidget = gtk_file_chooser_dialog_new(options->title, options->webview, options->action,
           "_Cancel", GTK_RESPONSE_CANCEL,
           "_Open", GTK_RESPONSE_ACCEPT,
 			NULL);

--- a/website/docs/reference/runtime/dialog.mdx
+++ b/website/docs/reference/runtime/dialog.mdx
@@ -75,16 +75,16 @@ type OpenDialogOptions struct {
 	TreatPackagesAsDirectories bool
 }
 ```
-| Field                      | Description                                    | Win | Mac |
-| -------------------------- | ---------------------------------------------- | --- | --- |
-| DefaultDirectory           | The directory the dialog will show when opened | ✅  | ✅  |
-| DefaultFilename            | The default filename                           | ✅  | ✅  |
-| Title                      | Title for the dialog                           | ✅  | ✅  |
-| [Filters](#filefilter)     | A list of file filters                         | ✅  | ✅  |
-| ShowHiddenFiles            | Show files hidden by the system                |     | ✅  |
-| CanCreateDirectories       | Allow user to create directories               |     | ✅  |
-| ResolvesAliases            | If true, returns the file not the alias        |     | ✅  |
-| TreatPackagesAsDirectories | Allow navigating into packages                 |     | ✅  |
+| Field                      | Description                                    | Win | Mac | Lin |
+| -------------------------- | ---------------------------------------------- | --- | --- | --- |
+| DefaultDirectory           | The directory the dialog will show when opened | ✅  | ✅  |  ✅  |
+| DefaultFilename            | The default filename                           | ✅  | ✅  |  ✅  |
+| Title                      | Title for the dialog                           | ✅  | ✅  |  ✅  |
+| [Filters](#filefilter)     | A list of file filters                         | ✅  | ✅  |  ✅  |
+| ShowHiddenFiles            | Show files hidden by the system                |     | ✅  | ✅  |
+| CanCreateDirectories       | Allow user to create directories               |     | ✅  |    |
+| ResolvesAliases            | If true, returns the file not the alias        |     | ✅  |    |
+| TreatPackagesAsDirectories | Allow navigating into packages                 |     | ✅  |    |
 
 
 ### SaveDialogOptions
@@ -101,15 +101,15 @@ type SaveDialogOptions struct {
 }
 ```
 
-| Field                      | Description                                    | Win | Mac |
-| -------------------------- | ---------------------------------------------- | --- | --- |
-| DefaultDirectory           | The directory the dialog will show when opened | ✅  | ✅  |
-| DefaultFilename            | The default filename                           | ✅  | ✅  |
-| Title                      | Title for the dialog                           | ✅  | ✅  |
-| [Filters](#filefilter)     | A list of file filters                         | ✅  | ✅  |
-| ShowHiddenFiles            | Show files hidden by the system                |     | ✅  |
-| CanCreateDirectories       | Allow user to create directories               |     | ✅  |
-| TreatPackagesAsDirectories | Allow navigating into packages                 |     | ✅  |
+| Field                      | Description                                    | Win | Mac | Lin |
+| -------------------------- | ---------------------------------------------- | --- | --- | --- |
+| DefaultDirectory           | The directory the dialog will show when opened | ✅  | ✅  |   ✅  |
+| DefaultFilename            | The default filename                           | ✅  | ✅  |   ✅  |
+| Title                      | Title for the dialog                           | ✅  | ✅  |   ✅  |
+| [Filters](#filefilter)     | A list of file filters                         | ✅  | ✅  |   ✅  |
+| ShowHiddenFiles            | Show files hidden by the system                |     | ✅  |  ✅  |
+| CanCreateDirectories       | Allow user to create directories               |     | ✅  |     |
+| TreatPackagesAsDirectories | Allow navigating into packages                 |     | ✅  |     |
 
 ### MessageDialogOptions
 
@@ -123,19 +123,24 @@ type MessageDialogOptions struct {
 	CancelButton  string
 }
 ```
-| Field         | Description                                                               | Win | Mac |
-| ------------- | ------------------------------------------------------------------------- | --- | --- |
-| Type          | The type of message dialog, eg question, info...                          | ✅  | ✅  |
-| Title         | Title for the dialog                                                      | ✅  | ✅  |
-| Message       | The message to show the user                                              | ✅  | ✅  |
-| Buttons       | A list of button titles                                                   |     | ✅  |
-| DefaultButton | The button with this text should be treated as default. Bound to `return` |     | ✅  |
-| CancelButton  | The button with this text should be treated as cancel. Bound to `escape`  |     | ✅  |
+| Field         | Description                                                               | Win | Mac | Lin |
+| ------------- | ------------------------------------------------------------------------- | --- | --- | --- |
+| Type          | The type of message dialog, eg question, info...                          | ✅  | ✅  |   ✅  |
+| Title         | Title for the dialog                                                      | ✅  | ✅  |   ✅  |
+| Message       | The message to show the user                                              | ✅  | ✅  |   ✅  |
+| Buttons       | A list of button titles                                                   |     | ✅  |      |
+| DefaultButton | The button with this text should be treated as default. Bound to `return` |     | ✅  |      |
+| CancelButton  | The button with this text should be treated as cancel. Bound to `escape`  |     | ✅  |      |
 
 #### Windows
 
 Windows has standard dialog types in which the buttons are not customisable.
 The value returned will be one of: "Ok", "Cancel", "Abort", "Retry", "Ignore", "Yes", "No", "Try Again" or "Continue"
+
+#### Linux
+
+Linux has standard dialog types in which the buttons are not customisable.
+The value returned will be one of: "Ok", "Cancel", "Yes", "No"
 
 #### Mac
 
@@ -221,6 +226,19 @@ dialog:
 <br/>
 <br/>
 <br/>
+
+#### Linux
+
+Linux allows you to use multiple file filters in dialog boxes. Each FileFilter will show up as a separate entry in the
+dialog:
+
+<div class="text--center">
+  <img src="/img/runtime/dialog_lin_filters.png" width="50%" style={{"box-shadow": "rgb(255 255 255 / 20%) 0px 4px 8px 0px, rgb(104 104 104) 0px 6px 20px 0px"}}/>
+</div>
+<br/>
+<br/>
+<br/>
+
 
 #### Mac
 


### PR DESCRIPTION
Uses the same technique as the ExecuteJS to run the dialog code as a callback on the main thread.

Note: Only the `OpenFileDialog` is implemented at this time.