### PR TITLE
docs: Add new template wails-astro-ts

### DIFF
--- a/website/versioned_docs/version-v2.8.1/community/templates.mdx
+++ b/website/versioned_docs/version-v2.8.1/community/templates.mdx
@@ -69,3 +69,7 @@ If you are unsure about a template, inspect `package.json` and `wails.json` for 
 ## Pure JavaScript (Vanilla)
 
 - [wails-pure-js-template](https://github.com/KiddoV/wails-pure-js-template) - A template with nothing but just basic JavaScript, HTML, and CSS
+
+## Astro
+
+- [wails-astro-ts](https://github.com/DiegPS/wails-astro-ts/) - Wails Template with Astro and Typescript, to use the framework you want, with Astro you have all the frameworks and libraries you want in one.


### PR DESCRIPTION
# Description

Add a community template to allow using Astro and TypeScript in Wails

## Type of change

- [x] This change requires a documentation update


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new `wails-astro-ts` template that integrates Astro and TypeScript into Wails, enhancing flexibility in framework and library selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->