### PR TITLE
set the background color for window

### DIFF
--- a/v2/internal/frontend/desktop/linux/window.c
+++ b/v2/internal/frontend/desktop/linux/window.c
@@ -139,11 +139,31 @@ void SetWindowTransparency(GtkWidget *widget)
     }
 }
 
+static GtkCssProvider *windowCssProvider = NULL;
+
 void SetBackgroundColour(void *data)
 {
+    // set webview's background color
     RGBAOptions *options = (RGBAOptions *)data;
     GdkRGBA colour = {options->r / 255.0, options->g / 255.0, options->b / 255.0, options->a / 255.0};
     webkit_web_view_set_background_color(WEBKIT_WEB_VIEW(options->webview), &colour);
+
+    // set window's background color
+    GtkWidget *window = GTK_WIDGET(options->window);
+    gchar *str = g_strdup_printf("window {background-color: rgba(%d, %d, %d, %d);}", options->r, options->g, options->b, options->a);
+
+    if (windowCssProvider == NULL)
+    {
+        windowCssProvider = gtk_css_provider_new();
+        gtk_style_context_add_provider(
+            gtk_widget_get_style_context(window),
+            GTK_STYLE_PROVIDER(windowCssProvider),
+            GTK_STYLE_PROVIDER_PRIORITY_APPLICATION);
+        g_object_unref(windowCssProvider);
+    }
+
+    gtk_css_provider_load_from_data(windowCssProvider, str, -1, NULL);
+    g_free(str);
 }
 
 static gboolean setTitle(gpointer data)

--- a/v2/internal/frontend/desktop/linux/window.go
+++ b/v2/internal/frontend/desktop/linux/window.go
@@ -271,6 +271,7 @@ func (w *Window) SetBackgroundColour(r uint8, g uint8, b uint8, a uint8) {
 		b:       C.uchar(b),
 		a:       C.uchar(a),
 		webview: w.webview,
+		window:  w.gtkWindow,
 	}
 	invokeOnMainThread(func() { C.SetBackgroundColour(unsafe.Pointer(&data)) })
 

--- a/v2/internal/frontend/desktop/linux/window.h
+++ b/v2/internal/frontend/desktop/linux/window.h
@@ -55,6 +55,7 @@ typedef struct RGBAOptions
     uint8_t b;
     uint8_t a;
     void *webview;
+    void *window;
 } RGBAOptions;
 
 typedef struct SetTitleArgs

--- a/website/src/pages/changelog.mdx
+++ b/website/src/pages/changelog.mdx
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Avoid app crashing when the Linux GTK key is empty. Fixed by @aminya in [PR](https://github.com/wailsapp/wails/pull/2672)
 - Fixed a race condition when positioning the window on Linux. Added by @lyimmi in [PR](https://github.com/wailsapp/wails/pull/2850)
+- Fixed `SetBackgroundColour` so it sets the window's background color to reduce resize flickering on Linux. Added by @lyimmi in [PR](https://github.com/wailsapp/wails/pull/2853)
 
 ### Added
 


### PR DESCRIPTION
# Description

With this PR the `SetBackgroundColour` function sets the window's and the webview's background color as well. To make the resize flickering less prominent.

Fixes #2852 

## Type of change
  
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
  
Tested it on existing and new projects, set the color from go and javascript.

- [ ] Windows
- [ ] macOS
- [x] Linux
  
## Test Configuration

```shell
# System

OS           | Ubuntu  
Version      | 23.04   
ID           | ubuntu  
Go Version   | go1.21.0
Platform     | linux   
Architecture | amd64   

# Wails

Version         | v2.5.1
Package Manager | apt   

# Dependencies

Dependency | Package Name          | Status    | Version                
*docker    | docker.io             | Installed | 24.0.5                 
gcc        | build-essential       | Installed | 12.9ubuntu3            
libgtk-3   | libgtk-3-dev          | Installed | 3.24.37-1ubuntu1       
libwebkit  | libwebkit2gtk-4.0-dev | Installed | 2.40.5-0ubuntu0.23.04.1
npm        | npm                   | Installed | 9.8.0                  
*nsis      | nsis                  | Installed | v3.08-3                
pkg-config | pkg-config            | Installed | 1.8.1-1ubuntu2
```

# Checklist:

- [x] I have updated `website/src/pages/changelog.mdx` with details of this PR
- [x] My code follows the general coding style of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
