### PR TITLE
[v2, windows] Suppress resizing during minimize of a frameless window

### DIFF
--- a/v2/internal/frontend/desktop/windows/frontend.go
+++ b/v2/internal/frontend/desktop/windows/frontend.go
@@ -143,6 +143,17 @@ func (f *Frontend) Run(ctx context.Context) error {
 	f.mainWindow.notifyParentWindowPositionChanged = f.chromium.NotifyParentWindowPositionChanged
 
 	mainWindow.OnSize().Bind(func(arg *winc.Event) {
+		if f.frontendOptions.Frameless {
+			// If the window is frameless and we are minimizing, then we need to suppress the Resize on the
+			// WebView2. If we don't do this, restoring does not work as expected and first restores with some wrong
+			// size during the restore animation and only fully renders when the animation is done. This highly
+			// depends on the content in the WebView, see https://github.com/wailsapp/wails/issues/1319
+			event, _ := arg.Data.(*winc.SizeEventData)
+			if event != nil && event.Type == w32.SIZE_MINIMIZED {
+				return
+			}
+		}
+
 		f.chromium.Resize()
 	})
 


### PR DESCRIPTION
If the window is frameless and we are minimizing, then we need to suppress
the Resize on the WebView2. If we don't do this, restoring does not work as
expected and first restores with some wrong size during the restore animation
and only fully renders when the animation is done.
This highly depends on the content in the WebView.
Fixes #1319