### PR TITLE
[Linux] Fix right mouse button event

### DIFF
--- a/v2/internal/frontend/desktop/linux/window.go
+++ b/v2/internal/frontend/desktop/linux/window.go
@@ -165,7 +165,6 @@ float xroot = 0.0f;
 float yroot = 0.0f;
 int dragTime = -1;
 uint mouseButton = 0;
-bool contextMenuDisabled = false;
 
 gboolean buttonPress(GtkWidget *widget, GdkEventButton *event, void* dummy)
 {
@@ -175,8 +174,8 @@ gboolean buttonPress(GtkWidget *widget, GdkEventButton *event, void* dummy)
 		return FALSE;
 	}
 	mouseButton = event->button;
-	if( event->button == 3 && contextMenuDisabled ) {
-		return TRUE;
+	if( event->button == 3 ) {
+		return FALSE;
 	}
 
 	if (event->type == GDK_BUTTON_PRESS && event->button == 1)
@@ -605,12 +604,15 @@ gboolean UnFullscreen(gpointer data) {
 	return G_SOURCE_REMOVE;
 }
 
-bool disableContextMenu(GtkWindow* window) {
+
+// function to disable the context menu but propogate the event
+gboolean disableContextMenu(GtkWidget *widget, WebKitContextMenu *context_menu, GdkEvent *event, WebKitHitTestResult *hit_test_result, gpointer data) {
+	// return true to disable the context menu
 	return TRUE;
 }
 
 void DisableContextMenu(void* webview) {
-	contextMenuDisabled = TRUE;
+	// Disable the context menu but propogate the event
 	g_signal_connect(WEBKIT_WEB_VIEW(webview), "context-menu", G_CALLBACK(disableContextMenu), NULL);
 }
 

--- a/v2/internal/platform/systray.go
+++ b/v2/internal/platform/systray.go
@@ -1,5 +1,3 @@
-//go:build windows
-
 package platform
 
 import (

--- a/v2/internal/platform/systray/systray_linux.go
+++ b/v2/internal/platform/systray/systray_linux.go
@@ -1,0 +1,83 @@
+//go:build linux
+
+/*
+ * Based on code originally from https://github.com/tadvi/systray. Copyright (C) 2019 The Systray Authors. All Rights Reserved.
+ */
+
+package systray
+
+import (
+	"github.com/wailsapp/wails/v2/pkg/menu"
+	"github.com/wailsapp/wails/v2/pkg/options"
+)
+
+type Systray struct {
+}
+
+func (p *Systray) Close() {
+	err := p.Stop()
+	if err != nil {
+		println(err.Error())
+	}
+}
+
+func (p *Systray) Update() error {
+	return nil
+}
+
+// SetTitle is unused on Windows
+func (p *Systray) SetTitle(_ string) {}
+
+func New() (*Systray, error) {
+	return nil, nil
+}
+
+func (p *Systray) SetMenu(popupMenu *menu.Menu) (err error) {
+	return
+}
+
+func (p *Systray) Stop() error {
+	return nil
+}
+
+func (p *Systray) OnLeftClick(fn func()) {
+}
+
+func (p *Systray) OnRightClick(fn func()) {
+}
+
+func (p *Systray) OnLeftDoubleClick(fn func()) {
+}
+
+func (p *Systray) OnRightDoubleClick(fn func()) {
+}
+
+func (p *Systray) OnMenuClose(fn func()) {
+}
+
+func (p *Systray) OnMenuOpen(fn func()) {
+}
+
+func (p *Systray) SetTooltip(tooltip string) error {
+	return nil
+}
+
+func (p *Systray) Show() error {
+	return p.setVisible(true)
+}
+
+func (p *Systray) Hide() error {
+	return p.setVisible(false)
+}
+
+func (p *Systray) setVisible(visible bool) error {
+	return nil
+}
+
+func (p *Systray) SetIcons(lightModeIcon, darkModeIcon *options.SystemTrayIcon) error {
+	return nil
+}
+
+func (p *Systray) Run() error {
+	return nil
+}


### PR DESCRIPTION
Allows the right mouse button event through whilst retaining the existing functionality of showing no context menu.
@mholt - please let me know if this fixes your issue 👍 

Also fixes the systray experiment compile issues on linux