### PR TITLE
Bump svelte vite version

### DIFF
--- a/v3/internal/templates/svelte-ts/frontend/package.json
+++ b/v3/internal/templates/svelte-ts/frontend/package.json
@@ -10,12 +10,12 @@
     "check": "svelte-check --tsconfig ./tsconfig.json"
   },
   "devDependencies": {
-    "@sveltejs/vite-plugin-svelte": "^2.0.0",
-    "@tsconfig/svelte": "^3.0.0",
-    "svelte": "^3.54.0",
-    "svelte-check": "^2.10.0",
-    "tslib": "^2.4.1",
-    "typescript": "^4.9.3",
-    "vite": "^4.0.0"
+    "@sveltejs/vite-plugin-svelte": "^2.4.2",
+    "@tsconfig/svelte": "^4.0.1",
+    "svelte": "^4.0.0",
+    "svelte-check": "^3.4.4",
+    "tslib": "^2.5.3",
+    "typescript": "^5.0.2",
+    "vite": "^4.3.9"
   }
 }

--- a/v3/internal/templates/svelte/frontend/package.json
+++ b/v3/internal/templates/svelte/frontend/package.json
@@ -9,8 +9,8 @@
     "preview": "vite preview"
   },
   "devDependencies": {
-    "@sveltejs/vite-plugin-svelte": "^2.0.0",
-    "svelte": "^3.54.0",
-    "vite": "^4.0.0"
+    "@sveltejs/vite-plugin-svelte": "^2.4.2",
+    "svelte": "^4.0.0",
+    "vite": "^4.3.9"
   }
 }


### PR DESCRIPTION
# Description

Svelte just released v4 and the package size has been reduced, vite also has already updated their templates.
Vite also is on v4.3.9 but wails is lacking behind, svelte-ts template is also outdated. 


Fixes [#2746](https://github.com/wailsapp/wails/issues/2746)

## Type of change
  
Please delete options that are not relevant.

# How Has This Been Tested?
  
I tested it locally by changing the versions and it still worked without issue.

- [ ] Windows
- [ ] macOS
- [X] Linux
  
## Test Configuration

Please paste the output of `wails doctor`. If you are unable to run this command, please describe your environment in as much detail as possible.

# Checklist:

- [ ] I have updated `website/src/pages/changelog.mdx` with details of this PR
- [ ] My code follows the general coding style of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
