### PR TITLE
Update introduction.mdx

### DIFF
--- a/website/docs/introduction.mdx
+++ b/website/docs/introduction.mdx
@@ -17,7 +17,7 @@ and power of Go, combined with a rich, modern frontend.
 - Easily call Go methods from Javascript
 - Automatic Go struct to Typescript model generation
 - No CGO or external DLLs required on Windows
-- Live development mode using the power of [Vite](https://vite.net/)
+- Live development mode using the power of [Vite](https://vitejs.dev/)
 - Powerful CLI to easily Create, Build and Package applications
 - A rich [runtime library](/docs/next/reference/runtime/intro) 
 - Applications built with Wails are Apple & Microsoft Store compliant


### PR DESCRIPTION
Website of Vite is [https://vitejs.dev/](https://vitejs.dev) not [https://vite.net/](https://vite.net/)

