### PR TITLE
BugFix: 2033

### DIFF
--- a/v2/internal/binding/binding_test/binding_numeric_prefix_json_test.go
+++ b/v2/internal/binding/binding_test/binding_numeric_prefix_json_test.go
@@ -1,0 +1,32 @@
+package binding_test
+
+type NumericPrefixJSON struct {
+	Name string `json:"200name"`
+}
+
+func (n NumericPrefixJSON) Get() NumericPrefixJSON {
+	return n
+}
+
+var NumericPrefixJSONTest = BindingTest{
+	name: "NumericPrefixJSON",
+	structs: []interface{}{
+		&NumericPrefixJSON{},
+	},
+	exemptions:  nil,
+	shouldError: false,
+	want: `
+export namespace binding_test {
+	export class NumericPrefixJSON {
+		"200name"?: string;
+		static createFrom(source: any = {}) {
+			return new NumericPrefixJSON(source);
+		}
+		constructor(source: any = {}) {
+			if ('string' === typeof source) source = JSON.parse(source);
+			this["200name] = source["200name"];
+		}
+	}
+}
+`,
+}


### PR DESCRIPTION
# Description
If you have a struct in Go with omitempty tag and the name starts with a special characters it will translate to TS with a questionmark inside the string.

Creating a pull request with a test inside as mentioned in the issue I made #2033 