### PR TITLE
[v3/Windows] Fix failing Windows build due to undefined options

### DIFF
--- a/mkdocs-website/docs/en/changelog.md
+++ b/mkdocs-website/docs/en/changelog.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix dpi scaling on start up (windows). Changed by @almas1992 in [PR](https://github.com/wailsapp/wails/pull/3145)
 - Fix replace line in `go.mod` to use relative paths. Fixes Windows paths with spaces - @leaanthony.
 - Fix MacOS systray click handling when no attached window by [thomas-senechal](https://github.com/thomas-senechal) in PR [#3207](https://github.com/wailsapp/wails/pull/3207)
+- Fix failing Windows build due to unknown option by [thomas-senechal](https://github.com/thomas-senechal) in PR [#3208](https://github.com/wailsapp/wails/pull/3208)
 
 ### Changed
 

--- a/v3/pkg/application/dialogs_windows.go
+++ b/v3/pkg/application/dialogs_windows.go
@@ -3,11 +3,12 @@
 package application
 
 import (
+	"path/filepath"
+	"strings"
+
 	"github.com/wailsapp/wails/v3/internal/go-common-file-dialog/cfd"
 	"github.com/wailsapp/wails/v3/pkg/w32"
 	"golang.org/x/sys/windows"
-	"path/filepath"
-	"strings"
 )
 
 func (m *windowsApp) showAboutDialog(title string, message string, _ []byte) {
@@ -169,8 +170,8 @@ func (m *windowSaveFileDialog) show() (chan string, error) {
 	}
 
 	// Original PR for v2 by @almas1992: https://github.com/wailsapp/wails/pull/3205
-	if len(options.Filters) > 0 {
-		config.DefaultExtension = strings.TrimPrefix(strings.Split(options.Filters[0].Pattern, ";")[0], "*")
+	if len(m.dialog.filters) > 0 {
+		config.DefaultExtension = strings.TrimPrefix(strings.Split(m.dialog.filters[0].Pattern, ";")[0], "*")
 	}
 
 	result, err := showCfdDialog(


### PR DESCRIPTION
<!--
READ CAREFULLY: Before submitting your PR, please ensure you have created an issue for your PR.
It is essential that you do this so that we can discuss the proposed changes before you spend time on them.
If you do not create an issue, your PR may be rejected without review.
If a relevant issue already exists, please reference it in your PR by including `Fixes #<issue number>` in your PR description.
-->

# Description

Fixes Windows build failing due to undefined `options`

## Type of change
  
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
  
I tested by compiling `dialogs` example for windows with:
```
GOOS=windows go build ./main.go
```

- [x] Windows
- [ ] macOS
- [ ] Linux
  
## Test Configuration

```
% wails3 doctor


          Wails Doctor



# Build Environment
Wails CLI    | v3.0.0-alpha.3
Go Version   | go1.21.5
-buildmode   | exe
-compiler    | gc
CGO_CFLAGS   |
CGO_CPPFLAGS |
CGO_CXXFLAGS |
CGO_ENABLED  | 1
CGO_LDFLAGS  |
GOARCH       | arm64
GOOS         | darwin

# System
Name            | MacOS
Version         | 14.2.1
ID              | 23C71
Branding        | Sonoma
Platform        | darwin
Architecture    | arm64
Apple Silicon   | true
CPU             | Apple M1 Pro
Xcode cli tools | 2405
CPU             | Unknown
GPU             | Unknown
Memory          | Unknown

# Diagnosis
 SUCCESS  Your system is ready for Wails development!
```

# Checklist:

- [ ] I have updated `website/src/pages/changelog.mdx` with details of this PR
- [x] My code follows the general coding style of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
