### PR TITLE
fix: avoid app crashing when the Linux GTK key is empty

### DIFF
--- a/v2/internal/frontend/desktop/linux/keys.go
+++ b/v2/internal/frontend/desktop/linux/keys.go
@@ -81,7 +81,8 @@ func parseKey(key string) C.guint {
 		return result
 	}
 	// Check for unknown namedkeys
-	if len(key) > 1 || len(key) == 0 {
+	// Check if we only have a single character
+	if len(key) != 1 {
 		return C.guint(0)
 	}
 	keyval := rune(key[0])

--- a/v2/internal/frontend/desktop/linux/keys.go
+++ b/v2/internal/frontend/desktop/linux/keys.go
@@ -81,7 +81,7 @@ func parseKey(key string) C.guint {
 		return result
 	}
 	// Check for unknown namedkeys
-	if len(key) > 1 {
+	if len(key) > 1 || len(key) == 0 {
 		return C.guint(0)
 	}
 	keyval := rune(key[0])

--- a/website/src/pages/changelog.mdx
+++ b/website/src/pages/changelog.mdx
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Avoid app crashing when the Linux GTK key is empty by @aminya in [PR](https://github.com/wailsapp/wails/pull/2672)
+
 ## [v2.5.1] - 2023-05-16
 
 ### Breaking Changes


### PR DESCRIPTION
# Description

On Linux, the keys could be empty. This adds a check to skip getting `key[0]` when this happens/

Fixes # (issue)

Fixes this error:

```
DEBUG | Log dir is: /root/.config/surrealdb_explorer/log.txt

Overriding existing handler for signal 10. Set JSC_SIGNAL_FOR_GC if you want WebKit to use a different signal
panic: runtime error: index out of range [0] with length 0

goroutine 1 [running, locked to thread]:
github.com/wailsapp/wails/v2/internal/frontend/desktop/linux.parseKey({0x0, 0x0})
        /home/aminya/go/pkg/mod/github.com/wailsapp/wails/v2@v2.5.1/internal/frontend/desktop/linux/keys.go:87 +0xa5
github.com/wailsapp/wails/v2/internal/frontend/desktop/linux.acceleratorToGTK(0xc0001c5f20)
        /home/aminya/go/pkg/mod/github.com/wailsapp/wails/v2@v2.5.1/internal/frontend/desktop/linux/keys.go:72 +0x2c
github.com/wailsapp/wails/v2/internal/frontend/desktop/linux.processMenuItem(0x866bc0?, 0xc0001c8a80, 0xc0001c8a80?)
        /home/aminya/go/pkg/mod/github.com/wailsapp/wails/v2@v2.5.1/internal/frontend/desktop/linux/menu.go:159 +0x40b
github.com/wailsapp/wails/v2/internal/frontend/desktop/linux.processSubmenu(0xc0001c8a20, 0x79a2a9?)
        /home/aminya/go/pkg/mod/github.com/wailsapp/wails/v2@v2.5.1/internal/frontend/desktop/linux/menu.go:99 +0xdc
github.com/wailsapp/wails/v2/internal/frontend/desktop/linux.processMenu(0xc00021f6c0, 0x12?)
        /home/aminya/go/pkg/mod/github.com/wailsapp/wails/v2@v2.5.1/internal/frontend/desktop/linux/menu.go:82 +0x46
github.com/wailsapp/wails/v2/internal/frontend/desktop/linux.(*Window).SetApplicationMenu(0xc00021f6c0, 0xc000128dc8)
        /home/aminya/go/pkg/mod/github.com/wailsapp/wails/v2@v2.5.1/internal/frontend/desktop/linux/menu.go:75 +0x1b6
github.com/wailsapp/wails/v2/internal/frontend/desktop/linux.NewWindow(0xc00011ba40, 0x0)
        /home/aminya/go/pkg/mod/github.com/wailsapp/wails/v2@v2.5.1/internal/frontend/desktop/linux/window.go:126 +0x37b
github.com/wailsapp/wails/v2/internal/frontend/desktop/linux.NewFrontend({0x1cea4e8?, 0xc00023b890}, 0xc00011ba40, 0xc000128e40, 0xc0001c8b40, {0x1ce7480?, 0xc000139840})
        /home/aminya/go/pkg/mod/github.com/wailsapp/wails/v2@v2.5.1/internal/frontend/desktop/linux/frontend.go:182 +0x5c5
github.com/wailsapp/wails/v2/internal/frontend/desktop.NewFrontend(...)
        /home/aminya/go/pkg/mod/github.com/wailsapp/wails/v2@v2.5.1/internal/frontend/desktop/desktop_linux.go:16
github.com/wailsapp/wails/v2/internal/app.CreateApp(0xc00011ba40)
        /home/aminya/go/pkg/mod/github.com/wailsapp/wails/v2@v2.5.1/internal/app/app_production.go:84 +0x5a5
github.com/wailsapp/wails/v2/pkg/application.(*Application).Run(0xc000131940)
        /home/aminya/go/pkg/mod/github.com/wailsapp/wails/v2@v2.5.1/pkg/application/application.go:57 +0x29
wails_vue/backend.BootApplication(0xc000131640, 0xc000138a40, 0xc0001c5320, 0xc0001c55c0, 0xc000128b40, 0xc00012ec30, 0xc000131880)
        /home/aminya/Documents/GitHub/teamnoon/SurrealDB-Explorer/backend/Application.go:103 +0x718
reflect.Value.call({0x874160?, 0x1c761f0?, 0xc000138a00?}, {0x8e263d, 0x4}, {0xc0001584d0, 0x7, 0x1c761f0?})
        /usr/local/go/src/reflect/value.go:586 +0xb0b
reflect.Value.Call({0x874160?, 0x1c761f0?, 0x1c761f0?}, {0xc0001584d0?, 0x0?, 0x1c761f0?})
        /usr/local/go/src/reflect/value.go:370 +0xbc
github.com/Envuso/go-ioc-container.(*Invocable).CallMethodWith(0xc000138a00, 0x1c761f0?, {0x0?, 0x1cef290?, 0x8bd180?})
        /home/aminya/go/pkg/mod/github.com/!envuso/go-ioc-container@v0.0.5/invocable.go:149 +0xad
github.com/Envuso/go-ioc-container.(*ContainerInstance).Call(0xc00011c630?, {0x874160?, 0x1c761f0?}, {0x0, 0x0, 0x0})
        /home/aminya/go/pkg/mod/github.com/!envuso/go-ioc-container@v0.0.5/container_invocation.go:30 +0x6c
main.main()
        /home/aminya/Documents/GitHub/teamnoon/SurrealDB-Explorer/main.go:34 +0x112
```

Unblocks https://github.com/iDevelopThings/SurrealDB-Explorer/issues/3
https://github.com/iDevelopThings/SurrealDB-Explorer/pull/4

## Type of change
  
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
  
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration using `wails doctor`.

Built Surrealdb explorer, and I was able to launch it successfully with this change.

- [ ] Windows
- [ ] macOS
- [x] Linux
  
## Test Configuration

```
Wails CLI v2.5.1

 SUCCESS  Done.                                                                                                                           

# System

OS           | Ubuntu  
Version      | 22.04   
ID           | ubuntu  
Go Version   | go1.20.4
Platform     | linux   
Architecture | amd64   

# Wails

Version         | v2.5.1
Package Manager | apt   

# Dependencies

Dependency | Package Name          | Status    | Version                
*docker    | docker.io             | Installed | 23.0.6                 
gcc        | build-essential       | Installed | 12.1.0                 
libgtk-3   | libgtk-3-dev          | Installed | 3.24.33-1ubuntu2       
libwebkit  | libwebkit2gtk-4.0-dev | Installed | 2.38.6-0ubuntu0.22.04.1
npm        | npm                   | Installed | 9.5.1                  
*nsis      | nsis                  | Available | 3.08-2                 
pkg-config | pkg-config            | Installed | 0.29.2-1ubuntu3        
* - Optional Dependency

# Diagnosis

Your system is ready for Wails development!
Optional package(s) installation details: 
  - nsis: sudo apt install nsis

```

# Checklist:

- [x] I have updated `website/src/pages/changelog.mdx` with details of this PR
- [x] My code follows the general coding style of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
