### PR TITLE
docs: fix admonitions syntax

### DIFF
--- a/website/docs/reference/cli.mdx
+++ b/website/docs/reference/cli.mdx
@@ -85,8 +85,10 @@ Example:
 
 `wails build -clean -o myproject.exe`
 
-:::Info
+:::info
+
 On Mac, the application will be bundled with `Info.plist`, not `Info.dev.plist`.
+
 :::
 
 :::info UPX on Apple Silicon


### PR DESCRIPTION
fix admonitions syntax in `/docs/reference/cli.mdx`