### PR TITLE
Fix apt command syntax (#1458)

### DIFF
--- a/v2/internal/system/packagemanager/apt.go
+++ b/v2/internal/system/packagemanager/apt.go
@@ -65,7 +65,7 @@ func (a *Apt) PackageInstalled(pkg *Package) (bool, error) {
 	if pkg.SystemPackage == false {
 		return false, nil
 	}
-	cmd := exec.Command("apt", "-qq", "list", pkg.Name)
+	cmd := exec.Command("apt", "list", "-qq", pkg.Name)
 	var stdo, stde bytes.Buffer
 	cmd.Stdout = &stdo
 	cmd.Stderr = &stde
@@ -79,7 +79,7 @@ func (a *Apt) PackageAvailable(pkg *Package) (bool, error) {
 	if pkg.SystemPackage == false {
 		return false, nil
 	}
-	stdout, _, err := shell.RunCommand(".", "apt", "-qq", "list", pkg.Name)
+	stdout, _, err := shell.RunCommand(".", "apt", "list", "-qq", pkg.Name)
 	// We add a space to ensure we get a full match, not partial match
 	output := a.removeEscapeSequences(stdout)
 	installed := strings.HasPrefix(output, pkg.Name)


### PR DESCRIPTION
A minor change to correct the order of parameters to the `apt` command.

Proof of fix:
_Before:_
```
$ wails doctor
Wails CLI v2.0.0-beta.37


Scanning system - Please wait (this may take a long time)...Failed.


ERROR: exit status 1

If Wails is useful to you or your company, please consider sponsoring the project:
https://github.com/sponsors/leaanthony
```
_After:_
```
Wails CLI v2.0.0-beta.37


Scanning system - Please wait (this may take a long time)...Done.

System
------
OS:		Linux Mint
Version: 	20.3
ID:		linuxmint
Go Version:	go1.18
Platform:	linux
Architecture:	amd64

Wails
------
Version: 		v2.0.0-beta.37
Package Manager: 	apt

Dependency	Package Name		Status		Version
----------	------------		------		-------
*docker		docker.io		Installed	20.10.17
gcc		build-essential		Installed	12.8ubuntu1.1
libgtk-3	libgtk-3-dev		Installed	3.24.20-0ubuntu1.1
libwebkit	libwebkit2gtk-4.0-dev	Available	2.36.3-0ubuntu0.20.04.1
npm		npm			Available	6.14.4+ds-1ubuntu2
*nsis		nsis			Available	3.05-2
pkg-config	pkg-config		Installed	0.29.1-0ubuntu4

* - Optional Dependency

Diagnosis
---------
Your system has missing dependencies!

Required package(s) installation details: 
  - libwebkit: sudo apt install libwebkit2gtk-4.0-dev
  - npm: sudo apt install npm

Optional package(s) installation details: 
  - nsis: sudo apt install nsis



If Wails is useful to you or your company, please consider sponsoring the project:
https://github.com/sponsors/leaanthony
