### PR TITLE
docs: add macos custom menu EditMenu tips

### DIFF
--- a/website/docs/reference/menus.mdx
+++ b/website/docs/reference/menus.mdx
@@ -18,6 +18,10 @@ An example of how to create a menu:
     FileMenu.AddText("Quit", keys.CmdOrCtrl("q"), func(_ *menu.CallbackData) {
         runtime.Quit()
     })
+    
+    if runtime.GOOS == "darwin" {
+	m.Append(menu.EditMenu())  // on macos platform, we should append EditMenu to enable Cmd+C,Cmd+V,Cmd+Z... shortcut
+    }
 
     err := wails.Run(&options.App{
         Title:             "Menus Demo",

--- a/website/docs/reference/menus.mdx
+++ b/website/docs/reference/menus.mdx
@@ -20,7 +20,7 @@ An example of how to create a menu:
     })
     
     if runtime.GOOS == "darwin" {
-	m.Append(menu.EditMenu())  // on macos platform, we should append EditMenu to enable Cmd+C,Cmd+V,Cmd+Z... shortcut
+	AppMenu.Append(menu.EditMenu())  // on macos platform, we should append EditMenu to enable Cmd+C,Cmd+V,Cmd+Z... shortcut
     }
 
     err := wails.Run(&options.App{


### PR DESCRIPTION
On macos platform, if custom the menu, we should append EditMenu to enable Cmd+C,Cmd+V,Cmd+Z... shortcut