### PR TITLE
runtime: Support selecting multiple directories

### DIFF
--- a/v2/internal/frontend/desktop/darwin/WailsContext.m
+++ b/v2/internal/frontend/desktop/darwin/WailsContext.m
@@ -577,9 +577,7 @@ typedef void (^schemeTaskCaller)(id<WKURLSchemeTask>);
             [dialog setNameFieldStringValue:defaultFilename];
         }
         
-        [dialog setAllowsMultipleSelection: allowMultipleSelection];
         [dialog setShowsHiddenFiles: showHiddenFiles];
-
     }
 
     // Default Directory
@@ -592,6 +590,7 @@ typedef void (^schemeTaskCaller)(id<WKURLSchemeTask>);
     // Setup Options
     [dialog setCanChooseFiles: allowFiles];
     [dialog setCanChooseDirectories: allowDirectories];
+    [dialog setAllowsMultipleSelection: allowMultipleSelection];
     [dialog setCanCreateDirectories: canCreateDirectories];
     [dialog setResolvesAliases: resolveAliases];
     [dialog setTreatsFilePackagesAsDirectories: treatPackagesAsDirectories];

--- a/v2/internal/frontend/desktop/darwin/dialog.go
+++ b/v2/internal/frontend/desktop/darwin/dialog.go
@@ -41,6 +41,14 @@ func (f *Frontend) OpenDirectoryDialog(options frontend.OpenDialogOptions) (stri
 	return selected, nil
 }
 
+func (f *Frontend) OpenMultipleDirectoriesDialog(options frontend.OpenDialogOptions) ([]string, error) {
+	results, err := f.openDialog(&options, true, false, true)
+	if err != nil {
+		return nil, err
+	}
+	return results, nil
+}
+
 func (f *Frontend) openDialog(options *frontend.OpenDialogOptions, multiple bool, allowfiles bool, allowdirectories bool) ([]string, error) {
 	dialogLock.Lock()
 	defer dialogLock.Unlock()

--- a/v2/internal/frontend/desktop/linux/dialog.go
+++ b/v2/internal/frontend/desktop/linux/dialog.go
@@ -38,6 +38,12 @@ func (f *Frontend) OpenMultipleFilesDialog(dialogOptions frontend.OpenDialogOpti
 	return result, nil
 }
 
+func (f *Frontend) OpenMultipleDirectoriesDialog(dialogOptions frontend.OpenDialogOptions) ([]string, error) {
+	f.mainWindow.OpenFileDialog(dialogOptions, 1, GTK_FILE_CHOOSER_ACTION_SELECT_FOLDER)
+	result := <-openFileResults
+	return result, nil
+}
+
 func (f *Frontend) OpenDirectoryDialog(dialogOptions frontend.OpenDialogOptions) (string, error) {
 	f.mainWindow.OpenFileDialog(dialogOptions, 0, GTK_FILE_CHOOSER_ACTION_SELECT_FOLDER)
 	result := <-openFileResults

--- a/v2/internal/frontend/frontend.go
+++ b/v2/internal/frontend/frontend.go
@@ -88,6 +88,7 @@ type Frontend interface {
 	OpenFileDialog(dialogOptions OpenDialogOptions) (string, error)
 	OpenMultipleFilesDialog(dialogOptions OpenDialogOptions) ([]string, error)
 	OpenDirectoryDialog(dialogOptions OpenDialogOptions) (string, error)
+	OpenMultipleDirectoriesDialog(dialogOptions OpenDialogOptions) ([]string, error)
 	SaveFileDialog(dialogOptions SaveDialogOptions) (string, error)
 	MessageDialog(dialogOptions MessageDialogOptions) (string, error)
 

--- a/v2/internal/go-common-file-dialog/cfd/CommonFileDialog.go
+++ b/v2/internal/go-common-file-dialog/cfd/CommonFileDialog.go
@@ -13,6 +13,7 @@ type Dialog interface {
 	// Blocks until the user has closed the dialog and returns their selection.
 	// Returns an error if the user cancelled the dialog.
 	// Do not use for the Open Multiple Files dialog. Use ShowAndGetResults instead.
+	// Do not use for Select Multiple Folders dialog. Use ShowAndGetResults instead.
 	ShowAndGetResult() (string, error)
 	// Sets the title of the dialog window.
 	SetTitle(title string) error
@@ -65,6 +66,15 @@ type OpenMultipleFilesDialog interface {
 
 type SelectFolderDialog interface {
 	Dialog
+}
+
+type SelectMultipleFoldersDialog interface {
+	Dialog
+	// ShowAndGetResults shows the dialog to the user.
+	// Blocks until the user has closed the dialog and returns the selected files.
+	ShowAndGetResults() ([]string, error)
+	// GetResults returns the selected file paths, as absolute paths eg. "C:\Folder\file.txt"
+	GetResults() ([]string, error)
 }
 
 type SaveFileDialog interface { // TODO Properties

--- a/v2/internal/go-common-file-dialog/cfd/CommonFileDialog_nonWindows.go
+++ b/v2/internal/go-common-file-dialog/cfd/CommonFileDialog_nonWindows.go
@@ -22,6 +22,10 @@ func NewSelectFolderDialog(config DialogConfig) (SelectFolderDialog, error) {
 	return nil, unsupportedError
 }
 
+func NewSelectMultipleFoldersDialog(config DialogConfig) (SelectMultipleFoldersDialog, error) {
+	return nil, unsupportedError
+}
+
 // TODO doc
 func NewSaveFileDialog(config DialogConfig) (SaveFileDialog, error) {
 	return nil, unsupportedError

--- a/v2/internal/go-common-file-dialog/cfd/CommonFileDialog_windows.go
+++ b/v2/internal/go-common-file-dialog/cfd/CommonFileDialog_windows.go
@@ -63,6 +63,27 @@ func NewSelectFolderDialog(config DialogConfig) (SelectFolderDialog, error) {
 	return openDialog, nil
 }
 
+func NewSelectMultipleFoldersDialog(config DialogConfig) (SelectMultipleFoldersDialog, error) {
+	initialize()
+
+	openDialog, err := newIFileOpenDialog()
+	if err != nil {
+		return nil, err
+	}
+	err = config.apply(openDialog)
+	if err != nil {
+		return nil, err
+	}
+	err = openDialog.setPickFolders(true)
+	if err != nil {
+		return nil, err
+	}
+	if err := openDialog.setIsMultiselect(true); err != nil {
+		return nil, err
+	}
+	return openDialog, nil
+}
+
 // TODO doc
 func NewSaveFileDialog(config DialogConfig) (SaveFileDialog, error) {
 	initialize()

--- a/v2/pkg/runtime/dialog.go
+++ b/v2/pkg/runtime/dialog.go
@@ -39,6 +39,16 @@ func OpenDirectoryDialog(ctx context.Context, dialogOptions OpenDialogOptions) (
 	return appFrontend.OpenDirectoryDialog(dialogOptions)
 }
 
+func OpenMultipleDirectoriesDialog(ctx context.Context, dialogOptions OpenDialogOptions) ([]string, error) {
+	appFrontend := getFrontend(ctx)
+	if dialogOptions.DefaultDirectory != "" {
+		if !fs.DirExists(dialogOptions.DefaultDirectory) {
+			return nil, fmt.Errorf("default directory '%s' does not exist", dialogOptions.DefaultDirectory)
+		}
+	}
+	return appFrontend.OpenMultipleDirectoriesDialog(dialogOptions)
+}
+
 // OpenFileDialog prompts the user to select a file
 func OpenFileDialog(ctx context.Context, dialogOptions OpenDialogOptions) (string, error) {
 	appFrontend := getFrontend(ctx)

--- a/website/docs/reference/runtime/dialog.mdx
+++ b/website/docs/reference/runtime/dialog.mdx
@@ -20,6 +20,14 @@ Go: `OpenDirectoryDialog(ctx context.Context, dialogOptions OpenDialogOptions) (
 
 Returns: Selected directory (blank if the user cancelled) or an error
 
+### OpenMultipleDirectoriesDialog
+
+Opens a dialog that prompts the user to select multiple directory. Can be customised using [OpenDialogOptions](#opendialogoptions).
+
+Go: `OpenMultipleDirectoriesDialog(ctx context.Context, dialogOptions OpenDialogOptions) ([]string, error)`
+
+Returns: Selected directories (blank if the user cancelled) or an error
+
 ### OpenFileDialog
 
 Opens a dialog that prompts the user to select a file. Can be customised using [OpenDialogOptions](#opendialogoptions).

--- a/website/src/pages/changelog.mdx
+++ b/website/src/pages/changelog.mdx
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - When building with `-devtools` flag, CMD/CTRL+SHIFT+F12 can be used to open the devtools. Added by @leaanthony in [PR](https://github.com/wailsapp/wails/pull/2915)
 - Added support for setting some of the Webview preferences, `textInteractionEnabled` and `tabFocusesLinks` on Mac. Added by @fkhadra in [PR](https://github.com/wailsapp/wails/pull/2937)
 - Added support for enabling/disabling fullscreen of the Webview on Mac. Added by @fkhadra in [PR](https://github.com/wailsapp/wails/pull/2953)
+- Added support for selecting multiple directories. Added by @mooijtech in [PR](https://github.com/wailsapp/wails/pull/2960)
 
 ### Changed
 


### PR DESCRIPTION
# Description

Allows selecting multiple directories (only single directory selection was supported).

Note that this is the minimal changes required adding support to the Go `runtime`.
The previous Pull Request which included JavaScript bindings was not to my satisfaction due to returning `any`.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

Tested for [Go Forensics](https://goforensics.io/) (Work In Progress): 

https://github.com/wailsapp/wails/assets/64754391/a1d76fdd-77f4-4f3c-899a-81ecb44a61a0



- [x] Windows
- [x] macOS
- [x] Linux
  
## Test Configuration

```
# Wails
Version         | v2.6.0                                  
Revision        | 01d2dc61237cea68fef2ab50f3747cae997cc985
Modified        | true                                    
Package Manager | pacman                                  

# System
┌───────────────────────────┐
| OS           | Arch Linux |
| Version      | Unknown    |
| ID           | arch       |
| Go Version   | go1.21.0   |
| Platform     | linux      |
| Architecture | amd64      |
└───────────────────────────┘

# Dependencies
┌─────────────────────────────────────────────────────┐
| Dependency | Package Name | Status    | Version     |
| *docker    | docker       | Installed | 1:24.0.5-1  |
| gcc        | gcc          | Installed | 13.2.1-3    |
| libgtk-3   | gtk3         | Installed | 1:3.24.38-1 |
| libwebkit  | webkit2gtk   | Installed | 2.40.5-1    |
| npm        | npm          | Installed | 9.8.1-1     |
| pkg-config | pkgconf      | Installed | 1.8.1-1     |
└────────────── * - Optional Dependency ──────────────┘

# Diagnosis
 SUCCESS  Your system is ready for Wails development!
```

# Checklist:

- [x] I have updated `website/src/pages/changelog.mdx` with details of this PR
- [x] My code follows the general coding style of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
