### PR TITLE
[templates] Use embed all to include all files

### DIFF
--- a/v2/cmd/wails/internal/commands/generate/template/base/main.tmpl.go
+++ b/v2/cmd/wails/internal/commands/generate/template/base/main.tmpl.go
@@ -11,7 +11,7 @@ import (
 	"github.com/wailsapp/wails/v2/pkg/options/windows"
 )
 
-//go:embed frontend/dist
+//go:embed all:frontend/dist
 var assets embed.FS
 
 //go:embed build/appicon.png

--- a/v2/cmd/wails/internal/commands/initialise/templates/base/main.tmpl.go
+++ b/v2/cmd/wails/internal/commands/initialise/templates/base/main.tmpl.go
@@ -7,7 +7,7 @@ import (
 	"github.com/wailsapp/wails/v2/pkg/options"
 )
 
-//go:embed frontend/dist
+//go:embed all:frontend/dist
 var assets embed.FS
 
 func main() {

--- a/v2/cmd/wails/internal/commands/initialise/templates/generate/plain/main.go.tmpl
+++ b/v2/cmd/wails/internal/commands/initialise/templates/generate/plain/main.go.tmpl
@@ -12,7 +12,7 @@ import (
 	"github.com/wailsapp/wails/v2/pkg/options/windows"
 )
 
-//go:embed frontend/src
+//go:embed all:frontend/src
 var assets embed.FS
 
 //go:embed build/appicon.png

--- a/v2/cmd/wails/internal/commands/initialise/templates/templates/lit-ts/main.tmpl.go
+++ b/v2/cmd/wails/internal/commands/initialise/templates/templates/lit-ts/main.tmpl.go
@@ -7,7 +7,7 @@ import (
 	"github.com/wailsapp/wails/v2/pkg/options"
 )
 
-//go:embed frontend/dist
+//go:embed all:frontend/dist
 var assets embed.FS
 
 func main() {

--- a/v2/cmd/wails/internal/commands/initialise/templates/templates/lit/main.tmpl.go
+++ b/v2/cmd/wails/internal/commands/initialise/templates/templates/lit/main.tmpl.go
@@ -7,7 +7,7 @@ import (
 	"github.com/wailsapp/wails/v2/pkg/options"
 )
 
-//go:embed frontend/dist
+//go:embed all:frontend/dist
 var assets embed.FS
 
 func main() {

--- a/v2/cmd/wails/internal/commands/initialise/templates/templates/plain/main.tmpl.go
+++ b/v2/cmd/wails/internal/commands/initialise/templates/templates/plain/main.tmpl.go
@@ -7,7 +7,7 @@ import (
 	"github.com/wailsapp/wails/v2/pkg/options"
 )
 
-//go:embed frontend/src
+//go:embed all:frontend/src
 var assets embed.FS
 
 func main() {

--- a/v2/cmd/wails/internal/commands/initialise/templates/templates/preact-ts/main.tmpl.go
+++ b/v2/cmd/wails/internal/commands/initialise/templates/templates/preact-ts/main.tmpl.go
@@ -7,7 +7,7 @@ import (
 	"github.com/wailsapp/wails/v2/pkg/options"
 )
 
-//go:embed frontend/dist
+//go:embed all:frontend/dist
 var assets embed.FS
 
 func main() {

--- a/v2/cmd/wails/internal/commands/initialise/templates/templates/preact/main.tmpl.go
+++ b/v2/cmd/wails/internal/commands/initialise/templates/templates/preact/main.tmpl.go
@@ -7,7 +7,7 @@ import (
 	"github.com/wailsapp/wails/v2/pkg/options"
 )
 
-//go:embed frontend/dist
+//go:embed all:frontend/dist
 var assets embed.FS
 
 func main() {

--- a/v2/cmd/wails/internal/commands/initialise/templates/templates/react-ts/main.tmpl.go
+++ b/v2/cmd/wails/internal/commands/initialise/templates/templates/react-ts/main.tmpl.go
@@ -7,7 +7,7 @@ import (
 	"github.com/wailsapp/wails/v2/pkg/options"
 )
 
-//go:embed frontend/dist
+//go:embed all:frontend/dist
 var assets embed.FS
 
 func main() {

--- a/v2/cmd/wails/internal/commands/initialise/templates/templates/react/main.tmpl.go
+++ b/v2/cmd/wails/internal/commands/initialise/templates/templates/react/main.tmpl.go
@@ -7,7 +7,7 @@ import (
 	"github.com/wailsapp/wails/v2/pkg/options"
 )
 
-//go:embed frontend/dist
+//go:embed all:frontend/dist
 var assets embed.FS
 
 func main() {

--- a/v2/cmd/wails/internal/commands/initialise/templates/templates/svelte-ts/main.tmpl.go
+++ b/v2/cmd/wails/internal/commands/initialise/templates/templates/svelte-ts/main.tmpl.go
@@ -7,7 +7,7 @@ import (
 	"github.com/wailsapp/wails/v2/pkg/options"
 )
 
-//go:embed frontend/dist
+//go:embed all:frontend/dist
 var assets embed.FS
 
 func main() {

--- a/v2/cmd/wails/internal/commands/initialise/templates/templates/svelte/main.tmpl.go
+++ b/v2/cmd/wails/internal/commands/initialise/templates/templates/svelte/main.tmpl.go
@@ -7,7 +7,7 @@ import (
 	"github.com/wailsapp/wails/v2/pkg/options"
 )
 
-//go:embed frontend/dist
+//go:embed all:frontend/dist
 var assets embed.FS
 
 func main() {

--- a/v2/cmd/wails/internal/commands/initialise/templates/templates/vanilla-ts/main.tmpl.go
+++ b/v2/cmd/wails/internal/commands/initialise/templates/templates/vanilla-ts/main.tmpl.go
@@ -7,7 +7,7 @@ import (
 	"github.com/wailsapp/wails/v2/pkg/options"
 )
 
-//go:embed frontend/dist
+//go:embed all:frontend/dist
 var assets embed.FS
 
 func main() {

--- a/v2/cmd/wails/internal/commands/initialise/templates/templates/vanilla/main.tmpl.go
+++ b/v2/cmd/wails/internal/commands/initialise/templates/templates/vanilla/main.tmpl.go
@@ -7,7 +7,7 @@ import (
 	"github.com/wailsapp/wails/v2/pkg/options"
 )
 
-//go:embed frontend/dist
+//go:embed all:frontend/dist
 var assets embed.FS
 
 func main() {

--- a/v2/cmd/wails/internal/commands/initialise/templates/templates/vue-ts/main.tmpl.go
+++ b/v2/cmd/wails/internal/commands/initialise/templates/templates/vue-ts/main.tmpl.go
@@ -7,7 +7,7 @@ import (
 	"github.com/wailsapp/wails/v2/pkg/options"
 )
 
-//go:embed frontend/dist
+//go:embed all:frontend/dist
 var assets embed.FS
 
 func main() {

--- a/v2/cmd/wails/internal/commands/initialise/templates/templates/vue/main.tmpl.go
+++ b/v2/cmd/wails/internal/commands/initialise/templates/templates/vue/main.tmpl.go
@@ -7,7 +7,7 @@ import (
 	"github.com/wailsapp/wails/v2/pkg/options"
 )
 
-//go:embed frontend/dist
+//go:embed all:frontend/dist
 var assets embed.FS
 
 func main() {

--- a/website/docs/guides/dynamic-assets.mdx
+++ b/website/docs/guides/dynamic-assets.mdx
@@ -24,7 +24,7 @@ import (
 	"strings"
 )
 
-//go:embed frontend/dist
+//go:embed all:frontend/dist
 var assets embed.FS
 
 type FileLoader struct {

--- a/website/docs/guides/frameless.mdx
+++ b/website/docs/guides/frameless.mdx
@@ -41,7 +41,7 @@ import (
     "github.com/wailsapp/wails/v2/pkg/options"
 )
 
-//go:embed frontend/dist
+//go:embed all:frontend/dist
 var assets embed.FS
 
 func main() {

--- a/website/docs/guides/migrating.mdx
+++ b/website/docs/guides/migrating.mdx
@@ -159,7 +159,7 @@ Example: An application has the following project layout. All final assets are p
 Those assets may be used by the application by simply creating an `embed.FS`:
 
 ```go title="Assets Example"
-//go:embed frontend/dist
+//go:embed all:frontend/dist
 var assets embed.FS
 
 func main() {

--- a/website/docs/guides/troubleshooting.mdx
+++ b/website/docs/guides/troubleshooting.mdx
@@ -15,7 +15,7 @@ Check that your application includes the assets from the correct directory. In y
 something similar to the following code:
 
 ```go
-//go:embed frontend/dist
+//go:embed all:frontend/dist
 var assets embed.FS
 ```
 

--- a/website/docs/howdoesitwork.mdx
+++ b/website/docs/howdoesitwork.mdx
@@ -33,7 +33,7 @@ import (
 	"github.com/wailsapp/wails/v2/pkg/options"
 )
 
-//go:embed frontend/dist
+//go:embed all:frontend/dist
 var assets embed.FS
 
 func main() {
@@ -95,7 +95,7 @@ there is no requirement on where in the `embed.FS` the files live. It is likely 
 directory relative to your main application code, such as `frontend/dist`:
 
 ```go title="main.go"
-//go:embed frontend/dist
+//go:embed all:frontend/dist
 var assets embed.FS
 ```
 
@@ -147,7 +147,7 @@ import (
 	"github.com/wailsapp/wails/v2/pkg/options"
 )
 
-//go:embed frontend/dist
+//go:embed all:frontend/dist
 var assets embed.FS
 
 func main() {

--- a/website/i18n/ja/docusaurus-plugin-content-docs/current/guides/dynamic-assets.mdx
+++ b/website/i18n/ja/docusaurus-plugin-content-docs/current/guides/dynamic-assets.mdx
@@ -21,7 +21,7 @@ import (
     "strings"
 )
 
-//go:embed frontend/dist
+//go:embed all:frontend/dist
 var assets embed.FS
 
 type FileLoader struct {

--- a/website/i18n/ja/docusaurus-plugin-content-docs/current/guides/frameless.mdx
+++ b/website/i18n/ja/docusaurus-plugin-content-docs/current/guides/frameless.mdx
@@ -36,7 +36,7 @@ import (
     "github.com/wailsapp/wails/v2/pkg/options"
 )
 
-//go:embed frontend/dist
+//go:embed all:frontend/dist
 var assets embed.FS
 
 func main() {

--- a/website/i18n/ja/docusaurus-plugin-content-docs/current/guides/migrating.mdx
+++ b/website/i18n/ja/docusaurus-plugin-content-docs/current/guides/migrating.mdx
@@ -145,7 +145,7 @@ Example: An application has the following project layout. All final assets are p
 Those assets may be used by the application by simply creating an `embed.FS`:
 
 ```go title="Assets Example"
-//go:embed frontend/dist
+//go:embed all:frontend/dist
 var assets embed.FS
 
 func main() {

--- a/website/i18n/ja/docusaurus-plugin-content-docs/current/guides/troubleshooting.mdx
+++ b/website/i18n/ja/docusaurus-plugin-content-docs/current/guides/troubleshooting.mdx
@@ -11,7 +11,7 @@ If your system is reporting that the `wails` command is missing, make sure you h
 Check that your application includes the assets from the correct directory. In your `main.go` file, you will have something similar to the following code:
 
 ```go
-//go:embed frontend/dist
+//go:embed all:frontend/dist
 var assets embed.FS
 ```
 

--- a/website/i18n/ja/docusaurus-plugin-content-docs/current/howdoesitwork.mdx
+++ b/website/i18n/ja/docusaurus-plugin-content-docs/current/howdoesitwork.mdx
@@ -27,7 +27,7 @@ import (
     "github.com/wailsapp/wails/v2/pkg/options"
 )
 
-//go:embed frontend/dist
+//go:embed all:frontend/dist
 var assets embed.FS
 
 func main() {
@@ -84,7 +84,7 @@ A full list of application options can be found in the [Options Reference](refer
 The `Assets` option is mandatory as you can't have a Wails application without frontend assets. Those assets can be any files you would expect to find in a web application - html, js, css, svg, png, etc. **There is no requirement to generate asset bundles** - plain files will do. When the application starts, it will attempt to load `index.html` from your assets and the frontend will essentially work as a browser from that point on. It is worth noting that there is no requirement on where in the `embed.FS` the files live. It is likely that the embed path uses a nested directory relative to your main application code, such as `frontend/dist`:
 
 ```go title="main.go"
-//go:embed frontend/dist
+//go:embed all:frontend/dist
 var assets embed.FS
 ```
 
@@ -123,7 +123,7 @@ import (
     "github.com/wailsapp/wails/v2/pkg/options"
 )
 
-//go:embed frontend/dist
+//go:embed all:frontend/dist
 var assets embed.FS
 
 func main() {

--- a/website/i18n/ko/docusaurus-plugin-content-docs/current/guides/dynamic-assets.mdx
+++ b/website/i18n/ko/docusaurus-plugin-content-docs/current/guides/dynamic-assets.mdx
@@ -21,7 +21,7 @@ import (
     "strings"
 )
 
-//go:embed frontend/dist
+//go:embed all:frontend/dist
 var assets embed.FS
 
 type FileLoader struct {

--- a/website/i18n/ko/docusaurus-plugin-content-docs/current/guides/frameless.mdx
+++ b/website/i18n/ko/docusaurus-plugin-content-docs/current/guides/frameless.mdx
@@ -36,7 +36,7 @@ import (
     "github.com/wailsapp/wails/v2/pkg/options"
 )
 
-//go:embed frontend/dist
+//go:embed all:frontend/dist
 var assets embed.FS
 
 func main() {

--- a/website/i18n/ko/docusaurus-plugin-content-docs/current/guides/migrating.mdx
+++ b/website/i18n/ko/docusaurus-plugin-content-docs/current/guides/migrating.mdx
@@ -145,7 +145,7 @@ Example: An application has the following project layout. All final assets are p
 Those assets may be used by the application by simply creating an `embed.FS`:
 
 ```go title="Assets Example"
-//go:embed frontend/dist
+//go:embed all:frontend/dist
 var assets embed.FS
 
 func main() {

--- a/website/i18n/ko/docusaurus-plugin-content-docs/current/guides/troubleshooting.mdx
+++ b/website/i18n/ko/docusaurus-plugin-content-docs/current/guides/troubleshooting.mdx
@@ -11,7 +11,7 @@ If your system is reporting that the `wails` command is missing, make sure you h
 Check that your application includes the assets from the correct directory. In your `main.go` file, you will have something similar to the following code:
 
 ```go
-//go:embed frontend/dist
+//go:embed all:frontend/dist
 var assets embed.FS
 ```
 

--- a/website/i18n/ko/docusaurus-plugin-content-docs/current/howdoesitwork.mdx
+++ b/website/i18n/ko/docusaurus-plugin-content-docs/current/howdoesitwork.mdx
@@ -27,7 +27,7 @@ import (
     "github.com/wailsapp/wails/v2/pkg/options"
 )
 
-//go:embed frontend/dist
+//go:embed all:frontend/dist
 var assets embed.FS
 
 func main() {
@@ -84,7 +84,7 @@ A full list of application options can be found in the [Options Reference](refer
 The `Assets` option is mandatory as you can't have a Wails application without frontend assets. Those assets can be any files you would expect to find in a web application - html, js, css, svg, png, etc. **There is no requirement to generate asset bundles** - plain files will do. When the application starts, it will attempt to load `index.html` from your assets and the frontend will essentially work as a browser from that point on. It is worth noting that there is no requirement on where in the `embed.FS` the files live. It is likely that the embed path uses a nested directory relative to your main application code, such as `frontend/dist`:
 
 ```go title="main.go"
-//go:embed frontend/dist
+//go:embed all:frontend/dist
 var assets embed.FS
 ```
 
@@ -123,7 +123,7 @@ import (
     "github.com/wailsapp/wails/v2/pkg/options"
 )
 
-//go:embed frontend/dist
+//go:embed all:frontend/dist
 var assets embed.FS
 
 func main() {

--- a/website/i18n/ru/docusaurus-plugin-content-docs/current/guides/dynamic-assets.mdx
+++ b/website/i18n/ru/docusaurus-plugin-content-docs/current/guides/dynamic-assets.mdx
@@ -21,7 +21,7 @@ import (
     "strings"
 )
 
-//go:embed frontend/dist
+//go:embed all:frontend/dist
 var assets embed.FS
 
 type FileLoader struct {

--- a/website/i18n/ru/docusaurus-plugin-content-docs/current/guides/frameless.mdx
+++ b/website/i18n/ru/docusaurus-plugin-content-docs/current/guides/frameless.mdx
@@ -36,7 +36,7 @@ import (
     "github.com/wailsapp/wails/v2/pkg/options"
 )
 
-//go:embed frontend/dist
+//go:embed all:frontend/dist
 var assets embed.FS
 
 func main() {

--- a/website/i18n/ru/docusaurus-plugin-content-docs/current/guides/migrating.mdx
+++ b/website/i18n/ru/docusaurus-plugin-content-docs/current/guides/migrating.mdx
@@ -147,7 +147,7 @@ Example: An application has the following project layout. All final assets are p
 Those assets may be used by the application by simply creating an `embed.FS`:
 
 ```go title="Assets Example"
-//go:embed frontend/dist
+//go:embed all:frontend/dist
 var assets embed.FS
 
 func main() {

--- a/website/i18n/ru/docusaurus-plugin-content-docs/current/guides/troubleshooting.mdx
+++ b/website/i18n/ru/docusaurus-plugin-content-docs/current/guides/troubleshooting.mdx
@@ -11,7 +11,7 @@ If your system is reporting that the `wails` command is missing, make sure you h
 Check that your application includes the assets from the correct directory. In your `main.go` file, you will have something similar to the following code:
 
 ```go
-//go:embed frontend/dist
+//go:embed all:frontend/dist
 var assets embed.FS
 ```
 

--- a/website/i18n/ru/docusaurus-plugin-content-docs/current/howdoesitwork.mdx
+++ b/website/i18n/ru/docusaurus-plugin-content-docs/current/howdoesitwork.mdx
@@ -27,7 +27,7 @@ import (
     "github.com/wailsapp/wails/v2/pkg/options"
 )
 
-//go:embed frontend/dist
+//go:embed all:frontend/dist
 var assets embed.FS
 
 func main() {
@@ -84,7 +84,7 @@ A full list of application options can be found in the [Options Reference](refer
 The `Assets` option is mandatory as you can't have a Wails application without frontend assets. Those assets can be any files you would expect to find in a web application - html, js, css, svg, png, etc. **There is no requirement to generate asset bundles** - plain files will do. When the application starts, it will attempt to load `index.html` from your assets and the frontend will essentially work as a browser from that point on. It is worth noting that there is no requirement on where in the `embed.FS` the files live. It is likely that the embed path uses a nested directory relative to your main application code, such as `frontend/dist`:
 
 ```go title="main.go"
-//go:embed frontend/dist
+//go:embed all:frontend/dist
 var assets embed.FS
 ```
 
@@ -123,7 +123,7 @@ import (
     "github.com/wailsapp/wails/v2/pkg/options"
 )
 
-//go:embed frontend/dist
+//go:embed all:frontend/dist
 var assets embed.FS
 
 func main() {

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/guides/dynamic-assets.mdx
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/guides/dynamic-assets.mdx
@@ -21,7 +21,7 @@ import (
     "strings"
 )
 
-//go:embed frontend/dist
+//go:embed all:frontend/dist
 var assets embed.FS
 
 type FileLoader struct {

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/guides/frameless.mdx
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/guides/frameless.mdx
@@ -36,7 +36,7 @@ import (
     "github.com/wailsapp/wails/v2/pkg/options"
 )
 
-//go:embed frontend/dist
+//go:embed all:frontend/dist
 var assets embed.FS
 
 func main() {

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/guides/migrating.mdx
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/guides/migrating.mdx
@@ -163,7 +163,7 @@ func (a *App) startup(ctx context.Context) {
 应用程序可以通过简单地创建一个`embed.FS`来使用这些资源：
 
 ```go title="Assets Example"
-//go:embed frontend/dist
+//go:embed all:frontend/dist
 var assets embed.FS
 
 func main() {

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/guides/troubleshooting.mdx
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/guides/troubleshooting.mdx
@@ -11,7 +11,7 @@ If your system is reporting that the `wails` command is missing, make sure you h
 检查您的应用程序是否在正确目录中包含资源。 Check that your application includes the assets from the correct directory. In your `main.go` file, you will have something similar to the following code:
 
 ```go
-//go:embed frontend/dist
+//go:embed all:frontend/dist
 var assets embed.FS
 ```
 

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/howdoesitwork.mdx
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/howdoesitwork.mdx
@@ -27,7 +27,7 @@ import (
     "github.com/wailsapp/wails/v2/pkg/options"
 )
 
-//go:embed frontend/dist
+//go:embed all:frontend/dist
 var assets embed.FS
 
 func main() {
@@ -84,7 +84,7 @@ func (b *App) Greet(name string) string {
 `Assets` 选项是必须的，因为您不能拥有没有前端资源的 Wails 应用程序。 这些资源可以是您希望在 Web 应用程序中找到的任何文件 - html、js、css、svg、png 等。 **不需要生成资源包** - 纯文件即可。 当应用程序启动时，它将尝试从您的资源中加载`index.html`，并且那时起前端基本上将作为浏览器工作。 值得注意的是`embed.FS`对文件所在的位置没有要求。 嵌入路径很可能使用了相对于您的主应用程序代码的嵌套目录，例如 `frontend/dist`：
 
 ```go title="main.go"
-//go:embed frontend/dist
+//go:embed all:frontend/dist
 var assets embed.FS
 ```
 
@@ -123,7 +123,7 @@ import (
     "github.com/wailsapp/wails/v2/pkg/options"
 )
 
-//go:embed frontend/dist
+//go:embed all:frontend/dist
 var assets embed.FS
 
 func main() {


### PR DESCRIPTION
Otherwise files prefixed with `.` and `_` won't get embedded.