### PR TITLE
Add nosyncgomod flag

### DIFF
--- a/v2/cmd/wails/build.go
+++ b/v2/cmd/wails/build.go
@@ -107,9 +107,11 @@ func buildApplication(f *flags.Build) error {
 		return err
 	}
 
-	err = gomod.SyncGoMod(logger, f.UpdateWailsVersionGoMod)
-	if err != nil {
-		return err
+	if !f.NoSyncGoMod {
+		err = gomod.SyncGoMod(logger, f.UpdateWailsVersionGoMod)
+		if err != nil {
+			return err
+		}
 	}
 
 	// Check platform

--- a/v2/cmd/wails/flags/buildcommon.go
+++ b/v2/cmd/wails/flags/buildcommon.go
@@ -8,6 +8,7 @@ type BuildCommon struct {
 	SkipFrontend bool   `name:"s" description:"Skips building the frontend"`
 	Verbosity    int    `name:"v" description:"Verbosity level (0 = quiet, 1 = normal, 2 = verbose)"`
 	Tags         string `description:"Build tags to pass to Go compiler. Must be quoted. Space or comma (but not both) separated"`
+	NoSyncGoMod  bool   `description:"Don't sync go.mod"`
 }
 
 func (c BuildCommon) Default() BuildCommon {

--- a/v2/cmd/wails/internal/dev/dev.go
+++ b/v2/cmd/wails/internal/dev/dev.go
@@ -75,7 +75,7 @@ func Application(f *flags.Dev, logger *clilogger.CLILogger) error {
 	cwd := lo.Must(os.Getwd())
 
 	// Update go.mod to use current wails version
-	err := gomod.SyncGoMod(logger, true)
+	err := gomod.SyncGoMod(logger, !f.NoSyncGoMod)
 	if err != nil {
 		return err
 	}

--- a/v2/internal/gomod/gomod.go
+++ b/v2/internal/gomod/gomod.go
@@ -2,8 +2,6 @@ package gomod
 
 import (
 	"fmt"
-	"strings"
-
 	"github.com/Masterminds/semver"
 	"golang.org/x/mod/modfile"
 )
@@ -38,12 +36,6 @@ func GoModOutOfSync(goModData []byte, currentVersion string) (bool, error) {
 	}
 	if gomodversion == nil {
 		return false, fmt.Errorf("Unable to find Wails in go.mod")
-	}
-
-	// check if a specific patch is targetted by a commit
-	// i.e. - v2.2.1-0.20221117091924-a8bbce6a126b
-	if strings.Contains(gomodversion.Original(), "-") {
-		return false, nil
 	}
 
 	result, err := semver.NewVersion(currentVersion)

--- a/v2/internal/gomod/gomod_data_unix.go
+++ b/v2/internal/gomod/gomod_data_unix.go
@@ -1,0 +1,135 @@
+//go:build unix
+
+package gomod
+
+const basic string = `module changeme
+
+go 1.17
+
+require github.com/wailsapp/wails/v2 v2.0.0-beta.7
+
+//replace github.com/wailsapp/wails/v2 v2.0.0-beta.7 => /home/lea/wails/v2
+`
+const basicUpdated string = `module changeme
+
+go 1.17
+
+require github.com/wailsapp/wails/v2 v2.0.0-beta.20
+
+//replace github.com/wailsapp/wails/v2 v2.0.0-beta.7 => /home/lea/wails/v2
+`
+
+const multilineRequire = `module changeme
+
+go 1.17
+
+require (
+	github.com/wailsapp/wails/v2 v2.0.0-beta.7
+)
+
+//replace github.com/wailsapp/wails/v2 v2.0.0-beta.7 => /home/lea/wails/v2
+`
+const multilineReplace = `module changeme
+
+go 1.17
+
+require (
+	github.com/wailsapp/wails/v2 v2.0.0-beta.7
+)
+
+replace github.com/wailsapp/wails/v2 v2.0.0-beta.7 => /home/lea/wails/v2
+`
+
+const multilineReplaceNoVersion = `module changeme
+
+go 1.17
+
+require (
+	github.com/wailsapp/wails/v2 v2.0.0-beta.7
+)
+
+replace github.com/wailsapp/wails/v2 => /home/lea/wails/v2
+`
+
+const multilineReplaceNoVersionBlock = `module changeme
+
+go 1.17
+
+require (
+	github.com/wailsapp/wails/v2 v2.0.0-beta.7
+)
+
+replace (
+	github.com/wailsapp/wails/v2 => /home/lea/wails/v2
+)
+`
+
+const multilineReplaceBlock = `module changeme
+
+go 1.17
+
+require (
+	github.com/wailsapp/wails/v2 v2.0.0-beta.7
+)
+
+replace (
+	github.com/wailsapp/wails/v2 v2.0.0-beta.7 => /home/lea/wails/v2
+)
+`
+
+const multilineRequireUpdated = `module changeme
+
+go 1.17
+
+require (
+	github.com/wailsapp/wails/v2 v2.0.0-beta.20
+)
+
+//replace github.com/wailsapp/wails/v2 v2.0.0-beta.7 => /home/lea/wails/v2
+`
+
+const multilineReplaceUpdated = `module changeme
+
+go 1.17
+
+require (
+	github.com/wailsapp/wails/v2 v2.0.0-beta.20
+)
+
+replace github.com/wailsapp/wails/v2 v2.0.0-beta.20 => /home/lea/wails/v2
+`
+const multilineReplaceNoVersionUpdated = `module changeme
+
+go 1.17
+
+require (
+	github.com/wailsapp/wails/v2 v2.0.0-beta.20
+)
+
+replace github.com/wailsapp/wails/v2 => /home/lea/wails/v2
+`
+const multilineReplaceNoVersionBlockUpdated = `module changeme
+
+go 1.17
+
+require (
+	github.com/wailsapp/wails/v2 v2.0.0-beta.20
+)
+
+replace (
+	github.com/wailsapp/wails/v2 => /home/lea/wails/v2
+)
+`
+
+const multilineReplaceBlockUpdated = `module changeme
+
+go 1.17
+
+require (
+	github.com/wailsapp/wails/v2 v2.0.0-beta.20
+)
+
+replace (
+	github.com/wailsapp/wails/v2 v2.0.0-beta.20 => /home/lea/wails/v2
+)
+`

--- a/v2/internal/gomod/gomod_data_windows.go
+++ b/v2/internal/gomod/gomod_data_windows.go
@@ -1,0 +1,135 @@
+//go:build windows
+
+package gomod
+
+const basic string = `module changeme
+
+go 1.17
+
+require github.com/wailsapp/wails/v2 v2.0.0-beta.7
+
+//replace github.com/wailsapp/wails/v2 v2.0.0-beta.7 => C:\Users\leaan\Documents\wails-v2-beta\wails\v2
+`
+const basicUpdated string = `module changeme
+
+go 1.17
+
+require github.com/wailsapp/wails/v2 v2.0.0-beta.20
+
+//replace github.com/wailsapp/wails/v2 v2.0.0-beta.7 => C:\Users\leaan\Documents\wails-v2-beta\wails\v2
+`
+
+const multilineRequire = `module changeme
+
+go 1.17
+
+require (
+	github.com/wailsapp/wails/v2 v2.0.0-beta.7
+)
+
+//replace github.com/wailsapp/wails/v2 v2.0.0-beta.7 => C:\Users\leaan\Documents\wails-v2-beta\wails\v2
+`
+const multilineReplace = `module changeme
+
+go 1.17
+
+require (
+	github.com/wailsapp/wails/v2 v2.0.0-beta.7
+)
+
+replace github.com/wailsapp/wails/v2 v2.0.0-beta.7 => C:\Users\leaan\Documents\wails-v2-beta\wails\v2
+`
+
+const multilineReplaceNoVersion = `module changeme
+
+go 1.17
+
+require (
+	github.com/wailsapp/wails/v2 v2.0.0-beta.7
+)
+
+replace github.com/wailsapp/wails/v2 => C:\Users\leaan\Documents\wails-v2-beta\wails\v2
+`
+
+const multilineReplaceNoVersionBlock = `module changeme
+
+go 1.17
+
+require (
+	github.com/wailsapp/wails/v2 v2.0.0-beta.7
+)
+
+replace (
+	github.com/wailsapp/wails/v2 => C:\Users\leaan\Documents\wails-v2-beta\wails\v2
+)
+`
+
+const multilineReplaceBlock = `module changeme
+
+go 1.17
+
+require (
+	github.com/wailsapp/wails/v2 v2.0.0-beta.7
+)
+
+replace (
+	github.com/wailsapp/wails/v2 v2.0.0-beta.7 => C:\Users\leaan\Documents\wails-v2-beta\wails\v2
+)
+`
+
+const multilineRequireUpdated = `module changeme
+
+go 1.17
+
+require (
+	github.com/wailsapp/wails/v2 v2.0.0-beta.20
+)
+
+//replace github.com/wailsapp/wails/v2 v2.0.0-beta.7 => C:\Users\leaan\Documents\wails-v2-beta\wails\v2
+`
+
+const multilineReplaceUpdated = `module changeme
+
+go 1.17
+
+require (
+	github.com/wailsapp/wails/v2 v2.0.0-beta.20
+)
+
+replace github.com/wailsapp/wails/v2 v2.0.0-beta.20 => C:\Users\leaan\Documents\wails-v2-beta\wails\v2
+`
+const multilineReplaceNoVersionUpdated = `module changeme
+
+go 1.17
+
+require (
+	github.com/wailsapp/wails/v2 v2.0.0-beta.20
+)
+
+replace github.com/wailsapp/wails/v2 => C:\Users\leaan\Documents\wails-v2-beta\wails\v2
+`
+const multilineReplaceNoVersionBlockUpdated = `module changeme
+
+go 1.17
+
+require (
+	github.com/wailsapp/wails/v2 v2.0.0-beta.20
+)
+
+replace (
+	github.com/wailsapp/wails/v2 => C:\Users\leaan\Documents\wails-v2-beta\wails\v2
+)
+`
+
+const multilineReplaceBlockUpdated = `module changeme
+
+go 1.17
+
+require (
+	github.com/wailsapp/wails/v2 v2.0.0-beta.20
+)
+
+replace (
+	github.com/wailsapp/wails/v2 v2.0.0-beta.20 => C:\Users\leaan\Documents\wails-v2-beta\wails\v2
+)
+`

--- a/v2/internal/gomod/gomod_test.go
+++ b/v2/internal/gomod/gomod_test.go
@@ -1,5 +1,3 @@
-//go:build windows
-
 package gomod
 
 import (

--- a/v2/internal/gomod/gomod_test.go
+++ b/v2/internal/gomod/gomod_test.go
@@ -8,15 +8,6 @@ import (
 	"github.com/matryer/is"
 )
 
-const basic string = `module changeme
-
-go 1.17
-
-require github.com/wailsapp/wails/v2 v2.0.0-beta.7
-
-//replace github.com/wailsapp/wails/v2 v2.0.0-beta.7 => C:\Users\leaan\Documents\wails-v2-beta\wails\v2
-`
-
 func TestGetWailsVersion(t *testing.T) {
 	tests := []struct {
 		name      string
@@ -39,84 +30,6 @@ func TestGetWailsVersion(t *testing.T) {
 		})
 	}
 }
-
-const basicUpdated string = `module changeme
-
-go 1.17
-
-require github.com/wailsapp/wails/v2 v2.0.0-beta.20
-
-//replace github.com/wailsapp/wails/v2 v2.0.0-beta.7 => C:\Users\leaan\Documents\wails-v2-beta\wails\v2
-`
-
-const multilineRequire = `module changeme
-
-go 1.17
-
-require (
-	github.com/wailsapp/wails/v2 v2.0.0-beta.7
-)
-
-//replace github.com/wailsapp/wails/v2 v2.0.0-beta.7 => C:\Users\leaan\Documents\wails-v2-beta\wails\v2
-`
-const multilineReplace = `module changeme
-
-go 1.17
-
-require (
-	github.com/wailsapp/wails/v2 v2.0.0-beta.7
-)
-
-replace github.com/wailsapp/wails/v2 v2.0.0-beta.7 => C:\Users\leaan\Documents\wails-v2-beta\wails\v2
-`
-
-const multilineReplaceNoVersion = `module changeme
-
-go 1.17
-
-require (
-	github.com/wailsapp/wails/v2 v2.0.0-beta.7
-)
-
-replace github.com/wailsapp/wails/v2 => C:\Users\leaan\Documents\wails-v2-beta\wails\v2
-`
-
-const multilineReplaceNoVersionBlock = `module changeme
-
-go 1.17
-
-require (
-	github.com/wailsapp/wails/v2 v2.0.0-beta.7
-)
-
-replace (
-	github.com/wailsapp/wails/v2 => C:\Users\leaan\Documents\wails-v2-beta\wails\v2
-)
-`
-
-const multilineReplaceBlock = `module changeme
-
-go 1.17
-
-require (
-	github.com/wailsapp/wails/v2 v2.0.0-beta.7
-)
-
-replace (
-	github.com/wailsapp/wails/v2 v2.0.0-beta.7 => C:\Users\leaan\Documents\wails-v2-beta\wails\v2
-)
-`
-
-const multilineRequireUpdated = `module changeme
-
-go 1.17
-
-require (
-	github.com/wailsapp/wails/v2 v2.0.0-beta.20
-)
-
-//replace github.com/wailsapp/wails/v2 v2.0.0-beta.7 => C:\Users\leaan\Documents\wails-v2-beta\wails\v2
-`
 
 func TestUpdateGoModVersion(t *testing.T) {
 	is2 := is.New(t)
@@ -177,52 +90,6 @@ func TestGoModOutOfSync(t *testing.T) {
 		})
 	}
 }
-
-const multilineReplaceUpdated = `module changeme
-
-go 1.17
-
-require (
-	github.com/wailsapp/wails/v2 v2.0.0-beta.20
-)
-
-replace github.com/wailsapp/wails/v2 v2.0.0-beta.20 => C:\Users\leaan\Documents\wails-v2-beta\wails\v2
-`
-const multilineReplaceNoVersionUpdated = `module changeme
-
-go 1.17
-
-require (
-	github.com/wailsapp/wails/v2 v2.0.0-beta.20
-)
-
-replace github.com/wailsapp/wails/v2 => C:\Users\leaan\Documents\wails-v2-beta\wails\v2
-`
-const multilineReplaceNoVersionBlockUpdated = `module changeme
-
-go 1.17
-
-require (
-	github.com/wailsapp/wails/v2 v2.0.0-beta.20
-)
-
-replace (
-	github.com/wailsapp/wails/v2 => C:\Users\leaan\Documents\wails-v2-beta\wails\v2
-)
-`
-
-const multilineReplaceBlockUpdated = `module changeme
-
-go 1.17
-
-require (
-	github.com/wailsapp/wails/v2 v2.0.0-beta.20
-)
-
-replace (
-	github.com/wailsapp/wails/v2 v2.0.0-beta.20 => C:\Users\leaan\Documents\wails-v2-beta\wails\v2
-)
-`
 
 const basicGo118 string = `module changeme
 

--- a/website/docs/reference/cli.mdx
+++ b/website/docs/reference/cli.mdx
@@ -74,6 +74,7 @@ If you are unsure about a template, inspect `package.json` and `wails.json` for 
 | -windowsconsole      | Keep the console window for Windows builds                                                                                                                                  |                                                                                                                                               |
 | -obfuscate           | Obfuscate the application using [garble](https://github.com/burrowers/garble)                                                                                               | false                                                                                                                                         |
 | -garbleargs          | Arguments to pass to garble                                                                                                                                                 | `-literals -tiny -seed=random`                                                                                                                |    
+| -nosyncgomod         | Do not sync go.mod with the Wails version                                                                                                                                   | false                                                                                                                                         |
 
 For a detailed description of the `webview2` flag, please refer to the [Windows](../guides/windows.mdx) Guide.
 
@@ -188,6 +189,9 @@ Your system is ready for Wails development!
 | -save                        | Saves the given `assetdir`, `reloaddirs`, `wailsjsdir`, `debounce`, `devserver` and `frontenddevserverurl` flags in `wails.json` to become the defaults for subsequent invocations. |                       |
 | -race                        | Build with Go's race detector                                                                                                                                                       | false                 |
 | -s                           | Skip building the frontend                                                                                                                                                          | false                 |
+| -nosyncgomod                 | Do not sync go.mod with the Wails version                                                                                                                                           | false                 |
+
+
 
 Example:
 


### PR DESCRIPTION
This is an alternative approach to not having the go.mod synced to your wails CLI version. It fixes the tests on master.

@mholt - could you please confirm this works for you? Adding `-nosyncgomod` to `dev` or `build` should trigger it 👍 