### PR TITLE
examples/customlayout: feature: add event listener for enter key

### DIFF
--- a/v2/examples/customlayout/myfrontend/src/main.js
+++ b/v2/examples/customlayout/myfrontend/src/main.js
@@ -2,7 +2,7 @@ import './style.css';
 import './app.css';
 
 import logo from './assets/images/logo-universal.png';
-import {Greet} from '../wailsjs/go/main/App';
+import { Greet } from '../wailsjs/go/main/App';
 
 document.querySelector('#app').innerHTML = `
     <img id="logo" class="logo">
@@ -14,6 +14,11 @@ document.querySelector('#app').innerHTML = `
     </div>
 `;
 document.getElementById('logo').src = logo;
+document.addEventListener("keydown", (e) => {
+    if (e.code === "Enter") {
+        window.greet();
+    }
+});
 
 let nameElement = document.getElementById("name");
 nameElement.focus();


### PR DESCRIPTION
## Description
Commonly expected UX on inputs is to handle submit on enter key.

## Changes
Attached an event listener on the document to call `window.greet()` on `keydown` for enter key.