### PR TITLE
feat(cli): use Spinner instead of Print

### DIFF
--- a/v2/cmd/wails/doctor.go
+++ b/v2/cmd/wails/doctor.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/pterm/pterm"
+
 	"github.com/wailsapp/wails/v2/cmd/wails/flags"
 	"github.com/wailsapp/wails/v2/internal/colour"
 	"github.com/wailsapp/wails/v2/internal/system"
@@ -21,15 +22,15 @@ func diagnoseEnvironment(f *flags.Doctor) error {
 
 	app.PrintBanner()
 
-	pterm.Print("Scanning system - Please wait (this may take a long time)...")
+	spinner, _ := pterm.DefaultSpinner.Start("Scanning system - Please wait (this may take a long time)...")
 
 	// Get system info
 	info, err := system.GetInfo()
 	if err != nil {
-		pterm.Println("Failed.")
+		spinner.Fail("Failed.")
 		return err
 	}
-	pterm.Println("Done.")
+	spinner.Success("Done.")
 
 	pterm.DefaultSection.Println("System")
 


### PR DESCRIPTION
- [x] Use `Spinner` instead of `Print` to optimize user experience.

<details>
  <summary>Preview</summary>
  
![wails-doctor](https://user-images.githubusercontent.com/28185258/235431651-9b131be6-2b30-4305-ba2b-eb23af87fcb9.gif)

</details>

