### PR TITLE
Feature/add support for server and hybrid

### DIFF
--- a/v2/cmd/wails/internal/commands/build/build.go
+++ b/v2/cmd/wails/internal/commands/build/build.go
@@ -146,6 +146,13 @@ func AddBuildSubcommand(app *clir.Cli, w io.Writer) {
 			}
 		}
 
+		// Validate experimental
+		if slicer.String([]string{"hybrid", "server"}).Contains(outputType) {
+			if !slicer.String(userTags).Contains("exp") {
+				return fmt.Errorf("output type '%s' requires the '-tags exp'", outputType)
+			}
+		}
+
 		// Webview2 installer strategy (download by default)
 		wv2rtstrategy := ""
 		webview2 = strings.ToLower(webview2)

--- a/v2/cmd/wails/internal/commands/build/build.go
+++ b/v2/cmd/wails/internal/commands/build/build.go
@@ -1,0 +1,432 @@
+package build
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"text/tabwriter"
+	"time"
+
+	"github.com/wailsapp/wails/v2/internal/colour"
+	"github.com/wailsapp/wails/v2/internal/project"
+	"github.com/wailsapp/wails/v2/internal/system"
+
+	"github.com/wailsapp/wails/v2/cmd/wails/internal"
+	"github.com/wailsapp/wails/v2/internal/gomod"
+
+	"github.com/leaanthony/clir"
+	"github.com/leaanthony/slicer"
+	"github.com/wailsapp/wails/v2/pkg/clilogger"
+	"github.com/wailsapp/wails/v2/pkg/commands/build"
+)
+
+// AddBuildSubcommand adds the `build` command for the Wails application
+func AddBuildSubcommand(app *clir.Cli, w io.Writer) {
+	command := app.NewSubCommand("build", "Builds the application")
+
+	outputType := "desktop"
+	validTargetTypes := slicer.String([]string{"desktop", "hybrid", "server"})
+
+	command.StringFlag("outputType", fmt.Sprintf("Type of binary %s", validTargetTypes.AsSlice()), &outputType)
+
+	// Setup noPackage flag
+	noPackage := false
+	command.BoolFlag("noPackage", "Skips platform specific packaging", &noPackage)
+
+	compilerCommand := "go"
+	command.StringFlag("compiler", "Use a different go compiler to build, eg go1.15beta1", &compilerCommand)
+
+	skipModTidy := false
+	command.BoolFlag("m", "Skip mod tidy before compile", &skipModTidy)
+
+	compress := false
+	command.BoolFlag("upx", "Compress final binary with UPX (if installed)", &compress)
+
+	compressFlags := ""
+	command.StringFlag("upxflags", "Flags to pass to upx", &compressFlags)
+
+	defaultPlatform := os.Getenv("GOOS")
+	if defaultPlatform == "" {
+		defaultPlatform = runtime.GOOS
+	}
+	defaultArch := os.Getenv("GOARCH")
+	if defaultArch == "" {
+		if system.IsAppleSilicon {
+			defaultArch = "arm64"
+		} else {
+			defaultArch = runtime.GOARCH
+		}
+	}
+	platform := defaultPlatform + "/" + defaultArch
+
+	command.StringFlag("platform", "Platform to target. Comma separate multiple platforms", &platform)
+
+	// Verbosity
+	verbosity := 1
+	command.IntFlag("v", "Verbosity level (0 - silent, 1 - default, 2 - verbose)", &verbosity)
+
+	// ldflags to pass to `go`
+	ldflags := ""
+	command.StringFlag("ldflags", "optional ldflags", &ldflags)
+
+	// tags to pass to `go`
+	tags := ""
+	command.StringFlag("tags", "tags to pass to Go compiler (quoted and space separated)", &tags)
+
+	outputFilename := ""
+	command.StringFlag("o", "Output filename", &outputFilename)
+
+	// Clean build directory
+	cleanBuildDirectory := false
+	command.BoolFlag("clean", "Clean the build directory before building", &cleanBuildDirectory)
+
+	webview2 := "download"
+	command.StringFlag("webview2", "WebView2 installer strategy: download,embed,browser,error.", &webview2)
+
+	skipFrontend := false
+	command.BoolFlag("s", "Skips building the frontend", &skipFrontend)
+
+	forceBuild := false
+	command.BoolFlag("f", "Force build application", &forceBuild)
+
+	updateGoMod := false
+	command.BoolFlag("u", "Updates go.mod to use the same Wails version as the CLI", &updateGoMod)
+
+	debug := false
+	command.BoolFlag("debug", "Retains debug data in the compiled application", &debug)
+
+	nsis := false
+	command.BoolFlag("nsis", "Generate NSIS installer for Windows", &nsis)
+
+	trimpath := false
+	command.BoolFlag("trimpath", "Remove all file system paths from the resulting executable", &trimpath)
+
+	raceDetector := false
+	command.BoolFlag("race", "Build with Go's race detector", &raceDetector)
+
+	windowsConsole := false
+	command.BoolFlag("windowsconsole", "Keep the console when building for Windows", &windowsConsole)
+
+	dryRun := false
+	command.BoolFlag("dryrun", "Dry run, prints the config for the command that would be executed", &dryRun)
+
+	command.Action(func() error {
+
+		quiet := verbosity == 0
+
+		// Create logger
+		logger := clilogger.New(w)
+		logger.Mute(quiet)
+
+		// Validate output type
+		if !validTargetTypes.Contains(outputType) {
+			return fmt.Errorf("output type '%s' is not valid", outputType)
+		}
+
+		if !quiet {
+			app.PrintBanner()
+		}
+
+		// Lookup compiler path
+		compilerPath, err := exec.LookPath(compilerCommand)
+		if err != nil {
+			return fmt.Errorf("unable to find compiler: %s", compilerCommand)
+		}
+
+		// Tags
+		userTags := []string{}
+		for _, tag := range strings.Split(tags, " ") {
+			thisTag := strings.TrimSpace(tag)
+			if thisTag != "" {
+				userTags = append(userTags, thisTag)
+			}
+		}
+
+		// Webview2 installer strategy (download by default)
+		wv2rtstrategy := ""
+		webview2 = strings.ToLower(webview2)
+		if webview2 != "" {
+			validWV2Runtime := slicer.String([]string{"download", "embed", "browser", "error"})
+			if !validWV2Runtime.Contains(webview2) {
+				return fmt.Errorf("invalid option for flag 'webview2': %s", webview2)
+			}
+			// These are the build tags associated with the strategies
+			switch webview2 {
+			case "embed":
+				wv2rtstrategy = "wv2runtime.embed"
+			case "error":
+				wv2rtstrategy = "wv2runtime.error"
+			case "browser":
+				wv2rtstrategy = "wv2runtime.browser"
+			}
+		}
+
+		mode := build.Production
+		modeString := "Production"
+		if debug {
+			mode = build.Debug
+			modeString = "Debug"
+		}
+
+		var targets slicer.StringSlicer
+		targets.AddSlice(strings.Split(platform, ","))
+		targets.Deduplicate()
+
+		// Create BuildOptions
+		buildOptions := &build.Options{
+			Logger:              logger,
+			OutputType:          outputType,
+			OutputFile:          outputFilename,
+			CleanBuildDirectory: cleanBuildDirectory,
+			Mode:                mode,
+			Pack:                !noPackage,
+			LDFlags:             ldflags,
+			Compiler:            compilerCommand,
+			SkipModTidy:         skipModTidy,
+			Verbosity:           verbosity,
+			ForceBuild:          forceBuild,
+			IgnoreFrontend:      skipFrontend,
+			Compress:            compress,
+			CompressFlags:       compressFlags,
+			UserTags:            userTags,
+			WebView2Strategy:    wv2rtstrategy,
+			TrimPath:            trimpath,
+			RaceDetector:        raceDetector,
+			WindowsConsole:      windowsConsole,
+		}
+
+		// Start a new tabwriter
+		if !quiet {
+			w := new(tabwriter.Writer)
+			w.Init(os.Stdout, 8, 8, 0, '\t', 0)
+
+			// Write out the system information
+			_, _ = fmt.Fprintf(w, "App Type: \t%s\n", buildOptions.OutputType)
+			_, _ = fmt.Fprintf(w, "Platforms: \t%s\n", platform)
+			_, _ = fmt.Fprintf(w, "Compiler: \t%s\n", compilerPath)
+			_, _ = fmt.Fprintf(w, "Build Mode: \t%s\n", modeString)
+			_, _ = fmt.Fprintf(w, "Skip Frontend: \t%t\n", skipFrontend)
+			_, _ = fmt.Fprintf(w, "Compress: \t%t\n", buildOptions.Compress)
+			_, _ = fmt.Fprintf(w, "Package: \t%t\n", buildOptions.Pack)
+			_, _ = fmt.Fprintf(w, "Clean Build Dir: \t%t\n", buildOptions.CleanBuildDirectory)
+			_, _ = fmt.Fprintf(w, "LDFlags: \t\"%s\"\n", buildOptions.LDFlags)
+			_, _ = fmt.Fprintf(w, "Tags: \t[%s]\n", strings.Join(buildOptions.UserTags, ","))
+			_, _ = fmt.Fprintf(w, "Race Detector: \t%t\n", buildOptions.RaceDetector)
+			if len(buildOptions.OutputFile) > 0 && targets.Length() == 1 {
+				_, _ = fmt.Fprintf(w, "Output File: \t%s\n", buildOptions.OutputFile)
+			}
+			_, _ = fmt.Fprintf(w, "\n")
+			err = w.Flush()
+			if err != nil {
+				return err
+			}
+		}
+		err = checkGoModVersion(logger, updateGoMod)
+		if err != nil {
+			return err
+		}
+
+		cwd, err := os.Getwd()
+		if err != nil {
+			return err
+		}
+		projectOptions, err := project.Load(cwd)
+		if err != nil {
+			return err
+		}
+
+		// Check platform
+		validPlatformArch := slicer.String([]string{
+			"darwin",
+			"darwin/amd64",
+			"darwin/arm64",
+			"darwin/universal",
+			"linux",
+			"linux/amd64",
+			"linux/arm64",
+			"linux/arm",
+			"windows",
+			"windows/amd64",
+			"windows/arm64",
+			"windows/386",
+		})
+
+		outputBinaries := map[string]string{}
+
+		// Allows cancelling the build after the first error. It would be nice if targets.Each would support funcs
+		// returning an error.
+		var targetErr error
+		targets.Each(func(platform string) {
+			if targetErr != nil {
+				return
+			}
+
+			if !validPlatformArch.Contains(platform) {
+				buildOptions.Logger.Println("platform '%s' is not supported - skipping. Supported platforms: %s", platform, validPlatformArch.Join(","))
+				return
+			}
+
+			desiredFilename := projectOptions.OutputFilename
+			if desiredFilename == "" {
+				desiredFilename = projectOptions.Name
+			}
+			desiredFilename = strings.TrimSuffix(desiredFilename, ".exe")
+
+			// Calculate platform and arch
+			platformSplit := strings.Split(platform, "/")
+			buildOptions.Platform = platformSplit[0]
+			buildOptions.Arch = defaultArch
+			if len(platformSplit) > 1 {
+				buildOptions.Arch = platformSplit[1]
+			}
+			banner := "Building target: " + buildOptions.Platform + "/" + buildOptions.Arch
+			logger.Println(banner)
+			logger.Println(strings.Repeat("-", len(banner)))
+
+			if compress && platform == "darwin/universal" {
+				logger.Println("Warning: compress flag unsupported for universal binaries. Ignoring.")
+				compress = false
+			}
+
+			switch buildOptions.Platform {
+			case "linux":
+				if runtime.GOOS != "linux" {
+					logger.Println("Crosscompiling to Linux not currently supported.\n")
+					return
+				}
+			case "darwin":
+				if runtime.GOOS != "darwin" {
+					logger.Println("Crosscompiling to Mac not currently supported.\n")
+					return
+				}
+				macTargets := targets.Filter(func(platform string) bool {
+					return strings.HasPrefix(platform, "darwin")
+				})
+				if macTargets.Length() == 2 {
+					buildOptions.BundleName = fmt.Sprintf("%s-%s.app", desiredFilename, buildOptions.Arch)
+				}
+			}
+
+			if targets.Length() > 1 {
+				// target filename
+				switch buildOptions.Platform {
+				case "windows":
+					desiredFilename = fmt.Sprintf("%s-%s", desiredFilename, buildOptions.Arch)
+				case "linux", "darwin":
+					desiredFilename = fmt.Sprintf("%s-%s-%s", desiredFilename, buildOptions.Platform, buildOptions.Arch)
+				}
+			}
+			if buildOptions.Platform == "windows" {
+				desiredFilename += ".exe"
+			}
+			buildOptions.OutputFile = desiredFilename
+
+			if outputFilename != "" {
+				buildOptions.OutputFile = outputFilename
+			}
+
+			if !dryRun {
+				// Start Time
+				start := time.Now()
+
+				compiledBinary, err := build.Build(buildOptions)
+				if err != nil {
+					logger.Println("Error: %s", err.Error())
+					targetErr = err
+					return
+				}
+
+				buildOptions.IgnoreFrontend = true
+				buildOptions.CleanBuildDirectory = false
+
+				// Output stats
+				buildOptions.Logger.Println(fmt.Sprintf("Built '%s' in %s.\n", compiledBinary, time.Since(start).Round(time.Millisecond).String()))
+
+				outputBinaries[buildOptions.Platform+"/"+buildOptions.Arch] = compiledBinary
+			} else {
+				logger.Println("Dry run: skipped build.")
+			}
+		})
+
+		if targetErr != nil {
+			return targetErr
+		}
+
+		if dryRun {
+			return nil
+		}
+
+		if nsis {
+			amd64Binary := outputBinaries["windows/amd64"]
+			arm64Binary := outputBinaries["windows/arm64"]
+			if amd64Binary == "" && arm64Binary == "" {
+				return fmt.Errorf("cannot build nsis installer - no windows targets")
+			}
+
+			if err := build.GenerateNSISInstaller(buildOptions, amd64Binary, arm64Binary); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+}
+
+func checkGoModVersion(logger *clilogger.CLILogger, updateGoMod bool) error {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return err
+	}
+	gomodFilename := filepath.Join(cwd, "go.mod")
+	gomodData, err := os.ReadFile(gomodFilename)
+	if err != nil {
+		return err
+	}
+	outOfSync, err := gomod.GoModOutOfSync(gomodData, internal.Version)
+	if err != nil {
+		return err
+	}
+	if !outOfSync {
+		return nil
+	}
+	gomodversion, err := gomod.GetWailsVersionFromModFile(gomodData)
+	if err != nil {
+		return err
+	}
+
+	if updateGoMod {
+		return syncGoModVersion(cwd)
+	}
+
+	logger.Println("Warning: go.mod is using Wails '%s' but the CLI is '%s'. Consider updating your project's `go.mod` file.\n", gomodversion.String(), internal.Version)
+	return nil
+}
+
+func LogGreen(message string, args ...interface{}) {
+	text := fmt.Sprintf(message, args...)
+	println(colour.Green(text))
+}
+
+func syncGoModVersion(cwd string) error {
+	gomodFilename := filepath.Join(cwd, "go.mod")
+	gomodData, err := os.ReadFile(gomodFilename)
+	if err != nil {
+		return err
+	}
+	outOfSync, err := gomod.GoModOutOfSync(gomodData, internal.Version)
+	if err != nil {
+		return err
+	}
+	if !outOfSync {
+		return nil
+	}
+	LogGreen("Updating go.mod to use Wails '%s'", internal.Version)
+	newGoData, err := gomod.UpdateGoModVersion(gomodData, internal.Version)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(gomodFilename, newGoData, 0755)
+}

--- a/v2/internal/app/app_dev.go
+++ b/v2/internal/app/app_dev.go
@@ -1,4 +1,4 @@
-//go:build dev
+//go:build dev && desktop
 
 package app
 

--- a/v2/internal/app/app_hybrid_server.go
+++ b/v2/internal/app/app_hybrid_server.go
@@ -1,5 +1,5 @@
-//go:build hybrid || server
-// +build hybrid server
+//go:build (exp && hybrid) || (exp && server)
+// +build exp,hybrid exp,server
 
 package app
 

--- a/v2/internal/app/app_hybrid_server.go
+++ b/v2/internal/app/app_hybrid_server.go
@@ -1,0 +1,209 @@
+//go:build hybrid || server
+// +build hybrid server
+
+package app
+
+import (
+	"context"
+	"embed"
+	"fmt"
+	iofs "io/fs"
+	"os"
+	"path/filepath"
+
+	"github.com/wailsapp/wails/v2/internal/binding"
+	"github.com/wailsapp/wails/v2/internal/frontend"
+	"github.com/wailsapp/wails/v2/internal/frontend/desktop"
+	"github.com/wailsapp/wails/v2/internal/frontend/devserver"
+	"github.com/wailsapp/wails/v2/internal/frontend/dispatcher"
+	"github.com/wailsapp/wails/v2/internal/frontend/hybrid"
+	"github.com/wailsapp/wails/v2/internal/frontend/runtime"
+	"github.com/wailsapp/wails/v2/internal/fs"
+	"github.com/wailsapp/wails/v2/internal/logger"
+	"github.com/wailsapp/wails/v2/internal/menumanager"
+	"github.com/wailsapp/wails/v2/internal/project"
+	"github.com/wailsapp/wails/v2/pkg/options"
+)
+
+// App defines a Wails application structure
+type App struct {
+	frontend frontend.Frontend
+	logger   *logger.Logger
+	options  *options.App
+
+	menuManager *menumanager.Manager
+
+	// Indicates if the app is in debug mode
+	debug bool
+
+	// OnStartup/OnShutdown
+	startupCallback  func(ctx context.Context)
+	shutdownCallback func(ctx context.Context)
+	ctx              context.Context
+}
+
+func (a *App) Run() error {
+	err := a.frontend.Run(a.ctx)
+	if a.shutdownCallback != nil {
+		a.shutdownCallback(a.ctx)
+	}
+	return err
+}
+
+func (a *App) Shutdown() {
+	if a.shutdownCallback != nil {
+		a.shutdownCallback(a.ctx)
+	}
+	a.frontend.Quit()
+}
+
+// CreateApp creates the app!
+func CreateApp(appoptions *options.App) (*App, error) {
+	// Set up logger
+	myLogger := logger.New(appoptions.Logger)
+	myLogger.SetLogLevel(appoptions.LogLevel)
+
+	// If no assetdir has been defined, let's try to infer it from the project root and the asset FS.
+	assetdir, err := tryInferAssetDirFromFS(appoptions.Assets)
+	if err != nil {
+		return nil, err
+	}
+
+	host := "localhost"
+	port := int32(3112)
+	if appoptions.Server != nil {
+		host = appoptions.Server.Host
+		port = appoptions.Server.Port
+	}
+
+	serverURI := fmt.Sprintf("%s:%d", host, port)
+	ctx := context.Background()
+	ctx = context.WithValue(ctx, "starturl", serverURI)
+
+	// This is to enable a backend server
+	//	ctx = context.WithValue(ctx, "frontenddevserverurl", serverURI)
+
+	myLogger.Info("Frontend available at '%s'", serverURI)
+
+	// configure devserver
+	ctx = context.WithValue(ctx, "devserver", fmt.Sprintf("%s:%d", host, port))
+
+	// Let's override the assets to serve from on disk, if needed
+	absdir, err := filepath.Abs(assetdir)
+	if err != nil {
+		return nil, err
+	}
+
+	myLogger.Info("Serving assets from disk: %s", absdir)
+	appoptions.Assets = os.DirFS(absdir)
+
+	ctx = context.WithValue(ctx, "assetdir", assetdir)
+
+	// Attach logger to context
+	ctx = context.WithValue(ctx, "logger", myLogger)
+	ctx = context.WithValue(ctx, "buildtype", "hybrid")
+
+	// Preflight checks
+	err = PreflightChecks(appoptions, myLogger)
+	if err != nil {
+		return nil, err
+	}
+
+	// Merge default options
+
+	options.MergeDefaults(appoptions)
+
+	var menuManager *menumanager.Manager
+
+	// Process the application menu
+	if appoptions.Menu != nil {
+		// Create the menu manager
+		menuManager = menumanager.NewManager()
+		err = menuManager.SetApplicationMenu(appoptions.Menu)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// Create binding exemptions - Ugly hack. There must be a better way
+	bindingExemptions := []interface{}{appoptions.OnStartup, appoptions.OnShutdown, appoptions.OnDomReady}
+	appBindings := binding.NewBindings(myLogger, appoptions.Bind, bindingExemptions)
+
+	err = generateBindings(appBindings)
+	if err != nil {
+		return nil, err
+	}
+	eventHandler := runtime.NewEvents(myLogger)
+	ctx = context.WithValue(ctx, "events", eventHandler)
+	messageDispatcher := dispatcher.NewDispatcher(ctx, myLogger, appBindings, eventHandler)
+	appFrontend := hybrid.NewFrontend(ctx, appoptions, myLogger, appBindings, messageDispatcher)
+	eventHandler.AddFrontend(appFrontend)
+
+	result := &App{
+		ctx:              ctx,
+		frontend:         appFrontend,
+		logger:           myLogger,
+		menuManager:      menuManager,
+		startupCallback:  appoptions.OnStartup,
+		shutdownCallback: appoptions.OnShutdown,
+	}
+
+	result.options = appoptions
+
+	return result, nil
+
+}
+
+func generateBindings(bindings *binding.Bindings) error {
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		return err
+	}
+	projectConfig, err := project.Load(cwd)
+	if err != nil {
+		return err
+	}
+
+	targetDir := filepath.Join(projectConfig.WailsJSDir, "wailsjs", "go")
+	err = os.RemoveAll(targetDir)
+	if err != nil {
+		return err
+	}
+	_ = fs.MkDirs(targetDir)
+
+	err = bindings.GenerateGoBindings(targetDir)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func tryInferAssetDirFromFS(assets iofs.FS) (string, error) {
+	if _, isEmbedFs := assets.(embed.FS); !isEmbedFs {
+		// We only infer the assetdir for embed.FS assets
+		return "", nil
+	}
+
+	path, err := fs.FindPathToFile(assets, "index.html")
+	if err != nil {
+		return "", err
+	}
+
+	path, err = filepath.Abs(path)
+	if err != nil {
+		return "", err
+	}
+
+	if _, err := os.Stat(filepath.Join(path, "index.html")); err != nil {
+		if os.IsNotExist(err) {
+			err = fmt.Errorf(
+				"inferred assetdir '%s' does not exist or does not contain an 'index.html' file, "+
+					"please specify it with -assetdir or set it in wails.json",
+				path)
+		}
+		return "", err
+	}
+
+	return path, nil
+}

--- a/v2/internal/app/app_hybrid_server.go
+++ b/v2/internal/app/app_hybrid_server.go
@@ -5,12 +5,7 @@ package app
 
 import (
 	"context"
-	"embed"
 	"fmt"
-	iofs "io/fs"
-	"os"
-	"path/filepath"
-
 	"github.com/wailsapp/wails/v2/internal/binding"
 	"github.com/wailsapp/wails/v2/internal/frontend"
 	"github.com/wailsapp/wails/v2/internal/frontend/desktop"
@@ -18,10 +13,8 @@ import (
 	"github.com/wailsapp/wails/v2/internal/frontend/dispatcher"
 	"github.com/wailsapp/wails/v2/internal/frontend/hybrid"
 	"github.com/wailsapp/wails/v2/internal/frontend/runtime"
-	"github.com/wailsapp/wails/v2/internal/fs"
 	"github.com/wailsapp/wails/v2/internal/logger"
 	"github.com/wailsapp/wails/v2/internal/menumanager"
-	"github.com/wailsapp/wails/v2/internal/project"
 	"github.com/wailsapp/wails/v2/pkg/options"
 )
 
@@ -42,6 +35,10 @@ type App struct {
 	ctx              context.Context
 }
 
+func (a *App) Shutdown() {
+	a.frontend.Quit()
+}
+
 func (a *App) Run() error {
 	err := a.frontend.Run(a.ctx)
 	if a.shutdownCallback != nil {
@@ -50,75 +47,49 @@ func (a *App) Run() error {
 	return err
 }
 
-func (a *App) Shutdown() {
-	if a.shutdownCallback != nil {
-		a.shutdownCallback(a.ctx)
-	}
-	a.frontend.Quit()
-}
-
 // CreateApp creates the app!
 func CreateApp(appoptions *options.App) (*App, error) {
-	// Set up logger
-	myLogger := logger.New(appoptions.Logger)
-	myLogger.SetLogLevel(appoptions.LogLevel)
+	var err error
 
-	// If no assetdir has been defined, let's try to infer it from the project root and the asset FS.
-	assetdir, err := tryInferAssetDirFromFS(appoptions.Assets)
-	if err != nil {
-		return nil, err
-	}
+	ctx := context.Background()
 
-	host := "localhost"
-	port := int32(3112)
+	host, port := "localhost", int32(3112)
 	if appoptions.Server != nil {
 		host = appoptions.Server.Host
 		port = appoptions.Server.Port
 	}
 
 	serverURI := fmt.Sprintf("%s:%d", host, port)
-	ctx := context.Background()
 	ctx = context.WithValue(ctx, "starturl", serverURI)
-
-	// This is to enable a backend server
-	//	ctx = context.WithValue(ctx, "frontenddevserverurl", serverURI)
-
-	myLogger.Info("Frontend available at '%s'", serverURI)
-
-	// configure devserver
 	ctx = context.WithValue(ctx, "devserver", fmt.Sprintf("%s:%d", host, port))
 
-	// Let's override the assets to serve from on disk, if needed
-	absdir, err := filepath.Abs(assetdir)
-	if err != nil {
-		return nil, err
+	// Merge default options
+	options.MergeDefaults(appoptions)
+
+	debug := IsDebug()
+	ctx = context.WithValue(ctx, "debug", debug)
+
+	// Set up logger
+	myLogger := logger.New(appoptions.Logger)
+	myLogger.Info("Frontend available at 'http://%s'", serverURI)
+	if IsDebug() {
+		myLogger.SetLogLevel(appoptions.LogLevel)
+	} else {
+		myLogger.SetLogLevel(appoptions.LogLevelProduction)
 	}
-
-	myLogger.Info("Serving assets from disk: %s", absdir)
-	appoptions.Assets = os.DirFS(absdir)
-
-	ctx = context.WithValue(ctx, "assetdir", assetdir)
-
-	// Attach logger to context
 	ctx = context.WithValue(ctx, "logger", myLogger)
-	ctx = context.WithValue(ctx, "buildtype", "hybrid")
 
-	// Preflight checks
+	// Preflight Checks
 	err = PreflightChecks(appoptions, myLogger)
 	if err != nil {
 		return nil, err
 	}
 
-	// Merge default options
-
-	options.MergeDefaults(appoptions)
-
-	var menuManager *menumanager.Manager
+	// Create the menu manager
+	menuManager := menumanager.NewManager()
 
 	// Process the application menu
 	if appoptions.Menu != nil {
-		// Create the menu manager
-		menuManager = menumanager.NewManager()
 		err = menuManager.SetApplicationMenu(appoptions.Menu)
 		if err != nil {
 			return nil, err
@@ -128,13 +99,15 @@ func CreateApp(appoptions *options.App) (*App, error) {
 	// Create binding exemptions - Ugly hack. There must be a better way
 	bindingExemptions := []interface{}{appoptions.OnStartup, appoptions.OnShutdown, appoptions.OnDomReady}
 	appBindings := binding.NewBindings(myLogger, appoptions.Bind, bindingExemptions)
-
-	err = generateBindings(appBindings)
-	if err != nil {
-		return nil, err
-	}
 	eventHandler := runtime.NewEvents(myLogger)
 	ctx = context.WithValue(ctx, "events", eventHandler)
+	// Attach logger to context
+	if debug {
+		ctx = context.WithValue(ctx, "buildtype", "debug")
+	} else {
+		ctx = context.WithValue(ctx, "buildtype", "production")
+	}
+
 	messageDispatcher := dispatcher.NewDispatcher(ctx, myLogger, appBindings, eventHandler)
 	appFrontend := hybrid.NewFrontend(ctx, appoptions, myLogger, appBindings, messageDispatcher)
 	eventHandler.AddFrontend(appFrontend)
@@ -146,64 +119,10 @@ func CreateApp(appoptions *options.App) (*App, error) {
 		menuManager:      menuManager,
 		startupCallback:  appoptions.OnStartup,
 		shutdownCallback: appoptions.OnShutdown,
+		debug:            debug,
+		options:          appoptions,
 	}
-
-	result.options = appoptions
 
 	return result, nil
 
-}
-
-func generateBindings(bindings *binding.Bindings) error {
-
-	cwd, err := os.Getwd()
-	if err != nil {
-		return err
-	}
-	projectConfig, err := project.Load(cwd)
-	if err != nil {
-		return err
-	}
-
-	targetDir := filepath.Join(projectConfig.WailsJSDir, "wailsjs", "go")
-	err = os.RemoveAll(targetDir)
-	if err != nil {
-		return err
-	}
-	_ = fs.MkDirs(targetDir)
-
-	err = bindings.GenerateGoBindings(targetDir)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-func tryInferAssetDirFromFS(assets iofs.FS) (string, error) {
-	if _, isEmbedFs := assets.(embed.FS); !isEmbedFs {
-		// We only infer the assetdir for embed.FS assets
-		return "", nil
-	}
-
-	path, err := fs.FindPathToFile(assets, "index.html")
-	if err != nil {
-		return "", err
-	}
-
-	path, err = filepath.Abs(path)
-	if err != nil {
-		return "", err
-	}
-
-	if _, err := os.Stat(filepath.Join(path, "index.html")); err != nil {
-		if os.IsNotExist(err) {
-			err = fmt.Errorf(
-				"inferred assetdir '%s' does not exist or does not contain an 'index.html' file, "+
-					"please specify it with -assetdir or set it in wails.json",
-				path)
-		}
-		return "", err
-	}
-
-	return path, nil
 }

--- a/v2/internal/app/app_production.go
+++ b/v2/internal/app/app_production.go
@@ -1,4 +1,4 @@
-//go:build production
+//go:build production && desktop
 
 package app
 

--- a/v2/internal/frontend/desktop/null/browser.go
+++ b/v2/internal/frontend/desktop/null/browser.go
@@ -1,0 +1,5 @@
+package null
+
+// BrowserOpenURL does nothing
+func (f *Frontend) BrowserOpenURL(url string) {
+}

--- a/v2/internal/frontend/desktop/null/dialog.go
+++ b/v2/internal/frontend/desktop/null/dialog.go
@@ -1,0 +1,28 @@
+package null
+
+import "github.com/wailsapp/wails/v2/internal/frontend"
+
+// OpenFileDialog does nothing
+func (f *Frontend) OpenFileDialog(dialogOptions frontend.OpenDialogOptions) (result string, err error) {
+	return "", nil
+}
+
+// OpenMultipleFilesDialog does nothing
+func (f *Frontend) OpenMultipleFilesDialog(dialogOptions frontend.OpenDialogOptions) ([]string, error) {
+	return []string{}, nil
+}
+
+// OpenDirectoryDialog does nothing
+func (f *Frontend) OpenDirectoryDialog(dialogOptions frontend.OpenDialogOptions) (string, error) {
+	return "", nil
+}
+
+// SaveFileDialog does nothing
+func (f *Frontend) SaveFileDialog(dialogOptions frontend.SaveDialogOptions) (string, error) {
+	return "", nil
+}
+
+// MessageDialog does nothing
+func (f *Frontend) MessageDialog(dialogOptions frontend.MessageDialogOptions) (string, error) {
+	return "", nil
+}

--- a/v2/internal/frontend/desktop/null/frontend.go
+++ b/v2/internal/frontend/desktop/null/frontend.go
@@ -11,14 +11,17 @@ import (
 // Frontend implements an empty Frontend that simply waits until the context is done.
 type Frontend struct {
 	// Context
-	ctx  context.Context
+	ctx             context.Context
+	frontendOptions *options.App
+
 	done bool
 }
 
 // NewFrontend returns an initialized Frontend
-func NewFrontend(ctx context.Context) *Frontend {
+func NewFrontend(ctx context.Context, appoptions *options.App) *Frontend {
 	return &Frontend{
-		ctx: ctx,
+		frontendOptions: appoptions,
+		ctx:             ctx,
 	}
 }
 
@@ -73,19 +76,25 @@ func (f *Frontend) WindowSetDarkTheme() {
 }
 
 // Run waits until the context is done and then exits
-func (f *Frontend) Run(ctx context.Context) error {
+func (f *Frontend) Run(ctx context.Context) (err error) {
+	err = nil
+	go func() {
+		if f.frontendOptions.OnStartup != nil {
+			f.frontendOptions.OnStartup(f.ctx)
+		}
+	}()
 	for {
 		select {
 		case <-ctx.Done():
-			break
+			return
 		default:
 			time.Sleep(1 * time.Millisecond)
 		}
 		if f.done {
-			break
+			return
 		}
 	}
-	return nil
+
 }
 
 // WindowCenter does nothing

--- a/v2/internal/frontend/desktop/null/frontend.go
+++ b/v2/internal/frontend/desktop/null/frontend.go
@@ -1,0 +1,202 @@
+package null
+
+import (
+	"context"
+	"time"
+
+	"github.com/wailsapp/wails/v2/internal/frontend"
+	"github.com/wailsapp/wails/v2/pkg/options"
+)
+
+// Frontend implements an empty Frontend that simply waits until the context is done.
+type Frontend struct {
+	// Context
+	ctx  context.Context
+	done bool
+}
+
+// NewFrontend returns an initialized Frontend
+func NewFrontend(ctx context.Context) *Frontend {
+	return &Frontend{
+		ctx: ctx,
+	}
+}
+
+// Show does nothing
+func (f *Frontend) Show() {
+
+}
+
+// Hide does nothing
+func (f *Frontend) Hide() {
+
+}
+
+// ScreenGetAll returns an empty slice
+func (f *Frontend) ScreenGetAll() ([]frontend.Screen, error) {
+	return []frontend.Screen{}, nil
+}
+
+// WindowSetBackgroundColour does nothing
+func (f *Frontend) WindowSetBackgroundColour(col *options.RGBA) {
+
+}
+
+// WindowReload does nothing
+func (f *Frontend) WindowReload() {
+
+}
+
+// WindowReloadApp does nothing
+func (f *Frontend) WindowReloadApp() {
+
+}
+
+// WindowSetAlwaysOnTop does nothing
+func (f *Frontend) WindowSetAlwaysOnTop(b bool) {
+
+}
+
+// WindowSetSystemDefaultTheme does nothing
+func (f *Frontend) WindowSetSystemDefaultTheme() {
+
+}
+
+// WindowSetLightTheme does nothing
+func (f *Frontend) WindowSetLightTheme() {
+
+}
+
+// WindowSetDarkTheme does nothing
+func (f *Frontend) WindowSetDarkTheme() {
+
+}
+
+// Run waits until the context is done and then exits
+func (f *Frontend) Run(ctx context.Context) error {
+	for {
+		select {
+		case <-ctx.Done():
+			break
+		default:
+			time.Sleep(1 * time.Millisecond)
+		}
+		if f.done {
+			break
+		}
+	}
+	return nil
+}
+
+// WindowCenter does nothing
+func (f *Frontend) WindowCenter() {
+
+}
+
+// WindowSetPosition does nothing
+func (f *Frontend) WindowSetPosition(x, y int) {
+
+}
+
+// WindowGetPosition does nothing
+func (f *Frontend) WindowGetPosition() (int, int) {
+	return 0, 0
+}
+
+// WindowSetSize does nothing
+func (f *Frontend) WindowSetSize(width, height int) {
+
+}
+
+// WindowGetSize does nothing
+func (f *Frontend) WindowGetSize() (int, int) {
+	return 0, 0
+}
+
+// WindowSetTitle does nothing
+func (f *Frontend) WindowSetTitle(title string) {
+
+}
+
+// WindowFullscreen does nothing
+func (f *Frontend) WindowFullscreen() {
+
+}
+
+// WindowUnfullscreen does nothing
+func (f *Frontend) WindowUnfullscreen() {
+
+}
+
+// WindowShow does nothing
+func (f *Frontend) WindowShow() {
+
+}
+
+// WindowHide does nothing
+func (f *Frontend) WindowHide() {
+
+}
+
+// WindowMaximize does nothing
+func (f *Frontend) WindowMaximise() {
+
+}
+
+// WindowToggleMaximise does nothing
+func (f *Frontend) WindowToggleMaximise() {
+
+}
+
+// WindowUnmaximise does nothing
+func (f *Frontend) WindowUnmaximise() {
+}
+
+// WindowMinimise does nothing
+func (f *Frontend) WindowMinimise() {
+
+}
+
+// WindowUnminimise does nothing
+func (f *Frontend) WindowUnminimise() {
+
+}
+
+// WindowSetMinSize does nothing
+func (f *Frontend) WindowSetMinSize(width int, height int) {
+
+}
+
+// WindowSetMaxSize does nothing
+func (f *Frontend) WindowSetMaxSize(width int, height int) {
+
+}
+
+// WindowSetRGBA does nothing
+func (f *Frontend) WindowSetRGBA(col *options.RGBA) {
+}
+
+// Quit does nothing
+func (f *Frontend) Quit() {
+	f.done = true
+}
+
+// Notify does nothing
+func (f *Frontend) Notify(name string, data ...interface{}) {
+
+}
+
+// Callback does nothing
+func (f *Frontend) Callback(message string) {
+
+}
+
+// startDrag does nothing
+func (f *Frontend) startDrag() {
+
+}
+
+// ExecJS does nothing
+func (f *Frontend) ExecJS(js string) {
+
+}

--- a/v2/internal/frontend/desktop/null/menu.go
+++ b/v2/internal/frontend/desktop/null/menu.go
@@ -1,0 +1,11 @@
+package null
+
+import "github.com/wailsapp/wails/v2/pkg/menu"
+
+//MenuSetApplicationMenu does nothing
+func (f *Frontend) MenuSetApplicationMenu(menu *menu.Menu) {
+}
+
+// MenuUpdateApplicationMenu does nothing
+func (f *Frontend) MenuUpdateApplicationMenu() {
+}

--- a/v2/internal/frontend/devserver/devserver.go
+++ b/v2/internal/frontend/devserver/devserver.go
@@ -1,5 +1,5 @@
-//go:build dev
-// +build dev
+//go:build dev || server || hybrid
+// +build dev server hybrid
 
 // Package devserver provides a web-based frontend so that
 // it is possible to run a Wails app in a browsers.

--- a/v2/internal/frontend/devserver/devserver.go
+++ b/v2/internal/frontend/devserver/devserver.go
@@ -110,7 +110,7 @@ func (d *DevWebServer) Run(ctx context.Context) error {
 		}
 		return nil
 	})
-
+	d.LogDebug("Serving DevServer at http://%s", d.devServerAddr)
 	if devServerAddr := d.devServerAddr; devServerAddr != "" {
 		// Start server
 		go func(server *echo.Echo, log *logger.Logger) {
@@ -156,7 +156,7 @@ func (d *DevWebServer) handleReloadApp(c echo.Context) error {
 
 func (d *DevWebServer) handleIPCWebSocket(c echo.Context) error {
 	websocket.Handler(func(c *websocket.Conn) {
-		d.LogDebug(fmt.Sprintf("Websocket client %p connected", c))
+		d.LogDebug(fmt.Sprintf("Websocket client %v connected", c.Request().RemoteAddr))
 		d.socketMutex.Lock()
 		d.websocketClients[c] = &sync.Mutex{}
 		locker := d.websocketClients[c]
@@ -166,7 +166,7 @@ func (d *DevWebServer) handleIPCWebSocket(c echo.Context) error {
 			d.socketMutex.Lock()
 			delete(d.websocketClients, c)
 			d.socketMutex.Unlock()
-			d.LogDebug(fmt.Sprintf("Websocket client %p disconnected", c))
+			d.LogDebug(fmt.Sprintf("Websocket client %v disconnected", c.Request().RemoteAddr))
 		}()
 
 		var msg string

--- a/v2/internal/frontend/hybrid/hybrid.go
+++ b/v2/internal/frontend/hybrid/hybrid.go
@@ -1,0 +1,22 @@
+//go:build hybrid
+// +build hybrid
+
+package hybrid
+
+import (
+	"context"
+
+	"github.com/wailsapp/wails/v2/internal/binding"
+	"github.com/wailsapp/wails/v2/internal/frontend"
+	"github.com/wailsapp/wails/v2/internal/frontend/desktop"
+	"github.com/wailsapp/wails/v2/internal/frontend/devserver"
+	"github.com/wailsapp/wails/v2/internal/logger"
+	"github.com/wailsapp/wails/v2/pkg/options"
+)
+
+// New returns a new Hybrid frontend
+// A hybrid Frontend implementation contains a devserver.Frontend wrapping a desktop.Frontend
+func NewFrontend(ctx context.Context, appoptions *options.App, logger *logger.Logger, appBindings *binding.Bindings, dispatcher frontend.Dispatcher) frontend.Frontend {
+	appFrontend := desktop.NewFrontend(ctx, appoptions, logger, appBindings, dispatcher)
+	return devserver.NewFrontend(ctx, appoptions, logger, appBindings, dispatcher, nil, appFrontend)
+}

--- a/v2/internal/frontend/hybrid/hybrid.go
+++ b/v2/internal/frontend/hybrid/hybrid.go
@@ -1,5 +1,5 @@
-//go:build hybrid
-// +build hybrid
+//go:build exp && hybrid
+// +build exp,hybrid
 
 package hybrid
 

--- a/v2/internal/frontend/hybrid/server.go
+++ b/v2/internal/frontend/hybrid/server.go
@@ -17,5 +17,5 @@ import (
 // New returns a new Server frontend
 // A server Frontend implementation contains a devserver.Frontend wrapping a null.Frontend
 func NewFrontend(ctx context.Context, appoptions *options.App, logger *logger.Logger, appBindings *binding.Bindings, dispatcher frontend.Dispatcher) frontend.Frontend {
-	return devserver.NewFrontend(ctx, appoptions, logger, appBindings, dispatcher, nil, null.NewFrontend(ctx))
+	return devserver.NewFrontend(ctx, appoptions, logger, appBindings, dispatcher, nil, null.NewFrontend(ctx, appoptions))
 }

--- a/v2/internal/frontend/hybrid/server.go
+++ b/v2/internal/frontend/hybrid/server.go
@@ -1,0 +1,21 @@
+//go:build server
+// +build server
+
+package hybrid
+
+import (
+	"context"
+
+	"github.com/wailsapp/wails/v2/internal/binding"
+	"github.com/wailsapp/wails/v2/internal/frontend"
+	"github.com/wailsapp/wails/v2/internal/frontend/desktop/null"
+	"github.com/wailsapp/wails/v2/internal/frontend/devserver"
+	"github.com/wailsapp/wails/v2/internal/logger"
+	"github.com/wailsapp/wails/v2/pkg/options"
+)
+
+// New returns a new Server frontend
+// A server Frontend implementation contains a devserver.Frontend wrapping a null.Frontend
+func NewFrontend(ctx context.Context, appoptions *options.App, logger *logger.Logger, appBindings *binding.Bindings, dispatcher frontend.Dispatcher) frontend.Frontend {
+	return devserver.NewFrontend(ctx, appoptions, logger, appBindings, dispatcher, nil, null.NewFrontend(ctx))
+}

--- a/v2/internal/frontend/hybrid/server.go
+++ b/v2/internal/frontend/hybrid/server.go
@@ -1,5 +1,5 @@
-//go:build server
-// +build server
+//go:build exp && server
+// +build exp,server
 
 package hybrid
 

--- a/v2/internal/frontend/runtime/ipc_websocket.go
+++ b/v2/internal/frontend/runtime/ipc_websocket.go
@@ -1,5 +1,5 @@
-//go:build dev
-// +build dev
+//go:build dev || server || hybrid
+// +build dev server hybrid
 
 package runtime
 

--- a/v2/pkg/assetserver/assethandler_external.go
+++ b/v2/pkg/assetserver/assethandler_external.go
@@ -1,12 +1,16 @@
+//go:build dev || hybrid || server
+// +build dev hybrid server
+
 package assetserver
 
 import (
 	"errors"
 	"fmt"
-	"github.com/wailsapp/wails/v2/pkg/options/assetserver"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
+
+	"github.com/wailsapp/wails/v2/pkg/options/assetserver"
 )
 
 func NewProxyServer(proxyURL string) http.Handler {

--- a/v2/pkg/commands/build/build.go
+++ b/v2/pkg/commands/build/build.go
@@ -97,7 +97,7 @@ func Build(options *Options) (string, error) {
 	switch options.OutputType {
 	case "desktop":
 		builder = newDesktopBuilder(options)
-	case "dev":
+	case "dev", "hybrid", "server":
 		builder = newDesktopBuilder(options)
 	default:
 		return "", fmt.Errorf("cannot build assets for output type %s", options.ProjectData.OutputType)

--- a/v2/pkg/options/options.go
+++ b/v2/pkg/options/options.go
@@ -12,6 +12,7 @@ import (
 	"github.com/wailsapp/wails/v2/pkg/options/assetserver"
 	"github.com/wailsapp/wails/v2/pkg/options/linux"
 	"github.com/wailsapp/wails/v2/pkg/options/mac"
+	"github.com/wailsapp/wails/v2/pkg/options/server"
 	"github.com/wailsapp/wails/v2/pkg/options/windows"
 
 	"github.com/wailsapp/wails/v2/pkg/menu"
@@ -98,6 +99,9 @@ type App struct {
 
 	// DragAndDrop options for drag and drop behavior
 	DragAndDrop *DragAndDrop
+
+	// Server options (also used by hybrid)
+	Server *server.Options
 }
 
 type ErrorFormatter func(error) any

--- a/v2/pkg/options/server/options.go
+++ b/v2/pkg/options/server/options.go
@@ -1,0 +1,8 @@
+package server
+
+// Options are options specific to the server
+type Options struct {
+	EnableServer bool
+	Host         string
+	Port         int32
+}


### PR DESCRIPTION
This is a first pass implementation of a Wails target type of `server` and `hybrid`.

    wails build -outputType hybrid
    wails build -outputType server

Both server and hybrid accept an optional `options.Server` argument to define the host and port on which to listen.
The intent was to allow the `hybrid` to enable / disable the server endpoint at runtime but this is not implemented at this time.

## `Server`
- only enables the dev server on the specified host and port (does not open a local window)

## `Hybrid`
- Always opens a local desktop window 
- Enables a remote access option using the devserver functionality on the specified host/port.

Default port is : `3112`