### PR TITLE
[windows] Improve fullscreen mode for frameless windows

### DIFF
--- a/v2/internal/frontend/desktop/windows/frontend.go
+++ b/v2/internal/frontend/desktop/windows/frontend.go
@@ -296,6 +296,9 @@ func (f *Frontend) WindowToggleMaximise() {
 func (f *Frontend) WindowUnmaximise() {
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()
+	if f.mainWindow.Form.IsFullScreen() {
+		return
+	}
 	f.mainWindow.Restore()
 }
 
@@ -312,6 +315,9 @@ func (f *Frontend) WindowMinimise() {
 func (f *Frontend) WindowUnminimise() {
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()
+	if f.mainWindow.Form.IsFullScreen() {
+		return
+	}
 	f.mainWindow.Restore()
 }
 

--- a/v2/internal/frontend/desktop/windows/frontend.go
+++ b/v2/internal/frontend/desktop/windows/frontend.go
@@ -338,6 +338,8 @@ func (f *Frontend) WindowSetBackgroundColour(col *options.RGBA) {
 	}
 
 	f.mainWindow.Invoke(func() {
+		win32.SetBackgroundColour(f.mainWindow.Handle(), col.R, col.G, col.B)
+
 		controller := f.chromium.GetController()
 		controller2 := controller.GetICoreWebView2Controller2()
 

--- a/v2/internal/frontend/desktop/windows/winc/form.go
+++ b/v2/internal/frontend/desktop/windows/winc/form.go
@@ -176,14 +176,15 @@ func (fm *Form) Fullscreen() {
 	if !w32.GetWindowPlacement(fm.hwnd, &fm.previousWindowPlacement) {
 		return
 	}
-	w32.SetWindowLong(fm.hwnd, w32.GWL_STYLE, fm.previousWindowStyle & ^uint32(w32.WS_OVERLAPPEDWINDOW))
+	// According to https://devblogs.microsoft.com/oldnewthing/20050505-04/?p=35703 one should use w32.WS_POPUP | w32.WS_VISIBLE
+	w32.SetWindowLong(fm.hwnd, w32.GWL_STYLE, fm.previousWindowStyle & ^uint32(w32.WS_OVERLAPPEDWINDOW) | (w32.WS_POPUP|w32.WS_VISIBLE))
+	fm.isFullscreen = true
 	w32.SetWindowPos(fm.hwnd, w32.HWND_TOP,
 		int(monitorInfo.RcMonitor.Left),
 		int(monitorInfo.RcMonitor.Top),
 		int(monitorInfo.RcMonitor.Right-monitorInfo.RcMonitor.Left),
 		int(monitorInfo.RcMonitor.Bottom-monitorInfo.RcMonitor.Top),
 		w32.SWP_NOOWNERZORDER|w32.SWP_FRAMECHANGED)
-	fm.isFullscreen = true
 }
 
 func (fm *Form) UnFullscreen() {
@@ -192,9 +193,9 @@ func (fm *Form) UnFullscreen() {
 	}
 	w32.SetWindowLong(fm.hwnd, w32.GWL_STYLE, fm.previousWindowStyle)
 	w32.SetWindowPlacement(fm.hwnd, &fm.previousWindowPlacement)
+	fm.isFullscreen = false
 	w32.SetWindowPos(fm.hwnd, 0, 0, 0, 0, 0,
 		w32.SWP_NOMOVE|w32.SWP_NOSIZE|w32.SWP_NOZORDER|w32.SWP_NOOWNERZORDER|w32.SWP_FRAMECHANGED)
-	fm.isFullscreen = false
 }
 
 func (fm *Form) IsFullScreen() bool {

--- a/website/src/pages/changelog.mdx
+++ b/website/src/pages/changelog.mdx
@@ -18,8 +18,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added Webview GPU acceleration options for [Windows](/docs/reference/options#webviewgpuisdisabled) and [Linux](/docs/reference/options#webviewgpupolicy). Added by @Lyimmi in [PR](https://github.com/wailsapp/wails/pull/2266)
 - Added `EnableFraudulentWebsiteDetection` option to opt-in to scan services for fraudulent content, such as malware or phishing attempts. Older releases had the scan services per default activated. Added by @stffabi in [PR](https://github.com/wailsapp/wails/pull/2269)
 
+### Changed
+- Improved fullscreen mode for frameless window on Windows. Changed by @stffabi in [PR](https://github.com/wailsapp/wails/pull/2279)
+- On Windows unmaximising a window has no effect anymore when the window is in fullscreen mode, this makes it consistent with e.g. macOS. Changed by @stffabi in [PR](https://github.com/wailsapp/wails/pull/2279)
+
 ### Fixed
 - Fixed failing build hooks when `build/bin` was missing. Fixed by @Lyimmi in [PR](https://github.com/wailsapp/wails/pull/2273) 
+- Fixed fullscreen mode for frameless window on Windows to fully cover the taskbar when changing into fullscreen from maximised state. Fixed by @stffabi in [PR](https://github.com/wailsapp/wails/pull/2279)
+- Fixed set window background colour on Windows when setting the colour via runtime. Fixed by @stffabi in [PR](https://github.com/wailsapp/wails/pull/2279)
 
 ## v2.3.0 - 2022-12-29
 


### PR DESCRIPTION
- In fullscreen the taskbar was not fully covered when previously maximized
- Unfullscreen did not correctly relayout the content
- Prevent Unmaximise/Unminimise when in fullscreen mode
- Use POPUP style for fullscreen mode