### PR TITLE
Generalize manual compile steps [Documentation]

### DIFF
--- a/website/versioned_docs/version-v2.0.0-beta.40/guides/manual-builds.mdx
+++ b/website/versioned_docs/version-v2.0.0-beta.40/guides/manual-builds.mdx
@@ -84,7 +84,7 @@ This step could be done from the command line or a script with `npm run build` o
 #### Manual steps
 
 - For dev build, the minimum command would be: `go build -tags dev -gcflags "all=-N -l"`
-- For production build, the minimum command would be: `go build -tags desktop,production -ldflags "-w -s -H windowsgui"`
+- For production build, the minimum command would be: `go build -tags desktop,production -ldflags "-w -s"`. Add `-H windowsgui` to `ldflags` on Windows
 - Ensure that you compile in the same directory as the `.syso` file
 
 ### Compress application


### PR DESCRIPTION
`go build -tags desktop,production -ldflags "-w -s -H windowsgui"` returns an error on MacOS/Linux.
It is referenced in Wails CLI that manually only `-w -s` are passed by default.