### PR TITLE
fix: init command not listed in wails help message

### DIFF
--- a/v2/cmd/wails/internal/commands/initialise/initialise.go
+++ b/v2/cmd/wails/internal/commands/initialise/initialise.go
@@ -40,7 +40,7 @@ func AddSubcommand(app *clir.Cli, w io.Writer) error {
 
 	// For CI
 	ciMode := false
-	command.BoolFlag("ci", "CI Mode", &ciMode).Hidden()
+	command.BoolFlag("ci", "CI Mode", &ciMode)
 
 	// Setup project directory
 	projectDirectory := ""


### PR DESCRIPTION
Closes #1915