### PR TITLE
Bugfix/2848 window set position timing

### DIFF
--- a/v2/internal/frontend/desktop/linux/window.go
+++ b/v2/internal/frontend/desktop/linux/window.go
@@ -173,7 +173,13 @@ func (w *Window) Center() {
 }
 
 func (w *Window) SetPosition(x int, y int) {
-	C.SetPosition(unsafe.Pointer(w.asGTKWindow()), C.int(x), C.int(y))
+	var wg sync.WaitGroup
+	wg.Add(1)
+	invokeOnMainThread(func() {
+		C.SetPosition(unsafe.Pointer(w.asGTKWindow()), C.int(x), C.int(y))
+		wg.Done()
+	})
+	wg.Wait()
 }
 
 func (w *Window) Size() (int, int) {

--- a/v2/internal/frontend/desktop/linux/window.go
+++ b/v2/internal/frontend/desktop/linux/window.go
@@ -173,13 +173,9 @@ func (w *Window) Center() {
 }
 
 func (w *Window) SetPosition(x int, y int) {
-	var wg sync.WaitGroup
-	wg.Add(1)
 	invokeOnMainThread(func() {
 		C.SetPosition(unsafe.Pointer(w.asGTKWindow()), C.int(x), C.int(y))
-		wg.Done()
 	})
-	wg.Wait()
 }
 
 func (w *Window) Size() (int, int) {

--- a/website/src/pages/changelog.mdx
+++ b/website/src/pages/changelog.mdx
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Avoid app crashing when the Linux GTK key is empty. Fixed by @aminya in [PR](https://github.com/wailsapp/wails/pull/2672)
+- Fixed a race condition when positioning the window on Linux. Added by @lyimmi in [PR](https://github.com/wailsapp/wails/pull/2850)
 
 ### Added
 


### PR DESCRIPTION
# Description

On linux the window positioning is not running on the main thread, this PR fixes it.

Fixes #2848

## Type of change
  
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
  
I have run it on multiple projects and machines.

- [ ] Windows
- [ ] macOS
- [x] Linux
  
## Test Configuration

```shell
# System

OS           | Ubuntu  
Version      | 22.04   
ID           | ubuntu  
Go Version   | go1.20.4
Platform     | linux   
Architecture | amd64   

# Wails

Version         | v2.5.1
Package Manager | apt   

# Dependencies

Dependency | Package Name          | Status    | Version                
*docker    | docker.io             | Installed | 24.0.5                 
gcc        | build-essential       | Installed | 12.9ubuntu3            
libgtk-3   | libgtk-3-dev          | Installed | 3.24.33-1ubuntu2       
libwebkit  | libwebkit2gtk-4.0-dev | Installed | 2.40.5-0ubuntu0.22.04.1
npm        | npm                   | Installed | 8.19.2                 
*nsis      | nsis                  | Available | 3.08-2                 
pkg-config | pkg-config            | Installed | 0.29.2-1ubuntu3   
```

# Checklist:

- [x] I have updated `website/src/pages/changelog.mdx` with details of this PR
- [x] My code follows the general coding style of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
