### PR TITLE
[dev] Don't save runtime wrappers for every build, it is part of the binding generation.

### DIFF
--- a/v2/cmd/wails/internal/dev/dev.go
+++ b/v2/cmd/wails/internal/dev/dev.go
@@ -132,6 +132,7 @@ func Application(f *flags.Dev, logger *clilogger.CLILogger) error {
 
 	// Do initial build but only for the application.
 	logger.Println("Building application for development...")
+	buildOptions.SkipRuntime = true // runtime JS scripts never need to be written again, they never change during a dev loop.
 	buildOptions.SkipBindings = true
 	buildOptions.IgnoreFrontend = true
 	debugBinaryProcess, appBinary, err := restartApp(buildOptions, nil, f, exitCodeChannel)

--- a/v2/cmd/wails/internal/dev/dev.go
+++ b/v2/cmd/wails/internal/dev/dev.go
@@ -103,6 +103,7 @@ func Application(f *flags.Dev, logger *clilogger.CLILogger) error {
 	signal.Notify(quitChannel, os.Interrupt, os.Kill, syscall.SIGTERM)
 	exitCodeChannel := make(chan int, 1)
 
+	skipBindings := buildOptions.SkipBindings
 	// Build the frontend if requested, but ignore building the application itself.
 	ignoreFrontend := buildOptions.IgnoreFrontend
 	if !ignoreFrontend {
@@ -131,8 +132,10 @@ func Application(f *flags.Dev, logger *clilogger.CLILogger) error {
 
 	// Do initial build but only for the application.
 	logger.Println("Building application for development...")
+	buildOptions.SkipBindings = true
 	buildOptions.IgnoreFrontend = true
 	debugBinaryProcess, appBinary, err := restartApp(buildOptions, nil, f, exitCodeChannel)
+	buildOptions.SkipBindings = skipBindings
 	buildOptions.IgnoreFrontend = ignoreFrontend || f.FrontendDevServerURL != ""
 	if err != nil {
 		return err

--- a/v2/internal/app/app_bindings.go
+++ b/v2/internal/app/app_bindings.go
@@ -42,6 +42,8 @@ func (a *App) Run() error {
 		tsPostfixFlag = bindingFlags.String("tssuffix", "", "Suffix for generated typescript entities")
 	}
 
+	skipRuntime := (os.Getenv("skipruntime") != "")
+
 	_ = bindingFlags.Parse(os.Args[1:])
 	if tsPrefixFlag != nil {
 		tsPrefix = *tsPrefixFlag
@@ -55,7 +57,7 @@ func (a *App) Run() error {
 	appBindings.SetTsPrefix(tsPrefix)
 	appBindings.SetTsSuffix(tsSuffix)
 
-	err := generateBindings(appBindings)
+	err := generateBindings(appBindings, skipRuntime)
 	if err != nil {
 		return err
 	}
@@ -77,7 +79,7 @@ func CreateApp(appoptions *options.App) (*App, error) {
 
 }
 
-func generateBindings(bindings *binding.Bindings) error {
+func generateBindings(bindings *binding.Bindings, skipRuntime bool) error {
 
 	cwd, err := os.Getwd()
 	if err != nil {
@@ -90,12 +92,14 @@ func generateBindings(bindings *binding.Bindings) error {
 
 	wailsjsbasedir := filepath.Join(projectConfig.GetWailsJSDir(), "wailsjs")
 
-	runtimeDir := filepath.Join(wailsjsbasedir, "runtime")
-	_ = os.RemoveAll(runtimeDir)
-	extractor := gosod.New(wrapper.RuntimeWrapper)
-	err = extractor.Extract(runtimeDir, nil)
-	if err != nil {
-		return err
+	if !skipRuntime {
+		runtimeDir := filepath.Join(wailsjsbasedir, "runtime")
+		_ = os.RemoveAll(runtimeDir)
+		extractor := gosod.New(wrapper.RuntimeWrapper)
+		err = extractor.Extract(runtimeDir, nil)
+		if err != nil {
+			return err
+		}
 	}
 
 	goBindingsDir := filepath.Join(wailsjsbasedir, "go")

--- a/v2/pkg/commands/bindings/bindings.go
+++ b/v2/pkg/commands/bindings/bindings.go
@@ -21,6 +21,8 @@ type Options struct {
 	GoModTidy        bool
 	TsPrefix         string
 	TsSuffix         string
+
+	SkipRuntime bool
 }
 
 // GenerateBindings generates bindings for the Wails project in the given ProjectDirectory.
@@ -66,6 +68,9 @@ func GenerateBindings(options Options) (string, error) {
 	env := os.Environ()
 	env = shell.SetEnv(env, "tsprefix", options.TsPrefix)
 	env = shell.SetEnv(env, "tssuffix", options.TsSuffix)
+	if options.SkipRuntime {
+		env = shell.SetEnv(env, "skipruntime", "1")
+	}
 
 	stdout, stderr, err = shell.RunCommandWithEnv(env, workingDirectory, filename)
 	if err != nil {

--- a/v2/pkg/commands/build/base.go
+++ b/v2/pkg/commands/build/base.go
@@ -14,9 +14,6 @@ import (
 
 	"github.com/wailsapp/wails/v2/internal/system"
 
-	"github.com/leaanthony/gosod"
-	"github.com/wailsapp/wails/v2/internal/frontend/runtime/wrapper"
-
 	"github.com/pkg/errors"
 
 	"github.com/leaanthony/slicer"
@@ -159,13 +156,6 @@ func (b *BaseBuilder) OutputFilename(options *Options) string {
 
 // CompileProject compiles the project
 func (b *BaseBuilder) CompileProject(options *Options) error {
-
-	// Check if the runtime wrapper exists
-	err := generateRuntimeWrapper(options)
-	if err != nil {
-		return err
-	}
-
 	verbose := options.Verbosity == VERBOSE
 	// Run go mod tidy first
 	if !options.SkipModTidy {
@@ -175,8 +165,7 @@ func (b *BaseBuilder) CompileProject(options *Options) error {
 			println("")
 			cmd.Stdout = os.Stdout
 		}
-		err = cmd.Run()
-		if err != nil {
+		if err := cmd.Run(); err != nil {
 			return err
 		}
 	}
@@ -267,8 +256,7 @@ func (b *BaseBuilder) CompileProject(options *Options) error {
 	// Get application build directory
 	appDir := options.BinDirectory
 	if options.CleanBinDirectory {
-		err = cleanBinDirectory(options)
-		if err != nil {
+		if err := cleanBinDirectory(options); err != nil {
 			return err
 		}
 	}
@@ -415,26 +403,6 @@ Please reinstall by doing the following:
 	pterm.Println("Done.")
 	if verbose {
 		pterm.Info.Println(string(output))
-	}
-
-	return nil
-}
-
-func generateRuntimeWrapper(options *Options) error {
-
-	if options.WailsJSDir == "" {
-		cwd, err := os.Getwd()
-		if err != nil {
-			return err
-		}
-		options.WailsJSDir = filepath.Join(cwd, "frontend")
-	}
-	wrapperDir := filepath.Join(options.WailsJSDir, "wailsjs", "runtime")
-	_ = os.RemoveAll(wrapperDir)
-	extractor := gosod.New(wrapper.RuntimeWrapper)
-	err := extractor.Extract(wrapperDir, nil)
-	if err != nil {
-		return err
 	}
 
 	return nil

--- a/v2/pkg/commands/build/build.go
+++ b/v2/pkg/commands/build/build.go
@@ -67,6 +67,7 @@ type Options struct {
 	Obfuscated        bool                 // Indicates that bound methods should be obfuscated
 	GarbleArgs        string               // The arguments for Garble
 	SkipBindings      bool                 // Skip binding generation
+	SkipRuntime       bool                 // Skip runtime js generation
 }
 
 // Build the project!
@@ -222,10 +223,11 @@ func GenerateBindings(buildOptions *Options) error {
 
 	// Generate Bindings
 	output, err := bindings.GenerateBindings(bindings.Options{
-		Tags:      buildOptions.UserTags,
-		GoModTidy: !buildOptions.SkipModTidy,
-		TsPrefix:  buildOptions.ProjectData.Bindings.TsGeneration.Prefix,
-		TsSuffix:  buildOptions.ProjectData.Bindings.TsGeneration.Suffix,
+		Tags:        buildOptions.UserTags,
+		GoModTidy:   !buildOptions.SkipModTidy,
+		TsPrefix:    buildOptions.ProjectData.Bindings.TsGeneration.Prefix,
+		TsSuffix:    buildOptions.ProjectData.Bindings.TsGeneration.Suffix,
+		SkipRuntime: buildOptions.SkipRuntime,
 	})
 	if err != nil {
 		return err


### PR DESCRIPTION
Skip bindings during the first application build, since that might interfere with the dev watcher.

Potentially fixes #2367 