### PR TITLE
import models on binding definition

### DIFF
--- a/v2/internal/binding/generate.go
+++ b/v2/internal/binding/generate.go
@@ -129,6 +129,7 @@ func (b *Bindings) GenerateBackendTS(targetfile string) error {
 	store := b.db.store
 	var output bytes.Buffer
 
+	output.WriteString("import * as models from './models';\n\n")
 	output.WriteString("export interface go {\n")
 
 	var sortedPackageNames slicer.StringSlicer
@@ -221,7 +222,7 @@ func goTypeToJSDocType(input string) string {
 		return "Array<" + arrayType + ">"
 	default:
 		if strings.ContainsRune(input, '.') {
-			return strings.Split(input, ".")[1]
+			return "models." + strings.Split(input, ".")[1]
 		}
 		return "any"
 	}

--- a/v2/internal/binding/generate_test.go
+++ b/v2/internal/binding/generate_test.go
@@ -81,6 +81,11 @@ func Test_goTypeToJSDocType(t *testing.T) {
 			input: "foo",
 			want:  "any",
 		},
+		{
+			name:  "types",
+			input: "main.SomeType",
+			want:  "models.SomeType",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
From the conversation on the issue #945 the generation of the file more specific here https://github.com/wailsapp/wails/issues/945#issuecomment-999378082 to avoid errors on the bindings definitions is necessary to reference the models. In order to import all the generated models it is necessary to us the `as` and give a namespace and of course it is necessary to add it to the use of the types.