### PR TITLE
Set Window Background colour if provided + debounce redraw option

### DIFF
--- a/v2/go.mod
+++ b/v2/go.mod
@@ -42,6 +42,7 @@ require github.com/bitfield/script v0.19.0
 require (
 	bitbucket.org/creachadair/shell v0.0.7 // indirect
 	github.com/Microsoft/go-winio v0.4.16 // indirect
+	github.com/bep/debounce v1.2.1 // indirect
 	github.com/emirpasic/gods v1.12.0 // indirect
 	github.com/go-git/gcfg v1.5.0 // indirect
 	github.com/go-ole/go-ole v1.2.6 // indirect

--- a/v2/go.sum
+++ b/v2/go.sum
@@ -11,6 +11,8 @@ github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239 h1:kFOfPq6dUM1hTo
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYUyUczH0OGQWaF5ceTx0UBShxjsH6f8oGKYe2c=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
+github.com/bep/debounce v1.2.1 h1:v67fRdBA9UQu2NhLFXrSg0Brw7CexQekrBwDMM8bzeY=
+github.com/bep/debounce v1.2.1/go.mod h1:H8yggRPQKLUhUoqrJC1bO2xNya7vanpDl7xR3ISbCJ0=
 github.com/bitfield/script v0.19.0 h1:W24f+FQuPab9gXcW8bhcbo5qO8AtrXyu3XOnR4zhHN0=
 github.com/bitfield/script v0.19.0/go.mod h1:ana6F8YOSZ3ImT8SauIzuYSqXgFVkSUJ6kgja+WMmIY=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=

--- a/v2/internal/frontend/desktop/windows/win32/consts.go
+++ b/v2/internal/frontend/desktop/windows/win32/consts.go
@@ -15,6 +15,7 @@ var (
 	moduser32                = syscall.NewLazyDLL("user32.dll")
 	procSystemParametersInfo = moduser32.NewProc("SystemParametersInfoW")
 	procGetWindowLong        = moduser32.NewProc("GetWindowLongW")
+	procSetClassLongPtr      = moduser32.NewProc("SetClassLongPtrW")
 	procShowWindow           = moduser32.NewProc("ShowWindow")
 )
 var (
@@ -22,6 +23,11 @@ var (
 	procDwmSetWindowAttribute        = moddwmapi.NewProc("DwmSetWindowAttribute")
 	procDwmExtendFrameIntoClientArea = moddwmapi.NewProc("DwmExtendFrameIntoClientArea")
 )
+var (
+	modwingdi            = syscall.NewLazyDLL("gdi32.dll")
+	procCreateSolidBrush = modwingdi.NewProc("CreateSolidBrush")
+)
+
 var windowsVersion, _ = operatingsystem.GetWindowsVersionInfo()
 
 func IsWindowsVersionAtLeast(major, minor, buildNumber int) bool {

--- a/v2/internal/frontend/desktop/windows/win32/window.go
+++ b/v2/internal/frontend/desktop/windows/win32/window.go
@@ -4,6 +4,7 @@ package win32
 
 import (
 	"fmt"
+	"github.com/wailsapp/wails/v2/internal/frontend/desktop/windows/winc"
 	"log"
 	"syscall"
 	"unsafe"
@@ -31,6 +32,10 @@ const (
 	SW_RESTORE         = 9
 	SW_SHOWDEFAULT     = 10
 	SW_FORCEMINIMIZE   = 11
+)
+
+const (
+	GCLP_HBRBACKGROUND int32 = -10
 )
 
 // http://msdn.microsoft.com/en-us/library/windows/desktop/bb773244.aspx
@@ -74,6 +79,12 @@ func ShowWindowMinimised(hwnd uintptr) {
 	showWindow(hwnd, SW_MINIMIZE)
 }
 
+func SetBackgroundColour(hwnd uintptr, r, g, b uint8) {
+	col := winc.RGB(r, g, b)
+	hbrush, _, _ := procCreateSolidBrush.Call(uintptr(col))
+	setClassLongPtr(hwnd, GCLP_HBRBACKGROUND, hbrush)
+}
+
 func dwmExtendFrameIntoClientArea(hwnd uintptr, margins *MARGINS) error {
 	ret, _, _ := procDwmExtendFrameIntoClientArea.Call(
 		hwnd,
@@ -84,6 +95,15 @@ func dwmExtendFrameIntoClientArea(hwnd uintptr, margins *MARGINS) error {
 	}
 
 	return nil
+}
+
+func setClassLongPtr(hwnd uintptr, param int32, val uintptr) bool {
+	ret, _, _ := procSetClassLongPtr.Call(
+		hwnd,
+		uintptr(param),
+		val,
+	)
+	return ret != 0
 }
 
 func getWindowLong(hwnd uintptr, index int) int32 {

--- a/v2/internal/frontend/desktop/windows/window.go
+++ b/v2/internal/frontend/desktop/windows/window.go
@@ -66,6 +66,10 @@ func NewWindow(parent winc.Controller, appoptions *options.App, versionInfo *ope
 		}
 	}
 
+	if appoptions.RGBA != nil {
+		win32.SetBackgroundColour(result.Handle(), appoptions.RGBA.R, appoptions.RGBA.G, appoptions.RGBA.B)
+	}
+
 	result.SetSize(appoptions.Width, appoptions.Height)
 	result.SetText(appoptions.Title)
 	result.EnableSizable(!appoptions.DisableResize)

--- a/v2/pkg/options/windows/windows.go
+++ b/v2/pkg/options/windows/windows.go
@@ -82,6 +82,10 @@ type Options struct {
 
 	// User messages that can be customised
 	Messages *Messages
+
+	// ResizeDebounceMS is the amount of time to debounce redraws of webview2
+	// when resizing the window
+	ResizeDebounceMS uint16
 }
 
 func DefaultMessages() *Messages {

--- a/website/docs/reference/options.mdx
+++ b/website/docs/reference/options.mdx
@@ -511,6 +511,15 @@ Type: `*windows.Messages`
 A struct of strings used by the webview2 installer if a valid webview2 runtime is not found.
 Customise this for any language you choose to support.
 
+### ResizeDebounceMS
+
+Name: ResizeDebounceMS
+
+Type: uint16
+
+ResizeDebounceMS is the amount of time to debounce redraws of webview2 when resizing the window.
+The default value (0) will perform redraws as fast as it can.
+
 ## Mac Specific Options
 
 ### TitleBar


### PR DESCRIPTION
Sets window background colour if provided.
Added `ResizeDebounceMS` for specifying the delay before redraw when resizing.

This PR provides options to decrease the "flicker" when resizing the app on Windows.