### PR TITLE
Add Fullscreen HTML content hook

### DIFF
--- a/v2/go.mod
+++ b/v2/go.mod
@@ -33,7 +33,7 @@ require (
 	github.com/tc-hib/winres v0.1.5
 	github.com/tidwall/sjson v1.1.7
 	github.com/tkrajina/go-reflector v0.5.6
-	github.com/wailsapp/go-webview2 v1.0.1
+	github.com/wailsapp/go-webview2 v1.0.3
 	github.com/wailsapp/mimetype v1.4.1
 	github.com/wzshiming/ctc v1.2.3
 	golang.org/x/mod v0.8.0

--- a/v2/go.sum
+++ b/v2/go.sum
@@ -216,6 +216,12 @@ github.com/valyala/fasttemplate v1.2.2 h1:lxLXG0uE3Qnshl9QyaK6XJxMXlQZELvChBOCmQ
 github.com/valyala/fasttemplate v1.2.2/go.mod h1:KHLXt3tVN2HBp8eijSv/kGJopbvo7S+qRAEEKiv+SiQ=
 github.com/wailsapp/go-webview2 v1.0.1 h1:dEJIeEApW/MhO2tTMISZBFZPuW7kwrFA1NtgFB1z1II=
 github.com/wailsapp/go-webview2 v1.0.1/go.mod h1:Uk2BePfCRzttBBjFrBmqKGJd41P6QIHeV9kTgIeOZNo=
+github.com/wailsapp/go-webview2 v1.0.2 h1:ypcJYe+f40+n8XjmV2nSsy3Dw506o6KYbt46tW4PFW4=
+github.com/wailsapp/go-webview2 v1.0.2/go.mod h1:Uk2BePfCRzttBBjFrBmqKGJd41P6QIHeV9kTgIeOZNo=
+github.com/wailsapp/go-webview2 v1.0.3-0.20230719093920-78c663df5f6e h1:hx4lfIEbo+GT0leauS5OQPS5GDfeBA9bGf9pcq1YWpc=
+github.com/wailsapp/go-webview2 v1.0.3-0.20230719093920-78c663df5f6e/go.mod h1:Uk2BePfCRzttBBjFrBmqKGJd41P6QIHeV9kTgIeOZNo=
+github.com/wailsapp/go-webview2 v1.0.3 h1:zgZgT58vNZauH0WF7chQbs6QGMybzzkPtZFb5c1Zb3Y=
+github.com/wailsapp/go-webview2 v1.0.3/go.mod h1:Uk2BePfCRzttBBjFrBmqKGJd41P6QIHeV9kTgIeOZNo=
 github.com/wailsapp/mimetype v1.4.1 h1:pQN9ycO7uo4vsUUuPeHEYoUkLVkaRntMnHJxVwYhwHs=
 github.com/wailsapp/mimetype v1.4.1/go.mod h1:9aV5k31bBOv5z6u+QP8TltzvNGJPmNJD4XlAL3U+j3o=
 github.com/wzshiming/ctc v1.2.3 h1:q+hW3IQNsjIlOFBTGZZZeIXTElFM4grF4spW/errh/c=

--- a/v2/internal/frontend/desktop/windows/frontend.go
+++ b/v2/internal/frontend/desktop/windows/frontend.go
@@ -453,6 +453,7 @@ func (f *Frontend) setupChromium() {
 	chromium.MessageCallback = f.processMessage
 	chromium.WebResourceRequestedCallback = f.processRequest
 	chromium.NavigationCompletedCallback = f.navigationCompleted
+	chromium.ContainsFullScreenElementChangedCallback = f.fullscreenChanged
 	chromium.AcceleratorKeyCallback = func(vkey uint) bool {
 		w32.PostMessage(f.mainWindow.Handle(), w32.WM_KEYDOWN, uintptr(vkey), 0)
 		return false
@@ -811,6 +812,18 @@ func (f *Frontend) ShowWindow() {
 
 func (f *Frontend) onFocus(arg *winc.Event) {
 	f.chromium.Focus()
+}
+
+func (f *Frontend) fullscreenChanged(sender *edge.ICoreWebView2, _ *edge.ICoreWebView2ContainsFullScreenElementChangedEventArgs) {
+	isFullscreen, err := sender.GetContainsFullScreenElement()
+	if err != nil {
+		log.Fatal(err)
+	}
+	if isFullscreen {
+		f.mainWindow.Fullscreen()
+	} else {
+		f.mainWindow.UnFullscreen()
+	}
 }
 
 func coreWebview2RequestToHttpRequest(coreReq *edge.ICoreWebView2WebResourceRequest) func() (*http.Request, error) {


### PR DESCRIPTION
# Description

This PR adds a hook into the `ContainsFullScreenElementChanged` event from WebView2 to fullscreen/unfullscreen automatically when elements request to go fullscreen.

It works, but the window moves slightly erratically. What seems to be happening is:
- Press button to go fullscreen - works reasonably well
- Press button to unfullscreen and the window returns to original size, but is left aligned with the window
- The unfullscreen happens but the window "goes to" the left to wrap the content
- It then realises it wasn't meant to be there and jumps back to the original position


https://github.com/wailsapp/wails/assets/1943904/44ac806a-b1cd-427d-ad1a-052173cdb329

