### PR TITLE
[v2, windows] Move assets from file://wails to https://wails.localhost

### DIFF
--- a/v2/internal/frontend/desktop/windows/frontend.go
+++ b/v2/internal/frontend/desktop/windows/frontend.go
@@ -55,7 +55,7 @@ func NewFrontend(ctx context.Context, appoptions *options.App, myLogger *logger.
 		bindings:        appBindings,
 		dispatcher:      dispatcher,
 		ctx:             ctx,
-		startURL:        "file://wails/",
+		startURL:        "https://wails.localhost/",
 	}
 
 	bindingsJSON, err := appBindings.ToJSON()
@@ -352,7 +352,7 @@ func (f *Frontend) processRequest(req *edge.ICoreWebView2WebResourceRequest, arg
 	//Get the request
 	uri, _ := req.GetUri()
 
-	res, err := common.ProcessRequest(uri, f.assets, "file", "wails")
+	res, err := common.ProcessRequest(uri, f.assets, "https", "wails.localhost")
 	if err == common.ErrUnexpectedScheme {
 		// In this case we should let the WebView2 handle the request with its default handler
 		return


### PR DESCRIPTION
This should allow web workers to be used

The purpose of this draft PR is to see if web workers would work as requested in #1210. I've just changed it and the vanilla template worked, I've not further tested it and I've not taken a look into all implications of this change. So the PR is open for discussions.