### PR TITLE
Add support for default No button

### DIFF
--- a/v2/internal/frontend/desktop/windows/dialog_test.go
+++ b/v2/internal/frontend/desktop/windows/dialog_test.go
@@ -1,0 +1,66 @@
+package windows
+
+import (
+	"github.com/wailsapp/wails/v2/internal/frontend"
+	"golang.org/x/sys/windows"
+	"testing"
+)
+
+func Test_calculateMessageDialogFlags(t *testing.T) {
+	tests := []struct {
+		name    string
+		options frontend.MessageDialogOptions
+		want    uint32
+	}{
+		{
+			name: "Test Info Dialog",
+			options: frontend.MessageDialogOptions{
+				Type: frontend.InfoDialog,
+			},
+			want: windows.MB_OK | windows.MB_ICONINFORMATION,
+		},
+		{
+			name: "Test Info Dialog",
+			options: frontend.MessageDialogOptions{
+				Type: frontend.ErrorDialog,
+			},
+			want: windows.MB_ICONERROR | windows.MB_OK,
+		},
+		{
+			name: "Test Question Dialog",
+			options: frontend.MessageDialogOptions{
+				Type: frontend.QuestionDialog,
+			},
+			want: windows.MB_YESNO,
+		},
+		{
+			name: "Test Question Dialog with default cancel",
+			options: frontend.MessageDialogOptions{
+				Type:          frontend.QuestionDialog,
+				DefaultButton: "Cancel",
+			},
+			want: windows.MB_YESNO | windows.MB_DEFBUTTON2,
+		},
+		{
+			name: "Test Warning Dialog",
+			options: frontend.MessageDialogOptions{
+				Type: frontend.WarningDialog,
+			},
+			want: windows.MB_OK | windows.MB_ICONWARNING,
+		},
+		{
+			name: "Test Error Dialog",
+			options: frontend.MessageDialogOptions{
+				Type: frontend.ErrorDialog,
+			},
+			want: windows.MB_ICONERROR | windows.MB_OK,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := calculateMessageDialogFlags(tt.options); got != tt.want {
+				t.Errorf("calculateMessageDialogFlags() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/v2/internal/frontend/desktop/windows/dialog_test.go
+++ b/v2/internal/frontend/desktop/windows/dialog_test.go
@@ -20,7 +20,7 @@ func Test_calculateMessageDialogFlags(t *testing.T) {
 			want: windows.MB_OK | windows.MB_ICONINFORMATION,
 		},
 		{
-			name: "Test Info Dialog",
+			name: "Test Error Dialog",
 			options: frontend.MessageDialogOptions{
 				Type: frontend.ErrorDialog,
 			},
@@ -37,7 +37,15 @@ func Test_calculateMessageDialogFlags(t *testing.T) {
 			name: "Test Question Dialog with default cancel",
 			options: frontend.MessageDialogOptions{
 				Type:          frontend.QuestionDialog,
-				DefaultButton: "Cancel",
+				DefaultButton: "No",
+			},
+			want: windows.MB_YESNO | windows.MB_DEFBUTTON2,
+		},
+		{
+			name: "Test Question Dialog with default cancel (lowercase)",
+			options: frontend.MessageDialogOptions{
+				Type:          frontend.QuestionDialog,
+				DefaultButton: "no",
 			},
 			want: windows.MB_YESNO | windows.MB_DEFBUTTON2,
 		},

--- a/website/docs/reference/runtime/dialog.mdx
+++ b/website/docs/reference/runtime/dialog.mdx
@@ -142,7 +142,6 @@ Example:
 		Message:       "Do you want to continue?",
 		DefaultButton: "No",
 	})
-
 ```
 
 #### Linux

--- a/website/docs/reference/runtime/dialog.mdx
+++ b/website/docs/reference/runtime/dialog.mdx
@@ -117,19 +117,33 @@ type MessageDialogOptions struct {
 }
 ```
 
-| Field         | Description                                                               | Win | Mac | Lin |
-| ------------- | ------------------------------------------------------------------------- | --- | --- | --- |
-| Type          | The type of message dialog, eg question, info...                          | ✅  | ✅  | ✅  |
-| Title         | Title for the dialog                                                      | ✅  | ✅  | ✅  |
-| Message       | The message to show the user                                              | ✅  | ✅  | ✅  |
-| Buttons       | A list of button titles                                                   |     | ✅  |     |
-| DefaultButton | The button with this text should be treated as default. Bound to `return` |     | ✅  |     |
-| CancelButton  | The button with this text should be treated as cancel. Bound to `escape`  |     | ✅  |     |
+| Field         | Description                                                                | Win            | Mac | Lin |
+|---------------|----------------------------------------------------------------------------|----------------|-----|-----|
+| Type          | The type of message dialog, eg question, info...                           | ✅              | ✅   | ✅   |
+| Title         | Title for the dialog                                                       | ✅              | ✅   | ✅   |
+| Message       | The message to show the user                                               | ✅              | ✅   | ✅   |
+| Buttons       | A list of button titles                                                    |                | ✅   |     |
+| DefaultButton | The button with this text should be treated as default. Bound to `return`. | ✅[*](#windows) | ✅   |     |
+| CancelButton  | The button with this text should be treated as cancel. Bound to `escape`   |                | ✅   |     |
 
 #### Windows
 
 Windows has standard dialog types in which the buttons are not customisable.
-The value returned will be one of: "Ok", "Cancel", "Abort", "Retry", "Ignore", "Yes", "No", "Try Again" or "Continue"
+The value returned will be one of: "Ok", "Cancel", "Abort", "Retry", "Ignore", "Yes", "No", "Try Again" or "Continue".
+
+For Question dialogs, the default button is "Yes" and the cancel button is "No". 
+This can be changed by setting the `DefaultButton` value to `"No"`.
+
+Example:
+```go
+	result, err := runtime.MessageDialog(a.ctx, runtime.MessageDialogOptions{
+		Type:          runtime.QuestionDialog,
+		Title:         "Question",
+		Message:       "Do you want to continue?",
+		DefaultButton: "No",
+	})
+
+```
 
 #### Linux
 


### PR DESCRIPTION
Adds support for specifying that the "No" button is default when opening a question dialog on Windows.

Example:
```go
	result, err := runtime.MessageDialog(a.ctx, runtime.MessageDialogOptions{
		Type:          runtime.QuestionDialog,
		Title:         "Question",
		Message:       "Do you want to continue?",
		DefaultButton: "No",
	})
```

Fixes #1871 