### PR TITLE
Remove duplicate defs in win32/window.go

### DIFF
--- a/v2/internal/frontend/desktop/windows/win32/window.go
+++ b/v2/internal/frontend/desktop/windows/win32/window.go
@@ -13,7 +13,6 @@ import (
 )
 
 const (
-	WS_MINIMIZE = 0x20000000
 	WS_MAXIMIZE = 0x01000000
 	WS_MINIMIZE = 0x20000000
 
@@ -141,11 +140,6 @@ func SetBackgroundColour(hwnd uintptr, r, g, b uint8) {
 	col := winc.RGB(r, g, b)
 	hbrush, _, _ := procCreateSolidBrush.Call(uintptr(col))
 	setClassLongPtr(hwnd, GCLP_HBRBACKGROUND, hbrush)
-}
-
-func IsWindowMinimised(hwnd uintptr) bool {
-	style := uint32(getWindowLong(hwnd, GWL_STYLE))
-	return style&WS_MINIMIZE != 0
 }
 
 func IsWindowNormal(hwnd uintptr) bool {


### PR DESCRIPTION
Introduced in 70c484f60317b3e2d50d154025869b3e6b9fe7d9

Until these duplicate defs are removed, bleeding edge Windows build fail with:

```
  Build command: go build -trimpath -tags desktop,production -ldflags -w -s -H windowsgui -o /app/build/bin/app.exe
  Environment: HOSTNAME=e7e5205f866a PATH=/go/bin:/usr/local/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin GOPATH=/go PWD=/app GOLANG_VERSION=1.19 GOOS=windows GOARCH=amd64
go list error: exit status 2: # github.com/wailsapp/wails/v2/internal/frontend/desktop/windows/win32
wails/v2/internal/frontend/desktop/windows/win32/window.go:18:2: WS_MINIMIZE redeclared in this block
	wails/v2/internal/frontend/desktop/windows/win32/window.go:16:2: other declaration of WS_MINIMIZE
wails/v2/internal/frontend/desktop/windows/win32/window.go:146:6: IsWindowMinimised redeclared in this block
	wails/v2/internal/frontend/desktop/windows/win32/window.go:120:6: other declaration of IsWindowMinimised
```