### PR TITLE
[bugfix] build hook command parsing

### DIFF
--- a/v2/pkg/commands/build/build.go
+++ b/v2/pkg/commands/build/build.go
@@ -7,6 +7,7 @@ import (
 	"runtime"
 	"strings"
 
+	"github.com/google/shlex"
 	"github.com/pterm/pterm"
 	"github.com/samber/lo"
 
@@ -392,7 +393,10 @@ func executeBuildHook(outputLogger *clilogger.CLILogger, options *Options, hookI
 	}
 
 	printBulletPoint("Executing %s build hook '%s': ", hookName, hookIdentifier)
-	args := strings.Split(buildHook, " ")
+	args, err := shlex.Split(buildHook, " ")
+	if err != nil {
+		return fmt.Errorf("could not parse %s build hook command: %w", hookName, err)
+	}
 	for i, arg := range args {
 		newArg := argReplacements[arg]
 		if newArg == "" {

--- a/v2/pkg/commands/build/build.go
+++ b/v2/pkg/commands/build/build.go
@@ -393,7 +393,7 @@ func executeBuildHook(outputLogger *clilogger.CLILogger, options *Options, hookI
 	}
 
 	printBulletPoint("Executing %s build hook '%s': ", hookName, hookIdentifier)
-	args, err := shlex.Split(buildHook, " ")
+	args, err := shlex.Split(buildHook)
 	if err != nil {
 		return fmt.Errorf("could not parse %s build hook command: %w", hookName, err)
 	}


### PR DESCRIPTION
# Description

use `shlex`, rather than `strings` package, to split pre/post-build command

## Type of change
  
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Yes
  
## Test Configuration

Wails CLI v2.5.1
# System

...|...
-------------|--------------
OS           | ArcoLinux
Version      | Unknown  
ID           | arcolinux
Go Version   | go1.20.5 
Platform     | linux    
Architecture | amd64    

# Wails

Version         | v2.5.1
------------------|---------
Package Manager | pacman

# Dependencies

Dependency | Package Name | Status    | Version
-------------------|------------------------|-------------|------------
*docker    | docker       | Installed | 1:24.0.5-1 
gcc        | gcc          | Installed | 13.2.1-3   
libgtk-3   | gtk3         | Installed | 1:3.24.38-1
libwebkit  | webkit2gtk   | Installed | 2.40.5-1   
npm        | npm          | Installed | 9.8.1-1    
pkg-config | pkgconf      | Installed | 1.8.1-1    

_* - Optional Dependency_

# Diagnosis

Your system is ready for Wails development!
 ♥   If Wails is useful to you or your company, please consider sponsoring the project:
https://github.com/sponsors/leaanthony


# Checklist:

- [x] My code follows the general coding style of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
