### PR TITLE
The outputFile was only being set for darwin universal builds. I move…

### DIFF
--- a/v2/pkg/commands/build/build.go
+++ b/v2/pkg/commands/build/build.go
@@ -262,9 +262,11 @@ func execBuildApplication(builder Builder, options *Options) (string, error) {
 
 	// Compile the application
 	printBulletPoint("Compiling application: ")
+	outputFile := builder.OutputFilename(options)
+	options.ProjectData.OutputFilename = outputFile
+	options.ProjectData.Name = outputFile
 
 	if options.Platform == "darwin" && options.Arch == "universal" {
-		outputFile := builder.OutputFilename(options)
 		amd64Filename := outputFile + "-amd64"
 		arm64Filename := outputFile + "-arm64"
 

--- a/v2/pkg/commands/build/build.go
+++ b/v2/pkg/commands/build/build.go
@@ -265,6 +265,7 @@ func execBuildApplication(builder Builder, options *Options) (string, error) {
 	outputFile := builder.OutputFilename(options)
 	options.ProjectData.OutputFilename = outputFile
 	options.ProjectData.Name = outputFile
+	options.ProjectData.Info.ProductName = outputFile
 
 	if options.Platform == "darwin" && options.Arch == "universal" {
 		amd64Filename := outputFile + "-amd64"

--- a/website/src/pages/changelog.mdx
+++ b/website/src/pages/changelog.mdx
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed the sometimes lagging drag experience with `--wails-draggable` on Windows.  Fixed by @stffabi in [PR](https://github.com/wailsapp/wails/pull/2302)
 - Fixed applying the default arch to platform flag in wails cli. If only a `GOOS` has been supplied as platform flag e.g. `wails build --platform windows` the current architecture wasn't applied and the build failed. Fixed by @stffabi in [PR](https://github.com/wailsapp/wails/pull/2309)
 - Fixed a segfault on opening the inspector on older macOS versions. Fixed by @stffabi in [PR](https://github.com/wailsapp/wails/pull/2397)
+- Fixed the macos single architecture builds not respecting an output file name specified with the '-o' flag. Fixed by @gwynforthewyn in [PR](https://github.com/wailsapp/wails/pull/2358)
 
 ## v2.3.0 - 2022-12-29
 


### PR DESCRIPTION
…d the

variable assignment to a location where it will take place for all builds.

The ProjectData entries are used in generating the .app plist file, so setting them here ensures that the app will run with the custom binary name.

===

#2290 

I wrote a bash script that runs the test cases. It's available at https://gist.github.com/gwynforthewyn/f045187d15f8be1a25d6be52f50e7497 - I didn't know whether there was a good location in the wails source repo for this file, so it's in a gist right now. Simply copy the script and put it anywhere on your file system to run it; it manages its own state internally and only relies on `wails` being in `PATH`, and maybe a macOS userland too.

### Test cases in the test script
The test case the script covers is running a `wails build` with the default build options, and then run `wails build -o ROFLCOPTER` with the and see whether the layout on the file system is the same or different. This script generates a shasum from the file system layout to validate the difference. As the macos builds need to support both universal and single architecture builds as explicit test cases, as they use different logical paths internally in the build subcommand but both should respect the -o flag, there is 1 test cases but on 2 architectures, for a total of 2 test cases.

To achieve these two test cases, the script initialises a wails project in a temporary directory, then runs in succession the following commands, capturing the state of the `build/` directory after each build command:

```bash
wails build -clean -platform "darwin/amd64" . > /dev/null" #build defaults
wails build -clean -platform "darwin/amd64" -o ROFLCOPTER . > /dev/null" #override output file name
```

Then it does the same file system layout check for the architecture "darwin/universal". 

Finally, it cleans the temporary test file system.

### Usage
To use it:

- download the script and run it with the latest install of wails from HEAD using ./tester.sh
- download my branch, build it, then run PATH=/path/to/your/build/wails ./tester.sh

The script has a built in help message you can activate with `--help`

Here's the output using the current version of wails 2.3.1:

```bash
;  ./tester.sh                                                         
Path to wails /Users/gwyn/go/bin/wails
Testing individual architecture was overridden successfully...
not ok - onearch_layout.txt and override_layout.txt are equal, overrides failed
Testing universal architecture was overridden successfully...
not ok - universal_layout.txt and override_universal_layout.txt are equal, overrides failed

Here's the output with the build from my branch:
```bash
;  PATH=~/Developer/wails/v2/cmd/wails/ ./tester.sh               
Path to wails /Users/gwyn/Developer/wails/v2/cmd/wails//wails
Testing individual architecture was overridden successfully...
ok - onearch_layout.txt and override_layout.txt are not equal, override succeeded
Testing universal architecture was overridden successfully...
ok - universal_layout.txt and override_universal_layout.txt are not equal, override succeeded
```

If you want to visually inspect a record of the data on the temporary file system, you can prevent the script from cleaning up the temporary file system it uses. This is detailed in the help message, but worth mentioning:

```bash
 CLEANUP=false ./tester.sh 
Path to wails /Users/gwyn/go/bin/wails
Testing individual architecture was overridden successfully...
not ok - onearch_layout.txt and override_layout.txt are equal, overrides failed
Testing universal architecture was overridden successfully...
not ok - universal_layout.txt and override_universal_layout.txt are equal, overrides failed
Top dir is /var/folders/s6/f8cljwsd5dj5m1sycmc2b_xm0000gn/T/tmp.s2B97o3b
``

Unfortunately, I couldn't see how to use unit tests for verifying this fix cf. https://github.com/wailsapp/wails/issues/2290#issuecomment-1414251083

This script provides a quick sanity check, which I'd been combining with manual inspection:

### Manual test cases
- the .app launches (`open path/to/app.app` in bash)
- verify the override file string is used

### All tests
[/] the amd64 build respects the override flag correctly
[/] the universal build respects the override flag correctly
[/] the amd64 build launches
[/] the universal build launches
