### PR TITLE
[webview2] Fix error handling in CreateWebResourceResponse

### DIFF
--- a/v2/internal/frontend/desktop/windows/go-webview2/pkg/edge/corewebview2.go
+++ b/v2/internal/frontend/desktop/windows/go-webview2/pkg/edge/corewebview2.go
@@ -4,6 +4,7 @@
 package edge
 
 import (
+	"fmt"
 	"log"
 	"runtime"
 	"syscall"
@@ -249,7 +250,7 @@ func (e *ICoreWebView2Environment) CreateWebResourceResponse(content []byte, sta
 		return nil, err
 	}
 	var response *ICoreWebView2WebResourceResponse
-	_, _, err = e.vtbl.CreateWebResourceResponse.Call(
+	hr, _, err := e.vtbl.CreateWebResourceResponse.Call(
 		uintptr(unsafe.Pointer(e)),
 		stream,
 		uintptr(statusCode),
@@ -257,7 +258,14 @@ func (e *ICoreWebView2Environment) CreateWebResourceResponse(content []byte, sta
 		uintptr(unsafe.Pointer(_headers)),
 		uintptr(unsafe.Pointer(&response)),
 	)
-	if err != windows.ERROR_SUCCESS {
+	if windows.Handle(hr) != windows.S_OK {
+		return nil, syscall.Errno(hr)
+	}
+
+	if response == nil {
+		if err == nil {
+			err = fmt.Errorf("unknown error")
+		}
 		return nil, err
 	}
 	return response, nil

--- a/website/src/pages/changelog.mdx
+++ b/website/src/pages/changelog.mdx
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Fixed panic when using `wails dev` and the AssetServer tried to log to the logger. Fixed by @stffabi in [PR](https://github.com/wailsapp/wails/pull/2481) 
+- Fixed compatibility with WebView2 Runtime > `110.0.1587.69` which showed a `connection refused` html page before doing a reload of the frontend. Fixed by @stffabi in [PR](https://github.com/wailsapp/wails/pull/2496) 
 
 ## v2.4.0 - 2022-03-08
 


### PR DESCRIPTION
The old error handling fails on WebView2Runtimes > 110.0.1587.69 and will show a "connection refused" page and reloads after a short time. After the reload everything wroked as expected again.