### PR TITLE
Bugfix: Don't stop if unable to remove temporary bindings build

### DIFF
--- a/v2/cmd/wails/internal/commands/generate/module.go
+++ b/v2/cmd/wails/internal/commands/generate/module.go
@@ -50,10 +50,8 @@ func AddModuleCommand(app *clir.Cli, parent *clir.Command, w io.Writer) error {
 			return fmt.Errorf("%s\n%s\n%s", stdout, stderr, err)
 		}
 
-		err = os.Remove(filename)
-		if err != nil {
-			return err
-		}
+		// Best effort removal of temp file
+		_ = os.Remove(filename)
 
 		return nil
 	})


### PR DESCRIPTION
Potential fix for #1422 