### PR TITLE
docs: add guides ide change goland option and reference cli add options vscode or goland

### DIFF
--- a/website/docs/guides/ides.mdx
+++ b/website/docs/guides/ides.mdx
@@ -3,7 +3,7 @@
 Wails aims to provide a great development experience. To that aim, we now support generating IDE specific configuration
 to provide smoother project setup.
 
-Currently, we support [Visual Studio Code](https://code.visualstudio.com/) but aim to support other IDEs such as Goland.
+Currently, we support [Visual Studio Code](https://code.visualstudio.com/) and [Goland](https://www.jetbrains.com/go/).
 
 ## Visual Studio Code
 

--- a/website/docs/reference/cli.mdx
+++ b/website/docs/reference/cli.mdx
@@ -20,7 +20,7 @@ The Wails CLI has a number of commands that are used for managing your projects.
 | -l                 | List available project templates                                                                                        |                     |
 | -q                 | Suppress output to console                                                                                              |                     |
 | -t "template name" | The project template to use. This can be the name of a default template or a URL to a remote template hosted on github. |       vanilla       |
-| -ide               | Generate IDE project files                                                                                              |                     |
+| -ide               | Generate IDE project files `vscode` or `goland`                                                                         |                     |
 | -f                 | Force build application                                                                                                 |        false        |
 
 Example:


### PR DESCRIPTION
# Description

Add the possibility for anyone to know that goland can also be used with the -ide goland by a brief mention in the documentation

Fixes # (https://github.com/wailsapp/wails/issues/3409)

## Type of change
  
- [x] This change requires a documentation update
