### PR TITLE
Add docs on wails generate module

### DIFF
--- a/website/versioned_docs/version-v2.0.0-beta.35/reference/cli.mdx
+++ b/website/versioned_docs/version-v2.0.0-beta.35/reference/cli.mdx
@@ -193,6 +193,9 @@ There is more information on using this feature with existing framework scripts 
 
 ## generate
 
+### module
+Wails creates a javascript module as described in `wails dev`. Use `wails generate module` to generate the javascript interface code.
+
 ### template
 
 Wails uses templates for project generation. The `wails generate template` command helps scaffold a template so that


### PR DESCRIPTION
For users who wish to keep the wailsjs directory out of source control, the `wails generate module` command is valuable in a CI environment where wails build does not automatically generate the needed javascript module.