### PR TITLE
[v2 mac] add fullscreen option to preference

### DIFF
--- a/v2/internal/frontend/desktop/darwin/WailsContext.h
+++ b/v2/internal/frontend/desktop/darwin/WailsContext.h
@@ -58,6 +58,7 @@
 struct Preferences {
   bool *tabFocusesLinks;
   bool *textInteractionEnabled;
+  bool *fullscreenEnabled;
 };
 
 - (void) CreateWindow:(int)width :(int)height :(bool)frameless :(bool)resizable :(bool)fullscreen :(bool)fullSizeContent :(bool)hideTitleBar :(bool)titlebarAppearsTransparent  :(bool)hideTitle :(bool)useToolbar :(bool)hideToolbarSeparator :(bool)webviewIsTransparent :(bool)hideWindowOnClose :(NSString *)appearance :(bool)windowIsTranslucent :(int)minWidth :(int)minHeight :(int)maxWidth :(int)maxHeight :(bool)fraudulentWebsiteWarningEnabled :(struct Preferences)preferences;

--- a/v2/internal/frontend/desktop/darwin/WailsContext.m
+++ b/v2/internal/frontend/desktop/darwin/WailsContext.m
@@ -224,6 +224,12 @@ typedef void (^schemeTaskCaller)(id<WKURLSchemeTask>);
             config.preferences.textInteractionEnabled = *preferences.textInteractionEnabled;
         }
     }
+
+    if (@available(macOS 12.3, *)) {
+        if (preferences.fullscreenEnabled != NULL) {
+            config.preferences.elementFullscreenEnabled = *preferences.fullscreenEnabled;
+        }
+    }
     
 //    [config.preferences setValue:[NSNumber numberWithBool:true] forKey:@"developerExtrasEnabled"];
 

--- a/v2/internal/frontend/desktop/darwin/window.go
+++ b/v2/internal/frontend/desktop/darwin/window.go
@@ -95,6 +95,10 @@ func NewWindow(frontendOptions *options.App, debug bool, devtools bool) *Window 
 			if mac.Preferences.TextInteractionEnabled.IsSet() {
 				preferences.textInteractionEnabled = bool2CboolPtr(mac.Preferences.TextInteractionEnabled.Get())
 			}
+
+			if mac.Preferences.FullscreenEnabled.IsSet() {
+				preferences.fullscreenEnabled = bool2CboolPtr(mac.Preferences.FullscreenEnabled.Get())
+			}
 		}
 
 		windowIsTranslucent = bool2Cint(mac.WindowIsTranslucent)

--- a/v2/pkg/options/mac/preferences.go
+++ b/v2/pkg/options/mac/preferences.go
@@ -13,4 +13,7 @@ type Preferences struct {
 	// A Boolean value that indicates whether to allow people to select or otherwise interact with text.
 	// Set to true by default.
 	TextInteractionEnabled u.Bool
+	// A Boolean value that indicates whether a web view can display content full screen.
+	// Set to false by default
+	FullscreenEnabled u.Bool
 }

--- a/website/docs/reference/options.mdx
+++ b/website/docs/reference/options.mdx
@@ -812,7 +812,7 @@ You can specify the webview preferences.
 type Preferences struct {
 	TabFocusesLinks        u.Bool
 	TextInteractionEnabled u.Bool
-    FullscreenEnabled      u.Bool 
+	FullscreenEnabled      u.Bool 
 }
 ```
 
@@ -829,7 +829,7 @@ Mac: &mac.Options{
     Preferences: &mac.Preferences{
 		TabFocusesLinks:        mac.Enabled,
 		TextInteractionEnabled: mac.Disabled,
-        FullscreenEnabled:      mac.Enabled,
+		FullscreenEnabled:      mac.Enabled,
 	}
 }
 ```

--- a/website/docs/reference/options.mdx
+++ b/website/docs/reference/options.mdx
@@ -812,6 +812,7 @@ You can specify the webview preferences.
 type Preferences struct {
 	TabFocusesLinks        u.Bool
 	TextInteractionEnabled u.Bool
+    FullscreenEnabled      u.Bool 
 }
 ```
 
@@ -819,6 +820,7 @@ type Preferences struct {
 | -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | TabFocusesLinks            | A Boolean value that indicates whether pressing the tab key changes the focus to links and form controls. [Apple Docs](https://developer.apple.com/documentation/webkit/wkpreferences/2818595-tabfocuseslinks?language=objc)         |
 | TextInteractionEnabled     | A Boolean value that indicates whether to allow people to select or otherwise interact with text. [Apple Docs](https://developer.apple.com/documentation/webkit/wkpreferences/3727362-textinteractionenabled?language=objc)          |
+| FullscreenEnabled          | A Boolean value that indicates whether a web view can display content full screen. [Apple Docs](https://developer.apple.com/documentation/webkit/wkpreferences/3917769-elementfullscreenenabled?language=objc)                       |
 
 Example:
 
@@ -827,6 +829,7 @@ Mac: &mac.Options{
     Preferences: &mac.Preferences{
 		TabFocusesLinks:        mac.Enabled,
 		TextInteractionEnabled: mac.Disabled,
+        FullscreenEnabled:      mac.Enabled,
 	}
 }
 ```

--- a/website/src/pages/changelog.mdx
+++ b/website/src/pages/changelog.mdx
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added support for enabling/disabling swipe gestures for Windows WebView2. Added by @leaanthony in [PR](https://github.com/wailsapp/wails/pull/2878)
 - When building with `-devtools` flag, CMD/CTRL+SHIFT+F12 can be used to open the devtools. Added by @leaanthony in [PR](https://github.com/wailsapp/wails/pull/2915)
 - Added support for setting some of the Webview preferences, `textInteractionEnabled` and `tabFocusesLinks` on Mac. Added by @fkhadra in [PR](https://github.com/wailsapp/wails/pull/2937)
+- Added support for enabling/disabling fullscreen of the Webview on Mac. Added by @fkhadra in [PR](https://github.com/wailsapp/wails/pull/2953)
 
 ### Changed
 


### PR DESCRIPTION
# Description

This PR adds the option to enable/disable fullscreen support on Mac. For example, when this option is enabled, it allows the user to display a video in fullscreen mode.

Fixes # 2099

## Type of change
  
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?
  
I've created a new wails app that point to my changes. The app only render a video. When the user hover the video a fullscreen button is displayed allowing the user to switch in fullscreen mode.

https://github.com/wailsapp/wails/assets/5574267/eb338fe3-437f-4f9f-9155-14d12145a7ba

Repository: https://github.com/fkhadra/wails-fix-2099

- [ ] Windows
- [x] macOS
- [ ] Linux
  
## Test Configuration

```sh
# Wails
Version | v2.6.0

# System
┌─────────────────────────┐
| OS           | MacOS    |
| Version      | 13.5.2   |
| ID           | 22G91    |
| Go Version   | go1.21.0 |
| Platform     | darwin   |
| Architecture | arm64    |
└─────────────────────────┘

# Dependencies
┌──────────────────────────────────────────────────────────────────┐
| Dependency                | Package Name | Status    | Version   |
| Xcode command line tools  | N/A          | Installed | 2397      |
| Nodejs                    | N/A          | Installed | 18.17.0   |
| npm                       | N/A          | Installed | 9.6.7     |
| *Xcode                    | N/A          | Available |           |
| *upx                      | N/A          | Installed | upx 4.1.0 |
| *nsis                     | N/A          | Available |           |
└──────────────────── * - Optional Dependency ─────────────────────┘

# Diagnosis
Optional package(s) installation details:
  - Xcode: Available at https://apps.apple.com/us/app/xcode/id497799835
  - nsis : More info at https://wails.io/docs/guides/windows-installer/

 SUCCESS  Your system is ready for Wails development!

 ♥   If Wails is useful to you or your company, please consider sponsoring the project:
https://github.com/sponsors/leaanthony
```

# Checklist:

- [x] I have updated `website/src/pages/changelog.mdx` with details of this PR
- [x] My code follows the general coding style of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
