### PR TITLE
Add `frontend:dev:install` configuration

### DIFF
--- a/v2/internal/project/project.go
+++ b/v2/internal/project/project.go
@@ -22,6 +22,7 @@ type Project struct {
 
 	// Commands used in `wails dev`
 	DevCommand        string `json:"frontend:dev"`
+	DevInstallCommand string `json:"frontend:dev:install"`
 	DevWatcherCommand string `json:"frontend:dev:watcher"`
 	// The url of the external wails dev server. If this is set, this server is used for the frontend. Default ""
 	FrontendDevServerURL string `json:"frontend:dev:serverUrl"`
@@ -85,8 +86,8 @@ type Project struct {
 }
 
 func (p *Project) GetDevInstallerCommand() string {
-	if p.DevCommand != "" {
-		return p.DevCommand
+	if p.DevInstallCommand != "" {
+		return p.DevInstallCommand
 	}
 	return p.InstallCommand
 }

--- a/website/docs/reference/project-config.mdx
+++ b/website/docs/reference/project-config.mdx
@@ -14,6 +14,7 @@ The project config resides in the `wails.json` file in the project directory. Th
 	"frontend:install": "[The command to install node dependencies, run in the frontend directory - often `npm install`]",
 	"frontend:build": "[The command to build the assets, run in the frontend directory - often `npm run build`]",
 	"frontend:dev": "[This command is the dev equivalent of frontend:build. If not specified falls back to frontend:build]",
+	"frontend:dev:install": "[This command is the dev equivalent of frontend:install. If not specified falls back to frontend:install]",
 	"frontend:dev:watcher": "[This command is run in a separate process on `wails dev`. Useful for 3rd party watchers or starting 3d party dev servers]",
 	"frontend:dev:serverUrl": "[URL to a 3rd party dev server to be used to serve assets, EG Vite. If this is set to 'auto' then the devServerUrl will be inferred from the Vite output]",
     "wailsjsdir": "[Relative path to the directory that the auto-generated JS modules will be created]",

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/reference/project-config.mdx
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/reference/project-config.mdx
@@ -14,6 +14,7 @@ sidebar_position: 5
   "frontend:install": "[安装 node 依赖的命令，在 frontend 目录下运行 - 通常是 `npm install`]",
   "frontend:build": "[构建资源的命令，在 frontend 目录下运行 - 通常是 `npm run build`]",
   "frontend:dev": "[此命令等效于开发模式中的 frontend:build，如果没有指定则只有 frontend:build]",
+  "frontend:dev:install": "[此命令等效于开发模式中的 frontend:install，如果没有指定则只有 frontend:install]",
   "frontend:dev:watcher": "[此命令在 `wails dev` 上的单独进程中运行。对第 3 方观察者有用]",
   "frontend:dev:serverUrl": "[使用第三方开发服务器提供资源，比如 Vite",
   "wailsjsdir": "[自动生成的JS模块将被创建的目录的相对路径]",


### PR DESCRIPTION
Add a `frontend:dev:install` configuration in wails.json to specify the dev dependencies installation command and update the docs.
Fixes #1663 