### PR TITLE
fix disable window resize

### DIFF
--- a/v2/internal/frontend/desktop/linux/window.go
+++ b/v2/internal/frontend/desktop/linux/window.go
@@ -110,11 +110,12 @@ func NewWindow(appoptions *options.App, debug bool, devtools bool) *Window {
 	// Setup window
 	result.SetKeepAbove(appoptions.AlwaysOnTop)
 	result.SetResizable(!appoptions.DisableResize)
-	result.SetSize(appoptions.Width, appoptions.Height)
+	result.SetDefaultSize(appoptions.Width, appoptions.Height)
 	result.SetDecorated(!appoptions.Frameless)
 	result.SetTitle(appoptions.Title)
 	result.SetMinSize(appoptions.MinWidth, appoptions.MinHeight)
 	result.SetMaxSize(appoptions.MaxWidth, appoptions.MaxHeight)
+
 	if appoptions.Linux != nil {
 		if appoptions.Linux.Icon != nil {
 			result.SetWindowIcon(appoptions.Linux.Icon)
@@ -313,6 +314,10 @@ func (w *Window) SetKeepAbove(top bool) {
 
 func (w *Window) SetResizable(resizable bool) {
 	C.gtk_window_set_resizable(w.asGTKWindow(), gtkBool(resizable))
+}
+
+func (w *Window) SetDefaultSize(width int, height int) {
+	C.gtk_window_set_default_size(w.asGTKWindow(), C.int(width), C.int(height))
 }
 
 func (w *Window) SetSize(width int, height int) {

--- a/website/src/pages/changelog.mdx
+++ b/website/src/pages/changelog.mdx
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix issue where app would exit before main() on linux if $DISPLAY env var was not set. Fixed by @phildrip in [PR](https://github.com/wailsapp/wails/pull/2841)
 - Fixed a race condition when positioning the window on Linux. Added by @lyimmi in [PR](https://github.com/wailsapp/wails/pull/2850)
 - Fixed `SetBackgroundColour` so it sets the window's background color to reduce resize flickering on Linux. Added by @lyimmi in [PR](https://github.com/wailsapp/wails/pull/2853)
+- Fixed disable window resize option and wrong initial window size when its enabled. Added by @lyimmi in [PR](https://github.com/wailsapp/wails/pull/2862)
 
 
 ### Added


### PR DESCRIPTION
# Description

This PR fixes disable window resize by setting the `gtk_window_set_default_size` when the window is created.

Fixes #2780 

## Type of change
  
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
  
Tested it on Ubuntu 23.04 with existing and new projects.

- [ ] Windows
- [ ] macOS
- [x] Linux
  
## Test Configuration

```shell
# System

OS           | Ubuntu  
Version      | 23.04   
ID           | ubuntu  
Go Version   | go1.21.0
Platform     | linux   
Architecture | amd64   

# Wails

Version         | v2.5.1
Package Manager | apt   

# Dependencies

Dependency | Package Name          | Status    | Version                
*docker    | docker.io             | Installed | 24.0.5                 
gcc        | build-essential       | Installed | 12.9ubuntu3            
libgtk-3   | libgtk-3-dev          | Installed | 3.24.37-1ubuntu1       
libwebkit  | libwebkit2gtk-4.0-dev | Installed | 2.40.5-0ubuntu0.23.04.1
npm        | npm                   | Installed | 9.8.0                  
*nsis      | nsis                  | Installed | v3.08-3                
pkg-config | pkg-config            | Installed | 1.8.1-1ubuntu2
```

# Checklist:

- [x] I have updated `website/src/pages/changelog.mdx` with details of this PR
- [x] My code follows the general coding style of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
