### PR TITLE
[v2] Refactor devtools (better naming to remove confusion)

### DIFF
--- a/v2/internal/app/app.go
+++ b/v2/internal/app/app.go
@@ -22,7 +22,7 @@ type App struct {
 	debug bool
 
 	// Indicates if the devtools is enabled
-	devtools bool
+	devtoolsEnabled bool
 
 	// OnStartup/OnShutdown
 	startupCallback  func(ctx context.Context)

--- a/v2/internal/app/app_dev.go
+++ b/v2/internal/app/app_dev.go
@@ -44,7 +44,7 @@ func CreateApp(appoptions *options.App) (*App, error) {
 
 	ctx := context.Background()
 	ctx = context.WithValue(ctx, "debug", true)
-	ctx = context.WithValue(ctx, "devtools", true)
+	ctx = context.WithValue(ctx, "devtoolsEnabled", true)
 
 	// Set up logger
 	myLogger := logger.New(appoptions.Logger)
@@ -230,7 +230,7 @@ func CreateApp(appoptions *options.App) (*App, error) {
 		startupCallback:  appoptions.OnStartup,
 		shutdownCallback: appoptions.OnShutdown,
 		debug:            true,
-		devtools:         true,
+		devtoolsEnabled:  true,
 	}
 
 	result.options = appoptions

--- a/v2/internal/app/app_devtools.go
+++ b/v2/internal/app/app_devtools.go
@@ -2,6 +2,7 @@
 
 package app
 
+// Note: devtools flag is also added in debug builds
 func IsDevtoolsEnabled() bool {
 	return true
 }

--- a/v2/internal/app/app_devtools_not.go
+++ b/v2/internal/app/app_devtools_not.go
@@ -2,6 +2,7 @@
 
 package app
 
+// Note: devtools flag is also added in debug builds
 func IsDevtoolsEnabled() bool {
 	return false
 }

--- a/v2/internal/app/app_production.go
+++ b/v2/internal/app/app_production.go
@@ -34,9 +34,9 @@ func CreateApp(appoptions *options.App) (*App, error) {
 	options.MergeDefaults(appoptions)
 
 	debug := IsDebug()
-	devtools := IsDevtoolsEnabled()
+	devtoolsEnabled := IsDevtoolsEnabled()
 	ctx = context.WithValue(ctx, "debug", debug)
-	ctx = context.WithValue(ctx, "devtools", devtools)
+	ctx = context.WithValue(ctx, "devtoolsEnabled", devtoolsEnabled)
 
 	// Set up logger
 	myLogger := logger.New(appoptions.Logger)
@@ -95,7 +95,7 @@ func CreateApp(appoptions *options.App) (*App, error) {
 		startupCallback:  appoptions.OnStartup,
 		shutdownCallback: appoptions.OnShutdown,
 		debug:            debug,
-		devtools:         devtools,
+		devtoolsEnabled:  devtoolsEnabled,
 		options:          appoptions,
 	}
 

--- a/v2/internal/frontend/desktop/darwin/Application.h
+++ b/v2/internal/frontend/desktop/darwin/Application.h
@@ -17,7 +17,7 @@
 #define WindowStartsMinimised 2
 #define WindowStartsFullscreen 3
 
-WailsContext* Create(const char* title, int width, int height, int frameless, int resizable, int fullscreen, int fullSizeContent, int hideTitleBar, int titlebarAppearsTransparent, int hideTitle, int useToolbar, int hideToolbarSeparator, int webviewIsTransparent, int alwaysOnTop, int hideWindowOnClose, const char *appearance, int windowIsTranslucent, int devtools, int defaultContextMenu, int windowStartState, int startsHidden, int minWidth, int minHeight, int maxWidth, int maxHeight, bool fraudulentWebsiteWarningEnabled);
+WailsContext* Create(const char* title, int width, int height, int frameless, int resizable, int fullscreen, int fullSizeContent, int hideTitleBar, int titlebarAppearsTransparent, int hideTitle, int useToolbar, int hideToolbarSeparator, int webviewIsTransparent, int alwaysOnTop, int hideWindowOnClose, const char *appearance, int windowIsTranslucent, int devtoolsEnabled, int defaultContextMenu, int windowStartState, int startsHidden, int minWidth, int minHeight, int maxWidth, int maxHeight, bool fraudulentWebsiteWarningEnabled);
 void Run(void*, const char* url);
 
 void SetTitle(void* ctx, const char *title);

--- a/v2/internal/frontend/desktop/darwin/Application.m
+++ b/v2/internal/frontend/desktop/darwin/Application.m
@@ -14,13 +14,13 @@
 #import "WailsMenu.h"
 #import "WailsMenuItem.h"
 
-WailsContext* Create(const char* title, int width, int height, int frameless, int resizable, int fullscreen, int fullSizeContent, int hideTitleBar, int titlebarAppearsTransparent, int hideTitle, int useToolbar, int hideToolbarSeparator, int webviewIsTransparent, int alwaysOnTop, int hideWindowOnClose, const char *appearance, int windowIsTranslucent, int devtools, int defaultContextMenu, int windowStartState, int startsHidden, int minWidth, int minHeight, int maxWidth, int maxHeight, bool fraudulentWebsiteWarningEnabled) {
+WailsContext* Create(const char* title, int width, int height, int frameless, int resizable, int fullscreen, int fullSizeContent, int hideTitleBar, int titlebarAppearsTransparent, int hideTitle, int useToolbar, int hideToolbarSeparator, int webviewIsTransparent, int alwaysOnTop, int hideWindowOnClose, const char *appearance, int windowIsTranslucent, int devtoolsEnabled, int defaultContextMenu, int windowStartState, int startsHidden, int minWidth, int minHeight, int maxWidth, int maxHeight, bool fraudulentWebsiteWarningEnabled) {
     
     [NSApplication sharedApplication];
 
     WailsContext *result = [WailsContext new];
 
-    result.devtools = devtools;
+    result.devtoolsEnabled = devtoolsEnabled;
     result.defaultContextMenu = defaultContextMenu;
     
     if ( windowStartState == WindowStartsFullscreen ) {

--- a/v2/internal/frontend/desktop/darwin/WailsContext.h
+++ b/v2/internal/frontend/desktop/darwin/WailsContext.h
@@ -44,7 +44,7 @@
 
 @property bool alwaysOnTop;
 
-@property bool devtools;
+@property bool devtoolsEnabled;
 @property bool defaultContextMenu;
 
 @property (retain) WKUserContentController* userContentController;

--- a/v2/internal/frontend/desktop/darwin/WailsContext.m
+++ b/v2/internal/frontend/desktop/darwin/WailsContext.m
@@ -225,7 +225,7 @@ typedef void (^schemeTaskCaller)(id<WKURLSchemeTask>);
     [userContentController addScriptMessageHandler:self name:@"external"];
     config.userContentController = userContentController;
     self.userContentController = userContentController;
-    if (self.devtools) {
+    if (self.devtoolsEnabled) {
         [config.preferences setValue:@YES forKey:@"developerExtrasEnabled"];
     } else if (!self.defaultContextMenu) {
         // Disable default context menus

--- a/v2/internal/frontend/desktop/darwin/frontend.go
+++ b/v2/internal/frontend/desktop/darwin/frontend.go
@@ -47,7 +47,7 @@ type Frontend struct {
 	frontendOptions *options.App
 	logger          *logger.Logger
 	debug           bool
-	devtools        bool
+	devtoolsEnabled bool
 
 	// Assets
 	assets   *assetserver.AssetServer
@@ -154,16 +154,16 @@ func (f *Frontend) Run(ctx context.Context) error {
 	f.ctx = ctx
 
 	var _debug = ctx.Value("debug")
-	var _devtools = ctx.Value("devtools")
+	var _devtoolsEnabled = ctx.Value("devtoolsEnabled")
 
 	if _debug != nil {
 		f.debug = _debug.(bool)
 	}
-	if _devtools != nil {
-		f.devtools = _devtools.(bool)
+	if _devtoolsEnabled != nil {
+		f.devtoolsEnabled = _devtoolsEnabled.(bool)
 	}
 
-	mainWindow := NewWindow(f.frontendOptions, f.debug, f.devtools)
+	mainWindow := NewWindow(f.frontendOptions, f.debug, f.devtoolsEnabled)
 	f.mainWindow = mainWindow
 	f.mainWindow.Center()
 

--- a/v2/internal/frontend/desktop/darwin/main.m
+++ b/v2/internal/frontend/desktop/darwin/main.m
@@ -215,11 +215,11 @@ int main(int argc, const char * argv[]) {
     int hideWindowOnClose = 0;
     const char* appearance = "NSAppearanceNameDarkAqua";
     int windowIsTranslucent = 1;
-    int devtools = 1;
+    int devtoolsEnabled = 1;
     int defaultContextMenu = 1;
     int windowStartState = 0;
     int startsHidden = 0;
-    WailsContext *result = Create("OI OI!",400,400, frameless,  resizable, fullscreen, fullSizeContent, hideTitleBar, titlebarAppearsTransparent, hideTitle, useToolbar, hideToolbarSeparator, webviewIsTransparent, alwaysOnTop, hideWindowOnClose, appearance, windowIsTranslucent, devtools, defaultContextMenu, windowStartState,
+    WailsContext *result = Create("OI OI!",400,400, frameless,  resizable, fullscreen, fullSizeContent, hideTitleBar, titlebarAppearsTransparent, hideTitle, useToolbar, hideToolbarSeparator, webviewIsTransparent, alwaysOnTop, hideWindowOnClose, appearance, windowIsTranslucent, devtoolsEnabled, defaultContextMenu, windowStartState,
                                   startsHidden, 400, 400, 600, 600, false);
     SetBackgroundColour(result, 255, 0, 0, 255);
     void *m = NewMenu("");

--- a/v2/internal/frontend/desktop/linux/frontend.go
+++ b/v2/internal/frontend/desktop/linux/frontend.go
@@ -110,7 +110,7 @@ type Frontend struct {
 	frontendOptions *options.App
 	logger          *logger.Logger
 	debug           bool
-	devtools        bool
+	devtoolsEnabled bool
 
 	// Assets
 	assets   *assetserver.AssetServer
@@ -182,16 +182,16 @@ func NewFrontend(ctx context.Context, appoptions *options.App, myLogger *logger.
 	go result.startMessageProcessor()
 
 	var _debug = ctx.Value("debug")
-	var _devtools = ctx.Value("devtools")
+	var _devtoolsEnabled = ctx.Value("devtoolsEnabled")
 
 	if _debug != nil {
 		result.debug = _debug.(bool)
 	}
-	if _devtools != nil {
-		result.devtools = _devtools.(bool)
+	if _devtoolsEnabled != nil {
+		result.devtoolsEnabled = _devtoolsEnabled.(bool)
 	}
 
-	result.mainWindow = NewWindow(appoptions, result.debug, result.devtools)
+	result.mainWindow = NewWindow(appoptions, result.debug, result.devtoolsEnabled)
 
 	C.install_signal_handlers()
 

--- a/v2/internal/frontend/desktop/linux/window.go
+++ b/v2/internal/frontend/desktop/linux/window.go
@@ -37,7 +37,7 @@ func gtkBool(input bool) C.gboolean {
 type Window struct {
 	appoptions                               *options.App
 	debug                                    bool
-	devtools                                 bool
+	devtoolsEnabled                          bool
 	gtkWindow                                unsafe.Pointer
 	contentManager                           unsafe.Pointer
 	webview                                  unsafe.Pointer
@@ -56,17 +56,17 @@ func bool2Cint(value bool) C.int {
 	return C.int(0)
 }
 
-func NewWindow(appoptions *options.App, debug bool, devtools bool) *Window {
+func NewWindow(appoptions *options.App, debug bool, devtoolsEnabled bool) *Window {
 	validateWebKit2Version(appoptions)
 
 	result := &Window{
-		appoptions: appoptions,
-		debug:      debug,
-		devtools:   devtools,
-		minHeight:  appoptions.MinHeight,
-		minWidth:   appoptions.MinWidth,
-		maxHeight:  appoptions.MaxHeight,
-		maxWidth:   appoptions.MaxWidth,
+		appoptions:      appoptions,
+		debug:           debug,
+		devtoolsEnabled: devtoolsEnabled,
+		minHeight:       appoptions.MinHeight,
+		minWidth:        appoptions.MinWidth,
+		maxHeight:       appoptions.MaxHeight,
+		maxWidth:        appoptions.MaxWidth,
 	}
 
 	gtkWindow := C.gtk_window_new(C.GTK_WINDOW_TOPLEVEL)
@@ -103,7 +103,7 @@ func NewWindow(appoptions *options.App, debug bool, devtools bool) *Window {
 	defer C.free(unsafe.Pointer(buttonPressedName))
 	C.ConnectButtons(unsafe.Pointer(webview))
 
-	if devtools {
+	if devtoolsEnabled {
 		C.DevtoolsEnabled(unsafe.Pointer(webview), C.int(1), C.bool(debug && appoptions.Debug.OpenInspectorOnStartup))
 		// Install Ctrl-Shift-F12 hotkey to call ShowInspector
 		C.InstallF12Hotkey(unsafe.Pointer(gtkWindow))

--- a/v2/internal/frontend/desktop/windows/frontend.go
+++ b/v2/internal/frontend/desktop/windows/frontend.go
@@ -48,7 +48,7 @@ type Frontend struct {
 	logger          *logger.Logger
 	chromium        *edge.Chromium
 	debug           bool
-	devtools        bool
+	devtoolsEnabled bool
 
 	// Assets
 	assets   *assetserver.AssetServer
@@ -143,13 +143,13 @@ func (f *Frontend) Run(ctx context.Context) error {
 	f.mainWindow = mainWindow
 
 	var _debug = ctx.Value("debug")
-	var _devtools = ctx.Value("devtools")
+	var _devtoolsEnabled = ctx.Value("devtoolsEnabled")
 
 	if _debug != nil {
 		f.debug = _debug.(bool)
 	}
-	if _devtools != nil {
-		f.devtools = _devtools.(bool)
+	if _devtoolsEnabled != nil {
+		f.devtoolsEnabled = _devtoolsEnabled.(bool)
 	}
 
 	f.WindowCenter()
@@ -458,7 +458,7 @@ func (f *Frontend) setupChromium() {
 	chromium.WebResourceRequestedCallback = f.processRequest
 	chromium.NavigationCompletedCallback = f.navigationCompleted
 	chromium.AcceleratorKeyCallback = func(vkey uint) bool {
-		if vkey == w32.VK_F12 && f.devtools {
+		if vkey == w32.VK_F12 && f.devtoolsEnabled {
 			var keyState [256]byte
 			if w32.GetKeyboardState(keyState[:]) {
 				// Check if CTRL is pressed
@@ -511,11 +511,11 @@ func (f *Frontend) setupChromium() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	err = settings.PutAreDefaultContextMenusEnabled(f.devtools || f.frontendOptions.EnableDefaultContextMenu)
+	err = settings.PutAreDefaultContextMenusEnabled(f.devtoolsEnabled || f.frontendOptions.EnableDefaultContextMenu)
 	if err != nil {
 		log.Fatal(err)
 	}
-	err = settings.PutAreDevToolsEnabled(f.devtools)
+	err = settings.PutAreDevToolsEnabled(f.devtoolsEnabled)
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
# Description

This removes some confusion regarding the devtools option by renaming some variables and params from `devtools` to `devtoolsEnabled` so it doesn't get confused with the `-devtools` option as `devtoolsEnabled` is `ture` for dev & debug also.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
  
It should not produce any change, testing should be done with :
`wails dev` => devtools is available
`wails build -debug` => devtools is available
`wails build -devtools` => devtools is available
`wails build` => devtools is NOT available

- [x] Windows
- [ ] macOS
- [x] Linux

# Checklist:

- [ ] I have updated `website/src/pages/changelog.mdx` with details of this PR
- [x] My code follows the general coding style of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
