### PR TITLE
[v2, build] gcflags don't need to be quoted

### DIFF
--- a/v2/pkg/commands/build/base.go
+++ b/v2/pkg/commands/build/base.go
@@ -171,7 +171,7 @@ func (b *BaseBuilder) CompileProject(options *Options) error {
 	// Add better debugging flags
 	if options.Mode == Dev || options.Mode == Debug {
 		commands.Add("-gcflags")
-		commands.Add(`"all=-N -l"`)
+		commands.Add("all=-N -l")
 	}
 
 	if options.ForceBuild {


### PR DESCRIPTION
This seemed to work for Go < 1.19 but since 1.19 this gives
an error.

Fixes #1688 