### PR TITLE
chore: add `Prettier` as format tool

### DIFF
--- a/.github/workflows/format-markdown-files.yml
+++ b/.github/workflows/format-markdown-files.yml
@@ -1,0 +1,37 @@
+name: Format Markdown Files
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [master]
+
+jobs:
+  format_markdown_files:
+    runs-on: ubuntu-latest
+    if: github.repository == 'wailsapp/wails'
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup Nodejs
+        uses: actions/setup-node@v2
+        with:
+          node-version: 18.x
+
+      - name: Install Task
+        uses: arduino/setup-task@v1
+        with:
+          version: 3.x
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Format All Markdown Files
+        run: task format-all-md
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v4
+        with:
+          commit-message: "docs: format document"
+          title: "docs: format document"
+          body: "- [x] Format all Markdown(x) documents"
+          branch: chore/format-markdown-files
+          delete-branch: true
+          draft: false

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,3 @@
+website
+v2
+v3

--- a/.prettierrc.yml
+++ b/.prettierrc.yml
@@ -1,0 +1,6 @@
+overrides:
+  - files:
+      - "**/*.md"
+    options:
+      printWidth: 80
+      proseWrap: always

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -2,8 +2,19 @@
 
 version: "3"
 
-vars:
-  GREETING: Hello, World!
+includes:
+  website:
+    taskfile: website
+    dir: website
+
+  v2:
+    taskfile: v2
+    dir: v2
+    optional: true
+  v3:
+    taskfile: v3
+    dir: v3
+    optional: true
 
 tasks:
   contributors:check:
@@ -18,7 +29,19 @@ tasks:
     cmds:
       - npx -y all-contributors-cli generate
 
-  release:
-    dir: v2/tools/release
+  format:md:
     cmds:
-      - go run release.go {{.CLI_ARGS}}
+      - npx prettier --write "**/*.md"
+
+  format:
+    cmds:
+      - task: format:md
+
+  format-all-md:
+    cmds:
+      - task: format:md
+      - task: website:format:md
+      - task: v2:format:md
+      # - task: v2:website:format
+      - task: v3:format:md
+      # - task: v3:website:format:md

--- a/v2/.prettierignore
+++ b/v2/.prettierignore
@@ -1,0 +1,1 @@
+website

--- a/v2/.prettierrc.yml
+++ b/v2/.prettierrc.yml
@@ -1,0 +1,6 @@
+overrides:
+  - files:
+      - "**/*.md"
+    options:
+      printWidth: 80
+      proseWrap: always

--- a/v2/Taskfile.yaml
+++ b/v2/Taskfile.yaml
@@ -1,0 +1,17 @@
+# https://taskfile.dev
+
+version: "3"
+
+tasks:
+  release:
+    dir: tools/release
+    cmds:
+      - go run release.go {{.CLI_ARGS}}
+
+  format:md:
+    cmds:
+      - npx prettier --write "**/*.md"
+
+  format:
+    cmds:
+      - task: format:md

--- a/v3/.prettierignore
+++ b/v3/.prettierignore
@@ -1,0 +1,1 @@
+website

--- a/v3/.prettierrc.yml
+++ b/v3/.prettierrc.yml
@@ -1,0 +1,6 @@
+overrides:
+  - files:
+      - "**/*.md"
+    options:
+      printWidth: 80
+      proseWrap: always

--- a/v3/Taskfile.yaml
+++ b/v3/Taskfile.yaml
@@ -1,9 +1,14 @@
 # https://taskfile.dev
 
-version: '3'
+version: "3"
+
+includes:
+  website:
+    taskfile: ./website
+    dir: ./website
+    optional: true
 
 tasks:
-
   build-runtime-debug:
     dir: internal/runtime
     internal: true
@@ -77,7 +82,6 @@ tasks:
       - package.json
     cmds:
       - npm install
-
 
   install-runtime-deps:
     dir: internal/runtime
@@ -200,3 +204,11 @@ tasks:
     cmds:
       - task: reinstall-cli
       - echo "Generated templates"
+
+  format:md:
+    cmds:
+      - npx prettier --write "**/*.md"
+
+  format:
+    cmds:
+      - task: format:md

--- a/website/.prettierignore
+++ b/website/.prettierignore
@@ -1,0 +1,2 @@
+i18n
+versioned_docs

--- a/website/Taskfile.yml
+++ b/website/Taskfile.yml
@@ -45,3 +45,11 @@ tasks:
     deps: [install]
     cmds:
       - npx crowdin pull -b v2 --export-only-approved
+
+  format:md:
+    cmds:
+      - npx prettier --write "**/*.{md,mdx}"
+
+  format:
+    cmds:
+      - task: format:md

--- a/website/prettier.config.js
+++ b/website/prettier.config.js
@@ -1,0 +1,11 @@
+module.exports = {
+  overrides: [
+    {
+      files: "**/*.{md,mdx}",
+      options: {
+        printWidth: 80,
+        proseWrap: "always",
+      },
+    },
+  ],
+};


### PR DESCRIPTION
# Description

- [x] Add `Prettier` as format tool
- [x] Add workflow to auto format Markdown(x) files

Add `Prettier` tool to the root directory of each major version and its corresponding `website` directory to format all `.md` and `.mdx` files. However, to reduce unnecessary work, all files synchronized by Crowdin are ignored because formatting these files is meaningless.


