### PR TITLE
Add missing className to input in React and Preact templates

### DIFF
--- a/v2/cmd/wails/internal/commands/initialise/templates/generate/assets/preact-ts/frontend/src/app.tsx
+++ b/v2/cmd/wails/internal/commands/initialise/templates/generate/assets/preact-ts/frontend/src/app.tsx
@@ -19,7 +19,7 @@ export function App(props: any) {
                 <img src={logo} id="logo" alt="logo"/>
                 <div id="result" className="result">{resultText}</div>
                 <div id="input" className="input-box">
-                    <input id="name" onChange={updateName} autoComplete="off" name="input" type="text"/>
+                    <input id="name" className="input" onChange={updateName} autoComplete="off" name="input" type="text"/>
                     <button className="btn" onClick={greet}>Greet</button>
                 </div>
             </div>

--- a/v2/cmd/wails/internal/commands/initialise/templates/generate/assets/preact/frontend/src/app.jsx
+++ b/v2/cmd/wails/internal/commands/initialise/templates/generate/assets/preact/frontend/src/app.jsx
@@ -19,7 +19,7 @@ export function App(props) {
                 <img src={logo} id="logo" alt="logo"/>
                 <div id="result" className="result">{resultText}</div>
                 <div id="input" className="input-box">
-                    <input id="name" onChange={updateName} autoComplete="off" name="input" type="text"/>
+                    <input id="name" className="input" onChange={updateName} autoComplete="off" name="input" type="text"/>
                     <button className="btn" onClick={greet}>Greet</button>
                 </div>
             </div>

--- a/v2/cmd/wails/internal/commands/initialise/templates/generate/assets/react-ts/frontend/src/App.tsx
+++ b/v2/cmd/wails/internal/commands/initialise/templates/generate/assets/react-ts/frontend/src/App.tsx
@@ -18,7 +18,7 @@ function App() {
             <img src={logo} id="logo" alt="logo"/>
             <div id="result" className="result">{resultText}</div>
             <div id="input" className="input-box">
-                <input id="name" onChange={updateName} autoComplete="off" name="input" type="text"/>
+                <input id="name" className="input" onChange={updateName} autoComplete="off" name="input" type="text"/>
                 <button className="btn" onClick={greet}>Greet</button>
             </div>
         </div>

--- a/v2/cmd/wails/internal/commands/initialise/templates/generate/assets/react/frontend/src/App.jsx
+++ b/v2/cmd/wails/internal/commands/initialise/templates/generate/assets/react/frontend/src/App.jsx
@@ -18,7 +18,7 @@ function App() {
             <img src={logo} id="logo" alt="logo"/>
             <div id="result" className="result">{resultText}</div>
             <div id="input" className="input-box">
-                <input id="name" onChange={updateName} autoComplete="off" name="input" type="text"/>
+                <input id="name" className="input" onChange={updateName} autoComplete="off" name="input" type="text"/>
                 <button className="btn" onClick={greet}>Greet</button>
             </div>
         </div>

--- a/v2/cmd/wails/internal/commands/initialise/templates/templates/preact-ts/frontend/src/app.tsx
+++ b/v2/cmd/wails/internal/commands/initialise/templates/templates/preact-ts/frontend/src/app.tsx
@@ -19,7 +19,7 @@ export function App(props: any) {
                 <img src={logo} id="logo" alt="logo"/>
                 <div id="result" className="result">{resultText}</div>
                 <div id="input" className="input-box">
-                    <input id="name" onChange={updateName} autoComplete="off" name="input" type="text"/>
+                    <input id="name" className="input" onChange={updateName} autoComplete="off" name="input" type="text"/>
                     <button className="btn" onClick={greet}>Greet</button>
                 </div>
             </div>

--- a/v2/cmd/wails/internal/commands/initialise/templates/templates/preact/frontend/src/app.jsx
+++ b/v2/cmd/wails/internal/commands/initialise/templates/templates/preact/frontend/src/app.jsx
@@ -19,7 +19,7 @@ export function App(props) {
                 <img src={logo} id="logo" alt="logo"/>
                 <div id="result" className="result">{resultText}</div>
                 <div id="input" className="input-box">
-                    <input id="name" onChange={updateName} autoComplete="off" name="input" type="text"/>
+                    <input id="name" className="input" onChange={updateName} autoComplete="off" name="input" type="text"/>
                     <button className="btn" onClick={greet}>Greet</button>
                 </div>
             </div>

--- a/v2/cmd/wails/internal/commands/initialise/templates/templates/react-ts/frontend/src/App.tsx
+++ b/v2/cmd/wails/internal/commands/initialise/templates/templates/react-ts/frontend/src/App.tsx
@@ -18,7 +18,7 @@ function App() {
             <img src={logo} id="logo" alt="logo"/>
             <div id="result" className="result">{resultText}</div>
             <div id="input" className="input-box">
-                <input id="name" onChange={updateName} autoComplete="off" name="input" type="text"/>
+                <input id="name" className="input" onChange={updateName} autoComplete="off" name="input" type="text"/>
                 <button className="btn" onClick={greet}>Greet</button>
             </div>
         </div>

--- a/v2/cmd/wails/internal/commands/initialise/templates/templates/react/frontend/src/App.jsx
+++ b/v2/cmd/wails/internal/commands/initialise/templates/templates/react/frontend/src/App.jsx
@@ -18,7 +18,7 @@ function App() {
             <img src={logo} id="logo" alt="logo"/>
             <div id="result" className="result">{resultText}</div>
             <div id="input" className="input-box">
-                <input id="name" onChange={updateName} autoComplete="off" name="input" type="text"/>
+                <input id="name" className="input" onChange={updateName} autoComplete="off" name="input" type="text"/>
                 <button className="btn" onClick={greet}>Greet</button>
             </div>
         </div>


### PR DESCRIPTION
CSS styling is not being applied to the input field in the hello world templates for React and Preact because the input tag is missing the class identifier present in the templates for the other frameworks.