### PR TITLE
Bugfix - Parsing structs with reference breaks types generation

### DIFF
--- a/v2/internal/binding/generate.go
+++ b/v2/internal/binding/generate.go
@@ -180,6 +180,9 @@ func arrayifyValue(valueArray string, valueType string) string {
 }
 
 func goTypeToJSDocType(input string, importNamespaces *slicer.StringSlicer) string {
+	// remove usage of reference
+	input = strings.TrimPrefix(input, "*")
+
 	matches := mapRegex.FindStringSubmatch(input)
 	keyPackage := matches[keyPackageIndex]
 	keyType := matches[keyTypeIndex]


### PR DESCRIPTION
Whenever parsing Go type to JS type, remove any `*` from the input, so that regexp can correctly match what is required (extract `valueType`, `valuePackage` etc).
