### PR TITLE
Fix OnBeforeClose code for Mac

### DIFF
--- a/v2/internal/frontend/desktop/darwin/frontend.go
+++ b/v2/internal/frontend/desktop/darwin/frontend.go
@@ -225,7 +225,12 @@ func (f *Frontend) WindowSetBackgroundColour(col *options.RGBA) {
 }
 
 func (f *Frontend) Quit() {
-	if f.frontendOptions.OnBeforeClose != nil && f.frontendOptions.OnBeforeClose(f.ctx) {
+	if f.frontendOptions.OnBeforeClose != nil {
+		go func() {
+			if !f.frontendOptions.OnBeforeClose(f.ctx) {
+				f.mainWindow.Quit()
+			}
+		}()
 		return
 	}
 	f.mainWindow.Quit()


### PR DESCRIPTION
There was a potential to lock the main thread in the `OnBeforeClose` method. This fixes that. 

Fixes #1552 