### PR TITLE
[darwin] Add a macOS version guard for opening the web inspector

### DIFF
--- a/v2/internal/frontend/desktop/darwin/inspector_dev.go
+++ b/v2/internal/frontend/desktop/darwin/inspector_dev.go
@@ -21,14 +21,28 @@ package darwin
 @end
 
 void showInspector(void *inctx) {
-    WailsContext *ctx = (__bridge WailsContext*) inctx;
+	if (@available(macOS 12.0, *)) {
+		WailsContext *ctx = (__bridge WailsContext*) inctx;
 
-	[ctx.webview._inspector show];
-	dispatch_time_t popTime = dispatch_time(DISPATCH_TIME_NOW, 1 * NSEC_PER_SEC);
-	dispatch_after(popTime, dispatch_get_main_queue(), ^(void){
-		// Detach must be deferred a little bit and is ignored directly after a show.
-  		[ctx.webview._inspector detach];
-	});
+		@try {
+			[ctx.webview._inspector show];
+		} @catch (NSException *exception) {
+			NSLog(@"Opening the inspector failed: %@", exception.reason);
+			return;
+		}
+
+		dispatch_time_t popTime = dispatch_time(DISPATCH_TIME_NOW, 1 * NSEC_PER_SEC);
+		dispatch_after(popTime, dispatch_get_main_queue(), ^(void){
+			// Detach must be deferred a little bit and is ignored directly after a show.
+			@try {
+				[ctx.webview._inspector detach];
+			} @catch (NSException *exception) {
+				NSLog(@"Detaching the inspector failed: %@", exception.reason);
+			}
+		});
+	} else {
+		NSLog(@"Opening the inspector needs at least MacOS 12");
+	}
 }
 */
 import "C"

--- a/website/src/pages/changelog.mdx
+++ b/website/src/pages/changelog.mdx
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed the showing of a white border around a fullscreen window when `DisableWindowIcon` is active on Windows. Fixed by @stffabi in [PR](https://github.com/wailsapp/wails/pull/2299)
 - Fixed the sometimes lagging drag experience with `--wails-draggable` on Windows.  Fixed by @stffabi in [PR](https://github.com/wailsapp/wails/pull/2302)
 - Fixed applying the default arch to platform flag in wails cli. If only a `GOOS` has been supplied as platform flag e.g. `wails build --platform windows` the current architecture wasn't applied and the build failed. Fixed by @stffabi in [PR](https://github.com/wailsapp/wails/pull/2309)
+- Fixed a segfault on opening the inspector on older macOS versions. Fixed by @stffabi in [PR](https://github.com/wailsapp/wails/pull/2397)
 
 ## v2.3.0 - 2022-12-29
 


### PR DESCRIPTION
Log if the inspector could not be opened due to missing or incorrect private API.

Fixes #2394 