### PR TITLE
[windows] Some improvements to fullscreen

### DIFF
--- a/v2/internal/frontend/desktop/windows/winc/form.go
+++ b/v2/internal/frontend/desktop/windows/winc/form.go
@@ -26,6 +26,7 @@ type Form struct {
 	// Fullscreen / Unfullscreen
 	isFullscreen            bool
 	previousWindowStyle     uint32
+	previousWindowExStyle   uint32
 	previousWindowPlacement w32.WINDOWPLACEMENT
 }
 
@@ -167,6 +168,8 @@ func (fm *Form) Fullscreen() {
 	}
 
 	fm.previousWindowStyle = uint32(w32.GetWindowLongPtr(fm.hwnd, w32.GWL_STYLE))
+	fm.previousWindowExStyle = uint32(w32.GetWindowLong(fm.hwnd, w32.GWL_EXSTYLE))
+
 	monitor := w32.MonitorFromWindow(fm.hwnd, w32.MONITOR_DEFAULTTOPRIMARY)
 	var monitorInfo w32.MONITORINFO
 	monitorInfo.CbSize = uint32(unsafe.Sizeof(monitorInfo))
@@ -178,6 +181,7 @@ func (fm *Form) Fullscreen() {
 	}
 	// According to https://devblogs.microsoft.com/oldnewthing/20050505-04/?p=35703 one should use w32.WS_POPUP | w32.WS_VISIBLE
 	w32.SetWindowLong(fm.hwnd, w32.GWL_STYLE, fm.previousWindowStyle & ^uint32(w32.WS_OVERLAPPEDWINDOW) | (w32.WS_POPUP|w32.WS_VISIBLE))
+	w32.SetWindowLong(fm.hwnd, w32.GWL_EXSTYLE, fm.previousWindowExStyle & ^uint32(w32.WS_EX_DLGMODALFRAME))
 	fm.isFullscreen = true
 	w32.SetWindowPos(fm.hwnd, w32.HWND_TOP,
 		int(monitorInfo.RcMonitor.Left),
@@ -192,6 +196,7 @@ func (fm *Form) UnFullscreen() {
 		return
 	}
 	w32.SetWindowLong(fm.hwnd, w32.GWL_STYLE, fm.previousWindowStyle)
+	w32.SetWindowLong(fm.hwnd, w32.GWL_EXSTYLE, fm.previousWindowExStyle)
 	w32.SetWindowPlacement(fm.hwnd, &fm.previousWindowPlacement)
 	fm.isFullscreen = false
 	w32.SetWindowPos(fm.hwnd, 0, 0, 0, 0, 0,

--- a/v2/internal/frontend/desktop/windows/window.go
+++ b/v2/internal/frontend/desktop/windows/window.go
@@ -291,7 +291,6 @@ func (w *Window) WndProc(msg uint32, wparam, lparam uintptr) uintptr {
 						}
 					}
 					w.chromium.SetPadding(edge.Rect{})
-					return 0
 				} else {
 					// This is needed to workaround the resize flickering in frameless mode with WindowDecorations
 					// See: https://stackoverflow.com/a/6558508
@@ -301,8 +300,8 @@ func (w *Window) WndProc(msg uint32, wparam, lparam uintptr) uintptr {
 					// therefore let's pad the content with 1px at the bottom.
 					rgrc.Bottom += 1
 					w.chromium.SetPadding(edge.Rect{Bottom: 1})
-					return 0
 				}
+				return 0
 			}
 		}
 	}

--- a/website/src/pages/changelog.mdx
+++ b/website/src/pages/changelog.mdx
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed failing build hooks when `build/bin` was missing. Fixed by @Lyimmi in [PR](https://github.com/wailsapp/wails/pull/2273) 
 - Fixed fullscreen mode for frameless window on Windows to fully cover the taskbar when changing into fullscreen from maximised state. Fixed by @stffabi in [PR](https://github.com/wailsapp/wails/pull/2279)
 - Fixed set window background colour on Windows when setting the colour via runtime. Fixed by @stffabi in [PR](https://github.com/wailsapp/wails/pull/2279)
+- Fixed the showing of a white border around a fullscreen window when `DisableWindowIcon` is active on Windows. Fixed by @stffabi in [PR](https://github.com/wailsapp/wails/pull/2299)
 
 ## v2.3.0 - 2022-12-29
 

--- a/website/src/pages/changelog.mdx
+++ b/website/src/pages/changelog.mdx
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `EnableFraudulentWebsiteDetection` option to opt-in to scan services for fraudulent content, such as malware or phishing attempts. Older releases had the scan services per default activated. Added by @stffabi in [PR](https://github.com/wailsapp/wails/pull/2269)
 
 ### Changed
-- Improved fullscreen mode for frameless window on Windows. Changed by @stffabi in [PR](https://github.com/wailsapp/wails/pull/2279) and [PR](https://github.com/wailsapp/wails/pull/2288)
+- Improved fullscreen mode for frameless window on Windows. Changed by @stffabi in [PR](https://github.com/wailsapp/wails/pull/2279), [PR](https://github.com/wailsapp/wails/pull/2288) and [PR](https://github.com/wailsapp/wails/pull/2299)
 - On Windows unmaximising a window has no effect anymore when the window is in fullscreen mode, this makes it consistent with e.g. macOS. Changed by @stffabi in [PR](https://github.com/wailsapp/wails/pull/2279)
 - Frameless resize now sets the cursor on documentElement, otherwise resizing cursor won't be shown outside of the body rectangle. Changed by @stffabi in [PR](https://github.com/wailsapp/wails/pull/2289)
 


### PR DESCRIPTION
- Do not show a white border for windows in fullscreen mode and when DisableWindowIcon is used
- Prevent a short showing of the window titlebar for frameless window when switching fullscreen/unfullscreen