### PR TITLE
feature - add race detector to build & dev

### DIFF
--- a/v2/cmd/wails/internal/commands/build/build.go
+++ b/v2/cmd/wails/internal/commands/build/build.go
@@ -99,6 +99,9 @@ func AddBuildSubcommand(app *clir.Cli, w io.Writer) {
 	trimpath := false
 	command.BoolFlag("trimpath", "Remove all file system paths from the resulting executable", &trimpath)
 
+	raceDetector := false
+	command.BoolFlag("race", "Build with Go's race detector", &raceDetector)
+
 	command.Action(func() error {
 
 		quiet := verbosity == 0
@@ -180,6 +183,7 @@ func AddBuildSubcommand(app *clir.Cli, w io.Writer) {
 			UserTags:            userTags,
 			WebView2Strategy:    wv2rtstrategy,
 			TrimPath:            trimpath,
+			RaceDetector:        raceDetector,
 		}
 
 		// Start a new tabwriter
@@ -197,6 +201,7 @@ func AddBuildSubcommand(app *clir.Cli, w io.Writer) {
 		_, _ = fmt.Fprintf(w, "Clean Build Dir: \t%t\n", buildOptions.CleanBuildDirectory)
 		_, _ = fmt.Fprintf(w, "LDFlags: \t\"%s\"\n", buildOptions.LDFlags)
 		_, _ = fmt.Fprintf(w, "Tags: \t[%s]\n", strings.Join(buildOptions.UserTags, ","))
+		_, _ = fmt.Fprintf(w, "Race Detector: \t%t\n", buildOptions.RaceDetector)
 		if len(buildOptions.OutputFile) > 0 && targets.Length() == 1 {
 			_, _ = fmt.Fprintf(w, "Output File: \t%s\n", buildOptions.OutputFile)
 		}

--- a/v2/cmd/wails/internal/commands/dev/dev.go
+++ b/v2/cmd/wails/internal/commands/dev/dev.go
@@ -76,6 +76,7 @@ type devFlags struct {
 	devServer       string
 	appargs         string
 	saveConfig      bool
+	raceDetector    bool
 
 	frontendDevServerURL string
 }
@@ -104,6 +105,7 @@ func AddSubcommand(app *clir.Cli, w io.Writer) error {
 	command.StringFlag("frontenddevserverurl", "The url of the external frontend dev server to use", &flags.frontendDevServerURL)
 	command.StringFlag("appargs", "arguments to pass to the underlying app (quoted and space searated)", &flags.appargs)
 	command.BoolFlag("save", "Save given flags as defaults", &flags.saveConfig)
+	command.BoolFlag("race", "Build with Go's race detector", &flags.raceDetector)
 
 	command.Action(func() error {
 		// Create logger
@@ -303,6 +305,7 @@ func generateBuildOptions(flags devFlags) *build.Options {
 		IgnoreFrontend: false,
 		Verbosity:      flags.verbosity,
 		WailsJSDir:     flags.wailsjsdir,
+		RaceDetector:   flags.raceDetector,
 	}
 
 	return result

--- a/v2/pkg/commands/build/base.go
+++ b/v2/pkg/commands/build/base.go
@@ -182,6 +182,10 @@ func (b *BaseBuilder) CompileProject(options *Options) error {
 		commands.Add("-trimpath")
 	}
 
+	if options.RaceDetector {
+		commands.Add("-race")
+	}
+
 	var tags slicer.StringSlicer
 	tags.Add(options.OutputType)
 	tags.AddSlice(options.UserTags)

--- a/v2/pkg/commands/build/build.go
+++ b/v2/pkg/commands/build/build.go
@@ -56,6 +56,7 @@ type Options struct {
 	ForceBuild          bool                 // Force
 	BundleName          string               // Bundlename for Mac
 	TrimPath            bool                 // Use Go's trimpath compiler flag
+	RaceDetector        bool                 // Build with Go's race detector
 }
 
 // Build the project!

--- a/website/docs/reference/cli.mdx
+++ b/website/docs/reference/cli.mdx
@@ -70,6 +70,7 @@ A list of community maintained templates can be found [here](../community/templa
 |  -u                  | Updates your project's `go.mod` to use the same version of Wails as the CLI | |
 |  -debug              | Retains debug information in the application | false |
 |  -trimpath           | Remove all file system paths from the resulting executable. | false |
+|  -race               | Build with Go's race detector           | false                      |
 
 For a detailed description of the `webview2` flag, please refer to the [Windows](../guides/windows.mdx) Guide.
 
@@ -177,6 +178,7 @@ Your system is ready for Wails development!
 |  -appargs "args"         | Arguments passed to the application in shell style  | |
 |  -platform "platform"    | Platform/Arch to target | `runtime.GOOS` |
 |  -save                   | Saves the given `assetdir`, `reloaddirs`, `wailsjsdir`, `debounce`, `devserver` and `frontenddevserverurl` flags in `wails.json` to become the defaults for subsequent invocations. | |
+|  -race               | Build with Go's race detector           | false                      |
 
 Example:
 


### PR DESCRIPTION
This pull request resolves wailsapp/wails#1425 feature request, by adding the `-race` flag to `wails build` and `wails dev` commands.