### PR TITLE
Fix #2280 - code block highlights

### DIFF
--- a/website/docs/guides/dynamic-assets.mdx
+++ b/website/docs/guides/dynamic-assets.mdx
@@ -11,7 +11,7 @@ By installing a custom AssetsHandler, you can serve your own assets using a cust
 
 In our example project, we will create a simple assets handler which will load files off disk:
 
-```go title=main.go {16-35,49}
+```go title=main.go {17-36,49}
 package main
 
 import (

--- a/website/docs/howdoesitwork.mdx
+++ b/website/docs/howdoesitwork.mdx
@@ -141,7 +141,7 @@ Wails requires that you pass in an _instance_ of the struct for it to bind it co
 
 In this example, we create a new `App` instance and then add this instance to the `Bind` option in `wails.Run`:
 
-```go {16,24} title="main.go"
+```go {17,27} title="main.go"
 package main
 
 import (
@@ -188,7 +188,7 @@ func (a *App) Greet(name string) string {
 
 You may bind as many structs as you like. Just make sure you create an instance of it and pass it in `Bind`:
 
-```go {8-10}
+```go {10-12}
     //...
 	err := wails.Run(&options.App{
 		Title:  "Basic Demo",
@@ -276,7 +276,7 @@ it will be returned to your frontend as a JavaScript class.
 
 :::info Note
 
-Struct fields *must* have a valid `json` tag to be included in the generated TypeScript.
+Struct fields _must_ have a valid `json` tag to be included in the generated TypeScript.
 
 Anonymous nested structs are not supported at this time.
 


### PR DESCRIPTION
Code reviewed the entire site's code blocks for those that use a highlight. Found 3 that needed adjusting. 

Only other change was from the Markdown linter which prefers underscores for italic text instead of asterisks for some reason. Either are allowed and assuming we all use the same linter I allowed the linter's opinionated change. 

Did not see an AUTHORS.md to add to; if you need that to maintain MIT let me know and we'll add it.