### PR TITLE
docs: make the install command easier to copy

### DIFF
--- a/website/versioned_docs/version-v2.6.0/gettingstarted/installation.mdx
+++ b/website/versioned_docs/version-v2.6.0/gettingstarted/installation.mdx
@@ -69,7 +69,11 @@ import TabItem from "@theme/TabItem";
 
 ## Installing Wails
 
-Run `go install github.com/wailsapp/wails/v2/cmd/wails@latest` to install the Wails CLI.
+To install the Wails CLI, run the following command:
+
+```shell
+go install github.com/wailsapp/wails/v2/cmd/wails@latest
+```
 
 Note: If you get an error similar to this:
 


### PR DESCRIPTION
# Description

just change doc to make the installation command easier to copy.