### PR TITLE
add gstreamer error documentation

### DIFF
--- a/website/docs/guides/linux.mdx
+++ b/website/docs/guides/linux.mdx
@@ -18,3 +18,55 @@ videoTag.addEventListener("timeupdate", (event) => {
 
 Source: [Lyimmi](https://github.com/Lyimmi) on the
 [discussions board](https://github.com/wailsapp/wails/issues/1729#issuecomment-1212291275)
+
+## GStreamer error when using Audio or Video elements
+
+If you are seeing the following error when including `<Audio>` or `<Video>` elements on Linux, you may need to install `gst-plugins-good`.
+
+```
+GStreamer element autoaudiosink not found. Please install it
+```
+
+### Installing
+
+Run the following distro relevant install command:
+
+```mdx-code-block
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
+
+<Tabs
+    defaultValue="Arch"
+    values={[
+        { label: "Arch", value: "Arch" },
+        { label: "Debian/Ubuntu", value: "Debian" },
+        { label: "Fedora", value: "Fedora" },
+    ]}
+>
+<TabItem value="Arch">
+
+    pacman -S gst-plugins-good
+
+</TabItem>
+<TabItem value="Debian">
+
+    apt-get install gstreamer1.0-plugins-good
+
+</TabItem>
+<TabItem value="Fedora">
+
+    dnf install gstreamer1-plugins-good
+
+</TabItem>
+</Tabs>
+```
+
+If the added package does not resolve the issue, additional GStreamer dependencies may be required. [See the GStreamer installation page for more details.](https://gstreamer.freedesktop.org/documentation/installing/on-linux.html)
+
+### Additional Notes
+
+- This issue is caused by [an upstream issue with WebkitGTK](https://bugs.webkit.org/show_bug.cgi?id=146351).
+- [Arch based systems](https://wiki.archlinux.org/title/Arch-based_distributions) seem to have this issue more often than other distributions.
+- This issue impacts [Tauri apps](https://tauri.app/).
+
+Source: [developomp](https://github.com/developomp) on the [Tauri discussion board](https://github.com/tauri-apps/tauri/issues/4642#issuecomment-1643229562).

--- a/website/src/pages/changelog.mdx
+++ b/website/src/pages/changelog.mdx
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added windows options supports `DisablePinchZoom` configuration. Added by @tuuzed in [PR](https://github.com/wailsapp/wails/pull/3115)
 - Add Apple Silicon hardware detection to `wails doctor`. Changed by @almas1992 in [PR](https://github.com/wailsapp/wails/pull/3129)
 - Remove quarantine attribute on macOS binaries. Changed by @leaanthony in [PR](https://github.com/wailsapp/wails/pull/3118)
-- Added documentation for a common GStreamer error on Linux systems. Changed by @mkwsnyder in [PR](https://github.com/wailsapp/wails/pull/3134)
+- Added documentation for a common GStreamer error on Linux systems. Changed by [@mkwsnyder](https://github.com/mkwsnyder) in [PR](https://github.com/wailsapp/wails/pull/3134)
 
 
 ## v2.7.1 - 2023-12-10

--- a/website/src/pages/changelog.mdx
+++ b/website/src/pages/changelog.mdx
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added windows options supports `DisablePinchZoom` configuration. Added by @tuuzed in [PR](https://github.com/wailsapp/wails/pull/3115)
 - Add Apple Silicon hardware detection to `wails doctor`. Changed by @almas1992 in [PR](https://github.com/wailsapp/wails/pull/3129)
 - Remove quarantine attribute on macOS binaries. Changed by @leaanthony in [PR](https://github.com/wailsapp/wails/pull/3118)
+- Added documentation for a common GStreamer error on Linux systems. Changed by @mkwsnyder in [PR](https://github.com/wailsapp/wails/pull/3134)
 
 
 ## v2.7.1 - 2023-12-10

--- a/website/versioned_docs/version-v2.6.0/guides/linux.mdx
+++ b/website/versioned_docs/version-v2.6.0/guides/linux.mdx
@@ -18,3 +18,55 @@ videoTag.addEventListener("timeupdate", (event) => {
 
 Source: [Lyimmi](https://github.com/Lyimmi) on the
 [discussions board](https://github.com/wailsapp/wails/issues/1729#issuecomment-1212291275)
+
+## GStreamer error when using Audio or Video elements
+
+If you are seeing the following error when including `<Audio>` or `<Video>` elements on Linux, you may need to install `gst-plugins-good`.
+
+```
+GStreamer element autoaudiosink not found. Please install it
+```
+
+### Installing
+
+Run the following distro relevant install command:
+
+```mdx-code-block
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
+
+<Tabs
+    defaultValue="Arch"
+    values={[
+        { label: "Arch", value: "Arch" },
+        { label: "Debian/Ubuntu", value: "Debian" },
+        { label: "Fedora", value: "Fedora" },
+    ]}
+>
+<TabItem value="Arch">
+
+    pacman -S gst-plugins-good
+
+</TabItem>
+<TabItem value="Debian">
+
+    apt-get install gstreamer1.0-plugins-good
+
+</TabItem>
+<TabItem value="Fedora">
+
+    dnf install gstreamer1-plugins-good
+
+</TabItem>
+</Tabs>
+```
+
+If the added package does not resolve the issue, additional GStreamer dependencies may be required. [See the GStreamer installation page for more details.](https://gstreamer.freedesktop.org/documentation/installing/on-linux.html)
+
+### Additional Notes
+
+- This issue is caused by [an upstream issue with WebkitGTK](https://bugs.webkit.org/show_bug.cgi?id=146351).
+- [Arch based systems](https://wiki.archlinux.org/title/Arch-based_distributions) seem to have this issue more often than other distributions.
+- This issue impacts [Tauri apps](https://tauri.app/).
+
+Source: [developomp](https://github.com/developomp) on the [Tauri discussion board](https://github.com/tauri-apps/tauri/issues/4642#issuecomment-1643229562).

--- a/website/versioned_docs/version-v2.7.0/guides/linux.mdx
+++ b/website/versioned_docs/version-v2.7.0/guides/linux.mdx
@@ -18,3 +18,55 @@ videoTag.addEventListener("timeupdate", (event) => {
 
 Source: [Lyimmi](https://github.com/Lyimmi) on the
 [discussions board](https://github.com/wailsapp/wails/issues/1729#issuecomment-1212291275)
+
+## GStreamer error when using Audio or Video elements
+
+If you are seeing the following error when including `<Audio>` or `<Video>` elements on Linux, you may need to install `gst-plugins-good`.
+
+```
+GStreamer element autoaudiosink not found. Please install it
+```
+
+### Installing
+
+Run the following distro relevant install command:
+
+```mdx-code-block
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
+
+<Tabs
+    defaultValue="Arch"
+    values={[
+        { label: "Arch", value: "Arch" },
+        { label: "Debian/Ubuntu", value: "Debian" },
+        { label: "Fedora", value: "Fedora" },
+    ]}
+>
+<TabItem value="Arch">
+
+    pacman -S gst-plugins-good
+
+</TabItem>
+<TabItem value="Debian">
+
+    apt-get install gstreamer1.0-plugins-good
+
+</TabItem>
+<TabItem value="Fedora">
+
+    dnf install gstreamer1-plugins-good
+
+</TabItem>
+</Tabs>
+```
+
+If the added package does not resolve the issue, additional GStreamer dependencies may be required. [See the GStreamer installation page for more details.](https://gstreamer.freedesktop.org/documentation/installing/on-linux.html)
+
+### Additional Notes
+
+- This issue is caused by [an upstream issue with WebkitGTK](https://bugs.webkit.org/show_bug.cgi?id=146351).
+- [Arch based systems](https://wiki.archlinux.org/title/Arch-based_distributions) seem to have this issue more often than other distributions.
+- This issue impacts [Tauri apps](https://tauri.app/).
+
+Source: [developomp](https://github.com/developomp) on the [Tauri discussion board](https://github.com/tauri-apps/tauri/issues/4642#issuecomment-1643229562).


### PR DESCRIPTION
# Description

Adds documentation for a solution to a common GStreamer error on some Linux distros [as discussed on this Discord thread](https://discord.com/channels/1042734330029547630/1182864593681387550).

**Note:** I know the `versioned_docs` will be deprecated, but I went and added this note there as well.

## Type of change

- Documentation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Added guidance for resolving GStreamer error on Linux when using `<Audio>` or `<Video>` elements.
	- Provided installation instructions for `gst-plugins-good` across various Linux distributions.
	- Included notes on the issue's impact on Tauri apps and its relation to WebkitGTK.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->