### PR TITLE
Update libwebkit package name for Fedora

### DIFF
--- a/v2/internal/system/packagemanager/dnf.go
+++ b/v2/internal/system/packagemanager/dnf.go
@@ -33,6 +33,7 @@ func (y *Dnf) Packages() packagemap {
 		},
 		"libwebkit": []*Package{
 			{Name: "webkit2gtk4.0-devel", SystemPackage: true, Library: true},
+			{Name: "webkit2gtk3-devel", SystemPackage: true, Library: true},
 			// {Name: "webkitgtk3-devel", SystemPackage: true, Library: true},
 		},
 		"gcc": []*Package{

--- a/v2/internal/system/packagemanager/dnf.go
+++ b/v2/internal/system/packagemanager/dnf.go
@@ -32,7 +32,7 @@ func (y *Dnf) Packages() packagemap {
 			{Name: "gtk3-devel", SystemPackage: true, Library: true},
 		},
 		"libwebkit": []*Package{
-			{Name: "webkit2gtk3-devel", SystemPackage: true, Library: true},
+			{Name: "webkit2gtk4.0-devel", SystemPackage: true, Library: true},
 			// {Name: "webkitgtk3-devel", SystemPackage: true, Library: true},
 		},
 		"gcc": []*Package{


### PR DESCRIPTION
(added a new commit in response to member comment)

Without this change, wails doctor reports libwebkit not being installed (even though it already is)
Old version of libwebkit has been retained for backwards compatibility
