### PR TITLE
Size() calculates DPIs back to default space.

### DIFF
--- a/v2/internal/frontend/desktop/windows/winc/controlbase.go
+++ b/v2/internal/frontend/desktop/windows/winc/controlbase.go
@@ -250,6 +250,7 @@ func (cba *ControlBase) Size() (width, height int) {
 	rect := w32.GetWindowRect(cba.hwnd)
 	width = int(rect.Right - rect.Left)
 	height = int(rect.Bottom - rect.Top)
+	width, height = cba.scaleToDefaultDPI(width, height)
 	return
 }
 
@@ -494,6 +495,14 @@ func (cba *ControlBase) scaleWithWindowDPI(width, height int) (int, int) {
 	dpix, dpiy := cba.GetWindowDPI()
 	scaledWidth := ScaleWithDPI(width, dpix)
 	scaledHeight := ScaleWithDPI(height, dpiy)
+
+	return scaledWidth, scaledHeight
+}
+
+func (cba *ControlBase) scaleToDefaultDPI(width, height int) (int, int) {
+	dpix, dpiy := cba.GetWindowDPI()
+	scaledWidth := ScaleToDefaultDPI(width, dpix)
+	scaledHeight := ScaleToDefaultDPI(height, dpiy)
 
 	return scaledWidth, scaledHeight
 }

--- a/v2/internal/frontend/desktop/windows/winc/utils.go
+++ b/v2/internal/frontend/desktop/windows/winc/utils.go
@@ -149,3 +149,8 @@ func ScreenToClientRect(hwnd w32.HWND, rect *w32.RECT) *Rect {
 func ScaleWithDPI(pixels int, dpi uint) int {
 	return (pixels * int(dpi)) / 96
 }
+
+// ScaleToDefaultDPI scales the pixels from scaled DPI-Space to default DPI-Space (96).
+func ScaleToDefaultDPI(pixels int, dpi uint) int {
+	return (pixels * 96) / int(dpi)
+}


### PR DESCRIPTION
Possible fix for #2023 and #2297.