### PR TITLE
[debug] Introducing debug options for debug builds to allow opening the inspector on startup

### DIFF
--- a/v2/internal/frontend/desktop/darwin/inspector.go
+++ b/v2/internal/frontend/desktop/darwin/inspector.go
@@ -1,0 +1,7 @@
+//go:build darwin && !dev
+
+package darwin
+
+func showInspector(context unsafe.Pointer) {
+
+}

--- a/v2/internal/frontend/desktop/darwin/inspector_dev.go
+++ b/v2/internal/frontend/desktop/darwin/inspector_dev.go
@@ -1,0 +1,41 @@
+//go:build darwin && dev
+
+package darwin
+
+// We are using private APIs here, make sure this is only included in a dev build and not in a production build.
+// Otherwise the binary might get rejected by the AppReview-Team when pushing it to the AppStore.
+
+/*
+#cgo CFLAGS: -x objective-c
+#cgo LDFLAGS: -framework Foundation -framework Cocoa -framework WebKit
+#import <Foundation/Foundation.h>
+#import "WailsContext.h"
+
+@interface _WKInspector : NSObject
+- (void)show;
+- (void)detach;
+@end
+
+@interface WKWebView ()
+- (_WKInspector *)_inspector;
+@end
+
+void showInspector(void *inctx) {
+    WailsContext *ctx = (__bridge WailsContext*) inctx;
+
+	[ctx.webview._inspector show];
+	dispatch_time_t popTime = dispatch_time(DISPATCH_TIME_NOW, 1 * NSEC_PER_SEC);
+	dispatch_after(popTime, dispatch_get_main_queue(), ^(void){
+		// Detach must be deferred a little bit and is ignored directly after a show.
+  		[ctx.webview._inspector detach];
+	});
+}
+*/
+import "C"
+import (
+	"unsafe"
+)
+
+func showInspector(context unsafe.Pointer) {
+	C.showInspector(context)
+}

--- a/v2/internal/frontend/desktop/darwin/window.go
+++ b/v2/internal/frontend/desktop/darwin/window.go
@@ -112,6 +112,9 @@ func NewWindow(frontendOptions *options.App, debugMode bool) *Window {
 		result.SetApplicationMenu(frontendOptions.Menu)
 	}
 
+	if debugMode && frontendOptions.Debug.OpenInspectorOnStartup {
+		showInspector(result.context)
+	}
 	return result
 }
 

--- a/v2/internal/frontend/desktop/linux/window.go
+++ b/v2/internal/frontend/desktop/linux/window.go
@@ -232,10 +232,15 @@ GtkWidget* setupWebview(void* contentManager, GtkWindow* window, int hideWindowO
 	return webview;
 }
 
-void devtoolsEnabled(void* webview, int enabled) {
+void devtoolsEnabled(void* webview, int enabled, bool showInspector) {
 	WebKitSettings *settings = webkit_web_view_get_settings(WEBKIT_WEB_VIEW(webview));
 	gboolean genabled = enabled == 1 ? true : false;
 	webkit_settings_set_enable_developer_extras(settings, genabled);
+
+	if (genabled && showInspector) {
+		WebKitWebInspector *inspector = webkit_web_view_get_inspector(WEBKIT_WEB_VIEW(webview));
+		webkit_web_inspector_show(WEBKIT_WEB_INSPECTOR(inspector));
+	}
 }
 
 void loadIndex(void* webview, char* url) {
@@ -704,7 +709,7 @@ func NewWindow(appoptions *options.App, debug bool) *Window {
 	C.connectButtons(unsafe.Pointer(webview))
 
 	if debug {
-		C.devtoolsEnabled(unsafe.Pointer(webview), C.int(1))
+		C.devtoolsEnabled(unsafe.Pointer(webview), C.int(1), C.bool(appoptions.Debug.OpenInspectorOnStartup))
 	} else {
 		C.DisableContextMenu(unsafe.Pointer(webview))
 	}

--- a/v2/internal/frontend/desktop/windows/frontend.go
+++ b/v2/internal/frontend/desktop/windows/frontend.go
@@ -443,7 +443,6 @@ func (f *Frontend) setupChromium() {
 		if err != nil {
 			log.Fatal(err)
 		}
-
 	}
 
 	err = settings.PutIsStatusBarEnabled(false)
@@ -457,6 +456,10 @@ func (f *Frontend) setupChromium() {
 	err = settings.PutIsSwipeNavigationEnabled(false)
 	if err != nil {
 		log.Fatal(err)
+	}
+
+	if f.debug && f.frontendOptions.Debug.OpenInspectorOnStartup {
+		chromium.OpenDevToolsWindow()
 	}
 
 	// Setup focus event handler

--- a/v2/internal/frontend/desktop/windows/go-webview2/pkg/edge/chromium.go
+++ b/v2/internal/frontend/desktop/windows/go-webview2/pkg/edge/chromium.go
@@ -364,3 +364,7 @@ func (e *Chromium) PutZoomFactor(zoomFactor float64) {
 		log.Fatal(err)
 	}
 }
+
+func (e *Chromium) OpenDevToolsWindow() {
+	e.webview.OpenDevToolsWindow()
+}

--- a/v2/internal/frontend/desktop/windows/go-webview2/pkg/edge/corewebview2.go
+++ b/v2/internal/frontend/desktop/windows/go-webview2/pkg/edge/corewebview2.go
@@ -469,3 +469,14 @@ func (i *ICoreWebView2) AddNavigationCompleted(eventHandler *ICoreWebView2Naviga
 	}
 	return nil
 }
+
+func (i *ICoreWebView2) OpenDevToolsWindow() error {
+	var err error
+	_, _, err = i.vtbl.OpenDevToolsWindow.Call(
+		uintptr(unsafe.Pointer(i)),
+	)
+	if err != windows.ERROR_SUCCESS {
+		return err
+	}
+	return nil
+}

--- a/v2/pkg/options/debug.go
+++ b/v2/pkg/options/debug.go
@@ -1,0 +1,7 @@
+package options
+
+// Debug options which are taken into account in debug builds.
+type Debug struct {
+	// OpenInspectorOnStartup opens the inspector on startup of the app.
+	OpenInspectorOnStartup bool
+}

--- a/v2/pkg/options/options.go
+++ b/v2/pkg/options/options.go
@@ -78,6 +78,9 @@ type App struct {
 
 	// Experimental options
 	Experimental *Experimental
+
+	// Debug options for debug builds. These options will be ignored in a production build.
+	Debug Debug
 }
 
 type RGBA struct {

--- a/website/docs/reference/options.mdx
+++ b/website/docs/reference/options.mdx
@@ -102,6 +102,9 @@ func main() {
             Icon: icon,
             WindowIsTranslucent: false,
         },
+        Debug: options.Debug{
+            OpenInspectorOnStartup: false,
+        },
     })
     if err != nil {
         log.Fatal(err)
@@ -821,4 +824,18 @@ Scaling is postponed until the last minute, when the desired final size is known
 Setting this to `true` will make the window background translucent. Some window managers may ignore it, or result in a black window.
 
 Name: WindowIsTranslucent<br/>
+Type: `bool`
+
+### Debug
+
+This defines [Debug specific options](#Debug) that apply to debug builds.
+
+Name: Debug<br/>
+Type: `options.Debug`
+
+#### OpenInspectorOnStartup
+
+Setting this to `true` will open the WebInspector on startup of the application.
+
+Name: OpenInspectorOnStartup<br/>
 Type: `bool`

--- a/website/src/pages/changelog.mdx
+++ b/website/src/pages/changelog.mdx
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Added `OpenInspectorOnStartup` to debug options to allow opening the WebInspector during startup of the application in debug mode. Added by @stffabi in [PR](https://github.com/wailsapp/wails/pull/2080)
+
 ### Fixed
 - The `noreload` flag in wails dev wasn't applied. Fixed by @stffabi in this [PR](https://github.com/wailsapp/wails/pull/2081)
 


### PR DESCRIPTION
Some known limitations
- The initial selected tab depends on the platform implementations. (macOS, Windows: Network-Tab, Linux: Sources-Tab) 
- The inspector is always in foreground
- Network records might be missing for the first load.
 
Fixes #2059 

Tested on:
- [x] Windows 11 Pro (22621.819)
- [x] Mac (13.0 - 22A380)
- [x] Linux (Fedora 35)