### PR TITLE
fix wails3 init for non-local builds

### DIFF
--- a/v3/internal/templates/templates.go
+++ b/v3/internal/templates/templates.go
@@ -213,17 +213,20 @@ func Install(options *flags.Init) error {
 	}
 
 	// Calculate relative path from project directory to LocalModulePath
-	var relativePath string
-	relativePath, err = filepath.Rel(projectDir, debug.LocalModulePath)
-	if err != nil {
-		return err
+	var localModulePath string
+	if debug.LocalModulePath != "" {
+		relativePath, err := filepath.Rel(projectDir, debug.LocalModulePath)
+		if err != nil {
+			return err
+		}
+		localModulePath = filepath.ToSlash(relativePath + "/")
 	}
 
 	UseTypescript := strings.HasSuffix(options.TemplateName, "-ts")
 
 	templateData := TemplateOptions{
 		Init:            options,
-		LocalModulePath: filepath.ToSlash(relativePath + "/"),
+		LocalModulePath: localModulePath,
 		UseTypescript:   UseTypescript,
 	}
 


### PR DESCRIPTION
# Description

`debug.LocalModulePath` is an empty string for non-local builds and causes an error in `filepaths.Rel` on [this](https://github.com/wailsapp/wails/blob/471d6260430acdd43b0e092d3236fc8347e077fe/v3/internal/templates/templates.go#L217) line in `templates.Install`.

Fixes # [(issue)](https://github.com/wailsapp/wails/issues/3255)

## Type of change
  
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
  
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration using `wails doctor`.

- [ ] Windows
- [x] macOS
- [ ] Linux
  
## Test Configuration

Please paste the output of `wails doctor`. If you are unable to run this command, please describe your environment in as much detail as possible.

# Checklist:

- [ ] I have updated `website/src/pages/changelog.mdx` with details of this PR
- [ ] My code follows the general coding style of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
