### PR TITLE
fix(cli): fix console printing

### DIFF
--- a/v2/cmd/wails/main.go
+++ b/v2/cmd/wails/main.go
@@ -41,7 +41,7 @@ func printBulletPoint(text string, args ...any) {
 		fatal(err.Error())
 	}
 	t = strings.Trim(t, "\n\r")
-	pterm.Printf(t, args...)
+	pterm.Printfln(t, args...)
 }
 
 func printFooter() {

--- a/v2/pkg/commands/build/build.go
+++ b/v2/pkg/commands/build/build.go
@@ -207,7 +207,7 @@ func printBulletPoint(text string, args ...any) {
 		fatal(err.Error())
 	}
 	t = strings.Trim(t, "\n\r")
-	pterm.Printf(t, args...)
+	pterm.Printfln(t, args...)
 }
 
 func GenerateBindings(buildOptions *Options) error {


### PR DESCRIPTION
Fix console printing.

Old:
```
$ wails generate template -name VT -frontend ./vue-project/
DEB | Using go webview2loader

# Generating template

  • Extracting base template files...  • Migrating existing project files to frontend directory...  • Updating package.json data...  • Renaming package.json -> package.tmpl.json...  • Updating package-lock.json data...  • Renaming package-lock.json -> package-lock.tmpl.json... ♥   If Wails is useful to you or your company, please consider sponsoring the project:
https://github.com/sponsors/leaanthony
```

New:
```
$ wails generate template -name VT -frontend ./vue-project/
DEB | Using go webview2loader

# Generating template

  • Extracting base template files...
  • Migrating existing project files to frontend directory...
  • Updating package.json data...
  • Renaming package.json -> package.tmpl.json...
  • Updating package-lock.json data...
  • Renaming package-lock.json -> package-lock.tmpl.json...
 ♥   If Wails is useful to you or your company, please consider sponsoring the project:
https://github.com/sponsors/leaanthony
```
