### PR TITLE
Pass obfuscation settings from wails.json

### DIFF
--- a/v2/cmd/wails/build.go
+++ b/v2/cmd/wails/build.go
@@ -49,6 +49,16 @@ func buildApplication(f *flags.Build) error {
 		return err
 	}
 
+	// Set obfuscation from project file
+	if projectOptions.Obfuscated {
+		f.Obfuscated = projectOptions.Obfuscated
+	}
+
+	// Set garble args from project file
+	if projectOptions.GarbleArgs != "" {
+		f.GarbleArgs = projectOptions.GarbleArgs
+	}
+
 	// Create BuildOptions
 	buildOptions := &build.Options{
 		Logger:            logger,

--- a/website/src/pages/changelog.mdx
+++ b/website/src/pages/changelog.mdx
@@ -44,6 +44,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed issue with npm being called npm20 on openSUSE-Tumbleweed. Fixed by @TuffenDuffen in [PR](https://github.com/wailsapp/wails/pull/2941)
 - Fixed memory corruption on Windows when using accelerator keys. Fixed by @stffabi in [PR](https://github.com/wailsapp/wails/pull/3002)
 - Fixed binding mapping for obfuscated build, when binding are in different structs. Fixed by @APshenkin in [PR](https://github.com/wailsapp/wails/pull/3071)
+- Fixed issue with obfuscation settings in wails.json. Fixed by @APshenkin in [PR](https://github.com/wailsapp/wails/pull/3080)
 
 ## v2.6.0 - 2023-09-06
 


### PR DESCRIPTION
# Description

There are `obfuscated` and `garbleargs` properties in wails.json. However they are not accepted in build command. This PR fixes this issue

## Type of change
  
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Tested locally with different project settings in `wails.json`
  
## Test Configuration
```
# Wails
Version  | v2.6.0
Revision | c15fb6235c28d310c8c04f95c4373a6ab38f8ad7
Modified | true

# System
┌─────────────────────────┐
| OS           | MacOS    |
| Version      | 14.0     |
| ID           | 23A344   |
| Go Version   | go1.21.3 |
| Platform     | darwin   |
| Architecture | arm64    |
| CPU          | Unknown  |
| GPU          | Unknown  |
| Memory       | Unknown  |
└─────────────────────────┘
```

# Checklist:

- [x] I have updated `website/src/pages/changelog.mdx` with details of this PR
- [x] My code follows the general coding style of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
