### PR TITLE
check a.map before use a.map

### DIFF
--- a/v2/internal/typescriptify/typescriptify.go
+++ b/v2/internal/typescriptify/typescriptify.go
@@ -21,7 +21,7 @@ const (
 	if (!a) {
 		return a;
 	}
-	if (a.slice) {
+	if (a.map) {
 		return (a as any[]).map(elem => this.convertValues(elem, classs));
 	} else if ("object" === typeof a) {
 		if (asMap) {


### PR DESCRIPTION
when a is a string, a.slice exists but a.map does not.
So, I believe it's better to check a.map instead of a.slice before calling a.map.