### PR TITLE
Fix memory leak on Darwin when toggling system tray icon

### DIFF
--- a/v3/pkg/application/systemtray_darwin.go
+++ b/v3/pkg/application/systemtray_darwin.go
@@ -47,7 +47,7 @@ void systemTraySetIcon(void* nsStatusItem, void* nsImage, int position, bool isT
 		if( isTemplate ) {
 			[image setTemplate:YES];
 		}
-		statusItem.button.image = image;
+		statusItem.button.image = [image autorelease];
 		statusItem.button.imagePosition = position;
 	});
 }


### PR DESCRIPTION
alloc should always be paired with autorelease if not running in ARC mode.

Resolves https://github.com/wailsapp/wails/issues/2321

Related: https://github.com/fyne-io/systray/pull/34
