### PR TITLE
mention Wails is for deskotp apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,9 +61,10 @@
 
 ## Introduction
 
-The traditional method of providing web interfaces to Go programs is via a built-in web server. Wails offers a different
-approach: it provides the ability to wrap both Go code and a web frontend into a single binary. Tools are provided to
-make this easy for you by handling project creation, compilation and bundling. All you have to do is get creative!
+The traditional method of providing web interfaces to desktop Go programs is via a built-in web server. Wails offers a
+different approach: it provides the ability to wrap both Go code and a web frontend into a single binary, similar to
+Electron for NodeJS. Tools are provided to make this easy for you by handling project creation, compilation and bundling.
+All you have to do is get creative!
 
 ## Features
 


### PR DESCRIPTION
By reading the README, I thought this program was a backend service for web apps, not desktop apps.

TBH, your Intro at the website is more clear; perhaps they should be the same? https://wails.io/docs/introduction