### PR TITLE
[windows] Disable frameless decorations during fullscreen

### DIFF
--- a/v2/internal/frontend/desktop/windows/win32/window.go
+++ b/v2/internal/frontend/desktop/windows/win32/window.go
@@ -81,14 +81,17 @@ type MONITORINFO struct {
 	DwFlags   uint32
 }
 
-func ExtendFrameIntoClientArea(hwnd uintptr) {
+func ExtendFrameIntoClientArea(hwnd uintptr, extend bool) {
 	// -1: Adds the default frame styling (aero shadow and e.g. rounded corners on Windows 11)
 	//     Also shows the caption buttons if transparent ant translucent but they don't work.
 	//  0: Adds the default frame styling but no aero shadow, does not show the caption buttons.
 	//  1: Adds the default frame styling (aero shadow and e.g. rounded corners on Windows 11) but no caption buttons
 	//     are shown if transparent ant translucent.
-	margins := &MARGINS{1, 1, 1, 1} // Only extend 1 pixel to have the default frame styling but no caption buttons
-	if err := dwmExtendFrameIntoClientArea(hwnd, margins); err != nil {
+	var margins MARGINS
+	if extend {
+		margins = MARGINS{1, 1, 1, 1} // Only extend 1 pixel to have the default frame styling but no caption buttons
+	}
+	if err := dwmExtendFrameIntoClientArea(hwnd, &margins); err != nil {
 		log.Fatal(fmt.Errorf("DwmExtendFrameIntoClientArea failed: %s", err))
 	}
 }

--- a/website/src/pages/changelog.mdx
+++ b/website/src/pages/changelog.mdx
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `EnableFraudulentWebsiteDetection` option to opt-in to scan services for fraudulent content, such as malware or phishing attempts. Older releases had the scan services per default activated. Added by @stffabi in [PR](https://github.com/wailsapp/wails/pull/2269)
 
 ### Changed
-- Improved fullscreen mode for frameless window on Windows. Changed by @stffabi in [PR](https://github.com/wailsapp/wails/pull/2279)
+- Improved fullscreen mode for frameless window on Windows. Changed by @stffabi in [PR](https://github.com/wailsapp/wails/pull/2279) and [PR](https://github.com/wailsapp/wails/pull/2288)
 - On Windows unmaximising a window has no effect anymore when the window is in fullscreen mode, this makes it consistent with e.g. macOS. Changed by @stffabi in [PR](https://github.com/wailsapp/wails/pull/2279)
 - Frameless resize now sets the cursor on documentElement, otherwise resizing cursor won't be shown outside of the body rectangle. Changed by @stffabi in [PR](https://github.com/wailsapp/wails/pull/2289)
 


### PR DESCRIPTION
Otherwise this leads to thin transparent lines on the window borders on older Windows versions.