### PR TITLE
[v3 darwin] change hex values for arrow keys pulled from "Key Codes" app

### DIFF
--- a/v2/internal/frontend/desktop/darwin/WailsMenu.m
+++ b/v2/internal/frontend/desktop/darwin/WailsMenu.m
@@ -184,16 +184,16 @@
         return unicode(0x001b);
     }
     if( [key isEqualToString:@"left"] ) {
-        return unicode(0x001c);
+        return unicode(0xf702);
     }
     if( [key isEqualToString:@"right"] ) {
-        return unicode(0x001d);
+        return unicode(0xf703);
     }
     if( [key isEqualToString:@"up"] ) {
-        return unicode(0x001e);
+        return unicode(0xf700);
     }
     if( [key isEqualToString:@"down"] ) {
-        return unicode(0x001f);
+        return unicode(0xf701);
     }
     if( [key isEqualToString:@"space"] ) {
         return unicode(0x0020);

--- a/v3/pkg/application/menuitem_darwin.go
+++ b/v3/pkg/application/menuitem_darwin.go
@@ -103,16 +103,16 @@ NSString* translateKey(NSString* key) {
         return unicode(0x001b);
     }
     if( [key isEqualToString:@"left"] ) {
-        return unicode(0x001c);
+        return unicode(0xf702);
     }
     if( [key isEqualToString:@"right"] ) {
-        return unicode(0x001d);
+        return unicode(0xf703);
     }
     if( [key isEqualToString:@"up"] ) {
-        return unicode(0x001e);
+        return unicode(0xf700);
     }
     if( [key isEqualToString:@"down"] ) {
-        return unicode(0x001f);
+        return unicode(0xf701);
     }
     if( [key isEqualToString:@"space"] ) {
         return unicode(0x0020);


### PR DESCRIPTION
# Description

Arrow keys are not working for OSX sonoma (wails doctor pasted below). Hex codes have been updated and were pulled from 
[Key Codes App](https://manytricks.com/keycodes/)

**Bug fix (non-breaking change which fixes an issue)**

Tested using the following accelerators
```
navigationMenu.Add("Previous Day").SetAccelerator("up").OnClick(func(ctx *application.Context) {

})
navigationMenu.Add("Next Day").SetAccelerator("down").OnClick(func(ctx *application.Context) {

})
navigationMenu.AddSeparator()
navigationMenu.Add("Prev 30 Seconds").SetAccelerator("left").OnClick(func(ctx *application.Context) {

})
navigationMenu.Add("Next 30 Seconds").SetAccelerator("right").OnClick(func(ctx *application.Context) {

})
```
## Test Configuration
```                                                                                      
# Build Environment
Wails CLI    | v3.0.0-alpha.0                          
Go Version   | go1.21.1                                
Revision     | d9a5130311680b3b6de37d9e9a55ab0142f14c08
Modified     | false                                   
-buildmode   | exe                                     
-compiler    | gc                                      
CGO_CFLAGS   |                                         
CGO_CPPFLAGS |                                         
CGO_CXXFLAGS |                                         
CGO_ENABLED  | 1                                       
CGO_LDFLAGS  |                                         
GOAMD64      | v1                                      
GOARCH       | amd64                                   
GOOS         | darwin                                  
vcs          | git                                     
vcs.modified | false                                   
vcs.revision | d9a5130311680b3b6de37d9e9a55ab0142f14c08
vcs.time     | 2023-09-25T10:56:29Z                    

# System
Name            | MacOS                                   
Version         | 14.0                                    
ID              | 23A344                                  
Branding        | Sonoma                                  
Platform        | darwin                                  
Architecture    | amd64                                   
Apple Silicon   | unknown                                 
CPU             | Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
Xcode cli tools | 2399                                    
```