### PR TITLE
allow for non-Window WailsEvent listeners

### DIFF
--- a/v3/pkg/application/application.go
+++ b/v3/pkg/application/application.go
@@ -789,7 +789,7 @@ func (a *App) dispatchEventToListeners(event *WailsEvent) {
 	listeners := a.wailsEventListeners
 
 	for _, window := range a.windows {
-		listeners = append(listeners, window)
+		window.DispatchWailsEvent(event)
 	}
 
 	for _, listener := range listeners {

--- a/v3/pkg/application/application.go
+++ b/v3/pkg/application/application.go
@@ -76,7 +76,7 @@ func New(appOptions Options) *App {
 	result.logStartup()
 	result.logPlatformInfo()
 
-	result.Events = NewWailsEventProcessor(result.dispatchEventToWindows)
+	result.Events = NewWailsEventProcessor(result.dispatchEventToListeners)
 
 	messageProc := NewMessageProcessor(result.Logger)
 	opts := &assetserver.Options{
@@ -326,6 +326,10 @@ type App struct {
 
 	// signalHandler is used to handle signals
 	signalHandler *signal.SignalHandler
+
+	// Wails Event Listener related
+	wailsEventListenerLock sync.Mutex
+	wailsEventListeners    []WailsEventListener
 }
 
 func (a *App) init() {
@@ -336,6 +340,7 @@ func (a *App) init() {
 	a.keyBindings = make(map[string]func(window *WebviewWindow))
 	a.Logger = a.options.Logger
 	a.pid = os.Getpid()
+	a.wailsEventListeners = make([]WailsEventListener, 0)
 }
 
 func (a *App) getSystemTrayID() uint {
@@ -398,6 +403,12 @@ func (a *App) RegisterHook(eventType events.ApplicationEventType, callback func(
 		a.applicationEventHooks[eventID] = lo.Without(a.applicationEventHooks[eventID], thisHook)
 		a.applicationEventHooksLock.Unlock()
 	}
+}
+
+func (a *App) RegisterListener(listener WailsEventListener) {
+	a.wailsEventListenerLock.Lock()
+	a.wailsEventListeners = append(a.wailsEventListeners, listener)
+	a.wailsEventListenerLock.Unlock()
 }
 
 func (a *App) NewWebviewWindow() *WebviewWindow {
@@ -774,9 +785,15 @@ func SaveFileDialogWithOptions(s *SaveFileDialogOptions) *SaveFileDialogStruct {
 	return result
 }
 
-func (a *App) dispatchEventToWindows(event *WailsEvent) {
+func (a *App) dispatchEventToListeners(event *WailsEvent) {
+	listeners := a.wailsEventListeners
+
 	for _, window := range a.windows {
-		window.DispatchWailsEvent(event)
+		listeners = append(listeners, window)
+	}
+
+	for _, listener := range listeners {
+		listener.DispatchWailsEvent(event)
 	}
 }
 

--- a/v3/pkg/application/events.go
+++ b/v3/pkg/application/events.go
@@ -60,6 +60,12 @@ func (e WailsEvent) ToJSON() string {
 	return string(marshal)
 }
 
+// WailsEventListener is an interface that can be implemented to listen for Wails events
+// It is used by the RegisterListener method of the Application.
+type WailsEventListener interface {
+	DispatchWailsEvent(event *WailsEvent)
+}
+
 type hook struct {
 	callback func(*WailsEvent)
 }


### PR DESCRIPTION
- adds a RegisterListener function on the App struct such that code can listen for WailsEvent(s) even if it isn't a Window

An assumption is made such that Window(s) are implicit listeners and therefore they also are always delivered all WailsEvent(s).

The intent here is to allow for non-Window listeners to be able to register for these events without being a Window itself opening up the ability of plugins or other code that wishes to receive **ALL** `WailsEvent(s)` such that they can be processed.





