### PR TITLE
[v2, darwin] Use kern.osversion for os id in doctor

### DIFF
--- a/v2/internal/system/operatingsystem/os_darwin.go
+++ b/v2/internal/system/operatingsystem/os_darwin.go
@@ -1,8 +1,9 @@
 package operatingsystem
 
 import (
-	"github.com/wailsapp/wails/v2/internal/shell"
 	"strings"
+
+	"github.com/wailsapp/wails/v2/internal/shell"
 )
 
 func getSysctlValue(key string) (string, error) {
@@ -26,7 +27,7 @@ func platformInfo() (*OS, error) {
 		return nil, err
 	}
 	result.Version = version
-	ID, err := getSysctlValue("kern.osrevision")
+	ID, err := getSysctlValue("kern.osversion")
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
It seems like kern.osrevision is always 199506 since several years
and kern.osversion maps to the official documented build id.

Example: MacOS 12.5 with ID 21G72