### PR TITLE
Add Docs for NixOS css bug

### DIFF
--- a/website/docs/guides/nixos-font.mdx
+++ b/website/docs/guides/nixos-font.mdx
@@ -1,0 +1,10 @@
+# NixOS FontSize Bug
+
+NixOS/Wayland can cause a bug where the `font-size` css property doesnt affect the rendered page. To fix this add the following to your devShell.
+
+```shell
+    shellHook = with pkgs; ''
+      export XDG_DATA_DIRS=${gsettings-desktop-schemas}/share/gsettings-schemas/${gsettings-desktop-schemas.name}:${gtk3}/share/gsettings-schemas/${gtk3.name}:$XDG_DATA_DIRS;
+      export GIO_MODULE_DIR="${pkgs.glib-networking}/lib/gio/modules/";
+    '';
+```

--- a/website/src/pages/changelog.mdx
+++ b/website/src/pages/changelog.mdx
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Security` in case of vulnerabilities.
 
 ## [Unreleased]
+- Added docs to help fix NixOs/Wayland font-size css issue. Added by @atterpac in [PR](https://github.com/wailsapp/wails/pull/3268)
 
 ### Added
 - Added option to specify platform for dev command. Thanks to [@pylotlight](https://github.com/pylotlight) for the fix ([#3117](https://github.com/wailsapp/wails/pull/3117)). Based on the work of [@evsign](https://github.com/evsign) in [Draft PR](https://github.com/wailsapp/wails/pull/2724).


### PR DESCRIPTION
Adds docs to help resolve the issue of NixOS/Wayland not being able to change the font size

Fixes # (issue)
No issue, bug reported in discord help channel
## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X ] This change requires a documentation update
  
## Test Configuration
No functional changes made

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Documentation**
	- Introduced a guide for resolving `font-size` rendering issues on NixOS/Wayland.
	- Added documentation to address the NixOs/Wayland font-size CSS issue.
	- Fixed Vue-TS template build error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->