### PR TITLE
Feature/explicit callbacks

### DIFF
--- a/v3/pkg/application/messageprocessor_call.go
+++ b/v3/pkg/application/messageprocessor_call.go
@@ -4,19 +4,16 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"strconv"
 )
 
 func (m *MessageProcessor) callErrorCallback(window *WebviewWindow, message string, callID *string, err error) {
 	errorMsg := fmt.Sprintf(message, err)
 	m.Error(errorMsg)
-	msg := "_wails.callErrorCallback('" + *callID + "', " + strconv.Quote(errorMsg) + ");"
-	window.ExecJS(msg)
+	window.CallError(callID, errorMsg)
 }
 
 func (m *MessageProcessor) callCallback(window *WebviewWindow, callID *string, result string, isJSON bool) {
-	msg := fmt.Sprintf("_wails.callCallback('%s', %s, %v);", *callID, strconv.Quote(result), isJSON)
-	window.ExecJS(msg)
+	window.CallResponse(callID, result)
 }
 
 func (m *MessageProcessor) processCallMethod(method string, rw http.ResponseWriter, _ *http.Request, window *WebviewWindow, params QueryParams) {

--- a/v3/pkg/application/messageprocessor_dialog.go
+++ b/v3/pkg/application/messageprocessor_dialog.go
@@ -5,19 +5,16 @@ import (
 	"fmt"
 	"net/http"
 	"runtime"
-	"strconv"
 )
 
 func (m *MessageProcessor) dialogErrorCallback(window *WebviewWindow, message string, dialogID *string, err error) {
 	errorMsg := fmt.Sprintf(message, err)
 	m.Error(errorMsg)
-	msg := "_wails.dialogErrorCallback('" + *dialogID + "', " + strconv.Quote(errorMsg) + ");"
-	window.ExecJS(msg)
+	window.DialogError(dialogID, errorMsg)
 }
 
 func (m *MessageProcessor) dialogCallback(window *WebviewWindow, dialogID *string, result string, isJSON bool) {
-	msg := fmt.Sprintf("_wails.dialogCallback('%s', %s, %v);", *dialogID, strconv.Quote(result), isJSON)
-	window.ExecJS(msg)
+	window.DialogResponse(dialogID, result)
 }
 
 func (m *MessageProcessor) processDialogMethod(method string, rw http.ResponseWriter, r *http.Request, window *WebviewWindow, params QueryParams) {

--- a/v3/pkg/application/webview_window.go
+++ b/v3/pkg/application/webview_window.go
@@ -12,52 +12,52 @@ import (
 
 type (
 	webviewWindowImpl interface {
-		setTitle(title string)
-		setSize(width, height int)
-		setAlwaysOnTop(alwaysOnTop bool)
-		setURL(url string)
-		setResizable(resizable bool)
-		setMinSize(width, height int)
-		setMaxSize(width, height int)
-		execJS(js string)
-		restore()
-		setBackgroundColour(color *RGBA)
-		run()
 		center()
-		size() (int, int)
-		width() int
-		height() int
-		position() (int, int)
+		close()
 		destroy()
-		reload()
+		disableSizeConstraints()
+		execJS(js string)
 		forceReload()
+		fullscreen()
+		getScreen() (*Screen, error)
+		getZoom() float64
+		height() int
+		hide()
+		isFullscreen() bool
+		isMaximised() bool
+		isMinimised() bool
+		maximise()
+		minimise()
+		on(eventID uint)
+		openContextMenu(menu *Menu, data *ContextMenuData)
+		position() (int, int)
+		reload()
+		restore()
+		run()
+		setAlwaysOnTop(alwaysOnTop bool)
+		setBackgroundColour(color *RGBA)
+		setFrameless(bool)
+		setFullscreenButtonEnabled(enabled bool)
+		setHTML(html string)
+		setMaxSize(width, height int)
+		setMinSize(width, height int)
+		setPosition(x int, y int)
+		setResizable(resizable bool)
+		setSize(width, height int)
+		setTitle(title string)
+		setURL(url string)
+		setZoom(zoom float64)
+		show()
+		size() (int, int)
 		toggleDevTools()
-		zoomReset()
+		unfullscreen()
+		unmaximise()
+		unminimise()
+		width() int
+		zoom()
 		zoomIn()
 		zoomOut()
-		getZoom() float64
-		setZoom(zoom float64)
-		close()
-		zoom()
-		setHTML(html string)
-		setPosition(x int, y int)
-		on(eventID uint)
-		minimise()
-		unminimise()
-		maximise()
-		unmaximise()
-		fullscreen()
-		unfullscreen()
-		isMinimised() bool
-		isMaximised() bool
-		isFullscreen() bool
-		disableSizeConstraints()
-		setFullscreenButtonEnabled(enabled bool)
-		show()
-		hide()
-		getScreen() (*Screen, error)
-		setFrameless(bool)
-		openContextMenu(menu *Menu, data *ContextMenuData)
+		zoomReset()
 	}
 )
 


### PR DESCRIPTION
Functional updates:

- update WebviewWindow to implement functions for each of the callback types currently in use
  -  CallError
  - CallResponse
  - DialogError
  - DialogResponse
- update MessageProcessor to utilize the above functions on the window
- move responsibility of creating the javascript for the callback to the webview window functions
- ensure 'result' data is JSON marshallable or panic

Non-Functional updates:

- Sorted the `webviewImpl` interface functions

Note: My original intent with this changeset was to add `call.Context|call.Response` type interfaces to the function calls as well.  I decided not to do that at this time.
This simplifies what i was doing to enable the `websocket server plugin`