### PR TITLE
Implementing directory and file Ignore for dev command

### DIFF
--- a/v2/cmd/wails/internal/dev/watcher.go
+++ b/v2/cmd/wails/internal/dev/watcher.go
@@ -17,7 +17,7 @@ type Watcher interface {
 }
 
 // initialiseWatcher creates the project directory watcher that will trigger recompile
-func initialiseWatcher(cwd string) (*fsnotify.Watcher, error) {
+func initialiseWatcher(cwd string, ignorer *gitignore.GitIgnore) (*fsnotify.Watcher, error) {
 
 	// Ignore dot files, node_modules and build directories by default
 	ignoreDirs := getIgnoreDirs(cwd)
@@ -34,6 +34,9 @@ func initialiseWatcher(cwd string) (*fsnotify.Watcher, error) {
 	}
 
 	for _, dir := range processDirectories(dirs.AsSlice(), ignoreDirs) {
+		if ignorer.MatchesPath(dir) {
+			continue
+		}
 		err := watcher.Add(dir)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
# Description
#1031 

When using the Dev command, you may not want to trigger a rebuild when a file or directory changes that are not related to the app
```diff
{
   "name": "app name",
...
+   "ignore": [
+      "*_test.go",
+      "*_generated.go",
+      "internal/cmd/test"
+   ],
...
}
```
In project, already using the github.com/sabhiram/go-gitignore package, so I use it, so the syntax is the same as that of gitignore.

Does have any other thoughts on that implementation, or a problem sword? @leaanthony 