### PR TITLE
fix missing bin dir on build hook

### DIFF
--- a/v2/pkg/commands/build/build.go
+++ b/v2/pkg/commands/build/build.go
@@ -405,6 +405,12 @@ func executeBuildHook(outputLogger *clilogger.CLILogger, options *Options, hookI
 
 	}
 
+	if !fs.DirExists(options.BinDirectory) {
+		if err := fs.MkDirs(options.BinDirectory); err != nil {
+			return fmt.Errorf("could not create target directory: %s", err.Error())
+		}
+	}
+
 	stdout, stderr, err := shell.RunCommand(options.BinDirectory, args[0], args[1:]...)
 	if options.Verbosity == VERBOSE {
 		pterm.Info.Println(stdout)

--- a/website/src/pages/changelog.mdx
+++ b/website/src/pages/changelog.mdx
@@ -18,6 +18,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added Webview GPU acceleration options for [Windows](/docs/reference/options#webviewgpuisdisabled) and [Linux](/docs/reference/options#webviewgpupolicy). Added by @Lyimmi in [PR](https://github.com/wailsapp/wails/pull/2266)
 - Added `EnableFraudulentWebsiteDetection` option to opt-in to scan services for fraudulent content, such as malware or phishing attempts. Older releases had the scan services per default activated. Added by @stffabi in [PR](https://github.com/wailsapp/wails/pull/2269)
 
+### Fixed
+- Fixed failing build hooks when `build/bin` was missing. Fixed by @Lyimmi in [PR](https://github.com/wailsapp/wails/pull/2273) 
+
 ## v2.3.0 - 2022-12-29
 
 ### Added


### PR DESCRIPTION
This PR fixes #2224.

Check the existence of build/bin directory and create it if needed before running build hooks.