### PR TITLE
Chore/react 18 create root

### DIFF
--- a/v2/cmd/wails/internal/commands/initialise/templates/generate/assets/preact/frontend/src/main.jsx
+++ b/v2/cmd/wails/internal/commands/initialise/templates/generate/assets/preact/frontend/src/main.jsx
@@ -1,5 +1,14 @@
-import {render} from 'preact';
-import {App} from './app';
-import './style.css';
+import React from 'react'
+import { createRoot } from 'react-dom/client'
+import './style.css'
+import App from './App'
 
-render(<App/>, document.getElementById('app'));
+const container = document.getElementById('root')
+
+const root = createRoot(container)
+
+root.render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+)

--- a/v2/cmd/wails/internal/commands/initialise/templates/generate/assets/react-ts/frontend/src/main.tsx
+++ b/v2/cmd/wails/internal/commands/initialise/templates/generate/assets/react-ts/frontend/src/main.tsx
@@ -1,14 +1,14 @@
-import React from 'react';
-import { createRoot } from 'react-dom/client';
-import './style.css';
-import App from './App';
+import React from 'react'
+import { createRoot } from 'react-dom/client'
+import './style.css'
+import App from './App'
 
-const container = document.getElementById('root');
+const container = document.getElementById('root')
 
-const root = createRoot(container!);
+const root = createRoot(container!)
 
 root.render(
   <React.StrictMode>
     <App />
   </React.StrictMode>
-);
+)

--- a/v2/cmd/wails/internal/commands/initialise/templates/generate/assets/react-ts/frontend/src/main.tsx
+++ b/v2/cmd/wails/internal/commands/initialise/templates/generate/assets/react-ts/frontend/src/main.tsx
@@ -1,9 +1,9 @@
-import React from "react";
-import { createRoot } from "react-dom/client";
-import "./style.css";
-import App from "./App";
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import './style.css';
+import App from './App';
 
-const container = document.getElementById("root");
+const container = document.getElementById('root');
 
 const root = createRoot(container!);
 

--- a/v2/cmd/wails/internal/commands/initialise/templates/generate/assets/react-ts/frontend/src/main.tsx
+++ b/v2/cmd/wails/internal/commands/initialise/templates/generate/assets/react-ts/frontend/src/main.tsx
@@ -1,11 +1,14 @@
-import React from 'react'
-import ReactDOM from 'react-dom'
-import './style.css'
-import App from './App'
+import React from "react";
+import { createRoot } from "react-dom/client";
+import "./style.css";
+import App from "./App";
 
-ReactDOM.render(
-    <React.StrictMode>
-        <App/>
-    </React.StrictMode>,
-    document.getElementById('root')
-)
+const container = document.getElementById("root");
+
+const root = createRoot(container!);
+
+root.render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/v2/cmd/wails/internal/commands/initialise/templates/generate/assets/react/frontend/src/main.jsx
+++ b/v2/cmd/wails/internal/commands/initialise/templates/generate/assets/react/frontend/src/main.jsx
@@ -1,11 +1,14 @@
-import React from 'react'
-import ReactDOM from 'react-dom'
-import './style.css'
-import App from './App'
+import React from "react";
+import { createRoot } from "react-dom/client";
+import "./style.css";
+import App from "./App";
 
-ReactDOM.render(
-    <React.StrictMode>
-        <App/>
-    </React.StrictMode>,
-    document.getElementById('root')
-)
+const container = document.getElementById("root");
+
+const root = createRoot(container);
+
+root.render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/v2/cmd/wails/internal/commands/initialise/templates/generate/assets/react/frontend/src/main.jsx
+++ b/v2/cmd/wails/internal/commands/initialise/templates/generate/assets/react/frontend/src/main.jsx
@@ -1,14 +1,14 @@
-import React from 'react';
-import { createRoot } from 'react-dom/client';
-import './style.css';
-import App from './App';
+import React from 'react'
+import { createRoot } from 'react-dom/client'
+import './style.css'
+import App from './App'
 
-const container = document.getElementById('root');
+const container = document.getElementById('root')
 
-const root = createRoot(container);
+const root = createRoot(container)
 
 root.render(
   <React.StrictMode>
     <App />
   </React.StrictMode>
-);
+)

--- a/v2/cmd/wails/internal/commands/initialise/templates/generate/assets/react/frontend/src/main.jsx
+++ b/v2/cmd/wails/internal/commands/initialise/templates/generate/assets/react/frontend/src/main.jsx
@@ -1,9 +1,9 @@
-import React from "react";
-import { createRoot } from "react-dom/client";
-import "./style.css";
-import App from "./App";
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import './style.css';
+import App from './App';
 
-const container = document.getElementById("root");
+const container = document.getElementById('root');
 
 const root = createRoot(container);
 

--- a/v2/cmd/wails/internal/commands/initialise/templates/templates/react-ts/frontend/src/main.tsx
+++ b/v2/cmd/wails/internal/commands/initialise/templates/templates/react-ts/frontend/src/main.tsx
@@ -1,11 +1,14 @@
 import React from 'react'
-import ReactDOM from 'react-dom'
+import { createRoot } from 'react-dom/client'
 import './style.css'
 import App from './App'
 
-ReactDOM.render(
-    <React.StrictMode>
-        <App/>
-    </React.StrictMode>,
-    document.getElementById('root')
+const container = document.getElementById('root')
+
+const root = createRoot(container!)
+
+root.render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
 )


### PR DESCRIPTION
- Updates the react & react-ts frontends to use `createRoot` instead of `ReactDOM.render` as ReactDOM.render is no longer supported in React 18 

Docs: https://reactjs.org/blog/2022/03/08/react-18-upgrade-guide.html#updates-to-client-rendering-apis