### PR TITLE
add support for 'DomReady' callback on linux

### DIFF
--- a/v2/internal/frontend/desktop/linux/frontend.go
+++ b/v2/internal/frontend/desktop/linux/frontend.go
@@ -226,6 +226,13 @@ func (f *Frontend) Notify(name string, data ...interface{}) {
 }
 
 func (f *Frontend) processMessage(message string) {
+	if message == "DomReady" {
+		if f.frontendOptions.OnDomReady != nil {
+			f.frontendOptions.OnDomReady(f.ctx)
+		}
+		return
+	}
+
 	if message == "drag" {
 		if !f.mainWindow.IsFullScreen() {
 			f.startDrag()
@@ -313,7 +320,7 @@ func (f *Frontend) processRequest(request unsafe.Pointer) {
 		cContent = C.malloc(C.ulong(bodyLen))
 		if cContent != nil {
 			C.memcpy(cContent, unsafe.Pointer(&res.Body[0]), C.size_t(bodyLen))
-			cLen = C.long(len(res.Body))
+			cLen = C.long(bodyLen)
 		}
 	}
 

--- a/v2/internal/frontend/desktop/linux/window.go
+++ b/v2/internal/frontend/desktop/linux/window.go
@@ -123,6 +123,13 @@ static void sendMessageToBackend(WebKitUserContentManager *contentManager,
     g_free(message);
 }
 
+static void webviewLoadChanged(WebKitWebView *web_view, WebKitLoadEvent load_event, gpointer data)
+{
+    if (load_event == WEBKIT_LOAD_FINISHED) {
+		processMessage("DomReady");
+    }
+}
+
 ulong setupInvokeSignal(void* contentManager) {
 	return g_signal_connect((WebKitUserContentManager*)contentManager, "script-message-received::external", G_CALLBACK(sendMessageToBackend), NULL);
 }
@@ -185,7 +192,7 @@ GtkWidget* setupWebview(void* contentManager, GtkWindow* window, int hideWindowO
 	//gtk_container_add(GTK_CONTAINER(window), webview);
 	WebKitWebContext *context = webkit_web_context_get_default();
 	webkit_web_context_register_uri_scheme(context, "wails", (WebKitURISchemeRequestCallback)processURLRequest, NULL, NULL);
-	//g_signal_connect(G_OBJECT(webview), "load-changed", G_CALLBACK(webview_load_changed_cb), NULL);
+	g_signal_connect(G_OBJECT(webview), "load-changed", G_CALLBACK(webviewLoadChanged), NULL);
 	if (hideWindowOnClose) {
 		g_signal_connect(GTK_WIDGET(window), "delete-event", G_CALLBACK(gtk_widget_hide_on_delete), NULL);
 	} else {
@@ -536,6 +543,7 @@ gboolean UnFullscreen(gpointer data) {
 bool disableContextMenu(GtkWindow* window) {
 	return TRUE;
 }
+
 void DisableContextMenu(void* webview) {
 	contextMenuDisabled = TRUE;
 	g_signal_connect(WEBKIT_WEB_VIEW(webview), "context-menu", G_CALLBACK(disableContextMenu), NULL);

--- a/v2/internal/frontend/desktop/linux/window.go
+++ b/v2/internal/frontend/desktop/linux/window.go
@@ -126,7 +126,7 @@ static void sendMessageToBackend(WebKitUserContentManager *contentManager,
 static void webviewLoadChanged(WebKitWebView *web_view, WebKitLoadEvent load_event, gpointer data)
 {
     if (load_event == WEBKIT_LOAD_FINISHED) {
-		processMessage("DomReady");
+        processMessage("DomReady");
     }
 }
 


### PR DESCRIPTION
cosmetic: use bodyLen instead of len() in processRequest()