### PR TITLE
[v3] Add `vhost` and `vport` flag to dev command

### DIFF
--- a/v3/internal/commands/dev.go
+++ b/v3/internal/commands/dev.go
@@ -1,0 +1,31 @@
+package commands
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+
+	"github.com/wailsapp/wails/v3/internal/flags"
+)
+
+type DevOptions struct {
+	flags.Common
+
+	Config   string `description:"The config file including path" default:"./build/devmode.config.toml"`
+	ViteHost string `name:"vhost" description:"The vite dev server host" default:"localhost"`
+	VitePort int    `name:"vport" description:"The vite dev server port" default:"5173"`
+}
+
+func Dev(options *DevOptions) error {
+
+	// Set variables for the dev:frontend task
+	os.Setenv("VITE_HOST", options.ViteHost)
+	os.Setenv("VITE_PORT", strconv.Itoa(options.VitePort))
+
+	// Set url of frontend dev server
+	os.Setenv("FRONTEND_DEVSERVER_URL", fmt.Sprintf("http://%s:%d", options.ViteHost, options.VitePort))
+
+	return Watcher(&WatcherOptions{
+		Config: options.Config,
+	})
+}

--- a/v3/internal/commands/task_wrapper.go
+++ b/v3/internal/commands/task_wrapper.go
@@ -1,17 +1,14 @@
 package commands
 
 import (
+	"os"
+
 	"github.com/pterm/pterm"
 	"github.com/wailsapp/wails/v3/internal/flags"
-	"os"
 )
 
 func Build(_ *flags.Build) error {
 	return wrapTask("build")
-}
-
-func Dev(_ *flags.Dev) error {
-	return wrapTask("dev")
 }
 
 func Package(_ *flags.Package) error {

--- a/v3/internal/templates/_common/Taskfile.tmpl.yml
+++ b/v3/internal/templates/_common/Taskfile.tmpl.yml
@@ -431,15 +431,22 @@ tasks:
     deps:
       - task: install:frontend:deps
     cmds:
-      - npm run dev
+      - npm run dev -- --host {{ "{{.VITE_HOST}}" }} --port {{ "{{.VITE_PORT}}" }} --strictPort
+    env:
+      VITE_HOST: {{ "'{{.VITE_HOST | default \"localhost\"}}'" }}
+      VITE_PORT: {{ "'{{.VITE_PORT | default 5173}}'" }}
 
   dev:
     summary: Runs the application in development mode
     cmds:
-      - wails3 tool watcher -config ./build/devmode.config.toml
-    env:
+      - wails3 dev -config ./build/devmode.config.toml -vhost {{ "{{.VITE_HOST}}" }} -vport {{ "{{.VITE_PORT}}" }}
+    vars:
+      # This is the default vite dev server host
+      # It can be set via wails3 task dev VITE_HOST=0.0.0.0
+      VITE_HOST: {{ "'{{.VITE_HOST | default \"localhost\"}}'" }}
       # This is the default vite dev server port
-      FRONTEND_DEVSERVER_URL: 'http://localhost:5173'
+      # It can be set via wails3 task dev VITE_PORT=5175
+      VITE_PORT: {{ "'{{.VITE_PORT | default 5173}}'" }}
 
   dev:reload:
     summary: Reloads the application


### PR DESCRIPTION
<!--
READ CAREFULLY: Before submitting your PR, please ensure you have created an issue for your PR.
It is essential that you do this so that we can discuss the proposed changes before you spend time on them.
If you do not create an issue, your PR may be rejected without review.
If a relevant issue already exists, please reference it in your PR by including `Fixes #<issue number>` in your PR description.
-->

# Description

This PR adds the following flags to the `dev` command:
- `vhost`: The vite dev server host, default: `localhost`
- `vport`: The vite dev server port, default: `5173`

[`server.strictport`](https://vitejs.dev/config/server-options#server-strictport) is set to exit if port is already in use.

Fixes #3379

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
  
The following commands have been executed inside a new project:

```shell
$ wails3 dev -vhost 0.0.0.0 -vport 3333
...
  VITE v5.2.10  ready in 109 ms

  ➜  Local:   http://localhost:3333/
  ➜  Network: http://192.168.1.11:3333/


$ wails3 task dev VITE_HOST=0.0.0.0 VITE_PORT=3333
...
  VITE v5.2.10  ready in 109 ms

  ➜  Local:   http://localhost:3333/
  ➜  Network: http://192.168.1.11:3333/
```

- [ ] Windows
- [ ] macOS
- [x] Linux
  
## Test Configuration

```shell
# System
┌───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
| Name         | Manjaro Linux                                                                                                  |
| Version      | Unknown                                                                                                        |
| ID           | manjaro                                                                                                        |
| Branding     |                                                                                                                |
| Platform     | linux                                                                                                          |
| Architecture | amd64                                                                                                          |
| CPU          | AMD Ryzen 5 3600 6-Core Processor                                                                              |
| GPU 1        | Navi 10 [Radeon RX 5600 OEM/5600 XT / 5700/5700 XT] (Advanced Micro Devices, Inc. [AMD/ATI]) - Driver: amdgpu  |
| Memory       | 32GB                                                                                                           |
└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘

# Build Environment
┌─────────────────────────────────────────────────────────────────────────────────────────────────┐
| Wails CLI      | v3.0.0-alpha.4                                                                 |
| Go Version     | go1.22.0                                                                       |
| Revision       | 1b288a0a1a37c849a4edc22430b372e8469308ec                                       |
| Modified       | true                                                                           |
| -buildmode     | exe                                                                            |
| -compiler      | gc                                                                             |
| CGO_CFLAGS     |                                                                                |
| CGO_CPPFLAGS   |                                                                                |
| CGO_CXXFLAGS   |                                                                                |
| CGO_ENABLED    | 1                                                                              |
| CGO_LDFLAGS    |                                                                                |
| DefaultGODEBUG | httplaxcontentlength=1,httpmuxgo121=1,tls10server=1,tlsrsakex=1,tlsunsafeekm=1 |
| GOAMD64        | v1                                                                             |
| GOARCH         | amd64                                                                          |
| GOOS           | linux                                                                          |
| vcs            | git                                                                            |
| vcs.modified   | true                                                                           |
| vcs.revision   | 1b288a0a1a37c849a4edc22430b372e8469308ec                                       |
| vcs.time       | 2024-04-23T14:32:21Z                                                           |
└─────────────────────────────────────────────────────────────────────────────────────────────────┘

# Dependencies
┌───────────────────────────┐
| gcc        | 13.2.1-5     |
| libgtk-3   | 1:3.24.41-1  |
| libwebkit  | 2.42.5-2     |
| npm        | 10.5.0       |
| pkg-config | 2.1.0-2      |
└─ * - Optional Dependency ─┘

# Diagnosis
 SUCCESS  Your system is ready for Wails development!
```

# Checklist:

- [ ] I have updated `website/src/pages/changelog.mdx` with details of this PR
- [x] My code follows the general coding style of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
