### PR TITLE
Supplement the missing WindowSetAlwaysOnTop in runtime.d.ts and runti…

### DIFF
--- a/v2/internal/frontend/runtime/wrapper/runtime.d.ts
+++ b/v2/internal/frontend/runtime/wrapper/runtime.d.ts
@@ -93,6 +93,10 @@ export function WindowReload(): void;
 // Reloads the application frontend.
 export function WindowReloadApp(): void;
 
+// [WindowSetAlwaysOnTop](https://wails.io/docs/reference/runtime/window#windowsetalwaysontop)
+// Sets the window AlwaysOnTop or not on top.
+export function WindowSetAlwaysOnTop(b: boolean): void;
+
 // [WindowSetSystemDefaultTheme](https://wails.io/docs/next/reference/runtime/window#windowsetsystemdefaulttheme)
 // *Windows only*
 // Sets window theme to system default (dark/light).

--- a/v2/internal/frontend/runtime/wrapper/runtime.js
+++ b/v2/internal/frontend/runtime/wrapper/runtime.js
@@ -65,6 +65,10 @@ export function WindowReloadApp() {
     window.runtime.WindowReloadApp();
 }
 
+export function WindowSetAlwaysOnTop(b) {
+    window.runtime.WindowSetAlwaysOnTop(b);
+}
+
 export function WindowSetSystemDefaultTheme() {
     window.runtime.WindowSetSystemDefaultTheme();
 }

--- a/v2/pkg/templates/generate/assets/common/frontend/wailsjs/runtime/runtime.d.ts
+++ b/v2/pkg/templates/generate/assets/common/frontend/wailsjs/runtime/runtime.d.ts
@@ -89,6 +89,10 @@ export function WindowReload(): void;
 // Reloads the application frontend.
 export function WindowReloadApp(): void;
 
+// [WindowSetAlwaysOnTop](https://wails.io/docs/reference/runtime/window#windowsetalwaysontop)
+// Sets the window AlwaysOnTop or not on top.
+export function WindowSetAlwaysOnTop(b: boolean): void;
+
 // [WindowSetSystemDefaultTheme](https://wails.io/docs/next/reference/runtime/window#windowsetsystemdefaulttheme)
 // *Windows only*
 // Sets window theme to system default (dark/light).
@@ -119,10 +123,6 @@ export function WindowFullscreen(): void;
 // [WindowUnfullscreen](https://wails.io/docs/reference/runtime/window#windowunfullscreen)
 // Restores the previous window dimensions and position prior to full screen.
 export function WindowUnfullscreen(): void;
-
-// [WindowIsFullscreen](https://wails.io/docs/reference/runtime/window#windowisfullscreen)
-// Returns the state of the window, i.e. whether the window is in full screen mode or not.
-export function WindowIsFullscreen(): Promise<boolean>;
 
 // [WindowSetSize](https://wails.io/docs/reference/runtime/window#windowsetsize)
 // Sets the width and height of the window.
@@ -170,10 +170,6 @@ export function WindowToggleMaximise(): void;
 // Restores the window to the dimensions and position prior to maximising.
 export function WindowUnmaximise(): void;
 
-// [WindowIsMaximised](https://wails.io/docs/reference/runtime/window#windowismaximised)
-// Returns the state of the window, i.e. whether the window is maximised or not.
-export function WindowIsMaximised(): Promise<boolean>;
-
 // [WindowMinimise](https://wails.io/docs/reference/runtime/window#windowminimise)
 // Minimises the window.
 export function WindowMinimise(): void;
@@ -181,14 +177,6 @@ export function WindowMinimise(): void;
 // [WindowUnminimise](https://wails.io/docs/reference/runtime/window#windowunminimise)
 // Restores the window to the dimensions and position prior to minimising.
 export function WindowUnminimise(): void;
-
-// [WindowIsMinimised](https://wails.io/docs/reference/runtime/window#windowisminimised)
-// Returns the state of the window, i.e. whether the window is minimised or not.
-export function WindowIsMinimised(): Promise<boolean>;
-
-// [WindowIsNormal](https://wails.io/docs/reference/runtime/window#windowisnormal)
-// Returns the state of the window, i.e. whether the window is normal or not.
-export function WindowIsNormal(): Promise<boolean>;
 
 // [WindowSetBackgroundColour](https://wails.io/docs/reference/runtime/window#windowsetbackgroundcolour)
 // Sets the background colour of the window to the given RGBA colour definition. This colour will show through for all transparent pixels.

--- a/v2/pkg/templates/generate/assets/common/frontend/wailsjs/runtime/runtime.js
+++ b/v2/pkg/templates/generate/assets/common/frontend/wailsjs/runtime/runtime.js
@@ -65,6 +65,10 @@ export function WindowReloadApp() {
     window.runtime.WindowReloadApp();
 }
 
+export function WindowSetAlwaysOnTop(b) {
+    window.runtime.WindowSetAlwaysOnTop(b);
+}
+
 export function WindowSetSystemDefaultTheme() {
     window.runtime.WindowSetSystemDefaultTheme();
 }
@@ -91,10 +95,6 @@ export function WindowFullscreen() {
 
 export function WindowUnfullscreen() {
     window.runtime.WindowUnfullscreen();
-}
-
-export function WindowIsFullscreen() {
-    return window.runtime.WindowIsFullscreen();
 }
 
 export function WindowGetSize() {
@@ -141,10 +141,6 @@ export function WindowUnmaximise() {
     window.runtime.WindowUnmaximise();
 }
 
-export function WindowIsMaximised() {
-    return window.runtime.WindowIsMaximised();
-}
-
 export function WindowMinimise() {
     window.runtime.WindowMinimise();
 }
@@ -159,14 +155,6 @@ export function WindowSetBackgroundColour(R, G, B, A) {
 
 export function ScreenGetAll() {
     return window.runtime.ScreenGetAll();
-}
-
-export function WindowIsMinimised() {
-    return window.runtime.WindowIsMinimised();
-}
-
-export function WindowIsNormal() {
-    return window.runtime.WindowIsNormal();
 }
 
 export function BrowserOpenURL(url) {

--- a/v2/pkg/templates/templates/lit-ts/frontend/wailsjs/runtime/runtime.d.ts
+++ b/v2/pkg/templates/templates/lit-ts/frontend/wailsjs/runtime/runtime.d.ts
@@ -89,6 +89,10 @@ export function WindowReload(): void;
 // Reloads the application frontend.
 export function WindowReloadApp(): void;
 
+// [WindowSetAlwaysOnTop](https://wails.io/docs/reference/runtime/window#windowsetalwaysontop)
+// Sets the window AlwaysOnTop or not on top.
+export function WindowSetAlwaysOnTop(b: boolean): void;
+
 // [WindowSetSystemDefaultTheme](https://wails.io/docs/next/reference/runtime/window#windowsetsystemdefaulttheme)
 // *Windows only*
 // Sets window theme to system default (dark/light).

--- a/v2/pkg/templates/templates/lit-ts/frontend/wailsjs/runtime/runtime.js
+++ b/v2/pkg/templates/templates/lit-ts/frontend/wailsjs/runtime/runtime.js
@@ -65,6 +65,10 @@ export function WindowReloadApp() {
     window.runtime.WindowReloadApp();
 }
 
+export function WindowSetAlwaysOnTop(b) {
+    window.runtime.WindowSetAlwaysOnTop(b);
+}
+
 export function WindowSetSystemDefaultTheme() {
     window.runtime.WindowSetSystemDefaultTheme();
 }
@@ -137,10 +141,6 @@ export function WindowUnmaximise() {
     window.runtime.WindowUnmaximise();
 }
 
-export function WindowIsMaximised() {
-    return window.runtime.WindowIsMaximised();
-}
-
 export function WindowMinimise() {
     window.runtime.WindowMinimise();
 }
@@ -155,14 +155,6 @@ export function WindowSetBackgroundColour(R, G, B, A) {
 
 export function ScreenGetAll() {
     return window.runtime.ScreenGetAll();
-}
-
-export function WindowIsMinimised() {
-    return window.runtime.WindowIsMinimised();
-}
-
-export function WindowIsNormal() {
-    return window.runtime.WindowIsNormal();
 }
 
 export function BrowserOpenURL(url) {

--- a/v2/pkg/templates/templates/lit/frontend/wailsjs/runtime/runtime.d.ts
+++ b/v2/pkg/templates/templates/lit/frontend/wailsjs/runtime/runtime.d.ts
@@ -89,6 +89,10 @@ export function WindowReload(): void;
 // Reloads the application frontend.
 export function WindowReloadApp(): void;
 
+// [WindowSetAlwaysOnTop](https://wails.io/docs/reference/runtime/window#windowsetalwaysontop)
+// Sets the window AlwaysOnTop or not on top.
+export function WindowSetAlwaysOnTop(b: boolean): void;
+
 // [WindowSetSystemDefaultTheme](https://wails.io/docs/next/reference/runtime/window#windowsetsystemdefaulttheme)
 // *Windows only*
 // Sets window theme to system default (dark/light).

--- a/v2/pkg/templates/templates/lit/frontend/wailsjs/runtime/runtime.js
+++ b/v2/pkg/templates/templates/lit/frontend/wailsjs/runtime/runtime.js
@@ -65,6 +65,10 @@ export function WindowReloadApp() {
     window.runtime.WindowReloadApp();
 }
 
+export function WindowSetAlwaysOnTop(b) {
+    window.runtime.WindowSetAlwaysOnTop(b);
+}
+
 export function WindowSetSystemDefaultTheme() {
     window.runtime.WindowSetSystemDefaultTheme();
 }

--- a/v2/pkg/templates/templates/preact-ts/frontend/wailsjs/runtime/runtime.d.ts
+++ b/v2/pkg/templates/templates/preact-ts/frontend/wailsjs/runtime/runtime.d.ts
@@ -89,6 +89,10 @@ export function WindowReload(): void;
 // Reloads the application frontend.
 export function WindowReloadApp(): void;
 
+// [WindowSetAlwaysOnTop](https://wails.io/docs/reference/runtime/window#windowsetalwaysontop)
+// Sets the window AlwaysOnTop or not on top.
+export function WindowSetAlwaysOnTop(b: boolean): void;
+
 // [WindowSetSystemDefaultTheme](https://wails.io/docs/next/reference/runtime/window#windowsetsystemdefaulttheme)
 // *Windows only*
 // Sets window theme to system default (dark/light).

--- a/v2/pkg/templates/templates/preact-ts/frontend/wailsjs/runtime/runtime.js
+++ b/v2/pkg/templates/templates/preact-ts/frontend/wailsjs/runtime/runtime.js
@@ -65,6 +65,10 @@ export function WindowReloadApp() {
     window.runtime.WindowReloadApp();
 }
 
+export function WindowSetAlwaysOnTop(b) {
+    window.runtime.WindowSetAlwaysOnTop(b);
+}
+
 export function WindowSetSystemDefaultTheme() {
     window.runtime.WindowSetSystemDefaultTheme();
 }
@@ -137,10 +141,6 @@ export function WindowUnmaximise() {
     window.runtime.WindowUnmaximise();
 }
 
-export function WindowIsMaximised() {
-    return window.runtime.WindowIsMaximised();
-}
-
 export function WindowMinimise() {
     window.runtime.WindowMinimise();
 }
@@ -155,14 +155,6 @@ export function WindowSetBackgroundColour(R, G, B, A) {
 
 export function ScreenGetAll() {
     return window.runtime.ScreenGetAll();
-}
-
-export function WindowIsMinimised() {
-    return window.runtime.WindowIsMinimised();
-}
-
-export function WindowIsNormal() {
-    return window.runtime.WindowIsNormal();
 }
 
 export function BrowserOpenURL(url) {

--- a/v2/pkg/templates/templates/preact/frontend/wailsjs/runtime/runtime.d.ts
+++ b/v2/pkg/templates/templates/preact/frontend/wailsjs/runtime/runtime.d.ts
@@ -89,6 +89,10 @@ export function WindowReload(): void;
 // Reloads the application frontend.
 export function WindowReloadApp(): void;
 
+// [WindowSetAlwaysOnTop](https://wails.io/docs/reference/runtime/window#windowsetalwaysontop)
+// Sets the window AlwaysOnTop or not on top.
+export function WindowSetAlwaysOnTop(b: boolean): void;
+
 // [WindowSetSystemDefaultTheme](https://wails.io/docs/next/reference/runtime/window#windowsetsystemdefaulttheme)
 // *Windows only*
 // Sets window theme to system default (dark/light).

--- a/v2/pkg/templates/templates/preact/frontend/wailsjs/runtime/runtime.js
+++ b/v2/pkg/templates/templates/preact/frontend/wailsjs/runtime/runtime.js
@@ -65,6 +65,10 @@ export function WindowReloadApp() {
     window.runtime.WindowReloadApp();
 }
 
+export function WindowSetAlwaysOnTop(b) {
+    window.runtime.WindowSetAlwaysOnTop(b);
+}
+
 export function WindowSetSystemDefaultTheme() {
     window.runtime.WindowSetSystemDefaultTheme();
 }
@@ -137,10 +141,6 @@ export function WindowUnmaximise() {
     window.runtime.WindowUnmaximise();
 }
 
-export function WindowIsMaximised() {
-    return window.runtime.WindowIsMaximised();
-}
-
 export function WindowMinimise() {
     window.runtime.WindowMinimise();
 }
@@ -155,14 +155,6 @@ export function WindowSetBackgroundColour(R, G, B, A) {
 
 export function ScreenGetAll() {
     return window.runtime.ScreenGetAll();
-}
-
-export function WindowIsMinimised() {
-    return window.runtime.WindowIsMinimised();
-}
-
-export function WindowIsNormal() {
-    return window.runtime.WindowIsNormal();
 }
 
 export function BrowserOpenURL(url) {

--- a/v2/pkg/templates/templates/react-ts/frontend/wailsjs/runtime/runtime.d.ts
+++ b/v2/pkg/templates/templates/react-ts/frontend/wailsjs/runtime/runtime.d.ts
@@ -89,6 +89,10 @@ export function WindowReload(): void;
 // Reloads the application frontend.
 export function WindowReloadApp(): void;
 
+// [WindowSetAlwaysOnTop](https://wails.io/docs/reference/runtime/window#windowsetalwaysontop)
+// Sets the window AlwaysOnTop or not on top.
+export function WindowSetAlwaysOnTop(b: boolean): void;
+
 // [WindowSetSystemDefaultTheme](https://wails.io/docs/next/reference/runtime/window#windowsetsystemdefaulttheme)
 // *Windows only*
 // Sets window theme to system default (dark/light).

--- a/v2/pkg/templates/templates/react-ts/frontend/wailsjs/runtime/runtime.js
+++ b/v2/pkg/templates/templates/react-ts/frontend/wailsjs/runtime/runtime.js
@@ -65,6 +65,10 @@ export function WindowReloadApp() {
     window.runtime.WindowReloadApp();
 }
 
+export function WindowSetAlwaysOnTop(b) {
+    window.runtime.WindowSetAlwaysOnTop(b);
+}
+
 export function WindowSetSystemDefaultTheme() {
     window.runtime.WindowSetSystemDefaultTheme();
 }
@@ -137,10 +141,6 @@ export function WindowUnmaximise() {
     window.runtime.WindowUnmaximise();
 }
 
-export function WindowIsMaximised() {
-    return window.runtime.WindowIsMaximised();
-}
-
 export function WindowMinimise() {
     window.runtime.WindowMinimise();
 }
@@ -155,14 +155,6 @@ export function WindowSetBackgroundColour(R, G, B, A) {
 
 export function ScreenGetAll() {
     return window.runtime.ScreenGetAll();
-}
-
-export function WindowIsMinimised() {
-    return window.runtime.WindowIsMinimised();
-}
-
-export function WindowIsNormal() {
-    return window.runtime.WindowIsNormal();
 }
 
 export function BrowserOpenURL(url) {

--- a/v2/pkg/templates/templates/react/frontend/wailsjs/runtime/runtime.d.ts
+++ b/v2/pkg/templates/templates/react/frontend/wailsjs/runtime/runtime.d.ts
@@ -89,6 +89,10 @@ export function WindowReload(): void;
 // Reloads the application frontend.
 export function WindowReloadApp(): void;
 
+// [WindowSetAlwaysOnTop](https://wails.io/docs/reference/runtime/window#windowsetalwaysontop)
+// Sets the window AlwaysOnTop or not on top.
+export function WindowSetAlwaysOnTop(b: boolean): void;
+
 // [WindowSetSystemDefaultTheme](https://wails.io/docs/next/reference/runtime/window#windowsetsystemdefaulttheme)
 // *Windows only*
 // Sets window theme to system default (dark/light).

--- a/v2/pkg/templates/templates/react/frontend/wailsjs/runtime/runtime.js
+++ b/v2/pkg/templates/templates/react/frontend/wailsjs/runtime/runtime.js
@@ -65,6 +65,10 @@ export function WindowReloadApp() {
     window.runtime.WindowReloadApp();
 }
 
+export function WindowSetAlwaysOnTop(b) {
+    window.runtime.WindowSetAlwaysOnTop(b);
+}
+
 export function WindowSetSystemDefaultTheme() {
     window.runtime.WindowSetSystemDefaultTheme();
 }
@@ -137,10 +141,6 @@ export function WindowUnmaximise() {
     window.runtime.WindowUnmaximise();
 }
 
-export function WindowIsMaximised() {
-    return window.runtime.WindowIsMaximised();
-}
-
 export function WindowMinimise() {
     window.runtime.WindowMinimise();
 }
@@ -155,14 +155,6 @@ export function WindowSetBackgroundColour(R, G, B, A) {
 
 export function ScreenGetAll() {
     return window.runtime.ScreenGetAll();
-}
-
-export function WindowIsMinimised() {
-    return window.runtime.WindowIsMinimised();
-}
-
-export function WindowIsNormal() {
-    return window.runtime.WindowIsNormal();
 }
 
 export function BrowserOpenURL(url) {

--- a/v2/pkg/templates/templates/svelte-ts/frontend/wailsjs/runtime/runtime.d.ts
+++ b/v2/pkg/templates/templates/svelte-ts/frontend/wailsjs/runtime/runtime.d.ts
@@ -89,6 +89,10 @@ export function WindowReload(): void;
 // Reloads the application frontend.
 export function WindowReloadApp(): void;
 
+// [WindowSetAlwaysOnTop](https://wails.io/docs/reference/runtime/window#windowsetalwaysontop)
+// Sets the window AlwaysOnTop or not on top.
+export function WindowSetAlwaysOnTop(b: boolean): void;
+
 // [WindowSetSystemDefaultTheme](https://wails.io/docs/next/reference/runtime/window#windowsetsystemdefaulttheme)
 // *Windows only*
 // Sets window theme to system default (dark/light).

--- a/v2/pkg/templates/templates/svelte-ts/frontend/wailsjs/runtime/runtime.js
+++ b/v2/pkg/templates/templates/svelte-ts/frontend/wailsjs/runtime/runtime.js
@@ -65,6 +65,10 @@ export function WindowReloadApp() {
     window.runtime.WindowReloadApp();
 }
 
+export function WindowSetAlwaysOnTop(b) {
+    window.runtime.WindowSetAlwaysOnTop(b);
+}
+
 export function WindowSetSystemDefaultTheme() {
     window.runtime.WindowSetSystemDefaultTheme();
 }
@@ -137,10 +141,6 @@ export function WindowUnmaximise() {
     window.runtime.WindowUnmaximise();
 }
 
-export function WindowIsMaximised() {
-    return window.runtime.WindowIsMaximised();
-}
-
 export function WindowMinimise() {
     window.runtime.WindowMinimise();
 }
@@ -155,14 +155,6 @@ export function WindowSetBackgroundColour(R, G, B, A) {
 
 export function ScreenGetAll() {
     return window.runtime.ScreenGetAll();
-}
-
-export function WindowIsMinimised() {
-    return window.runtime.WindowIsMinimised();
-}
-
-export function WindowIsNormal() {
-    return window.runtime.WindowIsNormal();
 }
 
 export function BrowserOpenURL(url) {

--- a/v2/pkg/templates/templates/svelte/frontend/wailsjs/runtime/runtime.d.ts
+++ b/v2/pkg/templates/templates/svelte/frontend/wailsjs/runtime/runtime.d.ts
@@ -89,6 +89,10 @@ export function WindowReload(): void;
 // Reloads the application frontend.
 export function WindowReloadApp(): void;
 
+// [WindowSetAlwaysOnTop](https://wails.io/docs/reference/runtime/window#windowsetalwaysontop)
+// Sets the window AlwaysOnTop or not on top.
+export function WindowSetAlwaysOnTop(b: boolean): void;
+
 // [WindowSetSystemDefaultTheme](https://wails.io/docs/next/reference/runtime/window#windowsetsystemdefaulttheme)
 // *Windows only*
 // Sets window theme to system default (dark/light).

--- a/v2/pkg/templates/templates/svelte/frontend/wailsjs/runtime/runtime.js
+++ b/v2/pkg/templates/templates/svelte/frontend/wailsjs/runtime/runtime.js
@@ -65,6 +65,10 @@ export function WindowReloadApp() {
     window.runtime.WindowReloadApp();
 }
 
+export function WindowSetAlwaysOnTop(b) {
+    window.runtime.WindowSetAlwaysOnTop(b);
+}
+
 export function WindowSetSystemDefaultTheme() {
     window.runtime.WindowSetSystemDefaultTheme();
 }
@@ -137,10 +141,6 @@ export function WindowUnmaximise() {
     window.runtime.WindowUnmaximise();
 }
 
-export function WindowIsMaximised() {
-    return window.runtime.WindowIsMaximised();
-}
-
 export function WindowMinimise() {
     window.runtime.WindowMinimise();
 }
@@ -155,14 +155,6 @@ export function WindowSetBackgroundColour(R, G, B, A) {
 
 export function ScreenGetAll() {
     return window.runtime.ScreenGetAll();
-}
-
-export function WindowIsMinimised() {
-    return window.runtime.WindowIsMinimised();
-}
-
-export function WindowIsNormal() {
-    return window.runtime.WindowIsNormal();
 }
 
 export function BrowserOpenURL(url) {

--- a/v2/pkg/templates/templates/vanilla-ts/frontend/wailsjs/runtime/runtime.d.ts
+++ b/v2/pkg/templates/templates/vanilla-ts/frontend/wailsjs/runtime/runtime.d.ts
@@ -89,6 +89,10 @@ export function WindowReload(): void;
 // Reloads the application frontend.
 export function WindowReloadApp(): void;
 
+// [WindowSetAlwaysOnTop](https://wails.io/docs/reference/runtime/window#windowsetalwaysontop)
+// Sets the window AlwaysOnTop or not on top.
+export function WindowSetAlwaysOnTop(b: boolean): void;
+
 // [WindowSetSystemDefaultTheme](https://wails.io/docs/next/reference/runtime/window#windowsetsystemdefaulttheme)
 // *Windows only*
 // Sets window theme to system default (dark/light).

--- a/v2/pkg/templates/templates/vanilla-ts/frontend/wailsjs/runtime/runtime.js
+++ b/v2/pkg/templates/templates/vanilla-ts/frontend/wailsjs/runtime/runtime.js
@@ -65,6 +65,10 @@ export function WindowReloadApp() {
     window.runtime.WindowReloadApp();
 }
 
+export function WindowSetAlwaysOnTop(b) {
+    window.runtime.WindowSetAlwaysOnTop(b);
+}
+
 export function WindowSetSystemDefaultTheme() {
     window.runtime.WindowSetSystemDefaultTheme();
 }
@@ -137,10 +141,6 @@ export function WindowUnmaximise() {
     window.runtime.WindowUnmaximise();
 }
 
-export function WindowIsMaximised() {
-    return window.runtime.WindowIsMaximised();
-}
-
 export function WindowMinimise() {
     window.runtime.WindowMinimise();
 }
@@ -155,14 +155,6 @@ export function WindowSetBackgroundColour(R, G, B, A) {
 
 export function ScreenGetAll() {
     return window.runtime.ScreenGetAll();
-}
-
-export function WindowIsMinimised() {
-    return window.runtime.WindowIsMinimised();
-}
-
-export function WindowIsNormal() {
-    return window.runtime.WindowIsNormal();
 }
 
 export function BrowserOpenURL(url) {

--- a/v2/pkg/templates/templates/vanilla/frontend/wailsjs/runtime/runtime.d.ts
+++ b/v2/pkg/templates/templates/vanilla/frontend/wailsjs/runtime/runtime.d.ts
@@ -89,6 +89,10 @@ export function WindowReload(): void;
 // Reloads the application frontend.
 export function WindowReloadApp(): void;
 
+// [WindowSetAlwaysOnTop](https://wails.io/docs/reference/runtime/window#windowsetalwaysontop)
+// Sets the window AlwaysOnTop or not on top.
+export function WindowSetAlwaysOnTop(b: boolean): void;
+
 // [WindowSetSystemDefaultTheme](https://wails.io/docs/next/reference/runtime/window#windowsetsystemdefaulttheme)
 // *Windows only*
 // Sets window theme to system default (dark/light).

--- a/v2/pkg/templates/templates/vanilla/frontend/wailsjs/runtime/runtime.js
+++ b/v2/pkg/templates/templates/vanilla/frontend/wailsjs/runtime/runtime.js
@@ -65,6 +65,10 @@ export function WindowReloadApp() {
     window.runtime.WindowReloadApp();
 }
 
+export function WindowSetAlwaysOnTop(b) {
+    window.runtime.WindowSetAlwaysOnTop(b);
+}
+
 export function WindowSetSystemDefaultTheme() {
     window.runtime.WindowSetSystemDefaultTheme();
 }
@@ -137,10 +141,6 @@ export function WindowUnmaximise() {
     window.runtime.WindowUnmaximise();
 }
 
-export function WindowIsMaximised() {
-    return window.runtime.WindowIsMaximised();
-}
-
 export function WindowMinimise() {
     window.runtime.WindowMinimise();
 }
@@ -155,14 +155,6 @@ export function WindowSetBackgroundColour(R, G, B, A) {
 
 export function ScreenGetAll() {
     return window.runtime.ScreenGetAll();
-}
-
-export function WindowIsMinimised() {
-    return window.runtime.WindowIsMinimised();
-}
-
-export function WindowIsNormal() {
-    return window.runtime.WindowIsNormal();
 }
 
 export function BrowserOpenURL(url) {

--- a/v2/pkg/templates/templates/vue-ts/frontend/wailsjs/runtime/runtime.d.ts
+++ b/v2/pkg/templates/templates/vue-ts/frontend/wailsjs/runtime/runtime.d.ts
@@ -89,6 +89,10 @@ export function WindowReload(): void;
 // Reloads the application frontend.
 export function WindowReloadApp(): void;
 
+// [WindowSetAlwaysOnTop](https://wails.io/docs/reference/runtime/window#windowsetalwaysontop)
+// Sets the window AlwaysOnTop or not on top.
+export function WindowSetAlwaysOnTop(b: boolean): void;
+
 // [WindowSetSystemDefaultTheme](https://wails.io/docs/next/reference/runtime/window#windowsetsystemdefaulttheme)
 // *Windows only*
 // Sets window theme to system default (dark/light).

--- a/v2/pkg/templates/templates/vue-ts/frontend/wailsjs/runtime/runtime.js
+++ b/v2/pkg/templates/templates/vue-ts/frontend/wailsjs/runtime/runtime.js
@@ -65,6 +65,10 @@ export function WindowReloadApp() {
     window.runtime.WindowReloadApp();
 }
 
+export function WindowSetAlwaysOnTop(b) {
+    window.runtime.WindowSetAlwaysOnTop(b);
+}
+
 export function WindowSetSystemDefaultTheme() {
     window.runtime.WindowSetSystemDefaultTheme();
 }
@@ -137,10 +141,6 @@ export function WindowUnmaximise() {
     window.runtime.WindowUnmaximise();
 }
 
-export function WindowIsMaximised() {
-    return window.runtime.WindowIsMaximised();
-}
-
 export function WindowMinimise() {
     window.runtime.WindowMinimise();
 }
@@ -155,14 +155,6 @@ export function WindowSetBackgroundColour(R, G, B, A) {
 
 export function ScreenGetAll() {
     return window.runtime.ScreenGetAll();
-}
-
-export function WindowIsMinimised() {
-    return window.runtime.WindowIsMinimised();
-}
-
-export function WindowIsNormal() {
-    return window.runtime.WindowIsNormal();
 }
 
 export function BrowserOpenURL(url) {

--- a/v2/pkg/templates/templates/vue/frontend/wailsjs/runtime/runtime.d.ts
+++ b/v2/pkg/templates/templates/vue/frontend/wailsjs/runtime/runtime.d.ts
@@ -89,6 +89,10 @@ export function WindowReload(): void;
 // Reloads the application frontend.
 export function WindowReloadApp(): void;
 
+// [WindowSetAlwaysOnTop](https://wails.io/docs/reference/runtime/window#windowsetalwaysontop)
+// Sets the window AlwaysOnTop or not on top.
+export function WindowSetAlwaysOnTop(b: boolean): void;
+
 // [WindowSetSystemDefaultTheme](https://wails.io/docs/next/reference/runtime/window#windowsetsystemdefaulttheme)
 // *Windows only*
 // Sets window theme to system default (dark/light).

--- a/v2/pkg/templates/templates/vue/frontend/wailsjs/runtime/runtime.js
+++ b/v2/pkg/templates/templates/vue/frontend/wailsjs/runtime/runtime.js
@@ -65,6 +65,10 @@ export function WindowReloadApp() {
     window.runtime.WindowReloadApp();
 }
 
+export function WindowSetAlwaysOnTop(b) {
+    window.runtime.WindowSetAlwaysOnTop(b);
+}
+
 export function WindowSetSystemDefaultTheme() {
     window.runtime.WindowSetSystemDefaultTheme();
 }
@@ -137,10 +141,6 @@ export function WindowUnmaximise() {
     window.runtime.WindowUnmaximise();
 }
 
-export function WindowIsMaximised() {
-    return window.runtime.WindowIsMaximised();
-}
-
 export function WindowMinimise() {
     window.runtime.WindowMinimise();
 }
@@ -155,14 +155,6 @@ export function WindowSetBackgroundColour(R, G, B, A) {
 
 export function ScreenGetAll() {
     return window.runtime.ScreenGetAll();
-}
-
-export function WindowIsMinimised() {
-    return window.runtime.WindowIsMinimised();
-}
-
-export function WindowIsNormal() {
-    return window.runtime.WindowIsNormal();
 }
 
 export function BrowserOpenURL(url) {


### PR DESCRIPTION
WindowSetAlwaysOnTop is not exported in runtime.d.ts and runtime.js, which makes this function unavailable.

The function has been completed in all runtime.d.ts and runtime.js.

After testing, it is ready for use.