### PR TITLE
Allow -appargs flag to pass flags to binary.

### DIFF
--- a/v2/cmd/wails/internal/commands/dev/dev.go
+++ b/v2/cmd/wails/internal/commands/dev/dev.go
@@ -104,7 +104,7 @@ func AddSubcommand(app *clir.Cli, w io.Writer) error {
 	command.IntFlag("debounce", "The amount of time to wait to trigger a reload on change", &flags.debounceMS)
 	command.StringFlag("devserver", "The address of the wails dev server", &flags.devServer)
 	command.StringFlag("frontenddevserverurl", "The url of the external frontend dev server to use", &flags.frontendDevServerURL)
-	command.StringFlag("appargs", "arguments to pass to the underlying app (quoted and space searated)", &flags.appargs)
+	command.StringFlag("appargs", "arguments to pass to the underlying app (quoted and space separated)", &flags.appargs)
 	command.BoolFlag("save", "Save given flags as defaults", &flags.saveConfig)
 	command.BoolFlag("race", "Build with Go's race detector", &flags.raceDetector)
 
@@ -560,7 +560,7 @@ func doWatcherLoop(buildOptions *build.Options, debugBinaryProcess *process.Proc
 	assetDirURL := joinPath(devServerURL, "/wails/assetdir")
 	reloadURL := joinPath(devServerURL, "/wails/reload")
 	for quit == false {
-		//reload := false
+		// reload := false
 		select {
 		case exitCode := <-exitCodeChannel:
 			if exitCode == 0 {
@@ -605,7 +605,7 @@ func doWatcherLoop(buildOptions *build.Options, debugBinaryProcess *process.Proc
 			if item.Op&fsnotify.Create == fsnotify.Create {
 				// If this is a folder, add it to our watch list
 				if fs.DirExists(item.Name) {
-					//node_modules is BANNED!
+					// node_modules is BANNED!
 					if !strings.Contains(item.Name, "node_modules") {
 						err := watcher.Add(item.Name)
 						if err != nil {

--- a/v2/internal/appng/app_dev.go
+++ b/v2/internal/appng/app_dev.go
@@ -68,6 +68,8 @@ func CreateApp(appoptions *options.App) (*App, error) {
 	myLogger.SetLogLevel(appoptions.LogLevel)
 
 	// Check for CLI Flags
+	devFlags := flag.NewFlagSet("dev", flag.ContinueOnError)
+
 	var assetdirFlag *string
 	var devServerFlag *string
 	var frontendDevServerURLFlag *string
@@ -75,25 +77,28 @@ func CreateApp(appoptions *options.App) (*App, error) {
 
 	assetdir := os.Getenv("assetdir")
 	if assetdir == "" {
-		assetdirFlag = flag.String("assetdir", "", "Directory to serve assets")
+		assetdirFlag = devFlags.String("assetdir", "", "Directory to serve assets")
 	}
+
 	devServer := os.Getenv("devserver")
 	if devServer == "" {
-		devServerFlag = flag.String("devserver", "", "Address to bind the wails dev server to")
+		devServerFlag = devFlags.String("devserver", "", "Address to bind the wails dev server to")
 	}
+
 	frontendDevServerURL := os.Getenv("frontenddevserverurl")
 	if frontendDevServerURL == "" {
-		frontendDevServerURLFlag = flag.String("frontenddevserverurl", "", "URL of the external frontend dev server")
+		frontendDevServerURLFlag = devFlags.String("frontenddevserverurl", "", "URL of the external frontend dev server")
 	}
 
 	loglevel := os.Getenv("loglevel")
 	if loglevel == "" {
-		loglevelFlag = flag.String("loglevel", "debug", "Loglevel to use - Trace, Debug, Info, Warning, Error")
+		loglevelFlag = devFlags.String("loglevel", "debug", "Loglevel to use - Trace, Debug, Info, Warning, Error")
 	}
 
 	// If we weren't given the assetdir in the environment variables
 	if assetdir == "" {
-		flag.Parse()
+		// Parse args but ignore errors in case -appargs was used to pass in args for the app.
+		_ = devFlags.Parse(os.Args[1:])
 		if assetdirFlag != nil {
 			assetdir = *assetdirFlag
 		}


### PR DESCRIPTION
Resolves #1533 

This change allows `-appargs` to pass flags to the binary when using `wails dev`.

This is needed because if you do not set "assetdir" in `wails.json` then the `App` created by `wails dev` tries to check the command line flags for `-assetdir` and a few more flags, and then fails when it finds the app specific flag being passed on the command line which is unknown to the flagset being used in the dev `CreateApp`.

The only way I could figure out to achieve this was to use a distinct FlagSet and set it to continue on error. I think this is ok as it only applies to running via `wails dev`, but wouldn't be too upset if someone has a better solution! :smile: 

There's a bonus typo fix in the help message for `-appargs` and gofmt fixes included for good measure too.