### PR TITLE
Add support for production log levels

### DIFF
--- a/v2/internal/appng/app_production.go
+++ b/v2/internal/appng/app_production.go
@@ -13,7 +13,6 @@ import (
 	"github.com/wailsapp/wails/v2/internal/frontend/runtime"
 	"github.com/wailsapp/wails/v2/internal/logger"
 	"github.com/wailsapp/wails/v2/internal/menumanager"
-	pkgLog "github.com/wailsapp/wails/v2/pkg/logger"
 	"github.com/wailsapp/wails/v2/pkg/options"
 )
 
@@ -61,11 +60,7 @@ func CreateApp(appoptions *options.App) (*App, error) {
 
 	// Set up logger
 	myLogger := logger.New(appoptions.Logger)
-	myLogger.SetLogLevel(appoptions.LogLevel)
-
-	if !IsDebug() {
-		myLogger.SetLogLevel(pkgLog.ERROR)
-	}
+	myLogger.SetLogLevel(appoptions.LogLevelProduction)
 	ctx = context.WithValue(ctx, "logger", myLogger)
 
 	// Preflight Checks

--- a/v2/pkg/options/default.go
+++ b/v2/pkg/options/default.go
@@ -7,10 +7,11 @@ import (
 
 // Default options for creating the App
 var Default = &App{
-	Width:    1024,
-	Height:   768,
-	Logger:   logger.NewDefaultLogger(),
-	LogLevel: logger.INFO,
+	Width:              1024,
+	Height:             768,
+	Logger:             logger.NewDefaultLogger(),
+	LogLevel:           logger.INFO,
+	LogLevelProduction: logger.ERROR,
 }
 
 var defaultMacMenu = menu.NewMenuFromItems(

--- a/v2/pkg/options/options.go
+++ b/v2/pkg/options/options.go
@@ -43,18 +43,19 @@ type App struct {
 	AlwaysOnTop       bool
 	BackgroundColour  *RGBA
 	// RGBA is deprecated. Please use BackgroundColour
-	RGBA             *RGBA
-	Assets           fs.FS
-	AssetsHandler    http.Handler
-	Menu             *menu.Menu
-	Logger           logger.Logger `json:"-"`
-	LogLevel         logger.LogLevel
-	OnStartup        func(ctx context.Context)                `json:"-"`
-	OnDomReady       func(ctx context.Context)                `json:"-"`
-	OnShutdown       func(ctx context.Context)                `json:"-"`
-	OnBeforeClose    func(ctx context.Context) (prevent bool) `json:"-"`
-	Bind             []interface{}
-	WindowStartState WindowStartState
+	RGBA               *RGBA
+	Assets             fs.FS
+	AssetsHandler      http.Handler
+	Menu               *menu.Menu
+	Logger             logger.Logger `json:"-"`
+	LogLevel           logger.LogLevel
+	LogLevelProduction logger.LogLevel
+	OnStartup          func(ctx context.Context)                `json:"-"`
+	OnDomReady         func(ctx context.Context)                `json:"-"`
+	OnShutdown         func(ctx context.Context)                `json:"-"`
+	OnBeforeClose      func(ctx context.Context) (prevent bool) `json:"-"`
+	Bind               []interface{}
+	WindowStartState   WindowStartState
 
 	//ContextMenus []*menu.ContextMenu
 	//TrayMenus    []*menu.TrayMenu

--- a/website/docs/reference/options.mdx
+++ b/website/docs/reference/options.mdx
@@ -15,30 +15,31 @@ import "github.com/wailsapp/wails/v2/pkg/options"
 func main() {
 
     err := wails.Run(&options.App{
-        Title:             "Menus Demo",
-        Width:             800,
-        Height:            600,
-        DisableResize:     false,
-        Fullscreen:        false,
-        Frameless:         true,
-        MinWidth:          400,
-        MinHeight:         400,
-        MaxWidth:          1280,
-        MaxHeight:         1024,
-        StartHidden:       false,
-        HideWindowOnClose: false,
-        BackgroundColour:  &options.RGBA{R: 0, G: 0, B: 0, A: 255},
-        AlwaysOnTop:       false,
-        Assets:            assets,
-        AssetsHandler:     assetsHandler,
-        Menu:              app.applicationMenu(),
-        Logger:            nil,
-        LogLevel:          logger.DEBUG,
-        OnStartup:         app.startup,
-        OnDomReady:        app.domready,
-        OnShutdown:        app.shutdown,
-        OnBeforeClose:     app.beforeClose,
-        WindowStartState:  options.Maximised,
+        Title:              "Menus Demo",
+        Width:              800,
+        Height:             600,
+        DisableResize:      false,
+        Fullscreen:         false,
+        Frameless:          true,
+        MinWidth:           400,
+        MinHeight:          400,
+        MaxWidth:           1280,
+        MaxHeight:          1024,
+        StartHidden:        false,
+        HideWindowOnClose:  false,
+        BackgroundColour:   &options.RGBA{R: 0, G: 0, B: 0, A: 255},
+        AlwaysOnTop:        false,
+        Assets:             assets,
+        AssetsHandler:      assetsHandler,
+        Menu:               app.applicationMenu(),
+        Logger:             nil,
+        LogLevel:           logger.DEBUG,
+        LogLevelProduction: logger.ERROR,
+        OnStartup:          app.startup,
+        OnDomReady:         app.domready,
+        OnShutdown:         app.shutdown,
+        OnBeforeClose:      app.beforeClose,
+        WindowStartState:   options.Maximised,
         Bind: []interface{}{
             app,
         },
@@ -285,6 +286,16 @@ Type: logger.LogLevel
 Default: `Info` in dev mode, `Error` in production mode
 
 The default log level. More details about logging in the [Log Reference](../reference/runtime/log.mdx).
+
+### LogLevelProduction
+
+Name: LogLevelProduction
+
+Type: logger.LogLevel
+
+Default: `Error`
+
+The default log level for production builds. More details about logging in the [Log Reference](../reference/runtime/log.mdx).
 
 ### OnStartup
 


### PR DESCRIPTION
Allows the developer to set the log level when running in production. Currently hardcoded to `ERROR`.