### PR TITLE
Fix single instance lock for macOS sandbox app

### DIFF
--- a/v2/internal/frontend/desktop/darwin/AppDelegate.h
+++ b/v2/internal/frontend/desktop/darwin/AppDelegate.h
@@ -28,4 +28,6 @@ extern void HandleSecondInstanceData(char * message);
 
 void SendDataToFirstInstance(char * singleInstanceUniqueId, char * text);
 
+char* GetMacOsNativeTempDir();
+
 #endif /* AppDelegate_h */

--- a/v2/internal/frontend/desktop/darwin/AppDelegate.m
+++ b/v2/internal/frontend/desktop/darwin/AppDelegate.m
@@ -57,6 +57,13 @@ void SendDataToFirstInstance(char * singleInstanceUniqueId, char * message) {
         deliverImmediately:YES];
 }
 
+char* GetMacOsNativeTempDir() {
+    NSString *tempDir = NSTemporaryDirectory();
+    char *copy = strdup([tempDir UTF8String]);
+
+    return copy;
+}
+
 - (void)handleSecondInstanceNotification:(NSNotification *)note;
 {
     if (note.object != nil) {

--- a/v2/internal/frontend/desktop/darwin/AppDelegate.m
+++ b/v2/internal/frontend/desktop/darwin/AppDelegate.m
@@ -48,17 +48,19 @@
 }
 
 void SendDataToFirstInstance(char * singleInstanceUniqueId, char * message) {
+    // we pass message in object because otherwise sandboxing will prevent us from sending it https://developer.apple.com/forums/thread/129437
+    NSString * myString = [NSString stringWithUTF8String:message];
     [[NSDistributedNotificationCenter defaultCenter]
         postNotificationName:[NSString stringWithUTF8String:singleInstanceUniqueId]
-        object:nil
-        userInfo:@{@"message": [NSString stringWithUTF8String:message]}
+        object:(__bridge const void *)(myString)
+        userInfo:nil
         deliverImmediately:YES];
 }
 
 - (void)handleSecondInstanceNotification:(NSNotification *)note;
 {
-    if (note.userInfo[@"message"] != nil) {
-        NSString *message = note.userInfo[@"message"];
+    if (note.object != nil) {
+        NSString * message = (__bridge NSString *)note.object;
         const char* utf8Message = message.UTF8String;
         HandleSecondInstanceData((char*)utf8Message);
     }


### PR DESCRIPTION
# Description

Recently Single Instance lock was introduced for all platforms. During application implementation I found two issues with case, when MacOs app is launched as sandbox app.

1. When app is sandboxed `os.TempDir()` return temp directory, which is not accessible by the app. Changed to native method to get temp directory. It returns proper directory in that case.
2. In sandboxed app `userInfo` is not allowed https://developer.apple.com/forums/thread/129437. Fix implemented to pass message via `object` instead

## Type of change
  
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
  
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration using `wails doctor`.

- [ ] Windows
- [x] macOS
- [ ] Linux
  
## Test Configuration
Signed application with `com.apple.security.app-sandbox` enabled

```
# Wails
Version  | v2.6.0
Revision | a419721dcdf16da7a4afd92b9ba63b2050229a26
Modified | true

# System
┌─────────────────────────┐
| OS           | MacOS    |
| Version      | 13.5.2   |
| ID           | 22G91    |
| Go Version   | go1.20.2 |
| Platform     | darwin   |
| Architecture | arm64    |
└─────────────────────────┘
```

# Checklist:

- [ ] I have updated `website/src/pages/changelog.mdx` with details of this PR
- [x] My code follows the general coding style of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
