### PR TITLE
refactor menu handling

### DIFF
--- a/v3/pkg/application/application_darwin.go
+++ b/v3/pkg/application/application_darwin.go
@@ -170,7 +170,7 @@ func (m *macosApp) setApplicationMenu(menu *Menu) {
 	}
 	menu.Update()
 
-	// Convert impl to macosMenu object
+	// Convert impl to macosMenu object 
 	m.applicationMenu = (menu.impl).(*macosMenu).nsMenu
 	C.setApplicationMenu(m.applicationMenu)
 }


### PR DESCRIPTION
- refactor 'processMenu' out of 'macosMenu' into 'Menu'
- update menuImpl interface to ensure methods required to create menus are present
- implement menuImpl methods in macosMenu

This refactoring was done to avoid having to reimplement the overall 'processMenu' code for each platform.