### PR TITLE
windows/nsis: add hidpi support for nsis installer

### DIFF
--- a/v2/examples/customlayout/build/windows/installer/project.nsi
+++ b/v2/examples/customlayout/build/windows/installer/project.nsi
@@ -45,6 +45,9 @@ VIAddVersionKey "FileVersion"     "${INFO_PRODUCTVERSION}"
 VIAddVersionKey "LegalCopyright"  "${INFO_COPYRIGHT}"
 VIAddVersionKey "ProductName"     "${INFO_PRODUCTNAME}"
 
+# Enable HiDPI support. https://nsis.sourceforge.io/Reference/ManifestDPIAware
+ManifestDPIAware true
+
 !include "MUI.nsh"
 
 !define MUI_ICON "..\icon.ico"

--- a/v2/pkg/buildassets/build/windows/installer/project.nsi
+++ b/v2/pkg/buildassets/build/windows/installer/project.nsi
@@ -45,6 +45,9 @@ VIAddVersionKey "FileVersion"     "${INFO_PRODUCTVERSION}"
 VIAddVersionKey "LegalCopyright"  "${INFO_COPYRIGHT}"
 VIAddVersionKey "ProductName"     "${INFO_PRODUCTNAME}"
 
+# Enable HiDPI support. https://nsis.sourceforge.io/Reference/ManifestDPIAware
+ManifestDPIAware true
+
 !include "MUI.nsh"
 
 !define MUI_ICON "..\icon.ico"

--- a/website/src/pages/changelog.mdx
+++ b/website/src/pages/changelog.mdx
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Changed styling of `doctor` command. Changed by @MarvinJWendt in [PR](https://github.com/wailsapp/wails/pull/2660)
+- Enable HiDPI option by default in windows nsis installer by @5aaee9 in [PR](https://github.com/wailsapp/wails/pull/2694)
 
 ## v2.5.1 - 2023-05-16
 


### PR DESCRIPTION
# Description

Enable Hi-DPI support for NSIS installer on windows, fix low resolution installer.

https://nsis.sourceforge.io/Reference/ManifestDPIAware

In before

![image](https://github.com/wailsapp/wails/assets/7685264/b54e4d08-51a0-4b9f-a435-03750bb9c9d4)

After the option (text is more clear)

![image](https://github.com/wailsapp/wails/assets/7685264/882adc15-3c26-42f4-b53c-ca2bac8ec015)


## Type of change
  
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
  
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration using `wails doctor`.

- [x] Windows
- [ ] macOS
- [ ] Linux
  
## Test Configuration

Please paste the output of `wails doctor`. If you are unable to run this command, please describe your environment in as much detail as possible.

# Checklist:

- [ ] I have updated `website/src/pages/changelog.mdx` with details of this PR
- [x] My code follows the general coding style of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
