### PR TITLE
[v3] fix deadlock when quit

### DIFF
--- a/mkdocs-website/docs/changelog.md
+++ b/mkdocs-website/docs/changelog.md
@@ -24,6 +24,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- [darwin] Fixed application frozen when quit by @5aaee9 in 
+  [#2982](https://github.com/wailsapp/wails/pull/2982)
 - Fixed background colours of examples on Windows by
   [mmgvh](https://github.com/mmghv) in
   [#2750](https://github.com/wailsapp/wails/pull/2750).

--- a/v3/pkg/application/application.go
+++ b/v3/pkg/application/application.go
@@ -235,7 +235,7 @@ type App struct {
 
 	// Windows
 	windows     map[uint]Window
-	windowsLock sync.Mutex
+	windowsLock sync.RWMutex
 
 	// System Trays
 	systemTrays      map[uint]*SystemTray
@@ -301,8 +301,8 @@ func (a *App) getSystemTrayID() uint {
 }
 
 func (a *App) getWindowForID(id uint) Window {
-	a.windowsLock.Lock()
-	defer a.windowsLock.Unlock()
+	a.windowsLock.RLock()
+	defer a.windowsLock.RUnlock()
 	return a.windows[id]
 }
 
@@ -539,9 +539,9 @@ func (a *App) handleDragAndDropMessage(event *dragAndDropMessage) {
 
 func (a *App) handleWindowMessage(event *windowMessage) {
 	// Get window from window map
-	a.windowsLock.Lock()
+	a.windowsLock.RLock()
 	window, ok := a.windows[event.windowId]
-	a.windowsLock.Unlock()
+	a.windowsLock.RUnlock()
 	if !ok {
 		log.Printf("WebviewWindow #%d not found", event.windowId)
 		return
@@ -556,9 +556,9 @@ func (a *App) handleWebViewRequest(request *webViewAssetRequest) {
 
 func (a *App) handleWindowEvent(event *windowEvent) {
 	// Get window from window map
-	a.windowsLock.Lock()
+	a.windowsLock.RLock()
 	window, ok := a.windows[event.WindowID]
-	a.windowsLock.Unlock()
+	a.windowsLock.RUnlock()
 	if !ok {
 		log.Printf("Window #%d not found", event.WindowID)
 		return
@@ -580,18 +580,18 @@ func (a *App) CurrentWindow() *WebviewWindow {
 		return nil
 	}
 	id := a.impl.getCurrentWindowID()
-	a.windowsLock.Lock()
-	defer a.windowsLock.Unlock()
+	a.windowsLock.RLock()
+	defer a.windowsLock.RUnlock()
 	return a.windows[id].(*WebviewWindow)
 }
 
 func (a *App) Quit() {
 	InvokeSync(func() {
-		a.windowsLock.Lock()
+		a.windowsLock.RLock()
 		for _, window := range a.windows {
 			window.Destroy()
 		}
-		a.windowsLock.Unlock()
+		a.windowsLock.RUnlock()
 		a.systemTraysLock.Lock()
 		for _, systray := range a.systemTrays {
 			systray.Destroy()
@@ -729,8 +729,8 @@ func (a *App) OnWindowCreation(callback func(window Window)) {
 }
 
 func (a *App) GetWindowByName(name string) Window {
-	a.windowsLock.Lock()
-	defer a.windowsLock.Unlock()
+	a.windowsLock.RLock()
+	defer a.windowsLock.RUnlock()
 	for _, window := range a.windows {
 		if window.Name() == name {
 			return window
@@ -772,9 +772,9 @@ func (a *App) processKeyBinding(acceleratorString string, window *WebviewWindow)
 
 func (a *App) handleWindowKeyEvent(event *windowKeyEvent) {
 	// Get window from window map
-	a.windowsLock.Lock()
+	a.windowsLock.RLock()
 	window, ok := a.windows[event.windowId]
-	a.windowsLock.Unlock()
+	a.windowsLock.RUnlock()
 	if !ok {
 		log.Printf("WebviewWindow #%d not found", event.windowId)
 		return


### PR DESCRIPTION
# Description

This will fix a dead lock issue. In darwin, when `Application.Quit` called, it will cause the app frozen in main thread. (use Command + Q in example/window can reproduce this issue)


<img width="1451" alt="In main thread" src="https://github.com/wailsapp/wails/assets/7685264/6dd8dc4d-cfdb-469d-bbaa-51a69627e0eb">
<img width="1265" alt="Waiting for lock" src="https://github.com/wailsapp/wails/assets/7685264/b23c073b-968d-4d2b-a49d-065dbe15ef1c">

The `Quit` function in `v3/pkgs/application/application.go` holding `windowsLock` and sent a `windowEvent`. The thread process this event also need this lock.

## Type of change
  
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
  
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration using `wails doctor`.

- [ ] Windows
- [x] macOS
- [ ] Linux
  
## Test Configuration

Please paste the output of `wails doctor`. If you are unable to run this command, please describe your environment in as much detail as possible.

# Checklist:

- [ ] I have updated `website/src/pages/changelog.mdx` with details of this PR
- [x] My code follows the general coding style of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
