### PR TITLE
Allow main to start even if no $DISPLAY is set

### DIFF
--- a/v2/internal/frontend/desktop/linux/frontend.go
+++ b/v2/internal/frontend/desktop/linux/frontend.go
@@ -96,6 +96,7 @@ import (
 )
 
 const startURL = "wails://wails/"
+var haveGtk = true
 
 type Frontend struct {
 
@@ -132,7 +133,10 @@ func init() {
 		_ = os.Setenv("GDK_BACKEND", "x11")
 	}
 
-	C.gtk_init(nil, nil)
+	gtkInit := C.gtk_init_check(nil, nil)
+	if gtkInit != 1 {
+		haveGtk = false
+	}
 }
 
 func NewFrontend(ctx context.Context, appoptions *options.App, myLogger *logger.Logger, appBindings *binding.Bindings, dispatcher frontend.Dispatcher) *Frontend {


### PR DESCRIPTION
I'm not happy with this - ideally the failure would be fed back up to the app, but there didn't seem to be an obvious path to doing that. 
At least with this I can check $DISPLAY in main() and take evasive action....