### PR TITLE
fix typo bindings.js to ipc.js

### DIFF
--- a/website/versioned_docs/version-v2.0.0-beta.35/guides/frontend.mdx
+++ b/website/versioned_docs/version-v2.0.0-beta.35/guides/frontend.mdx
@@ -2,7 +2,7 @@
 
 ## Script Injection
 
-When Wails serves your `index.html`, by default, it will inject 2 script entries into the `<body>` tag to load `/wails/bindings.js`
+When Wails serves your `index.html`, by default, it will inject 2 script entries into the `<body>` tag to load `/wails/ipc.js`
 and `/wails/runtime.js`. These files install the bindings and runtime respectively.
 
 The code below shows where these are injected by default:


### PR DESCRIPTION
As a result of examining the document and the html of the actual application, it is determined that ipc.js is correct and sends a PR.