### PR TITLE
fix: use string formatting in gtk_message_dialog_new

### DIFF
--- a/v3/pkg/application/linux_cgo.go
+++ b/v3/pkg/application/linux_cgo.go
@@ -86,6 +86,7 @@ static void* new_message_dialog(GtkWindow *parent, const gchar *msg, int dialogT
        GTK_DIALOG_MODAL | GTK_DIALOG_DESTROY_WITH_PARENT,
 	   dialogType,
 	   buttonMask,
+       "%s",
        msg);
 
    // g_signal_connect_swapped (dialog,


### PR DESCRIPTION
# Description

Currently v3 does not compile under Linux with the following error:

```shell
# github.com/wailsapp/wails/v3/pkg/application
In file included from _cgo_export.c:4:
linux_cgo.go: In function ‘new_message_dialog’:
linux_cgo.go:89:8: error: format not a string literal and no format arguments [-Werror=format-security]
cc1: some warnings being treated as errors
```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

It now compiles  

- [ ] Windows
- [ ] macOS
- [x] Linux
  
## Test Configuration

```shell
nix-shell -I nixpkgs=channel:nixpkgs-unstable -p gcc pkg-config nsis upx gtk3 webkitgtk go_1_21
```

(wails doctor seems to detect wrong Go version)
```console
# System

OS           | NixOS   
Version      | 23.05   
ID           | nixos   
Go Version   | go1.20.7
Platform     | linux   
Architecture | amd64   

# Wails

Version         | v2.5.1 
Package Manager | nixpkgs

# Dependencies

Dependency | Package Name     | Status    | Version         
*docker    | nixos.docker     | Installed | 20.10.25        
gcc        | nixos.gcc        | Installed | 12.2.0          
libgtk-3   | nixos.gtk3       | Installed | 3.24.37         
libwebkit  | nixos.webkitgtk  | Available | 2.40.5+abi=4.0  
npm        | nixos.nodejs     | Installed | 18.17.1         
*nsis      | nixos.nsis       | Installed | v12-Aug-2023.cvs
pkg-config | nixos.pkg-config | Installed | 0.29.2          
*upx       | nixos.upx        | Installed | upx 4.1.0       
* - Optional Dependency
```

# Checklist:

- [ ] I have updated `website/src/pages/changelog.mdx` with details of this PR
- [x] My code follows the general coding style of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
