### PR TITLE
[v2, dev] Use custom schemes for in-app dev mode

### DIFF
--- a/v2/cmd/wails/internal/dev/stdout_scanner.go
+++ b/v2/cmd/wails/internal/dev/stdout_scanner.go
@@ -2,30 +2,47 @@ package dev
 
 import (
 	"bufio"
+	"fmt"
 	"net/url"
 	"os"
 	"strings"
 
 	"github.com/acarl005/stripansi"
 	"github.com/wailsapp/wails/v2/cmd/wails/internal/logutils"
+	"golang.org/x/mod/semver"
 )
 
 // stdoutScanner acts as a stdout target that will scan the incoming
 // data to find out the vite server url
 type stdoutScanner struct {
-	ViteServerURLChan chan string
+	ViteServerURLChan  chan string
+	ViteServerVersionC chan string
+	versionDetected    bool
 }
 
 // NewStdoutScanner creates a new stdoutScanner
 func NewStdoutScanner() *stdoutScanner {
 	return &stdoutScanner{
-		ViteServerURLChan: make(chan string, 2),
+		ViteServerURLChan:  make(chan string, 2),
+		ViteServerVersionC: make(chan string, 2),
 	}
 }
 
 // Write bytes to the scanner. Will copy the bytes to stdout
 func (s *stdoutScanner) Write(data []byte) (n int, err error) {
 	input := stripansi.Strip(string(data))
+	if !s.versionDetected {
+		v, err := detectViteVersion(input)
+		if v != "" || err != nil {
+			if err != nil {
+				logutils.LogRed("ViteStdoutScanner: %s", err)
+				v = "v0.0.0"
+			}
+			s.ViteServerVersionC <- v
+			s.versionDetected = true
+		}
+	}
+
 	match := strings.Index(input, "Local:")
 	if match != -1 {
 		sc := bufio.NewScanner(strings.NewReader(input))
@@ -46,4 +63,22 @@ func (s *stdoutScanner) Write(data []byte) (n int, err error) {
 		}
 	}
 	return os.Stdout.Write(data)
+}
+
+func detectViteVersion(line string) (string, error) {
+	s := strings.Split(strings.TrimSpace(line), " ")
+	if strings.ToLower(s[0]) != "vite" {
+		return "", nil
+	}
+
+	if len(line) < 2 {
+		return "", fmt.Errorf("unable to parse vite version")
+	}
+
+	v := s[1]
+	if !semver.IsValid(v) {
+		return "", fmt.Errorf("%s is not a valid vite version string", v)
+	}
+
+	return v, nil
 }

--- a/v2/examples/customlayout/myfrontend/package.json
+++ b/v2/examples/customlayout/myfrontend/package.json
@@ -8,6 +8,6 @@
     "preview": "vite preview"
   },
   "devDependencies": {
-    "vite": "^2.9.9"
+    "vite": "^3.0.7"
   }
 }

--- a/v2/internal/app/app_dev.go
+++ b/v2/internal/app/app_dev.go
@@ -8,9 +8,11 @@ import (
 	"flag"
 	"fmt"
 	iofs "io/fs"
+	"net"
 	"net/url"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/wailsapp/wails/v2/pkg/assetserver"
 
@@ -104,17 +106,35 @@ func CreateApp(appoptions *options.App) (*App, error) {
 	}
 
 	if frontendDevServerURL != "" {
-		if devServer == "" {
-			return nil, fmt.Errorf("Unable to use FrontendDevServerUrl without a DevServer address")
+		if os.Getenv("legacyusedevsererinsteadofcustomscheme") != "" {
+			startURL, err := url.Parse("http://" + devServer)
+			if err != nil {
+				return nil, err
+			}
+
+			ctx = context.WithValue(ctx, "starturl", startURL)
 		}
 
-		startURL, err := url.Parse("http://" + devServer)
+		ctx = context.WithValue(ctx, "frontenddevserverurl", frontendDevServerURL)
+
+		externalURL, err := url.Parse(frontendDevServerURL)
 		if err != nil {
 			return nil, err
 		}
 
-		ctx = context.WithValue(ctx, "starturl", startURL)
-		ctx = context.WithValue(ctx, "frontenddevserverurl", frontendDevServerURL)
+		if externalURL.Host == "" {
+			return nil, fmt.Errorf("Invalid frontend:dev:serverUrl missing protocol scheme?")
+		}
+
+		waitCb := func() { myLogger.Debug("Waiting for frontend DevServer '%s' to be ready", externalURL) }
+		if !checkPortIsOpen(externalURL.Host, time.Minute, waitCb) {
+			myLogger.Error("Timeout waiting for frontend DevServer")
+		}
+
+		handler := assetserver.NewExternalAssetsHandler(myLogger, assetConfig, externalURL)
+		assetConfig.Assets = nil
+		assetConfig.Handler = handler
+		assetConfig.Middleware = nil
 
 		myLogger.Info("Serving assets from frontend DevServer URL: %s", frontendDevServerURL)
 	} else {
@@ -245,4 +265,23 @@ func tryInferAssetDirFromFS(assets iofs.FS) (string, error) {
 	}
 
 	return path, nil
+}
+
+func checkPortIsOpen(host string, timeout time.Duration, waitCB func()) (ret bool) {
+	if timeout == 0 {
+		timeout = time.Minute
+	}
+
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		conn, _ := net.DialTimeout("tcp", host, 2*time.Second)
+		if conn != nil {
+			conn.Close()
+			return true
+		}
+
+		waitCB()
+		time.Sleep(1 * time.Second)
+	}
+	return false
 }

--- a/v2/pkg/templates/templates/svelte-ts/frontend/package.json
+++ b/v2/pkg/templates/templates/svelte-ts/frontend/package.json
@@ -17,6 +17,6 @@
     "svelte-preprocess": "^4.10.7",
     "tslib": "^2.4.0",
     "typescript": "^4.6.4",
-    "vite": "^3.0.0"
+    "vite": "^3.0.7"
   }
 }

--- a/v2/pkg/templates/templates/svelte/frontend/package.json
+++ b/v2/pkg/templates/templates/svelte/frontend/package.json
@@ -11,6 +11,6 @@
   "devDependencies": {
     "@sveltejs/vite-plugin-svelte": "^1.0.1",
     "svelte": "^3.49.0",
-    "vite": "^3.0.0"
+    "vite": "^3.0.7"
   }
 }

--- a/v2/pkg/templates/templates/vanilla-ts/frontend/package.json
+++ b/v2/pkg/templates/templates/vanilla-ts/frontend/package.json
@@ -9,6 +9,6 @@
   },
   "devDependencies": {
     "typescript": "^4.5.4",
-    "vite": "^2.9.9"
+    "vite": "^3.0.7"
   }
 }

--- a/v2/pkg/templates/templates/vanilla/frontend/package.json
+++ b/v2/pkg/templates/templates/vanilla/frontend/package.json
@@ -8,6 +8,6 @@
     "preview": "vite preview"
   },
   "devDependencies": {
-    "vite": "^2.9.9"
+    "vite": "^3.0.7"
   }
 }

--- a/website/src/pages/changelog.mdx
+++ b/website/src/pages/changelog.mdx
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Breaking Changes
+
+- `wails dev` now uses the custom schemes `wails://` on macOS and Linux if Vite >= `v3.0.0` is used. This makes the dev application consistent in behaviour with the final production application and fixes some long-standing inconsistencies. Changed by @stffabi in [PR](https://github.com/wailsapp/wails/pull/2610)
+
 ### Added
 
 - Added Nodejs version in `wails doctor`. Added by @misitebao in [PR](https://github.com/wailsapp/wails/pull/2546)


### PR DESCRIPTION
This fixes some long-standing inconsistencies between dev mode builds and production builds but is a breaking change.  Dev mode uses custom scheme for Vite versions >= 3.0.0 and for older it still behaves in the old way.

Relates to
- #2590
- #2523
- #2090
- #2026
- #1568 