### PR TITLE
[V3 Linux]  Calling dialogs on main thread

### DIFF
--- a/v3/pkg/application/dialogs.go
+++ b/v3/pkg/application/dialogs.go
@@ -272,6 +272,7 @@ func (d *OpenFileDialogStruct) PromptForSingleSelection() (string, error) {
 	if err == nil {
 		result = <-selections
 	}
+	close(selections)
 
 	return result, err
 }

--- a/v3/pkg/application/dialogs_linux.go
+++ b/v3/pkg/application/dialogs_linux.go
@@ -10,10 +10,12 @@ func (a *linuxApp) showAboutDialog(title string, message string, icon []byte) {
 	about.SetTitle(title).
 		SetMessage(message).
 		SetIcon(icon)
-	runQuestionDialog(
-		pointer(parent),
-		about,
-	)
+	InvokeAsync(func() {
+		runQuestionDialog(
+			pointer(parent),
+			about,
+		)
+	})
 }
 
 type linuxDialog struct {
@@ -28,13 +30,15 @@ func (m *linuxDialog) show() {
 		parent, _ = window.(*WebviewWindow).NativeWindowHandle()
 	}
 
-	response := runQuestionDialog(pointer(parent), m.dialog)
-	if response >= 0 && response < len(m.dialog.Buttons) {
-		button := m.dialog.Buttons[response]
-		if button.Callback != nil {
-			go button.Callback()
+	InvokeAsync(func() {
+		response := runQuestionDialog(pointer(parent), m.dialog)
+		if response >= 0 && response < len(m.dialog.Buttons) {
+			button := m.dialog.Buttons[response]
+			if button.Callback != nil {
+				go button.Callback()
+			}
 		}
-	}
+	})
 }
 
 func newDialogImpl(d *MessageDialog) *linuxDialog {

--- a/v3/pkg/application/linux_cgo.go
+++ b/v3/pkg/application/linux_cgo.go
@@ -1570,11 +1570,10 @@ func runChooserDialog(window pointer, allowMultiple, createFolders, showHidden b
 					}
 					count++
 				}
-				close(selections)
-				C.gtk_widget_destroy((*C.GtkWidget)(unsafe.Pointer(fc)))
 			}
 		}()
 	})
+	C.gtk_widget_destroy((*C.GtkWidget)(unsafe.Pointer(fc)))
 	return selections, nil
 }
 


### PR DESCRIPTION
# Description
(New PR due to unfortunate git circumstances)
Linux file chooser dialogs were having varying errors due to not being called on the main gtk thread. The only change was removing the call to create the dialog from the go routine to handle the response so only the handling of the dialog is done outside of the main thread but the chooser is called correctly.


# TODO
Marked as draft because there is still an issue of selecting a directory it only ever goes into the directory and not selects.

Fixes #3378 

## Type of change

- [ X ] Bug fix (non-breaking change which fixes an issue)
 
# How Has This Been Tested?
- [ X ] Linux
  
## Test Configuration
```
# Build Environment
Wails CLI    | v3.0.0-alpha.4

Go Version   | go1.22.0
Revision     | c1ab0a91fdac1257c74244e45dbcb094d2ad4388
Modified     | true
-buildmode   | exe
-compiler    | gc
CGO_CFLAGS   |
CGO_CPPFLAGS |
CGO_CXXFLAGS |
CGO_ENABLED  | 1
CGO_LDFLAGS  |
GOAMD64      | v1
GOARCH       | amd64
GOOS         | linux
vcs          | git
vcs.modified | true
vcs.revision | c1ab0a91fdac1257c74244e45dbcb094d2ad4388
vcs.time     | 2024-03-24T18:30:19Z

# System
Name         | Ubuntu
Version      | 22.04
ID           | ubuntu
Branding     | 22.04.3 LTS (Jammy Jellyfish)
Platform     | linux
Architecture | amd64
gcc          | 12.9ubuntu3
libgtk-3     | 3.24.33-1ubuntu2
libwebkit    | 2.42.5-0ubuntu0.22.04.2
npm          | 8.5.1~ds-1
pkg-config   | 0.29.2-1ubuntu3
CPU          | AMD Ryzen 7 3700X 8-Core Processor
GPU 1        | Unknown
Memory       | 12GB
```

# Checklist:

- [ ] I have updated `website/src/pages/changelog.mdx` with details of this PR