### PR TITLE
Rename bleeding edge -> local development

### DIFF
--- a/website/docs/guides/local-development.mdx
+++ b/website/docs/guides/local-development.mdx
@@ -1,4 +1,4 @@
-# Bleeding Edge
+# Local Development
 
 ## Overview
 


### PR DESCRIPTION
It's the local development setup guide so let's rename it.