### PR TITLE
Allow ignore paths for dev

### DIFF
--- a/v2/cmd/wails/internal/dev/watcher.go
+++ b/v2/cmd/wails/internal/dev/watcher.go
@@ -17,10 +17,11 @@ type Watcher interface {
 }
 
 // initialiseWatcher creates the project directory watcher that will trigger recompile
-func initialiseWatcher(cwd string) (*fsnotify.Watcher, error) {
+func initialiseWatcher(cwd string, ignoredirs []string) (*fsnotify.Watcher, error) {
 
 	// Ignore dot files, node_modules and build directories by default
-	ignoreDirs := getIgnoreDirs(cwd)
+	// merge them with ignore dirs from the project file
+	ignoreDirs := getIgnoreDirs(cwd, ignoredirs)
 
 	// Get all subdirectories
 	dirs, err := fs.GetSubdirectories(cwd)
@@ -43,7 +44,7 @@ func initialiseWatcher(cwd string) (*fsnotify.Watcher, error) {
 	return watcher, nil
 }
 
-func getIgnoreDirs(cwd string) []string {
+func getIgnoreDirs(cwd string, knownIgnoreDirs []string) []string {
 	ignoreDirs := []string{filepath.Join(cwd, "build/*"), ".*", "node_modules"}
 
 	// Read .gitignore into ignoreDirs
@@ -56,6 +57,7 @@ func getIgnoreDirs(cwd string) []string {
 		}
 	}
 
+	ignoreDirs = append(ignoreDirs, knownIgnoreDirs...)
 	return lo.Uniq(ignoreDirs)
 }
 

--- a/v2/internal/project/project.go
+++ b/v2/internal/project/project.go
@@ -17,7 +17,8 @@ type Project struct {
 	Name           string `json:"name"`
 	AssetDirectory string `json:"assetdir,omitempty"`
 
-	ReloadDirectories string `json:"reloaddirs,omitempty"`
+	ReloadDirectories string   `json:"reloaddirs,omitempty"`
+	IgnoreReloadPaths []string `json:"ignorereloadpaths,omitempty"`
 
 	BuildCommand   string `json:"frontend:build"`
 	InstallCommand string `json:"frontend:install"`


### PR DESCRIPTION
Based on the issue #2053 the idea here is simple:
- adding a property ( `ignorereloadpaths` ) to `wails.json` file that accepts an array of globs
- you can mute folders, nested folders etc
- you can mute separate files in the project root folder or nested folders
- to mute all files, just add `"*"` glob

Need to update schema and come up with couple of unit tests, but the functionality of PR should be working as expected