### PR TITLE
docs: fix broken link for react router HashRouter

### DIFF
--- a/website/versioned_docs/version-v2.4.0/guides/routing.mdx
+++ b/website/versioned_docs/version-v2.4.0/guides/routing.mdx
@@ -27,7 +27,7 @@ RouterModule.forRoot(routes, { useHash: true });
 
 ## React
 
-The recommended approach for routing in React is [HashRouter](https://reactrouter.com/docs/en/v6/routers/hash-router):
+The recommended approach for routing in React is [HashRouter](https://reactrouter.com/en/main/router-components/hash-router):
 
 ```jsx
 import { HashRouter } from "react-router-dom";


### PR DESCRIPTION
just came across this broken link reading through the docs 