### PR TITLE
add new programName option to linux options

### DIFF
--- a/v2/internal/frontend/desktop/linux/frontend.go
+++ b/v2/internal/frontend/desktop/linux/frontend.go
@@ -190,6 +190,10 @@ func NewFrontend(ctx context.Context, appoptions *options.App, myLogger *logger.
 
 	C.install_signal_handlers()
 
+	if appoptions.Linux != nil && appoptions.Linux.ProgramName != "" {
+		C.g_set_prgname(C.CString(appoptions.Linux.ProgramName))
+	}
+
 	return result
 }
 

--- a/v2/internal/frontend/desktop/linux/frontend.go
+++ b/v2/internal/frontend/desktop/linux/frontend.go
@@ -191,7 +191,9 @@ func NewFrontend(ctx context.Context, appoptions *options.App, myLogger *logger.
 	C.install_signal_handlers()
 
 	if appoptions.Linux != nil && appoptions.Linux.ProgramName != "" {
-		C.g_set_prgname(C.CString(appoptions.Linux.ProgramName))
+		prgname := C.CString(appoptions.Linux.ProgramName)
+		C.g_set_prgname(prgname)
+		C.free(unsafe.Pointer(prgname))
 	}
 
 	return result

--- a/v2/pkg/options/linux/linux.go
+++ b/v2/pkg/options/linux/linux.go
@@ -29,6 +29,15 @@ type Options struct {
 	//   - WebviewGpuPolicyOnDemand
 	//   - WebviewGpuPolicyNever
 	WebviewGpuPolicy WebviewGpuPolicy
+
+	// ProgramName is used to set the program's name for the window manager via GTK's g_set_prgname().
+	//This name should not be localized. [see the docs]
+	//
+	//When a .desktop file is created this value helps with window grouping and desktop icons when the .desktop file's Name
+	//property differs form the executable's filename.
+	//
+	//[see the docs]: https://docs.gtk.org/glib/func.set_prgname.html
+	ProgramName string
 }
 
 type Messages struct {

--- a/website/docs/reference/options.mdx
+++ b/website/docs/reference/options.mdx
@@ -105,7 +105,8 @@ func main() {
         Linux: &linux.Options{
             Icon: icon,
             WindowIsTranslucent: false,
-			WebviewGpuPolicy: linux.WebviewGpuPolicyAlways,
+            WebviewGpuPolicy: linux.WebviewGpuPolicyAlways,
+            ProgramName: "wails"
         },
         Debug: options.Debug{
             OpenInspectorOnStartup: false,
@@ -897,6 +898,17 @@ Default: `WebviewGpuPolicyAlways`
 | WebviewGpuPolicyAlways   | Hardware acceleration is always enabled|
 | WebviewGpuPolicyOnDemand | Hardware acceleration is enabled/disabled as request by web contents|
 | WebviewGpuPolicyNever    | Hardware acceleration is always disabled |
+
+#### ProgramName
+
+This option is used to set the program's name for the window manager via GTK's g_set_prgname().
+This name should not be localized, [see the docs](https://docs.gtk.org/glib/func.set_prgname.html).
+
+When a .desktop file is created this value helps with window grouping and desktop icons when the .desktop file's `Name`
+property differs form the executable's filename.
+
+Name: ProgramName<br/>
+Type: string<br/>
 
 ### Debug
 

--- a/website/src/pages/changelog.mdx
+++ b/website/src/pages/changelog.mdx
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added smart functionality for the default context-menu in production with CSS styles to control it. Added by @mmghv in [PR](https://github.com/wailsapp/wails/pull/2748)
 - Added custom error formatting to allow passing structured errors back to the frontend.
 - Added sveltekit.mdx guide. Added by @figuerom16 in [PR](https://github.com/wailsapp/wails/pull/2771)
+- Added ProgramName option to [linux.Options](/docs/reference/options#linux). Added by @lyimmi in [PR](https://github.com/wailsapp/wails/pull/2817)
 
 ### Changed
 


### PR DESCRIPTION
# Description

When the program's executable name differs from the human readable name in a .desktop file sometimes the window manager won't draw the correct icon for it and if multiple instances are running the grouping can be weird too.

This PR aims to help with this issue by adding a new linux application option named `ProgramName`. This value is set when a new frontend instance is created by calling GTK's g_set_prgname() function.

Fixes #2800 (issue)

## Type of change
  
Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

Tested on existing and on newly created applications by creating different .desktop files with program names icons and executable filenames.

Tested on: Ubuntu 22.04.3 LTS, Ubuntu 23.04, !Pop_OS 22.04
Wayland and X11

- [ ] Windows
- [ ] macOS
- [x] Linux
  
## Test Configuration

```shell
# System

OS           | Ubuntu  
Version      | 22.04   
ID           | ubuntu  
Go Version   | go1.20.4
Platform     | linux   
Architecture | amd64   

# Wails

Version         | v2.5.1
Package Manager | apt   

# Dependencies

Dependency | Package Name          | Status    | Version                
*docker    | docker.io             | Installed | 24.0.5                 
gcc        | build-essential       | Installed | 12.9ubuntu3            
libgtk-3   | libgtk-3-dev          | Installed | 3.24.33-1ubuntu2       
libwebkit  | libwebkit2gtk-4.0-dev | Installed | 2.40.4-0ubuntu0.22.04.1
npm        | npm                   | Installed | 8.19.2                 
*nsis      | nsis                  | Available | 3.08-2                 
pkg-config | pkg-config            | Installed | 0.29.2-1ubuntu3        
* - Optional Dependency

```

# Checklist:

- [x] I have updated `website/src/pages/changelog.mdx` with details of this PR
- [x] My code follows the general coding style of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
