### PR TITLE
[v3] Add option for showing the toolbar in fullscreen mode on macOS

### DIFF
--- a/mkdocs-website/docs/en/API/fullapi.md
+++ b/mkdocs-website/docs/en/API/fullapi.md
@@ -1760,6 +1760,8 @@ type MacTitleBar struct {
     UseToolbar bool
     // HideToolbarSeparator will hide the toolbar separator
     HideToolbarSeparator bool
+    // ShowToolbarWhenFullscreen will keep the toolbar visible when the window is in fullscreen mode
+	ShowToolbarWhenFullscreen bool
     // ToolbarStyle is the style of toolbar to use
     ToolbarStyle MacToolbarStyle
 }

--- a/mkdocs-website/docs/en/changelog.md
+++ b/mkdocs-website/docs/en/changelog.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [darwin] add Event ApplicationShouldHandleReopen to be able to handle dock icon click by @5aaee9 in [#2991](https://github.com/wailsapp/wails/pull/2991)
 - [darwin] add getPrimaryScreen/getScreens to impl by @tmclane in [#2618](https://github.com/wailsapp/wails/pull/2618)
+- [darwin] add option for showing the toolbar in fullscreen mode on macOS by [@fbbdev](https://github.com/fbbdev) in [#3282](https://github.com/wailsapp/wails/pull/3282)
 - [linux] add onKeyPress logic to convert linux keypress into an accelerator @[Atterpac](https://github.com/Atterpac) in[#3022](https://github.com/wailsapp/wails/pull/3022])
 - [linux] add task `run:linux` by [@marcus-crane](https://github.com/marcus-crane) in [#3146](https://github.com/wailsapp/wails/pull/3146)
 - export `SetIcon` method by  @almas1992 in [PR](https://github.com/wailsapp/wails/pull/3147)

--- a/v3/examples/show-macos-toolbar/README.md
+++ b/v3/examples/show-macos-toolbar/README.md
@@ -1,0 +1,20 @@
+# Show macOS Toolbar Example
+
+This example is a demonstration of the macOS option `ShowToolbarWhenFullscreen`, which keeps
+the system toolbar visible when in fullscreen mode.
+
+## Running the example
+
+To run the example (on macOS), simply run the following command:
+
+```bash
+go run .
+```
+
+# Status
+
+| Platform | Status  |
+|----------|---------|
+| Mac      | Working |
+| Windows  | N/A     |
+| Linux    | N/A     |

--- a/v3/examples/show-macos-toolbar/main.go
+++ b/v3/examples/show-macos-toolbar/main.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	_ "embed"
+	"log"
+
+	"github.com/wailsapp/wails/v3/pkg/application"
+)
+
+func main() {
+	app := application.New(application.Options{
+		Name:        "Show macOS Toolbar",
+		Description: "A demo of the ShowToolbarWhenFullscreen option",
+		Mac: application.MacOptions{
+			ApplicationShouldTerminateAfterLastWindowClosed: true,
+		},
+	})
+
+	// Create window
+	app.NewWebviewWindowWithOptions(application.WebviewWindowOptions{
+		Title: "Toolbar hidden (default behaviour)",
+		HTML:  "<html><body><h1>Switch this window to fullscreen: the toolbar will be hidden</h1></body></html>",
+		CSS:   `body { background-color: blue; color: white; height: 100vh; display: flex; justify-content: center; align-items: center; }`,
+		Mac: application.MacWindow{
+			TitleBar: application.MacTitleBar{
+				UseToolbar:           true,
+				HideToolbarSeparator: true,
+			},
+		},
+	})
+
+	// Create window
+	app.NewWebviewWindowWithOptions(application.WebviewWindowOptions{
+		Title: "Toolbar visible",
+		HTML:  "<html><body><h1>Switch this window to fullscreen: the toolbar will stay visible</h1></body></html>",
+		CSS:   `body { background-color: red; color: white; height: 100vh; display: flex; justify-content: center; align-items: center; }`,
+		Mac: application.MacWindow{
+			TitleBar: application.MacTitleBar{
+				UseToolbar:                true,
+				HideToolbarSeparator:      true,
+				ShowToolbarWhenFullscreen: true,
+			},
+		},
+	})
+
+	err := app.Run()
+
+	if err != nil {
+		log.Fatal(err)
+	}
+}

--- a/v3/go.mod
+++ b/v3/go.mod
@@ -32,7 +32,6 @@ require (
 	github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8
 	github.com/pkg/errors v0.9.1
 	github.com/pterm/pterm v0.12.51
-	github.com/rjeczalik/notify v0.9.3
 	github.com/samber/lo v1.38.1
 	github.com/tc-hib/winres v0.1.6
 	github.com/wailsapp/go-webview2 v1.0.9
@@ -84,6 +83,7 @@ require (
 	github.com/radovskyb/watcher v1.0.7 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	github.com/rivo/uniseg v0.4.4 // indirect
+	github.com/rjeczalik/notify v0.9.3 // indirect
 	github.com/sajari/fuzzy v1.0.0 // indirect
 	github.com/sergi/go-diff v1.2.0 // indirect
 	github.com/skeema/knownhosts v1.2.1 // indirect

--- a/v3/pkg/application/options_mac.go
+++ b/v3/pkg/application/options_mac.go
@@ -1,7 +1,9 @@
 package application
 
-import "github.com/wailsapp/wails/v3/pkg/events"
-import "github.com/leaanthony/u"
+import (
+	"github.com/leaanthony/u"
+	"github.com/wailsapp/wails/v3/pkg/events"
+)
 
 // MacBackdrop is the backdrop type for macOS
 type MacBackdrop int
@@ -87,6 +89,8 @@ type MacTitleBar struct {
 	UseToolbar bool
 	// HideToolbarSeparator will hide the toolbar separator
 	HideToolbarSeparator bool
+	// ShowToolbarWhenFullscreen will keep the toolbar visible when the window is in fullscreen mode
+	ShowToolbarWhenFullscreen bool
 	// ToolbarStyle is the style of toolbar to use
 	ToolbarStyle MacToolbarStyle
 }

--- a/v3/pkg/application/webview_window_darwin.go
+++ b/v3/pkg/application/webview_window_darwin.go
@@ -443,18 +443,12 @@ void windowSetHideTitle(void* nsWindow, bool hideTitle) {
 }
 
 // Set Window use toolbar
-void windowSetUseToolbar(void* nsWindow, bool useToolbar, int toolbarStyle) {
+void windowSetUseToolbar(void* nsWindow, bool useToolbar) {
 	WebviewWindow* window = (WebviewWindow*)nsWindow;
 	if( useToolbar ) {
 		NSToolbar *toolbar = [[NSToolbar alloc] initWithIdentifier:@"wails.toolbar"];
 		[toolbar autorelease];
 		[window setToolbar:toolbar];
-
-		// If macos 11 or higher, set toolbar style
-		if (@available(macOS 11.0, *)) {
-			[window setToolbarStyle:toolbarStyle];
-		}
-
 	} else {
 		[window setToolbar:nil];
 	}
@@ -462,11 +456,15 @@ void windowSetUseToolbar(void* nsWindow, bool useToolbar, int toolbarStyle) {
 
 // Set window toolbar style
 void windowSetToolbarStyle(void* nsWindow, int style) {
+	WebviewWindow* window = (WebviewWindow*)nsWindow;
 	// use @available to check if the function is available
 	// if not, return
 	if (@available(macOS 11.0, *)) {
-		NSToolbar* toolbar = [(WebviewWindow*)nsWindow toolbar];
-		[toolbar setShowsBaselineSeparator:style];
+		NSToolbar* toolbar = [window toolbar];
+		if ( toolbar == nil ) {
+			return;
+		}
+		[window setToolbarStyle:style];
 	}
 }
 
@@ -477,6 +475,15 @@ void windowSetHideToolbarSeparator(void* nsWindow, bool hideSeparator) {
 		return;
 	}
 	[toolbar setShowsBaselineSeparator:!hideSeparator];
+}
+
+// Configure the toolbar auto-hide feature
+void windowSetShowToolbarWhenFullscreen(void* window, bool setting) {
+	WebviewWindow* nsWindow = (WebviewWindow*)window;
+	// Get delegate
+	WebviewWindowDelegate* delegate = (WebviewWindowDelegate*)[nsWindow delegate];
+	// Set height
+	delegate.showToolbarWhenFullscreen = setting;
 }
 
 // Set Window appearance type
@@ -745,10 +752,11 @@ void windowFocus(void *window) {
 */
 import "C"
 import (
-	"github.com/wailsapp/wails/v3/internal/assetserver"
-	"github.com/wailsapp/wails/v3/internal/runtime"
 	"sync"
 	"unsafe"
+
+	"github.com/wailsapp/wails/v3/internal/assetserver"
+	"github.com/wailsapp/wails/v3/internal/runtime"
 
 	"github.com/wailsapp/wails/v3/pkg/events"
 )
@@ -968,7 +976,6 @@ func (w *macosWebviewWindow) setEnabled(enabled bool) {
 }
 
 func (w *macosWebviewWindow) execJS(js string) {
-
 	InvokeAsync(func() {
 		if globalApplication.performingShutdown {
 			return
@@ -1146,11 +1153,12 @@ func (w *macosWebviewWindow) run() {
 			C.windowSetHideTitleBar(w.nsWindow, C.bool(titleBarOptions.Hide))
 			C.windowSetHideTitle(w.nsWindow, C.bool(titleBarOptions.HideTitle))
 			C.windowSetFullSizeContent(w.nsWindow, C.bool(titleBarOptions.FullSizeContent))
-			if titleBarOptions.UseToolbar {
-				C.windowSetUseToolbar(w.nsWindow, C.bool(titleBarOptions.UseToolbar), C.int(titleBarOptions.ToolbarStyle))
-			}
+			C.windowSetUseToolbar(w.nsWindow, C.bool(titleBarOptions.UseToolbar))
+			C.windowSetToolbarStyle(w.nsWindow, C.int(titleBarOptions.ToolbarStyle))
+			C.windowSetShowToolbarWhenFullscreen(w.nsWindow, C.bool(titleBarOptions.ShowToolbarWhenFullscreen))
 			C.windowSetHideToolbarSeparator(w.nsWindow, C.bool(titleBarOptions.HideToolbarSeparator))
 		}
+
 		if macOptions.Appearance != "" {
 			C.windowSetAppearanceTypeByName(w.nsWindow, C.CString(string(macOptions.Appearance)))
 		}
@@ -1186,7 +1194,7 @@ func (w *macosWebviewWindow) run() {
 				if options.CSS != "" {
 					C.windowInjectCSS(w.nsWindow, C.CString(options.CSS))
 				}
-				if options.Hidden == false {
+				if !options.Hidden {
 					C.windowShow(w.nsWindow)
 					w.setHasShadow(!options.Mac.DisableShadow)
 				} else {

--- a/v3/pkg/application/webview_window_darwin.h
+++ b/v3/pkg/application/webview_window_darwin.h
@@ -23,6 +23,7 @@
 @property unsigned int windowId;
 @property (retain) NSEvent* leftMouseEvent;
 @property unsigned int invisibleTitleBarHeight;
+@property BOOL showToolbarWhenFullscreen;
 @property NSWindowStyleMask previousStyleMask; // Used to restore the window style mask when using frameless
 
 - (void)handleLeftMouseUp:(NSWindow *)window;

--- a/v3/pkg/application/webview_window_darwin.m
+++ b/v3/pkg/application/webview_window_darwin.m
@@ -241,6 +241,13 @@ extern bool hasListeners(unsigned int);
         }
     }
 }
+- (NSApplicationPresentationOptions)window:(NSWindow *)window willUseFullScreenPresentationOptions:(NSApplicationPresentationOptions)proposedOptions {
+    if (self.showToolbarWhenFullscreen) {
+        return proposedOptions;
+    } else {
+        return proposedOptions | NSApplicationPresentationAutoHideToolbar;
+    }
+}
 // GENERATED EVENTS START
 - (void)windowDidBecomeKey:(NSNotification *)notification {
     if( hasListeners(EventWindowDidBecomeKey) ) {


### PR DESCRIPTION
# Description

When the MacTitleBar.UseToolbar option is enabled, the system toolbar is shown on macOS windows. Currently, when the windows are switched to fullscreen mode, the toolbar remains visible.

Although this might be desirable sometimes, in most common cases it is not the expected behaviour, as the full-screen toolbar cannot be made transparent and therefore clashes with the look of the application.

This patch introduces a new option in the `MacTitleBar` struct that when enabled hides the toolbar automatically upon entering fullscreen mode. It also enables the option by default in the predefined titlebar styles.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?
  
The new [`hide-macos-toolbar` example](https://github.com/fbbdev/wails/tree/feature/hide_fullscreen_toolbar/v3/examples/hide-macos-toolbar) creates two windows shocasing the two possible configurations of the new flag.

- [ ] Windows
- [x] macOS
- [ ] Linux
  
## Test Configuration

```
Go Version     | go1.22.0                                                                      
Revision       | 12d12a33dec1d31f487b70f87bc31e80252f327c                                      
Modified       | true                                                                          
-buildmode     | exe                                                                           
-compiler      | gc                                                                            
CGO_CFLAGS     |                                                                               
CGO_CPPFLAGS   |                                                                               
CGO_CXXFLAGS   |                                                                               
CGO_ENABLED    | 1                                                                             
CGO_LDFLAGS    |                                                                               
DefaultGODEBUG | httplaxcontentlength=1,httpmuxgo121=1,tls10server=1,tlsrsakex=1,tlsunsafeekm=1
GOAMD64        | v1                                                                            
GOARCH         | amd64                                                                         
GOOS           | darwin                                                                        
vcs            | git                                                                           
vcs.modified   | true                                                                          
vcs.revision   | 12d12a33dec1d31f487b70f87bc31e80252f327c                                      
vcs.time       | 2024-02-21T12:40:32Z                                                          

# System
Name            | MacOS                                   
Version         | 12.6.6                                  
ID              | 21G646                                  
Branding        | Monterey                                
Platform        | darwin                                  
Architecture    | amd64                                   
Apple Silicon   | unknown                                 
CPU             | Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
Xcode cli tools | 2395                                    
CPU             | Unknown                                 
GPU             | Unknown                                 
Memory          | Unknown                                 

# Diagnosis
 SUCCESS  Your system is ready for Wails development!
```

# Checklist:

- [x] I have updated `mkdocs-website/docs/en/changelog.md` with details of this PR
- [x] My code follows the general coding style of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
