### PR TITLE
[v2/windows] implement full file path resolver

### DIFF
--- a/v2/internal/frontend/desktop/windows/frontend.go
+++ b/v2/internal/frontend/desktop/windows/frontend.go
@@ -502,6 +502,10 @@ func (f *Frontend) setupChromium() {
 	if err != nil {
 		log.Fatal(err)
 	}
+	err = chromium.CheckCanAccessAdditionalWebMessageObjects()
+	if err != nil {
+		log.Fatal(err)
+	}
 	err = settings.PutAreDefaultContextMenusEnabled(f.devtools || f.frontendOptions.EnableDefaultContextMenu)
 	if err != nil {
 		log.Fatal(err)

--- a/v2/internal/frontend/desktop/windows/frontend.go
+++ b/v2/internal/frontend/desktop/windows/frontend.go
@@ -701,16 +701,12 @@ func (f *Frontend) processMessageWithAdditionalObjects(message string, sender *e
 		callbackID := message[5:]
 
 		objs, err := args.GetAdditionalObjects()
-		defer objs.Release()
-
 		if err != nil {
 			f.logger.Error(err.Error())
 			return
 		}
 
-		if objs == nil {
-			return
-		}
+		defer objs.Release()
 
 		count, err := objs.GetCount()
 		if err != nil {
@@ -721,12 +717,6 @@ func (f *Frontend) processMessageWithAdditionalObjects(message string, sender *e
 		files := []File{}
 		for i := uint32(0); i < count; i++ {
 			_file, err := objs.GetValueAtIndex(i)
-			defer func() {
-				err := _file.CallRelease(unsafe.Pointer(_file))
-				if err != nil {
-					f.logger.Error("cannot release resource: %s", err.Error())
-				}
-			}()
 			if err != nil {
 				f.logger.Error("cannot get value at %d : %s", i, err.Error())
 				return
@@ -744,7 +734,6 @@ func (f *Frontend) processMessageWithAdditionalObjects(message string, sender *e
 			files = append(files, File{
 				Path: filepath,
 			})
-
 		}
 
 		callbackMessage := &dispatcher.CallbackMessage{

--- a/v2/internal/frontend/desktop/windows/frontend.go
+++ b/v2/internal/frontend/desktop/windows/frontend.go
@@ -724,7 +724,7 @@ func (f *Frontend) processMessageWithAdditionalObjects(message string, sender *e
 				return
 			}
 
-			file := *(**edge.ICoreWebView2File)(unsafe.Pointer(&_file))
+			file := (*edge.ICoreWebView2File)(unsafe.Pointer(_file))
 			filepath, err := file.GetPath()
 			if err != nil {
 				f.logger.Error("cannot get path for object at %d : %s", i, err.Error())

--- a/v2/internal/frontend/desktop/windows/frontend.go
+++ b/v2/internal/frontend/desktop/windows/frontend.go
@@ -721,6 +721,12 @@ func (f *Frontend) processMessageWithAdditionalObjects(message string, sender *e
 		files := []File{}
 		for i := uint32(0); i < count; i++ {
 			_file, err := objs.GetValueAtIndex(i)
+			defer func() {
+				err := _file.CallRelease(unsafe.Pointer(_file))
+				if err != nil {
+					f.logger.Error("cannot release resource: %s", err.Error())
+				}
+			}()
 			if err != nil {
 				f.logger.Error("cannot get value at %d : %s", i, err.Error())
 				return

--- a/v2/internal/frontend/runtime/desktop/main.js
+++ b/v2/internal/frontend/runtime/desktop/main.js
@@ -35,6 +35,27 @@ export function Environment() {
     return Call(":wails:Environment");
 }
 
+export function ResolveFilePaths(files) {
+    return new Promise(function (resolve, reject) {
+        // Only for windows webview2 >= 1.0.1774.30
+        // https://learn.microsoft.com/en-us/microsoft-edge/webview2/reference/win32/icorewebview2webmessagereceivedeventargs2?view=webview2-1.0.1823.32#applies-to
+        if (!window.chrome?.webview?.postMessageWithAdditionalObjects) {
+            reject(new Error("Unsupported Platform"));
+            return;
+        }
+
+		var callbackID = `file-${new Date().getTime()}`;
+
+		callbacks[callbackID] = {
+			timeoutHandle: 0,
+			reject: reject,
+			resolve: resolve
+		};
+
+		chrome.webview.postMessageWithAdditionalObjects(`file:${callbackID}`, files);
+    });
+}
+
 // The JS runtime
 window.runtime = {
     ...Log,
@@ -50,7 +71,8 @@ window.runtime = {
     Environment,
     Show,
     Hide,
-    Quit
+    Quit,
+    ResolveFilePaths,
 };
 
 // Internal wails endpoints

--- a/v2/internal/frontend/runtime/desktop/main.js
+++ b/v2/internal/frontend/runtime/desktop/main.js
@@ -35,6 +35,10 @@ export function Environment() {
     return Call(":wails:Environment");
 }
 
+export function CanResolveFilePaths() {
+    return window.chrome?.webview?.postMessageWithAdditionalObjects != null;
+}
+
 export function ResolveFilePaths(files) {
     return new Promise(function (resolve, reject) {
         // Only for windows webview2 >= 1.0.1774.30
@@ -72,6 +76,7 @@ window.runtime = {
     Show,
     Hide,
     Quit,
+    CanResolveFilePaths,
     ResolveFilePaths,
 };
 

--- a/v2/internal/frontend/runtime/wrapper/runtime.d.ts
+++ b/v2/internal/frontend/runtime/wrapper/runtime.d.ts
@@ -233,3 +233,6 @@ export function ClipboardGetText(): Promise<string>;
 // [ClipboardSetText](https://wails.io/docs/reference/runtime/clipboard#clipboardsettext)
 // Sets a text on the clipboard
 export function ClipboardSetText(text: string): Promise<boolean>;
+
+// Resolves file paths for an array of files
+export function ResolveFilePaths(files: File[]): Promise<{ path: string }[]>;

--- a/v2/internal/frontend/runtime/wrapper/runtime.d.ts
+++ b/v2/internal/frontend/runtime/wrapper/runtime.d.ts
@@ -234,5 +234,8 @@ export function ClipboardGetText(): Promise<string>;
 // Sets a text on the clipboard
 export function ClipboardSetText(text: string): Promise<boolean>;
 
+// Check if the file path resolver is available
+export function CanResolveFilePaths(): boolean;
+
 // Resolves file paths for an array of files
 export function ResolveFilePaths(files: File[]): Promise<{ path: string }[]>;

--- a/v2/internal/frontend/runtime/wrapper/runtime.js
+++ b/v2/internal/frontend/runtime/wrapper/runtime.js
@@ -202,7 +202,7 @@ export function ClipboardSetText(text) {
 }
 
 export function CanResolveFilePaths() {
-    return window.runtime.CanResolveFilePaths();
+    return window.CanAccessAdditionalWebMessageObjects == true;
 }
 
 export function ResolveFilePaths(files) {

--- a/v2/internal/frontend/runtime/wrapper/runtime.js
+++ b/v2/internal/frontend/runtime/wrapper/runtime.js
@@ -201,6 +201,10 @@ export function ClipboardSetText(text) {
     return window.runtime.ClipboardSetText(text);
 }
 
+export function CanResolveFilePaths() {
+    return window.runtime.CanResolveFilePaths();
+}
+
 export function ResolveFilePaths(files) {
     return window.runtime.ResolveFilePaths(files);
 }

--- a/v2/internal/frontend/runtime/wrapper/runtime.js
+++ b/v2/internal/frontend/runtime/wrapper/runtime.js
@@ -200,3 +200,7 @@ export function ClipboardGetText() {
 export function ClipboardSetText(text) {
     return window.runtime.ClipboardSetText(text);
 }
+
+export function ResolveFilePaths(files) {
+    return window.runtime.ResolveFilePaths(files);
+}


### PR DESCRIPTION
# Description

This PR add a feature for resolving the full path of js [File](https://developer.mozilla.org/en-US/docs/Web/API/File).

Currently only tested in Windows 11 with WebView2 114.0.1823.79.

Fixes #1090 but only for Windows with WebView2 version >= 1.0.1774.30.

## Usage Demo

Source code of this demo is on https://github.com/ayatkyo/wails-2-file-drop-test

https://github.com/wailsapp/wails/assets/2143364/54a8781f-c098-4bbf-bd32-cd8550690255

## Type of change
  
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Another Solution

The previous solution that I tried before using this is using an overlay view in front of the webview, so it is something like this:
- Create a hidden Overlay view in front of the webview
- In the JS side, listen to `dragenter` event then get the target element size and position using `event.target.getBoundingClientRect()`
- Update Overlay size and position using that information
- Show Overlay and handle file drop event
- Send dropped file list to js side

But this solution will trigger `dragleave` to target the element on the JS side as soon as we show the Overlay view, but we can trigger `dragover` programmatically to webview with the mouse position (I have not tried this).

# Checklist:

- [ ] I have updated `website/src/pages/changelog.mdx` with details of this PR
- [ ] My code follows the general coding style of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
