### PR TITLE
[v2, windows] Invert the frameless border flag and rename it

### DIFF
--- a/v2/internal/frontend/desktop/windows/window.go
+++ b/v2/internal/frontend/desktop/windows/window.go
@@ -151,7 +151,7 @@ func (w *Window) WndProc(msg uint32, wparam, lparam uintptr) uintptr {
 			// This Option is not affected by returning 0 in WM_NCCALCSIZE.
 			// As a result we have hidden the titlebar but still have the default window frame styling.
 			// See: https://docs.microsoft.com/en-us/windows/win32/api/dwmapi/nf-dwmapi-dwmextendframeintoclientarea#remarks
-			if winoptions := w.frontendOptions.Windows; winoptions != nil && winoptions.EnableFramelessBorder {
+			if winoptions := w.frontendOptions.Windows; winoptions == nil || !winoptions.DisableFramelessWindowDecorations {
 				// -1: Adds the default frame styling (aero shadow and e.g. rounded corners on Windows 11)
 				//     Also shows the caption buttons if transparent ant translucent but they don't work.
 				//  0: Adds the default frame styling but no aero shadow, does not show the caption buttons.

--- a/v2/pkg/options/windows/windows.go
+++ b/v2/pkg/options/windows/windows.go
@@ -6,8 +6,9 @@ type Options struct {
 	WindowIsTranslucent  bool
 	DisableWindowIcon    bool
 
-	// Draw a border around the window, even if the window is frameless
-	EnableFramelessBorder bool
+	// Disable all window decorations in Frameless mode, which means no "Aero Shadow" and no "Rounded Corner" will be shown.
+	// "Rounded Corners" are only available on Windows 11.
+	DisableFramelessWindowDecorations bool
 
 	// Path where the WebView2 stores the user data. If empty %APPDATA%\[BinaryName.exe] will be used.
 	// If the path is not valid, a messagebox will be displayed with the error and the app will exit with error code.

--- a/website/docs/reference/options.mdx
+++ b/website/docs/reference/options.mdx
@@ -42,11 +42,11 @@ func main() {
             app,
         },
         Windows: &windows.Options{
-            WebviewIsTransparent:  false,
-            WindowIsTranslucent:   false,
-            DisableWindowIcon:     false,
-            EnableFramelessBorder: false,
-            WebviewUserDataPath:   "",
+            WebviewIsTransparent:              false,
+            WindowIsTranslucent:               false,
+            DisableWindowIcon:                 false,
+            DisableFramelessWindowDecorations: false,
+            WebviewUserDataPath:               "",
         },
         Mac: &mac.Options{
             TitleBar: &mac.TitleBar{
@@ -357,14 +357,15 @@ Type: bool
 
 Setting this to `true` will remove the icon in the top left corner of the title bar.
 
-### EnableFramelessBorder
+### DisableFramelessWindowDecorations
 
-Name: EnableFramelessBorder
+Name: DisableFramelessWindowDecorations
 
 Type: bool
 
-Setting this to `true` will add a border around the window if [Frameless](#Frameless) has been activated.
-This allows hiding the title bar but still having a border around the window.
+Setting this to `true` will remove the window decorations in [Frameless](#Frameless) mode. This means there will be no
+'Aero Shadow' and no 'Rounded Corners' shown for the window. Please note that 'Rounded Corners' are only supported on
+Windows 11.
 
 ### WebviewUserDataPath
 

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/reference/options.mdx
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/reference/options.mdx
@@ -42,11 +42,11 @@ func main() {
             app,
         },
         Windows: &windows.Options{
-            WebviewIsTransparent:  false,
-            WindowIsTranslucent:   false,
-            DisableWindowIcon:     false,
-            EnableFramelessBorder: false,
-            WebviewUserDataPath:   "",
+            WebviewIsTransparent:              false,
+            WindowIsTranslucent:               false,
+            DisableWindowIcon:                 false,
+            DisableFramelessWindowDecorations: false,
+            WebviewUserDataPath:               "",
         },
         Mac: &mac.Options{
             TitleBar: &mac.TitleBar{
@@ -336,13 +336,14 @@ func (b *App) beforeClose(ctx context.Context) (prevent bool) {
 
 将此设置为 `true` 将删除标题栏左上角的图标。
 
-### 启用无边框模式的外边框
+### 禁用无框窗饰
 
-名称：EnableFramelessBorder
+名称：DisableFramelessWindowDecorations
 
 类型：bool
 
-如果已激活[无边框](#无边框)，则将此设置为`true`将在窗口周围添加边框。这允许隐藏标题栏但仍然在窗口周围有边框。
+将此设置为 "true "将移除[无边框](#无边框)模式下的窗口装饰。这意味着将不会有
+空中阴影 "和 "圆角 "显示在窗口上。请注意，"圆角 "只支持在 Windows 11。
 
 ### Webview 用户数据路径
 


### PR DESCRIPTION
This is a breaking change for all users of the flag.

Fix #1147 