### PR TITLE
[V3] Changes dev mode to match OS executable

### DIFF
--- a/v3/internal/commands/build_assets/devmode.config.tmpl.toml
+++ b/v3/internal/commands/build_assets/devmode.config.tmpl.toml
@@ -31,5 +31,5 @@ blocking = true
 cmd = "KILL_STALE"
 
 [[config.executes]]
-cmd = "./bin/{{.Binary}}"
+cmd = "wails3 task run"
 primary = true

--- a/website/src/pages/changelog.mdx
+++ b/website/src/pages/changelog.mdx
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added documentation for a common GStreamer error on Linux systems. Changed by [@mkwsnyder](https://github.com/mkwsnyder) in [PR](https://github.com/wailsapp/wails/pull/3134)
 
 ### Fixed
+- Dev mode now adapts to what OS it is ran on to source the correct executable. Fixed by [@atterpac](https://github.com/atterpac) in [PR](https://github.com/wailsapp/wails/pull/3412) 
 - Docs for IsZoomControlEnabled and ZoomFactor. Fixed by @leaanthony in [PR](https://github.com/wailsapp/wails/pull/3137)
 - Fixed `-compiler` flag for `wails build`, `wails dev` and `wails generate module`. Fixed in [PR](https://github.com/wailsapp/wails/pull/3121) by [@xtrafrancyz](https://github.com/xtrafrancyz)
 


### PR DESCRIPTION
# Description
Current dev mode config calls the executable by its path, this changes the dev mode config to use `wails3 task run` to match whatever OS you are on

Fixes # (issue)
Issue mentioned in discord
## Type of change
- [ X ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
```
# System
| Name         | Ubuntu                             |
| Version      | 22.04                              |
| ID           | ubuntu                             |
| Branding     | 22.04.3 LTS (Jammy Jellyfish)      |
| Platform     | linux                              |
| Architecture | amd64                              |
| CPU          | AMD Ryzen 7 3700X 8-Core Processor |
| GPU 1        | Unknown                            |
| Memory       | 12GB                               |


# Build Environment
| Wails CLI      | v3.0.0-alpha.4                                                                 |
| Go Version     | go1.22.0                                                                       |
| Revision       | 021efab84de9a273ad73ac2a8c27d4af4d158bbb                                       |
| Modified       | true                                                                           |
| -buildmode     | exe                                                                            |
| -compiler      | gc                                                                             |
| CGO_CFLAGS     |                                                                                |
| CGO_CPPFLAGS   |                                                                                |
| CGO_CXXFLAGS   |                                                                                |
| CGO_ENABLED    | 1                                                                              |
| CGO_LDFLAGS    |                                                                                |
| DefaultGODEBUG | httplaxcontentlength=1,httpmuxgo121=1,tls10server=1,tlsrsakex=1,tlsunsafeekm=1 |
| GOAMD64        | v1                                                                             |
| GOARCH         | amd64                                                                          |
| GOOS           | linux                                                                          |
| vcs            | git                                                                            |
| vcs.modified   | true                                                                           |
| vcs.revision   | 021efab84de9a273ad73ac2a8c27d4af4d158bbb                                       |
| vcs.time       | 2024-04-19T23:39:57Z                                                           |


# Dependencies
| gcc        | 12.9ubuntu3             |
| libgtk-3   | 3.24.33-1ubuntu2        |
| libwebkit  | 2.44.0-0ubuntu0.22.04.1 |
| npm        | 10.5.0                  |
| pkg-config | 0.29.2-1ubuntu3         |

# Diagnosis
 SUCCESS  Your system is ready for Wails development!
```
