### PR TITLE
docs: add goland option in IDE section

### DIFF
--- a/website/versioned_docs/version-v2.8.1/guides/ides.mdx
+++ b/website/versioned_docs/version-v2.8.1/guides/ides.mdx
@@ -3,7 +3,7 @@
 Wails aims to provide a great development experience. To that aim, we now support generating IDE specific configuration
 to provide smoother project setup.
 
-Currently, we support [Visual Studio Code](https://code.visualstudio.com/) but aim to support other IDEs such as Goland.
+Currently, we support [Visual Studio Code](https://code.visualstudio.com/) and [Goland](https://www.jetbrains.com/go/).
 
 ## Visual Studio Code
 


### PR DESCRIPTION
# Description

Add the possibility for anyone to know that goland can also be used with the `-ide goland` by a brief mention in the documentation

Fixes # (https://github.com/wailsapp/wails/issues/3409)

## Type of change

- [x] This change requires a documentation update
