### PR TITLE
Fix issue with anonymous structures #2038

### DIFF
--- a/v2/internal/binding/binding_test/binding_anonymous_sub_struct_multi_level_test.go
+++ b/v2/internal/binding/binding_test/binding_anonymous_sub_struct_multi_level_test.go
@@ -1,0 +1,65 @@
+package binding_test
+
+type StructWithAnonymousSubMultiLevelStruct struct {
+	Name string `json:"name"`
+	Meta struct {
+		Age  int `json:"age"`
+		More struct {
+			Info       string `json:"info"`
+			MoreInMore struct {
+				Demo string `json:"demo"`
+			} `json:"more_in_more"`
+		} `json:"more"`
+	} `json:"meta"`
+}
+
+func (s StructWithAnonymousSubMultiLevelStruct) Get() StructWithAnonymousSubMultiLevelStruct {
+	return s
+}
+
+var AnonymousSubStructMultiLevelTest = BindingTest{
+	name: "StructWithAnonymousSubMultiLevelStruct",
+	structs: []interface{}{
+		&StructWithAnonymousSubMultiLevelStruct{},
+	},
+	exemptions:  nil,
+	shouldError: false,
+	want: `
+export namespace binding_test {
+	export class StructWithAnonymousSubMultiLevelStruct {
+		name: string;
+		// Go type: struct { Age int "json:\"age\""; More struct { Info string "json:\"info\""; MoreInMore struct { Demo string "json:\"demo\"" } "json:\"more_in_more\"" } "json:\"more\"" }
+		meta: any;
+	
+		static createFrom(source: any = {}) {
+			return new StructWithAnonymousSubMultiLevelStruct(source);
+		}
+	
+		constructor(source: any = {}) {
+			if ('string' === typeof source) source = JSON.parse(source);
+			this.name = source["name"];
+			this.meta = this.convertValues(source["meta"], Object);
+		}
+	
+		convertValues(a: any, classs: any, asMap: boolean = false): any {
+			if (!a) {
+				return a;
+			}
+			if (a.slice) {
+				return (a as any[]).map(elem => this.convertValues(elem, classs));
+			} else if ("object" === typeof a) {
+				if (asMap) {
+					for (const key of Object.keys(a)) {
+						a[key] = new classs(a[key]);
+					}
+					return a;
+				}
+				return new classs(a);
+			}
+			return a;
+		}
+	}
+
+}
+`,
+}

--- a/v2/internal/binding/binding_test/binding_anonymous_sub_struct_test.go
+++ b/v2/internal/binding/binding_test/binding_anonymous_sub_struct_test.go
@@ -1,39 +1,44 @@
 package binding_test
 
-type EmptyStruct struct {
-	Empty struct{} `json:"empty"`
+type StructWithAnonymousSubStruct struct {
+	Name string `json:"name"`
+	Meta struct {
+		Age int `json:"age"`
+	} `json:"meta"`
 }
 
-func (s EmptyStruct) Get() EmptyStruct {
+func (s StructWithAnonymousSubStruct) Get() StructWithAnonymousSubStruct {
 	return s
 }
 
-var EmptyStructTest = BindingTest{
-	name: "EmptyStruct",
+var AnonymousSubStructTest = BindingTest{
+	name: "StructWithAnonymousSubStruct",
 	structs: []interface{}{
-		&EmptyStruct{},
+		&StructWithAnonymousSubStruct{},
 	},
 	exemptions:  nil,
 	shouldError: false,
 	want: `
 export namespace binding_test {
-	export class EmptyStruct {
-		// Go type: struct {}
-
-		empty: any;
-
+	export class StructWithAnonymousSubStruct {
+		name: string;
+		// Go type: struct { Age int "json:\"age\"" }
+		meta: any;
+	
 		static createFrom(source: any = {}) {
-			return new EmptyStruct(source);
+			return new StructWithAnonymousSubStruct(source);
 		}
+	
 		constructor(source: any = {}) {
 			if ('string' === typeof source) source = JSON.parse(source);
-			this.empty = this.convertValues(source["empty"], Object);
+			this.name = source["name"];
+			this.meta = this.convertValues(source["meta"], Object);
 		}
+	
 		convertValues(a: any, classs: any, asMap: boolean = false): any {
 			if (!a) {
 				return a;
 			}
-
 			if (a.slice) {
 				return (a as any[]).map(elem => this.convertValues(elem, classs));
 			} else if ("object" === typeof a) {
@@ -48,6 +53,7 @@ export namespace binding_test {
 			return a;
 		}
 	}
+
 }
 `,
 }

--- a/v2/internal/binding/binding_test/binding_test.go
+++ b/v2/internal/binding/binding_test/binding_test.go
@@ -37,6 +37,8 @@ func TestBindings_GenerateModels(t *testing.T) {
 		MultistructTest,
 		EmptyStructTest,
 		GeneratedJsEntityTest,
+		AnonymousSubStructTest,
+		AnonymousSubStructMultiLevelTest,
 	}
 
 	testLogger := &logger.Logger{}


### PR DESCRIPTION
Add full support for anonymous structures

Empty anonymous (no fields defined) structures should return instance of Object (empty - {}) instead of try creating `new null()` that cause JS error. Such behavior make any structure with empty structure as a field unusable.