### PR TITLE
[cli] Add check for minimum required go version

### DIFF
--- a/v2/cmd/wails/internal/commands/build/build.go
+++ b/v2/cmd/wails/internal/commands/build/build.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"os"
 	"os/exec"
-	"path/filepath"
 	"runtime"
 	"strings"
 	"text/tabwriter"
@@ -15,9 +14,6 @@ import (
 	"github.com/wailsapp/wails/v2/internal/colour"
 	"github.com/wailsapp/wails/v2/internal/project"
 	"github.com/wailsapp/wails/v2/internal/system"
-
-	"github.com/wailsapp/wails/v2/cmd/wails/internal"
-	"github.com/wailsapp/wails/v2/internal/gomod"
 
 	"github.com/leaanthony/clir"
 	"github.com/leaanthony/slicer"
@@ -94,8 +90,8 @@ func AddBuildSubcommand(app *clir.Cli, w io.Writer) {
 	forceBuild := false
 	command.BoolFlag("f", "Force build application", &forceBuild)
 
-	updateGoMod := false
-	command.BoolFlag("u", "Updates go.mod to use the same Wails version as the CLI", &updateGoMod)
+	updateGoModWailsVersion := false
+	command.BoolFlag("u", "Updates go.mod to use the same Wails version as the CLI", &updateGoModWailsVersion)
 
 	debug := false
 	command.BoolFlag("debug", "Retains debug data in the compiled application", &debug)
@@ -249,7 +245,8 @@ func AddBuildSubcommand(app *clir.Cli, w io.Writer) {
 				return err
 			}
 		}
-		err = checkGoModVersion(logger, updateGoMod)
+
+		err = SyncGoMod(logger, updateGoModWailsVersion)
 		if err != nil {
 			return err
 		}
@@ -395,58 +392,7 @@ func AddBuildSubcommand(app *clir.Cli, w io.Writer) {
 	})
 }
 
-func checkGoModVersion(logger *clilogger.CLILogger, updateGoMod bool) error {
-	cwd, err := os.Getwd()
-	if err != nil {
-		return err
-	}
-	gomodFilename := filepath.Join(cwd, "go.mod")
-	gomodData, err := os.ReadFile(gomodFilename)
-	if err != nil {
-		return err
-	}
-	outOfSync, err := gomod.GoModOutOfSync(gomodData, internal.Version)
-	if err != nil {
-		return err
-	}
-	if !outOfSync {
-		return nil
-	}
-	gomodversion, err := gomod.GetWailsVersionFromModFile(gomodData)
-	if err != nil {
-		return err
-	}
-
-	if updateGoMod {
-		return syncGoModVersion(cwd)
-	}
-
-	logger.Println("Warning: go.mod is using Wails '%s' but the CLI is '%s'. Consider updating your project's `go.mod` file.\n", gomodversion.String(), internal.Version)
-	return nil
-}
-
 func LogGreen(message string, args ...interface{}) {
 	text := fmt.Sprintf(message, args...)
 	println(colour.Green(text))
-}
-
-func syncGoModVersion(cwd string) error {
-	gomodFilename := filepath.Join(cwd, "go.mod")
-	gomodData, err := os.ReadFile(gomodFilename)
-	if err != nil {
-		return err
-	}
-	outOfSync, err := gomod.GoModOutOfSync(gomodData, internal.Version)
-	if err != nil {
-		return err
-	}
-	if !outOfSync {
-		return nil
-	}
-	LogGreen("Updating go.mod to use Wails '%s'", internal.Version)
-	newGoData, err := gomod.UpdateGoModVersion(gomodData, internal.Version)
-	if err != nil {
-		return err
-	}
-	return os.WriteFile(gomodFilename, newGoData, 0755)
 }

--- a/v2/cmd/wails/internal/commands/build/gomod.go
+++ b/v2/cmd/wails/internal/commands/build/gomod.go
@@ -1,0 +1,56 @@
+package build
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/wailsapp/wails/v2/cmd/wails/internal"
+	"github.com/wailsapp/wails/v2/internal/gomod"
+	"github.com/wailsapp/wails/v2/internal/goversion"
+	"github.com/wailsapp/wails/v2/pkg/clilogger"
+)
+
+func SyncGoMod(logger *clilogger.CLILogger, updateWailsVersion bool) error {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return err
+	}
+	gomodFilename := filepath.Join(cwd, "go.mod")
+	gomodData, err := os.ReadFile(gomodFilename)
+	if err != nil {
+		return err
+	}
+
+	gomodData, updated, err := gomod.SyncGoVersion(gomodData, goversion.MinRequirement)
+	if err != nil {
+		return err
+	} else if updated {
+		LogGreen("Updated go.mod to use Go '%s'", goversion.MinRequirement)
+	}
+
+	if outOfSync, err := gomod.GoModOutOfSync(gomodData, internal.Version); err != nil {
+		return err
+	} else if outOfSync {
+		if updateWailsVersion {
+			LogGreen("Updating go.mod to use Wails '%s'", internal.Version)
+			gomodData, err = gomod.UpdateGoModVersion(gomodData, internal.Version)
+			if err != nil {
+				return err
+			}
+			updated = true
+		} else {
+			gomodversion, err := gomod.GetWailsVersionFromModFile(gomodData)
+			if err != nil {
+				return err
+			}
+
+			logger.Println("Warning: go.mod is using Wails '%s' but the CLI is '%s'. Consider updating your project's `go.mod` file.\n", gomodversion.String(), internal.Version)
+		}
+	}
+
+	if updated {
+		return os.WriteFile(gomodFilename, gomodData, 0755)
+	}
+
+	return nil
+}

--- a/v2/cmd/wails/internal/commands/initialise/initialise.go
+++ b/v2/cmd/wails/internal/commands/initialise/initialise.go
@@ -156,7 +156,7 @@ func initProject(options *templates.Options, quiet bool) error {
 	}
 
 	// Run `go mod tidy` to ensure `go.sum` is up to date
-	cmd := exec.Command("go", "mod", "tidy", "-compat=1.17")
+	cmd := exec.Command("go", "mod", "tidy")
 	cmd.Dir = options.TargetDir
 	cmd.Stderr = os.Stderr
 	if !quiet {

--- a/v2/internal/gomod/gomod_test.go
+++ b/v2/internal/gomod/gomod_test.go
@@ -589,3 +589,59 @@ replace (
 	github.com/wailsapp/wails/v2 v2.0.0-beta.20 => C:\Users\leaan\Documents\wails-v2-beta\wails\v2
 )
 `
+
+const basicGo117 string = `module changeme
+
+go 1.17
+
+require github.com/wailsapp/wails/v2 v2.0.0-beta.7
+
+`
+
+const basicGo118 string = `module changeme
+
+go 1.18
+
+require github.com/wailsapp/wails/v2 v2.0.0-beta.7
+`
+
+const basicGo119 string = `module changeme
+
+go 1.19
+
+require github.com/wailsapp/wails/v2 v2.0.0-beta.7
+`
+
+func TestUpdateGoModGoVersion(t *testing.T) {
+	is2 := is.New(t)
+
+	type args struct {
+		goModText      []byte
+		currentVersion string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    []byte
+		updated bool
+	}{
+		{"basic1.17", args{[]byte(basicGo117), "1.18"}, []byte(basicGo118), true},
+		{"basic1.18", args{[]byte(basicGo118), "1.18"}, []byte(basicGo118), false},
+		{"basic1.19", args{[]byte(basicGo119), "1.17"}, []byte(basicGo119), false},
+		{"basic1.19", args{[]byte(basicGo119), "1.18"}, []byte(basicGo119), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, updated, err := SyncGoVersion(tt.args.goModText, tt.args.currentVersion)
+			if err != nil {
+				t.Errorf("UpdateGoModVersion() error = %v", err)
+				return
+			}
+			if updated != tt.updated {
+				t.Errorf("UpdateGoModVersion() updated = %t, want = %t", updated, tt.updated)
+				return
+			}
+			is2.Equal(got, tt.want)
+		})
+	}
+}

--- a/v2/internal/goversion/build_constraint.go
+++ b/v2/internal/goversion/build_constraint.go
@@ -1,0 +1,10 @@
+//go:build !go1.18
+// +build !go1.18
+
+package goversion
+
+const MinGoVersionRequired = "You need Go " + MinRequirement + " or newer to compile this program"
+
+func init() {
+	MinGoVersionRequired
+}

--- a/v2/internal/goversion/min.go
+++ b/v2/internal/goversion/min.go
@@ -1,0 +1,3 @@
+package goversion
+
+const MinRequirement string = "1.18"

--- a/v2/wails.go
+++ b/v2/wails.go
@@ -4,6 +4,7 @@ package wails
 
 import (
 	"github.com/wailsapp/wails/v2/internal/app"
+	_ "github.com/wailsapp/wails/v2/internal/goversion" // Add Compile-Time version check for minimum go version
 	"github.com/wailsapp/wails/v2/internal/signal"
 	"github.com/wailsapp/wails/v2/pkg/options"
 )


### PR DESCRIPTION
- Update out of sync go.mod with minimum go version
- Check for minimum go version during build with build constraint
  “internal/goversion/build_constraint.go:9:2: MinGoVersionRequired (constant "You need Go 1.18 or newer to compile this program" of type string) is not used”