### PR TITLE
feat(cli): add Nodejs version in `wails doctor`

### DIFF
--- a/v2/internal/system/system.go
+++ b/v2/internal/system/system.go
@@ -1,11 +1,12 @@
 package system
 
 import (
+	"os/exec"
+	"strings"
+
 	"github.com/wailsapp/wails/v2/internal/shell"
 	"github.com/wailsapp/wails/v2/internal/system/operatingsystem"
 	"github.com/wailsapp/wails/v2/internal/system/packagemanager"
-	"os/exec"
-	"strings"
 )
 
 var (
@@ -30,6 +31,28 @@ func GetInfo() (*Info, error) {
 		return nil, err
 	}
 	return &result, nil
+}
+
+func checkNodejs() *packagemanager.Dependency {
+
+	// Check for Nodejs
+	output, err := exec.Command("node", "-v").Output()
+	installed := true
+	version := ""
+	if err != nil {
+		installed = false
+	} else {
+		version = strings.TrimSpace(strings.Split(string(output), "\n")[0])[1:]
+	}
+	return &packagemanager.Dependency{
+		Name:           "Nodejs",
+		PackageName:    "N/A",
+		Installed:      installed,
+		InstallCommand: "Available at https://nodejs.org/en/download/",
+		Version:        version,
+		Optional:       false,
+		External:       false,
+	}
 }
 
 func checkNPM() *packagemanager.Dependency {

--- a/v2/internal/system/system.go
+++ b/v2/internal/system/system.go
@@ -42,7 +42,9 @@ func checkNodejs() *packagemanager.Dependency {
 	if err != nil {
 		installed = false
 	} else {
-		version = strings.TrimSpace(strings.Split(string(output), "\n")[0])[1:]
+		if len(output) > 0 {
+			version = strings.TrimSpace(strings.Split(string(output), "\n")[0])[1:]
+		}
 	}
 	return &packagemanager.Dependency{
 		Name:           "Nodejs",

--- a/v2/internal/system/system_darwin.go
+++ b/v2/internal/system/system_darwin.go
@@ -9,9 +9,8 @@ import (
 	"strings"
 	"syscall"
 
-	"github.com/wailsapp/wails/v2/internal/system/packagemanager"
-
 	"github.com/wailsapp/wails/v2/internal/system/operatingsystem"
+	"github.com/wailsapp/wails/v2/internal/system/packagemanager"
 )
 
 // Determine if the app is running on Apple Silicon
@@ -34,6 +33,7 @@ func (i *Info) discover() error {
 	i.OS = osinfo
 
 	i.Dependencies = append(i.Dependencies, checkXCodeSelect())
+	i.Dependencies = append(i.Dependencies, checkNodejs())
 	i.Dependencies = append(i.Dependencies, checkNPM())
 	i.Dependencies = append(i.Dependencies, checkXCodeBuild())
 	i.Dependencies = append(i.Dependencies, checkUPX())

--- a/v2/internal/system/system_linux.go
+++ b/v2/internal/system/system_linux.go
@@ -49,6 +49,7 @@ func checkLocallyInstalled(checker func() *packagemanager.Dependency, dependency
 }
 
 var checkerFunctions = map[string]func() *packagemanager.Dependency{
+	"Nodejs":     checkNodejs,
 	"npm":        checkNPM,
 	"docker":     checkDocker,
 	"upx":        checkUPX,

--- a/v2/internal/system/system_windows.go
+++ b/v2/internal/system/system_windows.go
@@ -19,6 +19,7 @@ func (i *Info) discover() error {
 	i.OS = osinfo
 
 	i.Dependencies = append(i.Dependencies, checkWebView2())
+	i.Dependencies = append(i.Dependencies, checkNodejs())
 	i.Dependencies = append(i.Dependencies, checkNPM())
 	i.Dependencies = append(i.Dependencies, checkUPX())
 	i.Dependencies = append(i.Dependencies, checkNSIS())

--- a/website/src/pages/changelog.mdx
+++ b/website/src/pages/changelog.mdx
@@ -14,28 +14,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added Nodejs version in `wails doctor`. Added by @misitebao in [PR](https://github.com/wailsapp/wails/pull/2546)
+
 ### Changed
+
 - [v3] Typescript model generation using `StructDef`s from new AST-based parser. Added by @ATenderholt in [PR1](https://github.com/wailsapp/wails/pull/2428/files) and [PR2](https://github.com/wailsapp/wails/pull/2485).
 
+### Fixed
+
+- Fixed console printing in `wails generate template`. Fixed by @misitebao in [PR](https://github.com/wailsapp/wails/pull/2483)
 
 ## v2.4.1 - 2023-03-20
 
 ### Changed
+
 - Support single clicks on items with `--wails-draggable: drag` again on Windows. Changed by @stffabi in [PR](https://github.com/wailsapp/wails/pull/2482)
 
 ### Fixed
+
 - Fixed panic when using `wails dev` and the AssetServer tried to log to the logger. Fixed by @stffabi in [PR](https://github.com/wailsapp/wails/pull/2481)
 - Fixed compatibility with WebView2 Runtime > `110.0.1587.69` which showed a `connection refused` html page before doing a reload of the frontend. Fixed by @stffabi in [PR](https://github.com/wailsapp/wails/pull/2496)
 
 ## v2.4.0 - 2023-03-08
 
 ### Added
+
 - Added Webview GPU acceleration options for [Windows](/docs/reference/options#webviewgpuisdisabled) and [Linux](/docs/reference/options#webviewgpupolicy). Added by @Lyimmi in [PR](https://github.com/wailsapp/wails/pull/2266)
 - Added `EnableFraudulentWebsiteDetection` option to opt-in to scan services for fraudulent content, such as malware or phishing attempts. Older releases had the scan services per default activated. Added by @stffabi in [PR](https://github.com/wailsapp/wails/pull/2269)
 - Allow an [AssetServer Middleware](/docs/reference/options#middleware) to specify the `Content-Type` of a file served by the [Assets](/docs/reference/options#assets-1) `fs.FS`. Added by @stffabi in [PR](https://github.com/wailsapp/wails/pull/2286)
 - The AssetServer now detects more mimetypes by extension, e.g. `.mjs`. Added by @stffabi in [PR](https://github.com/wailsapp/wails/pull/2391)
 
 ### Changed
+
 - Improved fullscreen mode for frameless window on Windows. Changed by @stffabi in [PR](https://github.com/wailsapp/wails/pull/2279), [PR](https://github.com/wailsapp/wails/pull/2288) and [PR](https://github.com/wailsapp/wails/pull/2299)
 - On Windows unmaximising a window has no effect anymore when the window is in fullscreen mode, this makes it consistent with e.g. macOS. Changed by @stffabi in [PR](https://github.com/wailsapp/wails/pull/2279)
 - Frameless resize now sets the cursor on documentElement, otherwise resizing cursor won't be shown outside of the body rectangle. Changed by @stffabi in [PR](https://github.com/wailsapp/wails/pull/2289)
@@ -43,11 +55,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - NSIS template now installs the shortcuts for all users and not only for the current user. Changed by @stffabi in [PR](https://github.com/wailsapp/wails/pull/2373)
 
 ### Fixed
-- Fixed failing build hooks when `build/bin` was missing. Fixed by @Lyimmi in [PR](https://github.com/wailsapp/wails/pull/2273) 
+
+- Fixed failing build hooks when `build/bin` was missing. Fixed by @Lyimmi in [PR](https://github.com/wailsapp/wails/pull/2273)
 - Fixed fullscreen mode for frameless window on Windows to fully cover the taskbar when changing into fullscreen from maximised state. Fixed by @stffabi in [PR](https://github.com/wailsapp/wails/pull/2279)
 - Fixed set window background colour on Windows when setting the colour via runtime. Fixed by @stffabi in [PR](https://github.com/wailsapp/wails/pull/2279)
 - Fixed the showing of a white border around a fullscreen window when `DisableWindowIcon` is active on Windows. Fixed by @stffabi in [PR](https://github.com/wailsapp/wails/pull/2299)
-- Fixed the sometimes lagging drag experience with `--wails-draggable` on Windows.  Fixed by @stffabi in [PR](https://github.com/wailsapp/wails/pull/2302)
+- Fixed the sometimes lagging drag experience with `--wails-draggable` on Windows. Fixed by @stffabi in [PR](https://github.com/wailsapp/wails/pull/2302)
 - Fixed applying the default arch to platform flag in wails cli. If only a `GOOS` has been supplied as platform flag e.g. `wails build --platform windows` the current architecture wasn't applied and the build failed. Fixed by @stffabi in [PR](https://github.com/wailsapp/wails/pull/2309)
 - Fixed a segfault on opening the inspector on older macOS versions. Fixed by @stffabi in [PR](https://github.com/wailsapp/wails/pull/2397)
 - Fixed the macos single architecture builds not respecting an output file name specified with the '-o' flag. Fixed by @gwynforthewyn in [PR](https://github.com/wailsapp/wails/pull/2358)
@@ -59,6 +72,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## v2.3.0 - 2022-12-29
 
 ### Added
+
 - Added `OpenInspectorOnStartup` to debug options to allow opening the WebInspector during startup of the application in debug mode. Added by @stffabi in [PR](https://github.com/wailsapp/wails/pull/2080)
 - On macOS `wails doctor` now also shows the version of Xcode installed. Added by @stffabi in [PR](https://github.com/wailsapp/wails/pull/2089)
 - The [AssetServer](/docs/reference/options#assetserver) now supports handling range-requests if the [Assets](/docs/reference/options/#assets-1) `fs.FS` provides an `io.ReadSeeker`. Added by @stffabi in [PR](https://github.com/wailsapp/wails/pull/2091)
@@ -77,6 +91,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added Korean translation for the website. Added by @cybertramp in [PR](https://github.com/wailsapp/wails/pull/2093)
 
 ### Fixed
+
 - The `noreload` flag in wails dev wasn't applied. Fixed by @stffabi in this [PR](https://github.com/wailsapp/wails/pull/2081)
 - `build/bin` folder was duplicating itself on each reload in `wails dev` mode. Fixed by @OlegGulevskyy in this [PR](https://github.com/wailsapp/wails/pull/2103)
 - Prevent a thin white line at the bottom of a frameless window on Windows. Fixed by @stffabi in this [PR](https://github.com/wailsapp/wails/pull/2111)
@@ -92,6 +107,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed React Hash Router link in docs. Fixed by @marvinhosea in [PR](https://github.com/wailsapp/wails/pull/2050)
 
 ### Changed
+
 - Improve error message if no `index.html` could be found in the assets and validate assetserver options. Changed by @stffabi in this [PR](https://github.com/wailsapp/wails/pull/2110)
 - Promote the Go WebView2Loader from experimental to stable. This means now per default all Wails build use the new loader introduced with `v2.2.0`. The old loader remains usable with build tag `native_webview2loader` for the next few releases. Changed by @stffabi in this [PR](https://github.com/wailsapp/wails/pull/2199)
 - Refactored CLI. Changed by @leaanthony in this [PR](https://github.com/wailsapp/wails/pull/2123)


### PR DESCRIPTION
- [x] Add Nodejs version in `wails doctor`
- Test
  - [x] Windows
  - [x] Mac
  - [x] Linux
- [x] Update changelog

Resolve: https://github.com/wailsapp/wails/issues/2537
Preview:
```
$ wails doctor
DEB | Using go webview2loader
Wails CLI v2.4.1

Scanning system - Please wait (this may take a long time)...Done.

# System

OS           | Windows 10 Pro
Version      | 2009 (Build: 19045)
ID           | 22H2
Go Version   | go1.20
Platform     | windows
Architecture | amd64

# Wails

Version  | v2.4.1
Revision | 2a22933220a57eb34b461fa97a2b53026859c736
Modified | true

# Dependencies

Dependency | Package Name | Status    | Version
WebView2   | N/A          | Installed | 111.0.1661.54
Nodejs     | N/A          | Installed | 18.14.2
npm        | N/A          | Installed | 9.5.1
*upx       | N/A          | Available |
*nsis      | N/A          | Available |
* - Optional Dependency

# Diagnosis

Your system is ready for Wails development!
Optional package(s) installation details:
  - upx : Available at https://upx.github.io/
  - nsis : More info at https://wails.io/docs/guides/windows-installer/

 ♥   If Wails is useful to you or your company, please consider sponsoring the project:
https://github.com/sponsors/leaanthony

```