### PR TITLE
cleanup Version

### DIFF
--- a/v2/cmd/wails/internal/version.go
+++ b/v2/cmd/wails/internal/version.go
@@ -1,3 +1,3 @@
 package internal
 
-var Version = "v2.0.0-beta.34.frontenddevserver" // Just for testing purposes do not merge
+var Version = "v2.0.0-beta.34"


### PR DESCRIPTION
Looks like the an invalid version string got merged to master.
This just removes it.