### PR TITLE
chore: update npm and docker package names for dnf package manager

### DIFF
--- a/v2/internal/system/packagemanager/dnf.go
+++ b/v2/internal/system/packagemanager/dnf.go
@@ -44,6 +44,7 @@ func (y *Dnf) Packages() packagemap {
 		},
 		"npm": []*Package{
 			{Name: "npm", SystemPackage: true},
+			{Name: "nodejs-npm", SystemPackage: true},
 		},
 		"upx": []*Package{
 			{Name: "upx", SystemPackage: true, Optional: true},
@@ -57,6 +58,7 @@ func (y *Dnf) Packages() packagemap {
 					"fedora": "Follow the guide: https://docs.docker.com/engine/install/fedora/",
 				},
 			},
+			{Name: "moby-engine", SystemPackage: true, Optional: true},
 		},
 	}
 }

--- a/website/src/pages/changelog.mdx
+++ b/website/src/pages/changelog.mdx
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added correct NodeJS and Docker package names for DNF package manager of Fedora 38. Added by @aranggitoar in [PR](https://github.com/wailsapp/wails/pull/2790)
 - Added `-devtools` production build flag. Added by @mmghv in [PR](https://github.com/wailsapp/wails/pull/2725)
 - Added `EnableDefaultContextMenu` option to allow enabling the browser's default context-menu in production . Added by @mmghv in [PR](https://github.com/wailsapp/wails/pull/2733)
 - Added smart functionality for the default context-menu in production with CSS styles to control it. Added by @mmghv in [PR](https://github.com/wailsapp/wails/pull/2748)


### PR DESCRIPTION
# Description

This pull request added the current package names for NPM and Docker for Fedora 38.

Fixes #2638 

## Type of change
  
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
  
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration using `wails doctor`.

- [ ] Windows
- [ ] macOS
- [x] Linux
  
## Test Configuration

Please paste the output of `wails doctor`. If you are unable to run this command, please describe your environment in as much detail as possible.

![image](https://github.com/wailsapp/wails/assets/78088355/6428db9d-ffd0-49fd-8d6a-d4a410b768af)


# Checklist:

- [ ] I have updated `website/src/pages/changelog.mdx` with details of this PR
- [x] My code follows the general coding style of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
