### PR TITLE
[v2] Wails doctor add information about wails

### DIFF
--- a/v2/cmd/wails/internal/commands/doctor/doctor.go
+++ b/v2/cmd/wails/internal/commands/doctor/doctor.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"os"
 	"runtime"
+	"runtime/debug"
 	"strings"
 	"text/tabwriter"
 
@@ -52,6 +53,27 @@ func AddSubcommand(app *clir.Cli, w io.Writer) error {
 		fmt.Fprintf(w, "%s\t%s\n", "Go Version:", runtime.Version())
 		fmt.Fprintf(w, "%s\t%s\n", "Platform:", runtime.GOOS)
 		fmt.Fprintf(w, "%s\t%s\n", "Architecture:", runtime.GOARCH)
+
+		// Write out the wails information
+		fmt.Fprintf(w, "\n")
+		fmt.Fprintf(w, "Wails\n")
+		fmt.Fprintf(w, "------\n")
+		fmt.Fprintf(w, "%s\t%s\n", "Version: ", app.Version())
+
+		if buildInfo, _ := debug.ReadBuildInfo(); buildInfo != nil {
+			buildSettingToName := map[string]string{
+				"vcs.revision": "Revision",
+				"vcs.modified": "Modified",
+			}
+			for _, buildSetting := range buildInfo.Settings {
+				name := buildSettingToName[buildSetting.Key]
+				if name == "" {
+					continue
+				}
+
+				fmt.Fprintf(w, "%s:\t%s\n", name, buildSetting.Value)
+			}
+		}
 
 		// Exit early if PM not found
 		if info.PM != nil {


### PR DESCRIPTION
Also outputs VCS information if Go 1.18+ has been used to build wails.

Issue reports often miss the information about the version of wails, because only the output of `wails doctor` is provided. This PR adds build information and version of wails to the doctor output.