### PR TITLE
[V3/macos] Fix systray click handling when no attached window

### DIFF
--- a/mkdocs-website/docs/en/changelog.md
+++ b/mkdocs-website/docs/en/changelog.md
@@ -37,6 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed bug for linux in doctor in the event user doesn't have proper drivers installed. Added by [@pylotlight](https://github.com/pylotlight) in [PR](https://github.com/wailsapp/wails/pull/3032)
 - Fix dpi scaling on start up (windows). Changed by @almas1992 in [PR](https://github.com/wailsapp/wails/pull/3145)
 - Fix replace line in `go.mod` to use relative paths. Fixes Windows paths with spaces - @leaanthony.
+- Fix MacOS systray click handling when no attached window by [thomas-senechal](https://github.com/thomas-senechal) in PR [#3207](https://github.com/wailsapp/wails/pull/3207)
 
 ### Changed
 

--- a/v3/examples/hide-window/main.go
+++ b/v3/examples/hide-window/main.go
@@ -6,8 +6,8 @@ import (
 	"runtime"
 
 	"github.com/wailsapp/wails/v3/pkg/application"
-	"github.com/wailsapp/wails/v3/pkg/icons"
 	"github.com/wailsapp/wails/v3/pkg/events"
+	"github.com/wailsapp/wails/v3/pkg/icons"
 )
 
 func main() {
@@ -44,7 +44,6 @@ func main() {
 		systemTray.SetTemplateIcon(icons.SystrayMacTemplate)
 	}
 
-
 	// Click Dock icon tigger application show
 	app.On(events.Mac.ApplicationShouldHandleReopen, func(event *application.Event) {
 		println("reopen")
@@ -62,7 +61,7 @@ func main() {
 
 	systemTray.SetMenu(myMenu)
 	systemTray.OnClick(func() {
-		app.CurrentWindow().Show()
+		window.Show()
 	})
 
 	err := app.Run()

--- a/v3/pkg/application/systemtray.go
+++ b/v3/pkg/application/systemtray.go
@@ -266,6 +266,7 @@ func (s *SystemTray) WindowDebounce(debounce time.Duration) *SystemTray {
 
 func (s *SystemTray) defaultClickHandler() {
 	if s.attachedWindow.Window == nil {
+		s.OpenMenu()
 		return
 	}
 

--- a/v3/pkg/application/systemtray_darwin.go
+++ b/v3/pkg/application/systemtray_darwin.go
@@ -142,14 +142,7 @@ func (s *macosSystemTray) run() {
 			s.menu.Update()
 			// Convert impl to macosMenu object
 			s.nsMenu = (s.menu.impl).(*macosMenu).nsMenu
-			// We only set the tray menu if we don't have an attached
-			// window. If we do, then we manually operate the menu using
-			// the right mouse button
-			if s.parent.attachedWindow.Window == nil {
-				C.systemTraySetMenu(s.nsStatusItem, s.nsMenu)
-			}
 		}
-
 	})
 }
 

--- a/v3/pkg/application/systemtray_darwin.h
+++ b/v3/pkg/application/systemtray_darwin.h
@@ -12,7 +12,6 @@ void* createAttributedString(char *title, char *FG, char *BG);
 void* appendAttributedString(void* original, char* label, char* fg, char* bg);
 NSImage* imageFromBytes(const unsigned char *bytes, int length);
 void systemTraySetIcon(void* nsStatusItem, void* nsImage, int position, bool isTemplate);
-void systemTraySetMenu(void* nsStatusItem, void* nsMenu);
 void systemTrayDestroy(void* nsStatusItem);
 void showMenu(void* nsStatusItem, void *nsMenu);
 void systemTrayGetBounds(void* nsStatusItem, NSRect *rect);

--- a/v3/pkg/application/systemtray_darwin.m
+++ b/v3/pkg/application/systemtray_darwin.m
@@ -130,16 +130,6 @@ void systemTraySetIcon(void* nsStatusItem, void* nsImage, int position, bool isT
 	});
 }
 
-// Add menu to system tray
-void systemTraySetMenu(void* nsStatusItem, void* nsMenu) {
-	// Set the menu on the main thread
-	dispatch_async(dispatch_get_main_queue(), ^{
-		NSStatusItem *statusItem = (NSStatusItem *)nsStatusItem;
-		NSMenu *menu = (NSMenu *)nsMenu;
-		statusItem.menu = menu;
-	});
-}
-
 // Destroy system tray
 void systemTrayDestroy(void* nsStatusItem) {
 	// Remove the status item from the status bar and its associated menu


### PR DESCRIPTION
<!--
READ CAREFULLY: Before submitting your PR, please ensure you have created an issue for your PR.
It is essential that you do this so that we can discuss the proposed changes before you spend time on them.
If you do not create an issue, your PR may be rejected without review.
If a relevant issue already exists, please reference it in your PR by including `Fixes #<issue number>` in your PR description.
-->

# Description

While testing the systray features on `v3.0.0-alpha.3`, I noticed that systray OnClick (and OnRightClick etc) did not work when no window was attached on MacOS.

For example, with the `hide-window` example, there is a callback set for the systray `OnClick` that is supposed to show the window, but when clicked, the callback is never called and the menu opens.

I couldn't find an existing issue for this bug.

## Type of change
  
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
 
I tested using the `hide-window` and `systray` examples.
In the `hide-window` example, the systray `OnClick` callback was well triggered. 
In the `systray` example, everything was working as expected.

I built every examples using `task test:examples`
I ran every tests using `go test -v ./...` 

- [ ] Windows
- [x] macOS
- [ ] Linux
  
## Test Configuration

```
% wails3 doctor


          Wails Doctor



# Build Environment
Wails CLI    | v3.0.0-alpha.3
Go Version   | go1.21.5
-buildmode   | exe
-compiler    | gc
CGO_CFLAGS   |
CGO_CPPFLAGS |
CGO_CXXFLAGS |
CGO_ENABLED  | 1
CGO_LDFLAGS  |
GOARCH       | arm64
GOOS         | darwin

# System
Name            | MacOS
Version         | 14.2.1
ID              | 23C71
Branding        | Sonoma
Platform        | darwin
Architecture    | arm64
Apple Silicon   | true
CPU             | Apple M1 Pro
Xcode cli tools | 2405
CPU             | Unknown
GPU             | Unknown
Memory          | Unknown

# Diagnosis
 SUCCESS  Your system is ready for Wails development!
```
# Checklist:

- [x] I have updated `website/src/pages/changelog.mdx` with details of this PR
- [x] My code follows the general coding style of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
