### PR TITLE
Support GPU acceleration settings on Windows & Linux

### DIFF
--- a/v2/internal/frontend/desktop/linux/window.go
+++ b/v2/internal/frontend/desktop/linux/window.go
@@ -214,7 +214,7 @@ gboolean close_button_pressed(GtkWidget *widget, GdkEvent *event, void* data)
     return TRUE;
 }
 
-GtkWidget* setupWebview(void* contentManager, GtkWindow* window, int hideWindowOnClose) {
+GtkWidget* setupWebview(void* contentManager, GtkWindow* window, int hideWindowOnClose, int gpuPolicy) {
 	GtkWidget* webview = webkit_web_view_new_with_user_content_manager((WebKitUserContentManager*)contentManager);
 	//gtk_container_add(GTK_CONTAINER(window), webview);
 	WebKitWebContext *context = webkit_web_context_get_default();
@@ -228,6 +228,21 @@ GtkWidget* setupWebview(void* contentManager, GtkWindow* window, int hideWindowO
 
 	WebKitSettings *settings = webkit_web_view_get_settings(WEBKIT_WEB_VIEW(webview));
 	webkit_settings_set_user_agent_with_application_details(settings, "wails.io", "");
+
+	if(gpuPolicy < 0 || gpuPolicy > 2) {
+		gpuPolicy = 1; // fall back to on_demand when an unknown policy is set
+	}
+	switch (gpuPolicy) {
+		case 0:
+		  webkit_settings_set_hardware_acceleration_policy(settings, WEBKIT_HARDWARE_ACCELERATION_POLICY_ALWAYS);
+		  break;
+		case 1:
+		  webkit_settings_set_hardware_acceleration_policy(settings, WEBKIT_HARDWARE_ACCELERATION_POLICY_ON_DEMAND);
+		  break;
+		case 2:
+		  webkit_settings_set_hardware_acceleration_policy(settings, WEBKIT_HARDWARE_ACCELERATION_POLICY_NEVER);
+		  break;
+	}
 	return webview;
 }
 
@@ -706,7 +721,12 @@ func NewWindow(appoptions *options.App, debug bool) *Window {
 	C.webkit_user_content_manager_register_script_message_handler(result.cWebKitUserContentManager(), external)
 	C.setupInvokeSignal(result.contentManager)
 
-	webview := C.setupWebview(result.contentManager, result.asGTKWindow(), bool2Cint(appoptions.HideWindowOnClose))
+	webview := C.setupWebview(
+		result.contentManager,
+		result.asGTKWindow(),
+		bool2Cint(appoptions.HideWindowOnClose),
+		C.int(appoptions.Linux.WebviewGpuPolicy),
+	)
 	result.webview = unsafe.Pointer(webview)
 	buttonPressedName := C.CString("button-press-event")
 	defer C.free(unsafe.Pointer(buttonPressedName))

--- a/v2/internal/frontend/desktop/linux/window.go
+++ b/v2/internal/frontend/desktop/linux/window.go
@@ -229,19 +229,18 @@ GtkWidget* setupWebview(void* contentManager, GtkWindow* window, int hideWindowO
 	WebKitSettings *settings = webkit_web_view_get_settings(WEBKIT_WEB_VIEW(webview));
 	webkit_settings_set_user_agent_with_application_details(settings, "wails.io", "");
 
-	if(gpuPolicy < 0 || gpuPolicy > 2) {
-		gpuPolicy = 1; // fall back to on_demand when an unknown policy is set
-	}
 	switch (gpuPolicy) {
 		case 0:
-		  webkit_settings_set_hardware_acceleration_policy(settings, WEBKIT_HARDWARE_ACCELERATION_POLICY_ALWAYS);
+			webkit_settings_set_hardware_acceleration_policy(settings, WEBKIT_HARDWARE_ACCELERATION_POLICY_ALWAYS);
 		  break;
 		case 1:
-		  webkit_settings_set_hardware_acceleration_policy(settings, WEBKIT_HARDWARE_ACCELERATION_POLICY_ON_DEMAND);
+			webkit_settings_set_hardware_acceleration_policy(settings, WEBKIT_HARDWARE_ACCELERATION_POLICY_ON_DEMAND);
 		  break;
 		case 2:
-		  webkit_settings_set_hardware_acceleration_policy(settings, WEBKIT_HARDWARE_ACCELERATION_POLICY_NEVER);
+			webkit_settings_set_hardware_acceleration_policy(settings, WEBKIT_HARDWARE_ACCELERATION_POLICY_NEVER);
 		  break;
+		default:
+			webkit_settings_set_hardware_acceleration_policy(settings, WEBKIT_HARDWARE_ACCELERATION_POLICY_ON_DEMAND);
 	}
 	return webview;
 }

--- a/v2/internal/frontend/desktop/linux/window.go
+++ b/v2/internal/frontend/desktop/linux/window.go
@@ -721,11 +721,16 @@ func NewWindow(appoptions *options.App, debug bool) *Window {
 	C.webkit_user_content_manager_register_script_message_handler(result.cWebKitUserContentManager(), external)
 	C.setupInvokeSignal(result.contentManager)
 
+	var webviewGpuPolicy int
+	if appoptions.Linux != nil {
+		webviewGpuPolicy = int(appoptions.Linux.WebviewGpuPolicy)
+	}
+
 	webview := C.setupWebview(
 		result.contentManager,
 		result.asGTKWindow(),
 		bool2Cint(appoptions.HideWindowOnClose),
-		C.int(appoptions.Linux.WebviewGpuPolicy),
+		C.int(webviewGpuPolicy),
 	)
 	result.webview = unsafe.Pointer(webview)
 	buttonPressedName := C.CString("button-press-event")

--- a/v2/internal/frontend/desktop/windows/frontend.go
+++ b/v2/internal/frontend/desktop/windows/frontend.go
@@ -411,7 +411,12 @@ func (f *Frontend) setupChromium() {
 	if opts := f.frontendOptions.Windows; opts != nil {
 		chromium.DataPath = opts.WebviewUserDataPath
 		chromium.BrowserPath = opts.WebviewBrowserPath
+
+		if opts.WebviewGpuIsDisabled {
+			chromium.AdditionalBrowserArgs = append(chromium.AdditionalBrowserArgs, "--disable-gpu")
+		}
 	}
+
 	chromium.MessageCallback = f.processMessage
 	chromium.WebResourceRequestedCallback = f.processRequest
 	chromium.NavigationCompletedCallback = f.navigationCompleted
@@ -419,6 +424,7 @@ func (f *Frontend) setupChromium() {
 		w32.PostMessage(f.mainWindow.Handle(), w32.WM_KEYDOWN, uintptr(vkey), 0)
 		return false
 	}
+
 	chromium.Embed(f.mainWindow.Handle())
 	chromium.Resize()
 	settings, err := chromium.GetSettings()

--- a/v2/internal/frontend/desktop/windows/go-webview2/pkg/edge/chromium.go
+++ b/v2/internal/frontend/desktop/windows/go-webview2/pkg/edge/chromium.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync/atomic"
 	"syscall"
 	"unsafe"
@@ -36,9 +37,10 @@ type Chromium struct {
 	padding Rect
 
 	// Settings
-	Debug       bool
-	DataPath    string
-	BrowserPath string
+	Debug                 bool
+	DataPath              string
+	BrowserPath           string
+	AdditionalBrowserArgs []string
 
 	// permissions
 	permissions      map[CoreWebView2PermissionKind]CoreWebView2PermissionState
@@ -98,7 +100,8 @@ func (e *Chromium) Embed(hwnd uintptr) bool {
 		}
 	}
 
-	if err := createCoreWebView2EnvironmentWithOptions(e.BrowserPath, dataPath, e.envCompleted); err != nil {
+	browserArgs := strings.Join(e.AdditionalBrowserArgs, " ")
+	if err := createCoreWebView2EnvironmentWithOptions(e.BrowserPath, dataPath, e.envCompleted, browserArgs); err != nil {
 		log.Printf("Error calling Webview2Loader: %v", err)
 		return false
 	}

--- a/v2/internal/frontend/desktop/windows/go-webview2/pkg/edge/create_env_go.go
+++ b/v2/internal/frontend/desktop/windows/go-webview2/pkg/edge/create_env_go.go
@@ -8,12 +8,13 @@ import (
 	"github.com/wailsapp/wails/v2/internal/frontend/desktop/windows/go-webview2/webviewloader"
 )
 
-func createCoreWebView2EnvironmentWithOptions(browserExecutableFolder, userDataFolder string, environmentCompletedHandle *iCoreWebView2CreateCoreWebView2EnvironmentCompletedHandler) error {
+func createCoreWebView2EnvironmentWithOptions(browserExecutableFolder, userDataFolder string, environmentCompletedHandle *iCoreWebView2CreateCoreWebView2EnvironmentCompletedHandler, additionalBrowserArgs string) error {
 	e := &environmentCreatedHandler{environmentCompletedHandle}
 	return webviewloader.CreateCoreWebView2EnvironmentWithOptions(
 		e,
 		webviewloader.WithBrowserExecutableFolder(browserExecutableFolder),
 		webviewloader.WithUserDataFolder(userDataFolder),
+		webviewloader.WithAdditionalBrowserArguments(additionalBrowserArgs),
 	)
 }
 

--- a/v2/internal/frontend/desktop/windows/go-webview2/pkg/edge/create_env_native.go
+++ b/v2/internal/frontend/desktop/windows/go-webview2/pkg/edge/create_env_native.go
@@ -12,7 +12,7 @@ import (
 	"golang.org/x/sys/windows"
 )
 
-func createCoreWebView2EnvironmentWithOptions(browserExecutableFolder, userDataFolder string, environmentCompletedHandle *iCoreWebView2CreateCoreWebView2EnvironmentCompletedHandler) error {
+func createCoreWebView2EnvironmentWithOptions(browserExecutableFolder, userDataFolder string, environmentCompletedHandle *iCoreWebView2CreateCoreWebView2EnvironmentCompletedHandler, additionalBrowserArgs string) error {
 	browserPathPtr, err := windows.UTF16PtrFromString(browserExecutableFolder)
 	if err != nil {
 		return fmt.Errorf("Error calling UTF16PtrFromString for %s: %v", browserExecutableFolder, err)

--- a/v2/pkg/options/default.go
+++ b/v2/pkg/options/default.go
@@ -7,13 +7,13 @@ import (
 
 // Default options for creating the App
 var Default = &App{
-	Width:              1024,
-	Height:             768,
-	Logger:             logger.NewDefaultLogger(),
-	LogLevel:           logger.INFO,
-	LogLevelProduction: logger.ERROR,
-	CSSDragProperty:    "--wails-draggable",
-	CSSDragValue:       "drag",
+	Width:                  1024,
+	Height:                 768,
+	Logger:                 logger.NewDefaultLogger(),
+	LogLevel:               logger.INFO,
+	LogLevelProduction:     logger.ERROR,
+	CSSDragProperty:        "--wails-draggable",
+	CSSDragValue:           "drag",
 }
 
 var defaultMacMenu = menu.NewMenuFromItems(

--- a/v2/pkg/options/linux/linux.go
+++ b/v2/pkg/options/linux/linux.go
@@ -1,12 +1,34 @@
 package linux
 
+// WebviewGpuPolicy values used for determining the webview's hardware acceleration policy.
+type WebviewGpuPolicy int
+
+const (
+	// WebviewGpuPolicyAlways Hardware acceleration is always enabled.
+	WebviewGpuPolicyAlways WebviewGpuPolicy = iota
+	// WebviewGpuPolicyOnDemand Hardware acceleration is enabled/disabled as request by web contents.
+	WebviewGpuPolicyOnDemand
+	// WebviewGpuPolicyNever Hardware acceleration is always disabled.
+	WebviewGpuPolicyNever
+)
+
 // Options specific to Linux builds
 type Options struct {
-	Icon                []byte
+	// Icon Sets up the icon representing the window. This icon is used when the window is minimized
+	// (also known as iconified).
+	Icon []byte
+
+	// WindowIsTranslucent sets the window's background to transparent when enabled.
 	WindowIsTranslucent bool
 
-	// User messages that can be customised
+	// Messages are messages that can be customised
 	Messages *Messages
+
+	// WebviewGpuPolicy used for determining the hardware acceleration policy for the webview.
+	//   - WebviewGpuPolicyAlways
+	//   - WebviewGpuPolicyOnDemand
+	//   - WebviewGpuPolicyNever
+	WebviewGpuPolicy WebviewGpuPolicy
 }
 
 type Messages struct {

--- a/v2/pkg/options/options.go
+++ b/v2/pkg/options/options.go
@@ -2,6 +2,7 @@ package options
 
 import (
 	"context"
+	"github.com/wailsapp/wails/v2/pkg/options/linux"
 	"html"
 	"io/fs"
 	"log"
@@ -9,7 +10,6 @@ import (
 	"runtime"
 
 	"github.com/wailsapp/wails/v2/pkg/options/assetserver"
-	"github.com/wailsapp/wails/v2/pkg/options/linux"
 	"github.com/wailsapp/wails/v2/pkg/options/mac"
 	"github.com/wailsapp/wails/v2/pkg/options/windows"
 

--- a/v2/pkg/options/windows/windows.go
+++ b/v2/pkg/options/windows/windows.go
@@ -96,8 +96,12 @@ type Options struct {
 
 	// OnSuspend is called when Windows enters low power mode
 	OnSuspend func()
+
 	// OnResume is called when Windows resumes from low power mode
 	OnResume func()
+
+	// WebviewGpuIsDisabled is used to enable / disable GPU acceleration for the webview
+	WebviewGpuIsDisabled bool
 }
 
 func DefaultMessages() *Messages {

--- a/website/docs/reference/options.mdx
+++ b/website/docs/reference/options.mdx
@@ -78,7 +78,8 @@ func main() {
             // OnSuspend is called when Windows enters low power mode
             OnSuspend func()
             // OnResume is called when Windows resumes from low power mode
-            OnResume func()
+            OnResume func(),
+			WebviewGpuDisabled: false,
         },
         Mac: &mac.Options{
             TitleBar: &mac.TitleBar{
@@ -101,6 +102,7 @@ func main() {
         Linux: &linux.Options{
             Icon: icon,
             WindowIsTranslucent: false,
+			WebviewGpuPolicy: linux.WebviewGpuPolicyAlways,
         },
         Debug: options.Debug{
             OpenInspectorOnStartup: false,
@@ -628,6 +630,13 @@ If set, this function will be called when Windows resumes from low power mode (s
 Name: OnResume<br/>
 Type: `func()`
 
+#### WebviewGpuIsDisabled
+
+Setting this to `true` will disable GPU hardware acceleration for the webview.
+
+Name: WebviewGpuIsDisabled<br/>
+Type: `bool`
+
 ### Mac
 
 This defines [Mac specific options](#mac).
@@ -823,6 +832,22 @@ Setting this to `true` will make the window background translucent. Some window 
 
 Name: WindowIsTranslucent<br/>
 Type: `bool`
+
+#### WebviewGpuPolicy
+
+This option is used for determining the webview's hardware acceleration policy.
+
+Name: WebviewGpuPolicy<br/>
+Type: [`options.WebviewGpuPolicy`](#webviewgpupolicy-type)<br/>
+Default: `WebviewGpuPolicyAlways`
+
+##### WebviewGpuPolicy type
+
+| Value                    | Description |
+| -------------------------| ----------- |
+| WebviewGpuPolicyAlways   | Hardware acceleration is always enabled|
+| WebviewGpuPolicyOnDemand | Hardware acceleration is enabled/disabled as request by web contents|
+| WebviewGpuPolicyNever    | Hardware acceleration is always disabled |
 
 ### Debug
 

--- a/website/src/pages/changelog.mdx
+++ b/website/src/pages/changelog.mdx
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Added Webview GPU acceleration options for [Windows](/docs/reference/options#webviewgpuisdisabled) and [Linux](/docs/reference/options#webviewgpupolicy). Added by @Lyimmi in [PR](https://github.com/wailsapp/wails/pull/2266)
+
 ## v2.3.0 - 2022-12-29
 
 ### Added


### PR DESCRIPTION
This PR adds support for webview GPU settings on Windows and Linux as discussed in issue #2264.

**Windows:**

- Created a new option `WebviewGpuIsDisabled` in windows.Options
- Modified the new webview loader to be able to accept chromium switches.
- When `WebviewGpuIsDisabled` set to true the webview will be initialized with the `--disable-gpu` switch.

**Linux:**

- Created a new option `WebviewGpuPolicy` in linux.Options.
- Created a new type `WebviewGpuPolicy` and three constants to be used as options.
  - WebviewGpuPolicyAlways
  - WebviewGpuPolicyOnDemand
  - WebviewGpuPolicyNever
- When the webview is set up the hardware acceleration policy is set based on the option. The default setting is WebviewGpuPolicyAlways, if it is not a valid option for the system GTK ignores it and sets an appropriate value.

**Mac:**
This setting is not available.