### PR TITLE
use appargs when generating bindings

### DIFF
--- a/v2/cmd/wails/build.go
+++ b/v2/cmd/wails/build.go
@@ -75,6 +75,7 @@ func buildApplication(f *flags.Build) error {
 		GarbleArgs:        f.GarbleArgs,
 		SkipBindings:      f.SkipBindings,
 		ProjectData:       projectOptions,
+		AppArgs:           f.AppArgs,
 	}
 
 	tableData := pterm.TableData{

--- a/v2/cmd/wails/flags/buildcommon.go
+++ b/v2/cmd/wails/flags/buildcommon.go
@@ -9,6 +9,7 @@ type BuildCommon struct {
 	Verbosity    int    `name:"v" description:"Verbosity level (0 = quiet, 1 = normal, 2 = verbose)"`
 	Tags         string `description:"Build tags to pass to Go compiler. Must be quoted. Space or comma (but not both) separated"`
 	NoSyncGoMod  bool   `description:"Don't sync go.mod"`
+	AppArgs      string `flag:"appargs" description:"arguments to pass to the underlying app (quoted and space separated)"`
 }
 
 func (c BuildCommon) Default() BuildCommon {

--- a/v2/cmd/wails/flags/dev.go
+++ b/v2/cmd/wails/flags/dev.go
@@ -2,14 +2,15 @@ package flags
 
 import (
 	"fmt"
-	"github.com/samber/lo"
-	"github.com/wailsapp/wails/v2/internal/project"
-	"github.com/wailsapp/wails/v2/pkg/commands/build"
 	"net"
 	"net/url"
 	"os"
 	"path/filepath"
 	"runtime"
+
+	"github.com/samber/lo"
+	"github.com/wailsapp/wails/v2/internal/project"
+	"github.com/wailsapp/wails/v2/pkg/commands/build"
 )
 
 type Dev struct {
@@ -26,7 +27,6 @@ type Dev struct {
 	ForceBuild           bool   `flag:"f" description:"Force build of application"`
 	Debounce             int    `flag:"debounce" description:"The amount of time to wait to trigger a reload on change"`
 	DevServer            string `flag:"devserver" description:"The address of the wails dev server"`
-	AppArgs              string `flag:"appargs" description:"arguments to pass to the underlying app (quoted and space separated)"`
 	Save                 bool   `flag:"save" description:"Save the given flags as defaults"`
 	FrontendDevServerURL string `flag:"frontenddevserverurl" description:"The url of the external frontend dev server to use"`
 
@@ -45,7 +45,6 @@ func (*Dev) Default() *Dev {
 }
 
 func (d *Dev) Process() error {
-
 	var err error
 	err = d.loadAndMergeProjectConfig()
 	if err != nil {
@@ -111,7 +110,6 @@ func (d *Dev) loadAndMergeProjectConfig() error {
 	}
 
 	return nil
-
 }
 
 // GenerateBuildOptions creates a build.Options using the flags
@@ -130,6 +128,7 @@ func (d *Dev) GenerateBuildOptions() *build.Options {
 		WailsJSDir:     d.WailsJSDir,
 		RaceDetector:   d.RaceDetector,
 		ProjectData:    d.projectConfig,
+		AppArgs:        d.AppArgs,
 	}
 
 	return result

--- a/v2/pkg/commands/bindings/bindings.go
+++ b/v2/pkg/commands/bindings/bindings.go
@@ -21,12 +21,12 @@ type Options struct {
 	GoModTidy        bool
 	TsPrefix         string
 	TsSuffix         string
+	AppArgs          string
 }
 
 // GenerateBindings generates bindings for the Wails project in the given ProjectDirectory.
 // If no project directory is given then the current working directory is used.
 func GenerateBindings(options Options) (string, error) {
-
 	filename, _ := lo.Coalesce(options.Filename, "wailsbindings")
 	if runtime.GOOS == "windows" {
 		filename += ".exe"
@@ -67,7 +67,9 @@ func GenerateBindings(options Options) (string, error) {
 	env = shell.SetEnv(env, "tsprefix", options.TsPrefix)
 	env = shell.SetEnv(env, "tssuffix", options.TsSuffix)
 
-	stdout, stderr, err = shell.RunCommandWithEnv(env, workingDirectory, filename)
+	// TODO: split arguments by matching quotes
+	appArgs := []string{options.AppArgs}
+	stdout, stderr, err = shell.RunCommandWithEnv(env, workingDirectory, filename, appArgs...)
 	if err != nil {
 		return stdout, fmt.Errorf("%s\n%s\n%s", stdout, stderr, err)
 	}

--- a/v2/pkg/commands/build/build.go
+++ b/v2/pkg/commands/build/build.go
@@ -67,11 +67,11 @@ type Options struct {
 	Obfuscated        bool                 // Indicates that bound methods should be obfuscated
 	GarbleArgs        string               // The arguments for Garble
 	SkipBindings      bool                 // Skip binding generation
+	AppArgs           string               // Arguments to pass the application to launch the GUI. Needed to generate bindings.
 }
 
 // Build the project!
 func Build(options *Options) (string, error) {
-
 	// Extract logger
 	outputLogger := options.Logger
 
@@ -169,7 +169,7 @@ func CreateEmbedDirectories(cwd string, buildOptions *Options) error {
 	for _, embedDetail := range embedDetails {
 		fullPath := embedDetail.GetFullPath()
 		if _, err := os.Stat(fullPath); os.IsNotExist(err) {
-			err := os.MkdirAll(fullPath, 0755)
+			err := os.MkdirAll(fullPath, 0o755)
 			if err != nil {
 				return err
 			}
@@ -182,7 +182,6 @@ func CreateEmbedDirectories(cwd string, buildOptions *Options) error {
 	}
 
 	return nil
-
 }
 
 func fatal(message string) {
@@ -211,7 +210,6 @@ func printBulletPoint(text string, args ...any) {
 }
 
 func GenerateBindings(buildOptions *Options) error {
-
 	obfuscated := buildOptions.Obfuscated
 	if obfuscated {
 		printBulletPoint("Generating obfuscated bindings: ")
@@ -226,6 +224,7 @@ func GenerateBindings(buildOptions *Options) error {
 		GoModTidy: !buildOptions.SkipModTidy,
 		TsPrefix:  buildOptions.ProjectData.Bindings.TsGeneration.Prefix,
 		TsSuffix:  buildOptions.ProjectData.Bindings.TsGeneration.Suffix,
+		AppArgs:   buildOptions.AppArgs,
 	})
 	if err != nil {
 		return err
@@ -369,7 +368,6 @@ func execPostBuildHook(outputLogger *clilogger.CLILogger, options *Options, hook
 	}
 
 	return executeBuildHook(outputLogger, options, hookIdentifier, argReplacements, postBuildHook, "post")
-
 }
 
 func executeBuildHook(outputLogger *clilogger.CLILogger, options *Options, hookIdentifier string, argReplacements map[string]string, buildHook string, hookName string) error {
@@ -402,7 +400,6 @@ func executeBuildHook(outputLogger *clilogger.CLILogger, options *Options, hookI
 
 	if options.Verbosity == VERBOSE {
 		pterm.Info.Println(strings.Join(args, " "))
-
 	}
 
 	if !fs.DirExists(options.BinDirectory) {


### PR DESCRIPTION
This change makes binding generation respect `appargs` in `wails.json`.

--

I ran into a bug where wails was not generating JS bindings for my (exported) struct methods.

This was because the binding generation did not respect `appargs` and was silently failing during binding generation.

My project only executes wails if the `gui` argument is passed, as in: `./myprogram gui`. Prior to this change, when adding `"appargs": "gui"` to the `wails.json` file, everything worked *except* binding generation.

--

Also, sorry for the code formatting noise, my editor has a mind of its own.