### PR TITLE
Override error formatting

### DIFF
--- a/v2/internal/app/app_dev.go
+++ b/v2/internal/app/app_dev.go
@@ -213,7 +213,7 @@ func CreateApp(appoptions *options.App) (*App, error) {
 
 	eventHandler := runtime.NewEvents(myLogger)
 	ctx = context.WithValue(ctx, "events", eventHandler)
-	messageDispatcher := dispatcher.NewDispatcher(ctx, myLogger, appBindings, eventHandler)
+	messageDispatcher := dispatcher.NewDispatcher(ctx, myLogger, appBindings, eventHandler, appoptions.ErrorFormatter)
 
 	// Create the frontends and register to event handler
 	desktopFrontend := desktop.NewFrontend(ctx, appoptions, myLogger, appBindings, messageDispatcher)

--- a/v2/internal/app/app_production.go
+++ b/v2/internal/app/app_production.go
@@ -82,7 +82,7 @@ func CreateApp(appoptions *options.App) (*App, error) {
 		ctx = context.WithValue(ctx, "buildtype", "production")
 	}
 
-	messageDispatcher := dispatcher.NewDispatcher(ctx, myLogger, appBindings, eventHandler)
+	messageDispatcher := dispatcher.NewDispatcher(ctx, myLogger, appBindings, eventHandler, appoptions.ErrorFormatter)
 	appFrontend := desktop.NewFrontend(ctx, appoptions, myLogger, appBindings, messageDispatcher)
 	eventHandler.AddFrontend(appFrontend)
 

--- a/v2/internal/frontend/dispatcher/calls.go
+++ b/v2/internal/frontend/dispatcher/calls.go
@@ -3,8 +3,9 @@ package dispatcher
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/wailsapp/wails/v2/internal/frontend"
 	"strings"
+
+	"github.com/wailsapp/wails/v2/internal/frontend"
 )
 
 type callMessage struct {
@@ -49,7 +50,12 @@ func (d *Dispatcher) processCallMessage(message string, sender frontend.Frontend
 		CallbackID: payload.CallbackID,
 	}
 	if err != nil {
-		callbackMessage.Err = err.Error()
+		// Use the error formatter if one was provided
+		if d.errfmt != nil {
+			callbackMessage.Err = d.errfmt(err)
+		} else {
+			callbackMessage.Err = err.Error()
+		}
 	} else {
 		callbackMessage.Result = result
 	}
@@ -66,7 +72,7 @@ func (d *Dispatcher) processCallMessage(message string, sender frontend.Frontend
 // CallbackMessage defines a message that contains the result of a call
 type CallbackMessage struct {
 	Result     interface{} `json:"result"`
-	Err        string      `json:"error"`
+	Err        any         `json:"error"`
 	CallbackID string      `json:"callbackid"`
 }
 

--- a/v2/internal/frontend/dispatcher/dispatcher.go
+++ b/v2/internal/frontend/dispatcher/dispatcher.go
@@ -7,6 +7,7 @@ import (
 	"github.com/wailsapp/wails/v2/internal/binding"
 	"github.com/wailsapp/wails/v2/internal/frontend"
 	"github.com/wailsapp/wails/v2/internal/logger"
+	"github.com/wailsapp/wails/v2/pkg/options"
 )
 
 type Dispatcher struct {
@@ -15,15 +16,17 @@ type Dispatcher struct {
 	events     frontend.Events
 	bindingsDB *binding.DB
 	ctx        context.Context
+	errfmt     options.ErrorFormatter
 }
 
-func NewDispatcher(ctx context.Context, log *logger.Logger, bindings *binding.Bindings, events frontend.Events) *Dispatcher {
+func NewDispatcher(ctx context.Context, log *logger.Logger, bindings *binding.Bindings, events frontend.Events, errfmt options.ErrorFormatter) *Dispatcher {
 	return &Dispatcher{
 		log:        log,
 		bindings:   bindings,
 		events:     events,
 		bindingsDB: bindings.DB(),
 		ctx:        ctx,
+		errfmt:     errfmt,
 	}
 }
 

--- a/v2/pkg/options/options.go
+++ b/v2/pkg/options/options.go
@@ -64,6 +64,9 @@ type App struct {
 	Bind               []interface{}
 	WindowStartState   WindowStartState
 
+	// ErrorFormatter overrides the formatting of errors returned by backend methods
+	ErrorFormatter ErrorFormatter
+
 	// CSS property to test for draggable elements. Default "--wails-draggable"
 	CSSDragProperty string
 
@@ -89,6 +92,8 @@ type App struct {
 	// Debug options for debug builds. These options will be ignored in a production build.
 	Debug Debug
 }
+
+type ErrorFormatter func(error) any
 
 type RGBA struct {
 	R uint8 `json:"r"`

--- a/website/docs/reference/options.mdx
+++ b/website/docs/reference/options.mdx
@@ -58,6 +58,7 @@ func main() {
         Bind: []interface{}{
             app,
         },
+        ErrorFormatter: func(err error) any { return err.Error() },
         Windows: &windows.Options{
             WebviewIsTransparent:              false,
             WindowIsTranslucent:               false,
@@ -476,6 +477,14 @@ A slice of struct instances defining methods that need to be bound to the fronte
 
 Name: Bind<br/>
 Type: `[]interface{}`
+
+### ErrorFormatter
+
+A function that determines how errors are formatted when returned by a JS-to-Go
+method call. The returned value will be marshalled as JSON.
+
+Name: ErrorFormatter<br/>
+Type: `func (error) any`
 
 ### Windows
 

--- a/website/src/pages/changelog.mdx
+++ b/website/src/pages/changelog.mdx
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `-devtools` production build flag. Added by @mmghv in [PR](https://github.com/wailsapp/wails/pull/2725)
 - Added `EnableDefaultContextMenu` option to allow enabling the browser's default context-menu in production . Added by @mmghv in [PR](https://github.com/wailsapp/wails/pull/2733)
 - Added smart functionality for the default context-menu in production with CSS styles to control it. Added by @mmghv in [PR](https://github.com/wailsapp/wails/pull/2748)
+- Added custom error formatting to allow passing structured errors back to the frontend.
 
 ### Changed
 


### PR DESCRIPTION
# Description

When a call from the frontend to the backend returns an error, this change allows the formatting of the error to be customized. This allows for preserving the structure of the error in cases where the error is providing information the frontend needs to act on.

Fixes #2569

## Type of change
  
Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update **maybe?**

# How Has This Been Tested?
  
I've been running this for a while with my own app. Testing is pretty straightforward - I override the error formatter with one that formats the error as a JSON object then use that object on the frontend.

- [ ] Windows
- [ ] macOS
- [x] Linux
  
## Test Configuration

I don't know why this says my system is missing dependencies. Wails definitely works.

<pre>
# System

OS           | Gentoo  
Version      | 2.13    
ID           | gentoo  
Go Version   | go1.19.2
Platform     | linux   
Architecture | amd64   

# Wails

Version         | v2.4.1                                  
Revision        | bd96e617d8f73a11b7a086ff64657043b72a969b
Modified        | false                                   
Package Manager | emerge                                  

# Dependencies

Dependency | Package Name | Status    | Version
*docker    | Unknown      | Not Found | 23.0.3 
gcc        | Unknown      | Not Found | 12.2.1 
libgtk-3   | Unknown      | Not Found |        
libwebkit  | Unknown      | Not Found |        
npm        | Unknown      | Not Found | 8.19.4 
pkg-config | Unknown      | Not Found | 1.8.1  
* - Optional Dependency

# Diagnosis

Your system has missing dependencies!
Fatal:
Required dependencies missing: gcc libgtk-3 libwebkit npm pkg-config
Please read this article on how to resolve this: https://wails.io/guides/resolving-missing-packages
 ♥   If Wails is useful to you or your company, please consider sponsoring the project:
https://github.com/sponsors/leaanthony
</pre>

# Checklist:

- [x] I have updated `website/src/pages/changelog.mdx` with details of this PR
- [x] My code follows the general coding style of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
