### PR TITLE
linux: workaround for #2977

### DIFF
--- a/v2/internal/frontend/desktop/linux/window.go
+++ b/v2/internal/frontend/desktop/linux/window.go
@@ -25,6 +25,7 @@ import (
 	"github.com/wailsapp/wails/v2/internal/frontend"
 	"github.com/wailsapp/wails/v2/pkg/menu"
 	"github.com/wailsapp/wails/v2/pkg/options"
+	"github.com/wailsapp/wails/v2/pkg/options/linux"
 )
 
 func gtkBool(input bool) C.gboolean {
@@ -90,6 +91,9 @@ func NewWindow(appoptions *options.App, debug bool, devtoolsEnabled bool) *Windo
 	var webviewGpuPolicy int
 	if appoptions.Linux != nil {
 		webviewGpuPolicy = int(appoptions.Linux.WebviewGpuPolicy)
+	} else {
+		// workaround for https://github.com/wailsapp/wails/issues/2977
+		webviewGpuPolicy = int(linux.WebviewGpuPolicyNever)
 	}
 
 	webview := C.SetupWebview(

--- a/v2/pkg/options/linux/linux.go
+++ b/v2/pkg/options/linux/linux.go
@@ -28,6 +28,11 @@ type Options struct {
 	//   - WebviewGpuPolicyAlways
 	//   - WebviewGpuPolicyOnDemand
 	//   - WebviewGpuPolicyNever
+	//
+	// Due to https://github.com/wailsapp/wails/issues/2977, if options.Linux is nil
+	// in the call to wails.Run(), WebviewGpuPolicy is set by default to WebviewGpuPolicyNever.
+	// Client code may override this behavior by passing a non-nil Options and set
+	// WebviewGpuPolicy as needed.
 	WebviewGpuPolicy WebviewGpuPolicy
 
 	// ProgramName is used to set the program's name for the window manager via GTK's g_set_prgname().


### PR DESCRIPTION
# Description

In NewWindow, set options.Linux.WebviewGpuPolicy to WebviewGpuPolicyNever if options.Linux is nil, disabling GPU acceleration by default on linux until the upstream bugs https://bugs.webkit.org/show_bug.cgi?id=228268 and https://bugs.webkit.org/show_bug.cgi?id=261874 are fixed.

## Type of change
  
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
  
```sh
wails dev
wails build
./build/bin/demo-app
```

- [x] Linux
  
## Test Configuration

```
# Wails
Version         | v2.6.0
Package Manager | pacman

# System
┌──────────────────────────────────────────────────────────────────────────────────┐
| OS           | Manjaro Linux                                                     |
| Version      | Unknown                                                           |
| ID           | manjaro                                                           |
| Go Version   | go1.21.3                                                          |
| Platform     | linux                                                             |
| Architecture | amd64                                                             |
| CPU          | AMD FX(tm)-6300 Six-Core Processor                                |
| GPU          | GP107 [GeForce GTX 1050 Ti] (NVIDIA Corporation) - Driver: nvidia |
| Memory       | 8GB                                                               |
└──────────────────────────────────────────────────────────────────────────────────┘

# Dependencies
┌─────────────────────────────────────────────────────┐
| Dependency | Package Name | Status    | Version     |
| *docker    | docker       | Available | 1:24.0.6-1  |
| gcc        | gcc          | Installed | 13.2.1-3    |
| libgtk-3   | gtk3         | Installed | 1:3.24.38-1 |
| libwebkit  | webkit2gtk   | Installed | 2.42.1-1    |
| npm        | npm          | Installed | 10.2.0-1    |
| pkg-config | pkgconf      | Installed | 1.8.1-1     |
└────────────── * - Optional Dependency ──────────────┘

 SUCCESS  Your system is ready for Wails development!
```

# Checklist:

- [ ] I have updated `website/src/pages/changelog.mdx` with details of this PR
- [x] My code follows the general coding style of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
