### PR TITLE
Bugfix/remove miniaturize

### DIFF
--- a/v3/pkg/application/webview_window.go
+++ b/v3/pkg/application/webview_window.go
@@ -39,7 +39,6 @@ type (
 		setZoom(zoom float64)
 		close()
 		zoom()
-		minimize()
 		setHTML(html string)
 		setPosition(x int, y int)
 		on(eventID uint)
@@ -485,7 +484,7 @@ func (w *WebviewWindow) Minimize() {
 	if w.impl == nil {
 		return
 	}
-	w.impl.minimize()
+	w.impl.minimise()
 }
 
 func (w *WebviewWindow) Zoom() {

--- a/v3/pkg/application/webview_window_darwin.go
+++ b/v3/pkg/application/webview_window_darwin.go
@@ -649,14 +649,6 @@ static void windowZoom(void *window) {
 	});
 }
 
-// miniaturize
-static void windowMiniaturize(void *window) {
-	dispatch_async(dispatch_get_main_queue(), ^{
-		// miniaturize window
-		[(WebviewWindow*)window miniaturize:nil];
-	});
-}
-
 // webviewRenderHTML renders the given HTML
 static void windowRenderHTML(void *window, const char *html) {
 	dispatch_async(dispatch_get_main_queue(), ^{
@@ -883,10 +875,6 @@ func (w *macosWebviewWindow) on(eventID uint) {
 
 func (w *macosWebviewWindow) zoom() {
 	C.windowZoom(w.nsWindow)
-}
-
-func (w *macosWebviewWindow) minimize() {
-	C.windowMiniaturize(w.nsWindow)
 }
 
 func (w *macosWebviewWindow) windowZoom() {


### PR DESCRIPTION
Removes the `minimize` call from the `webviewWindowImpl` and the code which it was calling.
This appeared to be duplicate logic to the `minimise` call and was therefore redundant.