### PR TITLE
:memo: Fixed typo in documentation page docs/howdoesitwork

### DIFF
--- a/website/docs/howdoesitwork.mdx
+++ b/website/docs/howdoesitwork.mdx
@@ -207,7 +207,7 @@ This makes it incredibly simple to call Go code from the frontend, using the sam
 
 ### Overview
 
-The frontend is a collection of files rendered by webkit. It''s like a browser and webserver in one.
+The frontend is a collection of files rendered by webkit. It's like a browser and webserver in one.
 There is virtually[^1] no limit to which frameworks or libraries you can use. The main points of interaction between
 the frontend and your Go code are:
 
@@ -253,7 +253,7 @@ export function Greet(arg1:string):Promise<string>;
 ```
 
 The generated methods return a Promise. A successful call will result in the first return value from the Go call to be passed
-to the `resolve` handler. An unsuccessful call is when a Go method that has an error type as it''s second return value,
+to the `resolve` handler. An unsuccessful call is when a Go method that has an error type as it's second return value,
 passes an error instance back to the caller. This is passed back via the `reject` handler.
 In the example above, `Greet` only returns a `string` so the Javascript call will never reject - unless invalid data
 is passed to it.
@@ -268,12 +268,12 @@ Anonymous nested structs are not supported at this time.
 
 It is possible to send structs back to Go. Any Javascript map/class passed as an argument that
 is expecting a struct, will be converted to that struct type. To make this process a lot easier, in `dev` mode,
-a TypeScript module is generated, defining all the struct types used in bound methods. Using this module, it''s possible
+a TypeScript module is generated, defining all the struct types used in bound methods. Using this module, it's possible
 to construct and send native Javascript objects to the Go code.
 
 There is also support for Go methods that use structs in their signature. All Go structs
 specified by a bound method (either as parameters or return types) will have Typescript versions auto
-generated as part of the Go code wrapper module. Using these, it''s possible to share the same data
+generated as part of the Go code wrapper module. Using these, it's possible to share the same data
 model between Go and Javascript.
 
 Example: We update our `Greet` method to accept a `Person` instead of a string:


### PR DESCRIPTION
This fixed a small typo on the page https://wails.io/docs/howdoesitwork. For whatever reason, the word "it's" was spelled incorrectly to "it''s". 

This typo seems to have been introduced in: https://github.com/wailsapp/wails/commit/f21c9ba88031d0fbc2faaa4a4799566c757839f3



