### PR TITLE
Use json.Marshal instead of strconv.Quote to correctly support unicode

### DIFF
--- a/v2/internal/frontend/desktop/darwin/frontend.go
+++ b/v2/internal/frontend/desktop/darwin/frontend.go
@@ -20,7 +20,6 @@ import (
 	"html/template"
 	"log"
 	"net/url"
-	"strconv"
 	"unsafe"
 
 	"github.com/wailsapp/wails/v2/pkg/assetserver"
@@ -337,7 +336,11 @@ func (f *Frontend) processMessage(message string) {
 }
 
 func (f *Frontend) Callback(message string) {
-	f.ExecJS(`window.wails.Callback(` + strconv.Quote(message) + `);`)
+	escaped, err := json.Marshal(message)
+	if err != nil {
+		panic(err)
+	}
+	f.ExecJS(`window.wails.Callback(` + string(escaped) + `);`)
 }
 
 func (f *Frontend) ExecJS(js string) {

--- a/v2/internal/frontend/desktop/linux/frontend.go
+++ b/v2/internal/frontend/desktop/linux/frontend.go
@@ -81,7 +81,6 @@ import (
 	"net/url"
 	"os"
 	"runtime"
-	"strconv"
 	"strings"
 	"text/template"
 	"unsafe"
@@ -434,7 +433,11 @@ func (f *Frontend) processMessage(message string) {
 }
 
 func (f *Frontend) Callback(message string) {
-	f.ExecJS(`window.wails.Callback(` + strconv.Quote(message) + `);`)
+	escaped, err := json.Marshal(message)
+	if err != nil {
+		panic(err)
+	}
+	f.ExecJS(`window.wails.Callback(` + string(escaped) + `);`)
 }
 
 func (f *Frontend) startDrag() {

--- a/v2/internal/frontend/desktop/windows/frontend.go
+++ b/v2/internal/frontend/desktop/windows/frontend.go
@@ -13,7 +13,6 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"runtime"
-	"strconv"
 	"strings"
 	"sync"
 	"text/template"
@@ -637,8 +636,12 @@ func (f *Frontend) processMessage(message string) {
 }
 
 func (f *Frontend) Callback(message string) {
+	escaped, err := json.Marshal(message)
+	if err != nil {
+		panic(err)
+	}
 	f.mainWindow.Invoke(func() {
-		f.chromium.Eval(`window.wails.Callback(` + strconv.Quote(message) + `);`)
+		f.chromium.Eval(`window.wails.Callback(` + string(escaped) + `);`)
 	})
 }
 

--- a/website/src/pages/changelog.mdx
+++ b/website/src/pages/changelog.mdx
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed console printing in `wails generate template`. Fixed by @misitebao in [PR](https://github.com/wailsapp/wails/pull/2483)
+- Fixed unicode encoding of strings for multi-rune characters. Fixed by @joshbuddy in [PR](https://github.com/wailsapp/wails/pull/2509)
 
 ## v2.4.1 - 2023-03-20
 


### PR DESCRIPTION
I came across a bug where unicode values such as 🫣 would not get correctly escaped. This is due to using `strconv.Quote` which would encode this value as "\U0001fae3" which is not a valid js string. This would, in turn, get turned into "U0001fae3" in the frontend.

To correctly represent these values we need to use the new js format for multi-rune characters "\u{0001fae3}"[1], but I thought, instead of figuring out the correct quoting strategy, why not just use `json.Marshal` here instead. Certainly open to finding a different approach if you don't think this is a good idea.

Also decided to panic on error here as this error should never come up, and I saw similar panics in the code encountering things like this.

[1] https://exploringjs.com/es6/ch_unicode.html#sec_escape-sequences