### PR TITLE
Correctly compute 'startURL' when using a frontend development server.

### DIFF
--- a/mkdocs-website/docs/en/changelog.md
+++ b/mkdocs-website/docs/en/changelog.md
@@ -43,6 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix failing Windows build due to unknown option by [thomas-senechal](https://github.com/thomas-senechal) in PR [#3208](https://github.com/wailsapp/wails/pull/3208)
 - Fix wrong baseURL when open window twice by @5aaee9 in PR [#3273](https://github.com/wailsapp/wails/pull/3273)
 - Fix ordering of if branches in `WebviewWindow.Restore` method by [@fbbdev](https://github.com/fbbdev) in [#3279](https://github.com/wailsapp/wails/pull/3279)
+- Correctly compute `startURL` across multiple `GetStartURL` invocations when `FRONTEND_DEVSERVER_URL` is present. [#3299](https://github.com/wailsapp/wails/pull/3299)
 
 ### Changed
 

--- a/v3/internal/assetserver/assetserver.go
+++ b/v3/internal/assetserver/assetserver.go
@@ -148,7 +148,7 @@ func GetStartURL(userURL string) (string, error) {
 		}
 		port := parsedURL.Port()
 		if port != "" {
-			baseURL.Host = net.JoinHostPort(baseURL.Host, port)
+			baseURL.Host = net.JoinHostPort(baseURL.Hostname(), port)
 			startURL = baseURL.String()
 		}
 	} else {

--- a/v3/internal/assetserver/assetserver.go
+++ b/v3/internal/assetserver/assetserver.go
@@ -151,23 +151,24 @@ func GetStartURL(userURL string) (string, error) {
 			baseURL.Host = net.JoinHostPort(baseURL.Hostname(), port)
 			startURL = baseURL.String()
 		}
-	} else {
-		if userURL != "" {
-			// parse the url
-			parsedURL, err := url.Parse(userURL)
-			if err != nil {
-				return "", fmt.Errorf("Error parsing URL: " + err.Error())
+	}
+
+	if userURL != "" {
+		// parse the url
+		parsedURL, err := url.Parse(userURL)
+		if err != nil {
+			return "", fmt.Errorf("Error parsing URL: " + err.Error())
+		}
+		if parsedURL.Scheme == "" {
+			startURL = baseURL.ResolveReference(&url.URL{Path: userURL}).String()
+			// if the original URL had a trailing slash, add it back
+			if strings.HasSuffix(userURL, "/") && !strings.HasSuffix(startURL, "/") {
+				startURL = startURL + "/"
 			}
-			if parsedURL.Scheme == "" {
-				startURL = baseURL.ResolveReference(&url.URL{Path: userURL}).String()
-				// if the original URL had a trailing slash, add it back
-				if strings.HasSuffix(userURL, "/") && !strings.HasSuffix(startURL, "/") {
-					startURL = startURL + "/"
-				}
-			} else {
-				startURL = userURL
-			}
+		} else {
+			startURL = userURL
 		}
 	}
+
 	return startURL, nil
 }

--- a/v3/internal/assetserver/assetserver.go
+++ b/v3/internal/assetserver/assetserver.go
@@ -154,20 +154,12 @@ func GetStartURL(userURL string) (string, error) {
 	}
 
 	if userURL != "" {
-		// parse the url
-		parsedURL, err := url.Parse(userURL)
+		parsedURL, err := baseURL.Parse(userURL)
 		if err != nil {
 			return "", fmt.Errorf("Error parsing URL: " + err.Error())
 		}
-		if parsedURL.Scheme == "" {
-			startURL = baseURL.ResolveReference(&url.URL{Path: userURL}).String()
-			// if the original URL had a trailing slash, add it back
-			if strings.HasSuffix(userURL, "/") && !strings.HasSuffix(startURL, "/") {
-				startURL = startURL + "/"
-			}
-		} else {
-			startURL = userURL
-		}
+
+		startURL = parsedURL.String()
 	}
 
 	return startURL, nil


### PR DESCRIPTION
<!--
READ CAREFULLY: Before submitting your PR, please ensure you have created an issue for your PR.
It is essential that you do this so that we can discuss the proposed changes before you spend time on them.
If you do not create an issue, your PR may be rejected without review.
If a relevant issue already exists, please reference it in your PR by including `Fixes #<issue number>` in your PR description.
-->

# Description

Correctly compute `startURL` across multiple `GetStartURL` invocations when `FRONTEND_DEVSERVER_URL` is present.

Fixes [#3298](https://github.com/wailsapp/wails/issues/3298)

## Type of change
  
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
  
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration using `wails doctor`.

- [ ] Windows
- [x] macOS
- [x] Linux
  
## Test Configuration

# Build Environment
Wails CLI      | v3.0.0-alpha.3
Go Version     | go1.22.0
Revision       | 4467a1ffa273059da10b45bbfd38c656f9e6dc28
Modified       | true
-buildmode     | exe
-compiler      | gc
CGO_CFLAGS     |
CGO_CPPFLAGS   |
CGO_CXXFLAGS   |
CGO_ENABLED    | 1
CGO_LDFLAGS    |
DefaultGODEBUG | httplaxcontentlength=1,httpmuxgo121=1,tls10server=1,tlsrsakex=1,tlsunsafeekm=1
GOAMD64        | v1
GOARCH         | amd64
GOOS           | linux
vcs            | git
vcs.modified   | true
vcs.revision   | 4467a1ffa273059da10b45bbfd38c656f9e6dc28
vcs.time       | 2024-03-04T11:38:21Z

# System
Name         | Fedora Linux
Version      | 38
ID           | fedora
Branding     | 38 (Workstation Edition)
Platform     | linux
Architecture | amd64
gcc          | 13.2.1
libgtk-3     | 3.24.41
libwebkit    | 2.42.5
npm          | 10.2.3
pkg-config   | 1.8.0
CPU          | AMD Ryzen 5 7600X 6-Core Processor
GPU 1        | Raphael (Advanced Micro Devices, Inc. [AMD/ATI]) - Driver: amdgpu
GPU 2        | Navi 23 [Radeon RX 6600/6600 XT/6600M] (Advanced Micro Devices, Inc. [AMD/ATI]) - Driver: amdgpu
Memory       | 64GB

# Diagnosis
 SUCCESS  Your system is ready for Wails development!

# Checklist:

- [x] I have updated `website/src/pages/changelog.mdx` with details of this PR
- [x] My code follows the general coding style of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
