### PR TITLE
use path to first index.html file for 'index'

### DIFF
--- a/v2/internal/fs/fs.go
+++ b/v2/internal/fs/fs.go
@@ -417,7 +417,14 @@ func FindPathToFile(fsys fs.FS, file string) (string, error) {
 	}
 
 	if indexFiles.Length() > 1 {
-		return "", fmt.Errorf("multiple '%s' files found in assets", file)
+		selected := indexFiles.AsSlice()[0]
+		for _, f := range indexFiles.AsSlice() {
+			if len(f) < len(selected) {
+				selected = f
+			}
+		}
+		path, _ := filepath.Split(selected)
+		return path, nil
 	}
 
 	path, _ := filepath.Split(indexFiles.AsSlice()[0])


### PR DESCRIPTION
Ran into an issue using Svelte-Kit where it creates an `index.html` page for each `route`.  This update locates the index.html with the shortest path i.e. the first one in the directory hierarchy.

Note: For Svelte-Kit you really need to use Go 1.18 beta2 and add the `all:` prefix to the `embed.FS` in the `main.go` for your application.