### PR TITLE
Added TypeScript interface export for the window.go object

### DIFF
--- a/v2/internal/binding/generate.go
+++ b/v2/internal/binding/generate.go
@@ -129,7 +129,7 @@ func (b *Bindings) GenerateBackendTS(targetfile string) error {
 	store := b.db.store
 	var output bytes.Buffer
 
-	output.WriteString("interface go {\n")
+	output.WriteString("export interface go {\n")
 
 	var sortedPackageNames slicer.StringSlicer
 	for packageName := range store {

--- a/v2/internal/binding/generate.go
+++ b/v2/internal/binding/generate.go
@@ -201,6 +201,8 @@ declare global {
 
 func goTypeToJSDocType(input string) string {
 	switch true {
+	case input == "interface{}":
+		return "any"
 	case input == "string":
 		return "string"
 	case input == "error":

--- a/v2/internal/binding/generate_test.go
+++ b/v2/internal/binding/generate_test.go
@@ -64,12 +64,12 @@ func Test_goTypeToJSDocType(t *testing.T) {
 		{
 			name:  "[]int",
 			input: "[]int",
-			want:  "Array.<number>",
+			want:  "Array<number>",
 		},
 		{
 			name:  "[]bool",
 			input: "[]bool",
-			want:  "Array.<boolean>",
+			want:  "Array<boolean>",
 		},
 		{
 			name:  "anything else",

--- a/v2/internal/binding/generate_test.go
+++ b/v2/internal/binding/generate_test.go
@@ -57,6 +57,11 @@ func Test_goTypeToJSDocType(t *testing.T) {
 			want:  "boolean",
 		},
 		{
+			name:  "interface{}",
+			input: "interface{}",
+			want:  "any",
+		},
+		{
 			name:  "[]byte",
 			input: "[]byte",
 			want:  "string",


### PR DESCRIPTION
The `wailsjs/runtime/runtime.d.ts` already has the `window.runtime` interface exported by default. I changed one line of code to add an export for the `window.go` interface within `wailsjs/go/bindings.d.ts` for linting purposes (the compiled JavaScript previously correctly referenced `window.go` during runtime even with the linting error).

The test located in `generate_test.go` failed as well but seems to be a false positive - it seemed to give the same error both before and after the change so I fixed it. Here's the original failure output when running `go test` in the directory:
```
--- FAIL: Test_goTypeToJSDocType (0.00s)
    --- FAIL: Test_goTypeToJSDocType/[]int (0.00s)
        generate_test.go:83: goTypeToJSDocType() = Array<number>, want Array.<number>
    --- FAIL: Test_goTypeToJSDocType/[]bool (0.00s)
        generate_test.go:83: goTypeToJSDocType() = Array<boolean>, want Array.<boolean>
FAIL
exit status 1
FAIL    github.com/wailsapp/wails/v2/internal/binding   0.006s
``` 