### PR TITLE
Improve `crowdin` init to be able to work locally

### DIFF
--- a/website/src/api/crowdin.js
+++ b/website/src/api/crowdin.js
@@ -1,14 +1,33 @@
 const crowdin = require("@crowdin/crowdin-api-client");
+const personalToken = process.env.CROWDIN_PERSONAL_TOKEN;
+const projectId = 531392;
 
 // initialization of crowdin client
-const { translationStatusApi } = new crowdin.default({
-  token: process.env.CROWDIN_PERSONAL_TOKEN,
-});
+const initClient = async () => {
+  if (!personalToken) {
+    console.warn(
+      "No crowding personal token, some features might not work as expected"
+    );
+    return;
+  }
+
+  return new crowdin.default({
+    token: personalToken,
+  });
+};
+
+const client = initClient() || {};
 
 async function getTranslationProgress() {
   let translationProgress = {};
+  const { translationStatusApi } = client;
 
-  await translationStatusApi.getProjectProgress(531392).then((res) => {
+  // do nothing if client failed to init
+  if (!translationStatusApi) {
+    return translationProgress;
+  }
+
+  await translationStatusApi.getProjectProgress(projectId).then((res) => {
     for (const item of res.data) {
       translationProgress[item.data.languageId] = item.data.approvalProgress;
     }


### PR DESCRIPTION
This just refactors the way `crowdin` initialised, to not throw away from the docs build time should there be no personal token in env variables.
If there is no token, it will log a warning message, but the rest of the functionality is available to the developer to keep on contributing