### PR TITLE
Quote command arguments if they have a space

### DIFF
--- a/v2/pkg/commands/build/base.go
+++ b/v2/pkg/commands/build/base.go
@@ -108,6 +108,20 @@ func (b *BaseBuilder) CleanUp() {
 	})
 }
 
+func commandPrettifier(args []string) string {
+	// If we have a single argument, just return it
+	if len(args) == 1 {
+		return args[0]
+	}
+	// If an argument contains a space, quote it
+	for i, arg := range args {
+		if strings.Contains(arg, " ") {
+			args[i] = fmt.Sprintf("\"%s\"", arg)
+		}
+	}
+	return strings.Join(args, " ")
+}
+
 func (b *BaseBuilder) OutputFilename(options *Options) string {
 	outputFile := options.OutputFile
 	if outputFile == "" {
@@ -270,7 +284,7 @@ func (b *BaseBuilder) CompileProject(options *Options) error {
 	cmd := exec.Command(compiler, commands.AsSlice()...)
 	cmd.Stderr = os.Stderr
 	if verbose {
-		println("  Build command:", compiler, commands.Join(" "))
+		println("  Build command:", compiler, commandPrettifier(commands.AsSlice()))
 		cmd.Stdout = os.Stdout
 	}
 	// Set the directory

--- a/v2/pkg/commands/build/base_test.go
+++ b/v2/pkg/commands/build/base_test.go
@@ -35,3 +35,34 @@ func TestUpdateEnv(t *testing.T) {
 	}
 
 }
+
+func Test_commandPrettifier(t *testing.T) {
+	tests := []struct {
+		name  string
+		input []string
+		want  string
+	}{
+		{
+			name:  "empty",
+			input: []string{},
+			want:  "",
+		},
+		{
+			name:  "one arg",
+			input: []string{"one"},
+			want:  "one",
+		},
+		{
+			name:  "args where one has spaces",
+			input: []string{"one", "two three"},
+			want:  `one "two three"`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := commandPrettifier(tt.input); got != tt.want {
+				t.Errorf("commandPrettifier() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Generates better output when using `-v 2`.

Before:
` Build command: go build -tags desktop,production -ldflags -w -s -H windowsgui -o default_no.exe`

After:
` Build command: go build -tags desktop,production -ldflags "-w -s -H windowsgui" -o default_no.exe`

Fixes: #1885 