### PR TITLE
Added quasar-js and quasar-ts templates

### DIFF
--- a/website/docs/community/templates.mdx
+++ b/website/docs/community/templates.mdx
@@ -26,6 +26,8 @@ If you are unsure about a template, inspect `package.json` and `wails.json` for 
 - [wails-template-vue](https://github.com/misitebao/wails-template-vue) - Wails template based on Vue ecology (Integrated TypeScript, Dark theme, Internationalization, Single page routing, TailwindCSS)
 - [wails-vite-vue-ts](https://github.com/codydbentley/wails-vite-vue-ts) - Vue 3 TypeScript with Vite (and instructions to add features)
 - [wails-vite-vue-the-works](https://github.com/codydbentley/wails-vite-vue-the-works) - Vue 3 TypeScript with Vite, Vuex, Vue Router, Sass, and ESLint + Prettier
+- [wails-template-quasar-js](https://github.com/sgosiaco/wails-template-quasar-js) - A template using JavaScript + Quasar V2 (Vue 3, Vite, Sass, Pinia, ESLint, Prettier)
+- [wails-template-quasar-ts](https://github.com/sgosiaco/wails-template-quasar-ts) - A template using TypeScript + Quasar V2 (Vue 3, Vite, Sass, Pinia, ESLint, Prettier, Composition API with <script setup>)
 
 ## Angular
 


### PR DESCRIPTION
I added two new community templates based on [quasar](https://quasar.dev/)
Quasar has quite a few configuration options so these templates use relatively "safe/standard" defaults.
There is one template for JavaScript and one for TypeScript.