### PR TITLE
Fix linux unexpected signal errors

### DIFF
--- a/v2/internal/frontend/desktop/linux/window.go
+++ b/v2/internal/frontend/desktop/linux/window.go
@@ -192,27 +192,18 @@ void loadIndex(void* webview) {
 }
 
 typedef struct DragOptions {
-	void *webview;
-	GtkWindow* mainwindow;
+	void* webview;
+	void* mainwindow;
 } DragOptions;
 
-static void startDrag(gpointer data)
-{
+void startDrag(gpointer* data) {
 	DragOptions* options = (DragOptions*)data;
 
-   // Ignore non-toplevel widgets
-   GtkWidget *window = gtk_widget_get_toplevel(GTK_WIDGET(options->webview));
-   if (!GTK_IS_WINDOW(window)) return;
+	// Ignore non-toplevel widgets
+	GtkWidget *window = gtk_widget_get_toplevel(GTK_WIDGET(options->webview));
+	if (!GTK_IS_WINDOW(window)) return;
 
-   gtk_window_begin_move_drag(options->mainwindow, 1, xroot, yroot, dragTime);
-	free(data);
-}
-
-static void StartDrag(void *webview, GtkWindow* mainwindow) {
-	DragOptions* data = malloc(sizeof(DragOptions));
-	data->webview = webview;
-	data->mainwindow = mainwindow;
-	ExecuteOnMainThread(startDrag, (gpointer)data);
+	gtk_window_begin_move_drag(options->mainwindow, 1, xroot, yroot, dragTime);
 }
 
 typedef struct JSCallback {
@@ -731,7 +722,11 @@ func (w *Window) ExecJS(js string) {
 }
 
 func (w *Window) StartDrag() {
-	C.StartDrag(w.webview, w.asGTKWindow())
+	data := C.DragOptions{
+		webview:    w.webview,
+		mainwindow: w.gtkWindow,
+	}
+	C.ExecuteOnMainThread(C.startDrag, C.gpointer(&data))
 }
 
 func (w *Window) Quit() {

--- a/v2/internal/frontend/desktop/linux/window.go
+++ b/v2/internal/frontend/desktop/linux/window.go
@@ -413,25 +413,6 @@ void setRGBA(gpointer* data) {
 	webkit_web_view_set_background_color(WEBKIT_WEB_VIEW(options->webview), &colour);
 }
 
-typedef struct SetTitleArgs {
-	GtkWindow* window;
-	char* title;
-} SetTitleArgs;
-
-void setTitle(gpointer data) {
-	SetTitleArgs* args = (SetTitleArgs*)data;
-	gtk_window_set_title(args->window, args->title);
-	free((void*)args->title);
-	free((void*)data);
-}
-
-void SetTitle(GtkWindow* window, char* title) {
-	SetTitleArgs* args = malloc(sizeof(SetTitleArgs));
-	args->window = window;
-	args->title = title;
-	ExecuteOnMainThread(setTitle, (gpointer)args);
-}
-
 typedef struct SetPositionArgs {
 	int x;
 	int y;
@@ -736,7 +717,9 @@ func (w *Window) SetDecorated(frameless bool) {
 }
 
 func (w *Window) SetTitle(title string) {
-	C.SetTitle(w.asGTKWindow(), C.CString(title))
+	newTitle := C.CString(title)
+	defer C.free(unsafe.Pointer(newTitle))
+	C.gtk_window_set_title(w.asGTKWindow(), newTitle)
 }
 
 func (w *Window) ExecJS(js string) {

--- a/v2/internal/frontend/desktop/linux/window.go
+++ b/v2/internal/frontend/desktop/linux/window.go
@@ -197,13 +197,15 @@ typedef struct DragOptions {
 	GtkWindow* mainwindow;
 } DragOptions;
 
-static gboolean startDrag(gpointer data)
-{
+static gboolean startDrag(gpointer data) {
 	DragOptions* options = (DragOptions*)data;
 
 	// Ignore non-toplevel widgets
 	GtkWidget *window = gtk_widget_get_toplevel(GTK_WIDGET(options->webview));
-	if (!GTK_IS_WINDOW(window)) return G_SOURCE_REMOVE;
+	if (!GTK_IS_WINDOW(window)) {
+		free(data);
+		return G_SOURCE_REMOVE;
+	}
 
 	gtk_window_begin_move_drag(options->mainwindow, 1, xroot, yroot, dragTime);
 	free(data);

--- a/v2/internal/frontend/desktop/linux/window.go
+++ b/v2/internal/frontend/desktop/linux/window.go
@@ -609,8 +609,8 @@ func (w *Window) UnFullscreen() {
 }
 
 func (w *Window) Destroy() {
-	C.g_object_unref(C.gpointer(w.gtkWindow))
 	C.gtk_widget_destroy(w.asGTKWidget())
+	C.g_object_unref(C.gpointer(w.gtkWindow))
 }
 
 func (w *Window) Close() {

--- a/v2/internal/frontend/desktop/linux/window.go
+++ b/v2/internal/frontend/desktop/linux/window.go
@@ -500,6 +500,18 @@ gboolean UnMinimise(gpointer data) {
 	return G_SOURCE_REMOVE;
 }
 
+gboolean Fullscreen(gpointer data) {
+	gtk_window_fullscreen((GtkWindow*)data);
+
+	return G_SOURCE_REMOVE;
+}
+
+gboolean UnFullscreen(gpointer data) {
+	gtk_window_unfullscreen((GtkWindow*)data);
+
+	return G_SOURCE_REMOVE;
+}
+
 bool disableContextMenu(GtkWindow* window) {
 	return TRUE;
 }
@@ -619,14 +631,14 @@ func (w *Window) cWebKitUserContentManager() *C.WebKitUserContentManager {
 
 func (w *Window) Fullscreen() {
 	C.SetMinMaxSize(w.asGTKWindow(), C.int(0), C.int(0), C.int(0), C.int(0))
-	C.ExecuteOnMainThread(C.gtk_window_fullscreen, C.gpointer(w.asGTKWindow()))
+	C.ExecuteOnMainThread(C.Fullscreen, C.gpointer(w.asGTKWindow()))
 }
 
 func (w *Window) UnFullscreen() {
 	if !w.IsFullScreen() {
 		return
 	}
-	C.ExecuteOnMainThread(C.gtk_window_unfullscreen, C.gpointer(w.asGTKWindow()))
+	C.ExecuteOnMainThread(C.UnFullscreen, C.gpointer(w.asGTKWindow()))
 	w.SetMinSize(w.minWidth, w.minHeight)
 	w.SetMaxSize(w.maxWidth, w.maxHeight)
 }


### PR DESCRIPTION
As seen in discussion https://github.com/wailsapp/wails/discussions/1156, I've noticed a few unexpected signal errors and panics when running a Wails app in NixOS.

This PR fixes the errors I've seen:

1. When quitting the app it would always fatal error because the window reference was released before destroy was called on it.
2. There was often an error related to setting the title on the window due to a race condition.
3. Clicking a blank/background area in the window caused a crash when drag move was initiated.