### PR TITLE
[Github] Exclude `/website` from language stats

### DIFF
--- a/website/.gitattributes
+++ b/website/.gitattributes
@@ -1,0 +1,3 @@
+# Mark all files as documentation so it gets excluded from github language statistics
+# https://github.com/github-linguist/linguist/blob/master/docs/overrides.md#documentation
+** linguist-documentation


### PR DESCRIPTION
## Before

![image](https://github.com/wailsapp/wails/assets/5418859/f90b5785-e5ea-4cee-97cb-c0f27231bb74)

## After

![image](https://github.com/wailsapp/wails/assets/5418859/c2297d63-c16a-4a34-bf38-0e0bd691205c)

## Source

https://github.com/github-linguist/linguist/blob/master/docs/overrides.md#documentation