### PR TITLE
docs: add possible options in terms of choosing the ide either vscode or goland

### DIFF
--- a/website/versioned_docs/version-v2.8.1/reference/cli.mdx
+++ b/website/versioned_docs/version-v2.8.1/reference/cli.mdx
@@ -20,7 +20,7 @@ The Wails CLI has a number of commands that are used for managing your projects.
 | -l                 | List available project templates                                                                                        |                     |
 | -q                 | Suppress output to console                                                                                              |                     |
 | -t "template name" | The project template to use. This can be the name of a default template or a URL to a remote template hosted on github. |       vanilla       |
-| -ide               | Generate IDE project files                                                                                              |                     |
+| -ide               | Generate IDE project files `vscode` or `goland`                                                                         |                     |
 | -f                 | Force build application                                                                                                 |        false        |
 
 Example:


### PR DESCRIPTION
# Description

Add possible options in terms of choosing the "ide" either "visual studio code" or "goland", in CLI section.

Fixes # ([issue](https://github.com/wailsapp/wails/issues/3409))

## Type of change
  
Please delete options that are not relevant.

- [x] This change requires a documentation update

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the CLI reference to include options for generating IDE project files specifically for `vscode` or `goland`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->