### PR TITLE
Fix signal handler

### DIFF
--- a/v2/internal/frontend/desktop/linux/frontend.go
+++ b/v2/internal/frontend/desktop/linux/frontend.go
@@ -9,6 +9,69 @@ package linux
 #include "gtk/gtk.h"
 #include "webkit2/webkit2.h"
 
+// CREDIT: https://github.com/rainycape/magick
+#include <errno.h>
+#include <signal.h>
+#include <stdio.h>
+#include <string.h>
+
+static void fix_signal(int signum)
+{
+    struct sigaction st;
+
+    if (sigaction(signum, NULL, &st) < 0) {
+        goto fix_signal_error;
+    }
+    st.sa_flags |= SA_ONSTACK;
+    if (sigaction(signum, &st,  NULL) < 0) {
+        goto fix_signal_error;
+    }
+    return;
+fix_signal_error:
+        fprintf(stderr, "error fixing handler for signal %d, please "
+                "report this issue to "
+                "https://github.com/wailsapp/wails: %s\n",
+                signum, strerror(errno));
+}
+
+static void install_signal_handlers()
+{
+#if defined(SIGCHLD)
+    fix_signal(SIGCHLD);
+#endif
+#if defined(SIGHUP)
+    fix_signal(SIGHUP);
+#endif
+#if defined(SIGINT)
+    fix_signal(SIGINT);
+#endif
+#if defined(SIGQUIT)
+    fix_signal(SIGQUIT);
+#endif
+#if defined(SIGABRT)
+    fix_signal(SIGABRT);
+#endif
+#if defined(SIGFPE)
+    fix_signal(SIGFPE);
+#endif
+#if defined(SIGTERM)
+    fix_signal(SIGTERM);
+#endif
+#if defined(SIGBUS)
+    fix_signal(SIGBUS);
+#endif
+#if defined(SIGSEGV)
+    fix_signal(SIGSEGV);
+#endif
+#if defined(SIGXCPU)
+    fix_signal(SIGXCPU);
+#endif
+#if defined(SIGXFSZ)
+    fix_signal(SIGXFSZ);
+#endif
+}
+
+
 */
 import "C"
 import (
@@ -115,6 +178,8 @@ func NewFrontend(ctx context.Context, appoptions *options.App, myLogger *logger.
 		result.debug = _debug.(bool)
 	}
 	result.mainWindow = NewWindow(appoptions, result.debug)
+
+	C.install_signal_handlers()
 
 	return result
 }

--- a/website/src/pages/changelog.mdx
+++ b/website/src/pages/changelog.mdx
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The `noreload` flag in wails dev wasn't applied. Fixed by @stffabi in this [PR](https://github.com/wailsapp/wails/pull/2081)
 - `build/bin` folder was duplicating itself on each reload in `wails dev` mode. Fixed by @OlegGulevskyy in this [PR](https://github.com/wailsapp/wails/pull/2103)
 - Prevent a thin white line at the bottom of a frameless window on Windows. Fixed by @stffabi in this [PR](https://github.com/wailsapp/wails/pull/2111)
+- Better signal handling for Linux. Fixed by @leaanthony in this [PR](https://github.com/wailsapp/wails/pull/2152)
 
 ### Changed
 - Improve error message if no `index.html` could be found in the assets and validate assetserver options. Changed by @stffabi in this [PR](https://github.com/wailsapp/wails/pull/2110)


### PR DESCRIPTION
This PR sets up a new signal handler in C that overrides the current one (in C) so that `SA_ONSTACK` is used. When used against the nil dereference example @mholt gave, it appears to work as expected.

Closes #2134 