### PR TITLE
Windows dialogs - Handle scenario when window is not visible yet.

### DIFF
--- a/v2/internal/frontend/desktop/windows/dialog.go
+++ b/v2/internal/frontend/desktop/windows/dialog.go
@@ -135,7 +135,13 @@ func (f *Frontend) MessageDialog(options frontend.MessageDialogOptions) (string,
 		flags = windows.MB_OK | windows.MB_ICONWARNING
 	}
 
-	button, _ := windows.MessageBox(windows.HWND(f.mainWindow.Handle()), message, title, flags|windows.MB_SYSTEMMODAL)
+	// Check if window is visible or not
+	handle := f.mainWindow.Handle()
+	if !f.mainWindow.IsVisible() {
+		handle = 0
+	}
+
+	button, _ := windows.MessageBox(windows.HWND(handle), message, title, flags|windows.MB_SYSTEMMODAL)
 	// This maps MessageBox return values to strings
 	responses := []string{"", "Ok", "Cancel", "Abort", "Retry", "Ignore", "Yes", "No", "", "", "Try Again", "Continue"}
 	result := "Error"

--- a/v2/internal/frontend/desktop/windows/dialog.go
+++ b/v2/internal/frontend/desktop/windows/dialog.go
@@ -5,10 +5,18 @@ package windows
 
 import (
 	"github.com/wailsapp/wails/v2/internal/frontend"
+	"github.com/wailsapp/wails/v2/internal/frontend/desktop/windows/winc/w32"
 	"github.com/wailsapp/wails/v2/internal/go-common-file-dialog/cfd"
 	"golang.org/x/sys/windows"
 	"syscall"
 )
+
+func (f *Frontend) getHandleForDialog() w32.HWND {
+	if f.mainWindow.IsVisible() {
+		return f.mainWindow.Handle()
+	}
+	return 0
+}
 
 // OpenDirectoryDialog prompts the user to select a directory
 func (f *Frontend) OpenDirectoryDialog(options frontend.OpenDialogOptions) (string, error) {
@@ -21,7 +29,7 @@ func (f *Frontend) OpenDirectoryDialog(options frontend.OpenDialogOptions) (stri
 	if err != nil {
 		return "", err
 	}
-	thisDialog.SetParentWindowHandle(f.mainWindow.Handle())
+	thisDialog.SetParentWindowHandle(f.getHandleForDialog())
 	defer func(thisDialog cfd.SelectFolderDialog) {
 		err := thisDialog.Release()
 		if err != nil {
@@ -47,7 +55,7 @@ func (f *Frontend) OpenFileDialog(options frontend.OpenDialogOptions) (string, e
 	if err != nil {
 		return "", err
 	}
-	thisdialog.SetParentWindowHandle(f.mainWindow.Handle())
+	thisdialog.SetParentWindowHandle(f.getHandleForDialog())
 	defer func(thisdialog cfd.OpenFileDialog) {
 		err := thisdialog.Release()
 		if err != nil {
@@ -74,7 +82,7 @@ func (f *Frontend) OpenMultipleFilesDialog(dialogOptions frontend.OpenDialogOpti
 	if err != nil {
 		return nil, err
 	}
-	thisdialog.SetParentWindowHandle(f.mainWindow.Handle())
+	thisdialog.SetParentWindowHandle(f.getHandleForDialog())
 	defer func(thisdialog cfd.OpenMultipleFilesDialog) {
 		err := thisdialog.Release()
 		if err != nil {
@@ -100,7 +108,7 @@ func (f *Frontend) SaveFileDialog(dialogOptions frontend.SaveDialogOptions) (str
 	if err != nil {
 		return "", err
 	}
-	saveDialog.SetParentWindowHandle(f.mainWindow.Handle())
+	saveDialog.SetParentWindowHandle(f.getHandleForDialog())
 	err = saveDialog.Show()
 	if err != nil {
 		return "", err
@@ -135,13 +143,7 @@ func (f *Frontend) MessageDialog(options frontend.MessageDialogOptions) (string,
 		flags = windows.MB_OK | windows.MB_ICONWARNING
 	}
 
-	// Check if window is visible or not
-	handle := f.mainWindow.Handle()
-	if !f.mainWindow.IsVisible() {
-		handle = 0
-	}
-
-	button, _ := windows.MessageBox(windows.HWND(handle), message, title, flags|windows.MB_SYSTEMMODAL)
+	button, _ := windows.MessageBox(windows.HWND(f.getHandleForDialog()), message, title, flags|windows.MB_SYSTEMMODAL)
 	// This maps MessageBox return values to strings
 	responses := []string{"", "Ok", "Cancel", "Abort", "Retry", "Ignore", "Yes", "No", "", "", "Try Again", "Continue"}
 	result := "Error"

--- a/v2/internal/frontend/desktop/windows/win32/consts.go
+++ b/v2/internal/frontend/desktop/windows/win32/consts.go
@@ -18,6 +18,7 @@ var (
 	procSetClassLong         = moduser32.NewProc("SetClassLongW")
 	procSetClassLongPtr      = moduser32.NewProc("SetClassLongPtrW")
 	procShowWindow           = moduser32.NewProc("ShowWindow")
+	procIsWindowVisible      = moduser32.NewProc("IsWindowVisible")
 )
 var (
 	moddwmapi                        = syscall.NewLazyDLL("dwmapi.dll")

--- a/v2/internal/frontend/desktop/windows/win32/window.go
+++ b/v2/internal/frontend/desktop/windows/win32/window.go
@@ -78,6 +78,11 @@ func ExtendFrameIntoClientArea(hwnd uintptr) {
 	}
 }
 
+func IsVisible(hwnd uintptr) bool {
+	ret, _, _ := procIsWindowVisible.Call(hwnd)
+	return ret != 0
+}
+
 func IsWindowMaximised(hwnd uintptr) bool {
 	style := uint32(getWindowLong(hwnd, GWL_STYLE))
 	return style&WS_MAXIMIZE != 0

--- a/v2/internal/frontend/desktop/windows/window.go
+++ b/v2/internal/frontend/desktop/windows/window.go
@@ -30,8 +30,8 @@ type Window struct {
 	theme        winoptions.Theme
 	themeChanged bool
 
-	OnSuspend                                func()
-	OnResume                                 func()
+	OnSuspend func()
+	OnResume  func()
 }
 
 func NewWindow(parent winc.Controller, appoptions *options.App, versionInfo *operatingsystem.WindowsVersionInfo) *Window {
@@ -156,6 +156,10 @@ func (w *Window) SetMaxSize(maxWidth int, maxHeight int) {
 	w.maxWidth = maxWidth
 	w.maxHeight = maxHeight
 	w.Form.SetMaxSize(maxWidth, maxHeight)
+}
+
+func (w *Window) IsVisible() bool {
+	return win32.IsVisible(w.Handle())
 }
 
 func (w *Window) WndProc(msg uint32, wparam, lparam uintptr) uintptr {


### PR DESCRIPTION
On Windows, if the window has not yet been activated, calls to dialog methods will crash due to some weirdness deep inside a windows syscall. This PR will use the desktop (nil HWND) if the window is not visible. Fixes #1660 