### PR TITLE
[windows] Prevent a thin white line at the bottom of a frameless window

### DIFF
--- a/v2/internal/frontend/desktop/windows/frontend.go
+++ b/v2/internal/frontend/desktop/windows/frontend.go
@@ -130,7 +130,9 @@ func (f *Frontend) WindowSetDarkTheme() {
 func (f *Frontend) Run(ctx context.Context) error {
 	f.ctx = ctx
 
-	mainWindow := NewWindow(nil, f.frontendOptions, f.versionInfo)
+	f.chromium = edge.NewChromium()
+
+	mainWindow := NewWindow(nil, f.frontendOptions, f.versionInfo, f.chromium)
 	f.mainWindow = mainWindow
 
 	var _debug = ctx.Value("debug")
@@ -140,8 +142,6 @@ func (f *Frontend) Run(ctx context.Context) error {
 
 	f.WindowCenter()
 	f.setupChromium()
-
-	f.mainWindow.notifyParentWindowPositionChanged = f.chromium.NotifyParentWindowPositionChanged
 
 	mainWindow.OnSize().Bind(func(arg *winc.Event) {
 		if f.frontendOptions.Frameless {
@@ -406,8 +406,8 @@ func (f *Frontend) Quit() {
 }
 
 func (f *Frontend) setupChromium() {
-	chromium := edge.NewChromium()
-	f.chromium = chromium
+	chromium := f.chromium
+
 	if opts := f.frontendOptions.Windows; opts != nil {
 		chromium.DataPath = opts.WebviewUserDataPath
 		chromium.BrowserPath = opts.WebviewBrowserPath
@@ -421,7 +421,6 @@ func (f *Frontend) setupChromium() {
 	}
 	chromium.Embed(f.mainWindow.Handle())
 	chromium.Resize()
-	f.mainWindow.chromium = chromium
 	settings, err := chromium.GetSettings()
 	if err != nil {
 		log.Fatal(err)

--- a/v2/internal/frontend/desktop/windows/go-webview2/pkg/edge/chromium.go
+++ b/v2/internal/frontend/desktop/windows/go-webview2/pkg/edge/chromium.go
@@ -16,6 +16,8 @@ import (
 	"golang.org/x/sys/windows"
 )
 
+type Rect = w32.Rect
+
 type Chromium struct {
 	hwnd                  uintptr
 	controller            *ICoreWebView2Controller
@@ -30,6 +32,8 @@ type Chromium struct {
 	navigationCompleted   *ICoreWebView2NavigationCompletedEventHandler
 
 	environment *ICoreWebView2Environment
+
+	padding Rect
 
 	// Settings
 	Debug       bool
@@ -118,6 +122,33 @@ func (e *Chromium) Embed(hwnd uintptr) bool {
 	}
 	e.Init("window.external={invoke:s=>window.chrome.webview.postMessage(s)}")
 	return true
+}
+
+func (e *Chromium) SetPadding(padding Rect) {
+	if e.padding.Top == padding.Top && e.padding.Bottom == padding.Bottom &&
+		e.padding.Left == padding.Left && e.padding.Right == padding.Right {
+
+		return
+	}
+
+	e.padding = padding
+	e.Resize()
+}
+
+func (e *Chromium) Resize() {
+	if e.hwnd == 0 {
+		return
+	}
+
+	var bounds w32.Rect
+	w32.User32GetClientRect.Call(e.hwnd, uintptr(unsafe.Pointer(&bounds)))
+
+	bounds.Top += e.padding.Top
+	bounds.Bottom -= e.padding.Bottom
+	bounds.Left += e.padding.Left
+	bounds.Right -= e.padding.Right
+
+	e.SetSize(bounds)
 }
 
 func (e *Chromium) Navigate(url string) {

--- a/v2/internal/frontend/desktop/windows/go-webview2/pkg/edge/chromium_386.go
+++ b/v2/internal/frontend/desktop/windows/go-webview2/pkg/edge/chromium_386.go
@@ -8,12 +8,11 @@ import (
 	"unsafe"
 )
 
-func (e *Chromium) Resize() {
+func (e *Chromium) SetSize(bounds w32.Rect) {
 	if e.controller == nil {
 		return
 	}
-	var bounds w32.Rect
-	w32.User32GetClientRect.Call(e.hwnd, uintptr(unsafe.Pointer(&bounds)))
+
 	e.controller.vtbl.PutBounds.Call(
 		uintptr(unsafe.Pointer(e.controller)),
 		uintptr(bounds.Left),

--- a/v2/internal/frontend/desktop/windows/go-webview2/pkg/edge/chromium_amd64.go
+++ b/v2/internal/frontend/desktop/windows/go-webview2/pkg/edge/chromium_amd64.go
@@ -8,12 +8,11 @@ import (
 	"unsafe"
 )
 
-func (e *Chromium) Resize() {
+func (e *Chromium) SetSize(bounds w32.Rect) {
 	if e.controller == nil {
 		return
 	}
-	var bounds w32.Rect
-	w32.User32GetClientRect.Call(e.hwnd, uintptr(unsafe.Pointer(&bounds)))
+
 	e.controller.vtbl.PutBounds.Call(
 		uintptr(unsafe.Pointer(e.controller)),
 		uintptr(unsafe.Pointer(&bounds)),

--- a/v2/internal/frontend/desktop/windows/go-webview2/pkg/edge/chromium_arm64.go
+++ b/v2/internal/frontend/desktop/windows/go-webview2/pkg/edge/chromium_arm64.go
@@ -9,13 +9,10 @@ import (
 	"github.com/wailsapp/wails/v2/internal/frontend/desktop/windows/go-webview2/internal/w32"
 )
 
-func (e *Chromium) Resize() {
+func (e *Chromium) SetSize(bounds w32.Rect) {
 	if e.controller == nil {
 		return
 	}
-
-	var bounds w32.Rect
-	w32.User32GetClientRect.Call(e.hwnd, uintptr(unsafe.Pointer(&bounds)))
 
 	words := (*[2]uintptr)(unsafe.Pointer(&bounds))
 	e.controller.vtbl.PutBounds.Call(

--- a/website/src/pages/changelog.mdx
+++ b/website/src/pages/changelog.mdx
@@ -21,8 +21,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - The `noreload` flag in wails dev wasn't applied. Fixed by @stffabi in this [PR](https://github.com/wailsapp/wails/pull/2081)
-- `build/bin` folder was duplicating itself on each reload in `wails dev`
-mode. Fixed by @OlegGulevskyy in this [PR](https://github.com/wailsapp/wails/pull/2103)
+- `build/bin` folder was duplicating itself on each reload in `wails dev` mode. Fixed by @OlegGulevskyy in this [PR](https://github.com/wailsapp/wails/pull/2103)
+- Prevent a thin white line at the bottom of a frameless window on Windows. Fixed by @stffabi in this [PR](https://github.com/wailsapp/wails/pull/2111)
 
 ## v2.2.0 - 2022-11-09
 


### PR DESCRIPTION
This seems to be only a problem on some Windows versions.

Fixes #2108 