### PR TITLE
Only set GDK_BACKEND to "x11" if GDK_BACKEND is unset and XDG_SESSION_TYPE is not "wayland"

### DIFF
--- a/v2/internal/frontend/desktop/linux/frontend.go
+++ b/v2/internal/frontend/desktop/linux/frontend.go
@@ -58,8 +58,8 @@ func init() {
 
 func NewFrontend(ctx context.Context, appoptions *options.App, myLogger *logger.Logger, appBindings *binding.Bindings, dispatcher frontend.Dispatcher) *Frontend {
 
-	// Set GDK_BACKEND=x11 if currently unset and XDG_SESSION_TYPE isn't wayland to prevent warnings
-	if os.Getenv("GDK_BACKEND") == "" && os.Getenv("XDG_SESSION_TYPE") != "wayland" {
+	// Set GDK_BACKEND=x11 if currently unset and XDG_SESSION_TYPE is unset, unspecified or x11 to prevent warnings
+	if os.Getenv("GDK_BACKEND") == "" && (os.Getenv("XDG_SESSION_TYPE") == "" || os.Getenv("XDG_SESSION_TYPE") == "unspecified" || os.Getenv("XDG_SESSION_TYPE") == "x11") {
 		_ = os.Setenv("GDK_BACKEND", "x11")
 	}
 

--- a/v2/internal/frontend/desktop/linux/frontend.go
+++ b/v2/internal/frontend/desktop/linux/frontend.go
@@ -58,8 +58,10 @@ func init() {
 
 func NewFrontend(ctx context.Context, appoptions *options.App, myLogger *logger.Logger, appBindings *binding.Bindings, dispatcher frontend.Dispatcher) *Frontend {
 
-	// Set GDK_BACKEND=x11 to prevent warnings
-	_ = os.Setenv("GDK_BACKEND", "x11")
+	// Set GDK_BACKEND=x11 if currently unset and XDG_SESSION_TYPE isn't wayland to prevent warnings
+	if os.Getenv("GDK_BACKEND") == "" && os.Getenv("XDG_SESSION_TYPE") != "wayland" {
+		_ = os.Setenv("GDK_BACKEND", "x11")
+	}
 
 	result := &Frontend{
 		frontendOptions: appoptions,


### PR DESCRIPTION
The existing logic always sets the `GDK_BACKEND` variable to `x11`, which prevents the application from using the wayland backend (or running at all in a wayland compositor if xwayland is unavailable). The reason this logic is present is because windows would fail to centre without it, so we need to keep the behaviour in x11 sessions.

The `GDK_BACKEND` variable can and typically should remain unset in a wayland session, and the `XDG_SESSION_TYPE` variable is usually set and can have a value of `unspecified`, `tty`, `x11`, `wayland` or `mir`.

The logic in the patch is as follows; if the system has already set the `GDK_BACKEND` variable, we should assume that it knows what it's doing and keep the existing value. If the `GDK_BACKEND` variable is empty however, we check to see if the `XDG_SESSION_TYPE` variable is set to `wayland`, and if it is we shouldn't touch the `GDK_BACKEND` variable. If the `XDG_SESSION_TYPE` variable is not set to `wayland` though, we can assume we're most likely in an x11 environment in those cases. If we're in an x11 environment, we set `GDK_BACKEND` to `x11` and windows can be centred :)

I tested this in x11 and wayland with xwayland disabled using all combinations of `XDG_SESSION_TYPE` and `GDK_BACKEND` being set appropriately, inappropriately and being unset, and got the expected behaviour in all cases.

This resolves #1420 