### PR TITLE
Fixed issue where createFrom would misidentify strings as arrays

### DIFF
--- a/v2/internal/binding/binding_test/binding_anonymous_sub_struct_multi_level_test.go
+++ b/v2/internal/binding/binding_test/binding_anonymous_sub_struct_multi_level_test.go
@@ -45,7 +45,7 @@ export namespace binding_test {
 			if (!a) {
 				return a;
 			}
-			if (a.slice) {
+			if (a.slice && a.map) {
 				return (a as any[]).map(elem => this.convertValues(elem, classs));
 			} else if ("object" === typeof a) {
 				if (asMap) {

--- a/v2/internal/binding/binding_test/binding_anonymous_sub_struct_test.go
+++ b/v2/internal/binding/binding_test/binding_anonymous_sub_struct_test.go
@@ -39,7 +39,7 @@ export namespace binding_test {
 			if (!a) {
 				return a;
 			}
-			if (a.slice) {
+			if (a.slice && a.map) {
 				return (a as any[]).map(elem => this.convertValues(elem, classs));
 			} else if ("object" === typeof a) {
 				if (asMap) {

--- a/v2/internal/binding/binding_test/binding_emptystruct_test.go
+++ b/v2/internal/binding/binding_test/binding_emptystruct_test.go
@@ -34,7 +34,7 @@ export namespace binding_test {
 				return a;
 			}
 
-			if (a.slice) {
+			if (a.slice && a.map) {
 				return (a as any[]).map(elem => this.convertValues(elem, classs));
 			} else if ("object" === typeof a) {
 				if (asMap) {

--- a/v2/internal/binding/binding_test/binding_importedmap_test.go
+++ b/v2/internal/binding/binding_test/binding_importedmap_test.go
@@ -32,7 +32,7 @@ export namespace binding_test {
 			if (!a) {
 				return a;
 			}
-			if (a.slice) {
+			if (a.slice && a.map) {
 				return (a as any[]).map(elem => this.convertValues(elem, classs));
 			} else if ("object" === typeof a) {
 				if (asMap) {
@@ -62,7 +62,7 @@ export namespace binding_test_import {
 			if (!a) {
 				return a;
 			}
-			if (a.slice) {
+			if (a.slice && a.map) {
 				return (a as any[]).map(elem => this.convertValues(elem, classs));
 			} else if ("object" === typeof a) {
 				if (asMap) {

--- a/v2/internal/binding/binding_test/binding_importedslice_test.go
+++ b/v2/internal/binding/binding_test/binding_importedslice_test.go
@@ -32,7 +32,7 @@ export namespace binding_test {
 			if (!a) {
 				return a;
 			}
-			if (a.slice) {
+			if (a.slice && a.map) {
 				return (a as any[]).map(elem => this.convertValues(elem, classs));
 			} else if ("object" === typeof a) {
 				if (asMap) {
@@ -62,7 +62,7 @@ export namespace binding_test_import {
 			if (!a) {
 				return a;
 			}
-			if (a.slice) {
+			if (a.slice && a.map) {
 				return (a as any[]).map(elem => this.convertValues(elem, classs));
 			} else if ("object" === typeof a) {
 				if (asMap) {

--- a/v2/internal/binding/binding_test/binding_importedstruct_test.go
+++ b/v2/internal/binding/binding_test/binding_importedstruct_test.go
@@ -33,7 +33,7 @@ export namespace binding_test {
 				return a;
 			}
 
-			if (a.slice) {
+			if (a.slice && a.map) {
 				return (a as any[]).map(elem => this.convertValues(elem, classs));
 			} else if ("object" === typeof a) {
 				if (asMap) {
@@ -63,7 +63,7 @@ export namespace binding_test_import {
 			if (!a) {
 				return a;
 			}
-			if (a.slice) {
+			if (a.slice && a.map) {
 				return (a as any[]).map(elem => this.convertValues(elem, classs));
 			} else if ("object" === typeof a) {
 				if (asMap) {

--- a/v2/internal/binding/binding_test/binding_nestedfield_test.go
+++ b/v2/internal/binding/binding_test/binding_nestedfield_test.go
@@ -44,7 +44,7 @@ export namespace binding_test {
 			if (!a) {
 				return a;
 			}
-			if (a.slice) {
+			if (a.slice && a.map) {
 				return (a as any[]).map(elem => this.convertValues(elem, classs));
 			} else if ("object" === typeof a) {
 				if (asMap) {

--- a/v2/internal/binding/binding_test/binding_tsgeneration_test.go
+++ b/v2/internal/binding/binding_test/binding_tsgeneration_test.go
@@ -107,7 +107,7 @@ export namespace binding_test {
 						if (!a) {
 							return a;
 						}
-						if (a.slice) {
+						if (a.slice && a.map) {
 							return (a as any[]).map(elem => this.convertValues(elem, classs));
 						} else if ("object" === typeof a) {
 							if (asMap) {
@@ -172,7 +172,7 @@ export namespace binding_test {
             		    if (!a) {
             		        return a;
             		    }
-            		    if (a.slice) {
+            		    if (a.slice && a.map) {
             		        return (a as any[]).map(elem => this.convertValues(elem, classs));
             		    } else if ("object" === typeof a) {
             		        if (asMap) {
@@ -204,7 +204,7 @@ export namespace binding_test {
             		    if (!a) {
             		        return a;
             		    }
-            		    if (a.slice) {
+            		    if (a.slice && a.map) {
             		        return (a as any[]).map(elem => this.convertValues(elem, classs));
             		    } else if ("object" === typeof a) {
             		        if (asMap) {
@@ -239,7 +239,7 @@ export namespace binding_test {
             		    if (!a) {
             		        return a;
             		    }
-            		    if (a.slice) {
+            		    if (a.slice && a.map) {
             		        return (a as any[]).map(elem => this.convertValues(elem, classs));
             		    } else if ("object" === typeof a) {
             		        if (asMap) {

--- a/v2/internal/typescriptify/typescriptify.go
+++ b/v2/internal/typescriptify/typescriptify.go
@@ -24,7 +24,7 @@ const (
 	if (!a) {
 		return a;
 	}
-	if (a.slice) {
+	if (a.slice && a.map) {
 		return (a as any[]).map(elem => this.convertValues(elem, classs));
 	} else if ("object" === typeof a) {
 		if (asMap) {

--- a/website/docs/howdoesitwork.mdx
+++ b/website/docs/howdoesitwork.mdx
@@ -418,7 +418,7 @@ export namespace main {
       if (!a) {
         return a;
       }
-      if (a.slice) {
+      if (a.slice && a.map) {
         return (a as any[]).map((elem) => this.convertValues(elem, classs));
       } else if ("object" === typeof a) {
         if (asMap) {

--- a/website/src/pages/changelog.mdx
+++ b/website/src/pages/changelog.mdx
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed an issue where certain calls to createFrom in TypeScript would fail. Changed by [@twonull](https://github.com/twonull) in [PR](https://github.com/wailsapp/wails/pull/3434)
 - Fixed some typos in comments. Changed by [@reallylowest](https://github.com/reallylowest) in [PR](https://github.com/wailsapp/wails/pull/3357)
 - Fixed an issue where the destination file was not properly closed after copying. Changed by [@testwill](https://github.com/testwill) in [PR](https://github.com/wailsapp/wails/pull/3384)
 - Fixed an issue where `xattr` calls were not working. Fixed by [@leaanthony](https://github.com/wailsapp/wails/pull/3328)

--- a/website/src/pages/changelog.mdx
+++ b/website/src/pages/changelog.mdx
@@ -25,7 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fixed an issue where certain calls to createFrom in TypeScript would fail. Changed by [@twonull](https://github.com/twonull) in [PR](https://github.com/wailsapp/wails/pull/3434)
+- Fixed an issue where certain calls to createFrom in TypeScript would fail. Changed by [@twonull](https://github.com/twonull) in [PR](https://github.com/wailsapp/wails/pull/3435)
 - Fixed some typos in comments. Changed by [@reallylowest](https://github.com/reallylowest) in [PR](https://github.com/wailsapp/wails/pull/3357)
 - Fixed an issue where the destination file was not properly closed after copying. Changed by [@testwill](https://github.com/testwill) in [PR](https://github.com/wailsapp/wails/pull/3384)
 - Fixed an issue where `xattr` calls were not working. Fixed by [@leaanthony](https://github.com/wailsapp/wails/pull/3328)


### PR DESCRIPTION
<!--
READ CAREFULLY: Before submitting your PR, please ensure you have created an issue for your PR.
It is essential that you do this so that we can discuss the proposed changes before you spend time on them.
If you do not create an issue, your PR may be rejected without review.
If a relevant issue already exists, please reference it in your PR by including `Fixes #<issue number>` in your PR description.
-->

# Description

Modifies the `convertValues` TypeScript function defined in `v2/internal/typescriptify/typescriptify.go` to check for both .slice() and .map() functions on an array-like variable, fixing an issue where strings were improperly identified as arrays if the field type was any.

Also updates the relevant tests in `v2/internal/binding/binding_test` to reflect this change.

Fixes #3432

## Type of change
  
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

# How Has This Been Tested?
  
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration using `wails doctor`.

I ran the binding generation tests in `v2/internal/binding/binding_test`, as well as attempted to reproduce issue #3432 which ran as expected.

- [ ] Windows
- [x] macOS
- [ ] Linux
  
## Test Configuration

```
# Wails
Version | v2.8.1

# System
┌─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
| OS           | MacOS                                                                                                                                                                                                                                                                                                                                            |
| Version      | 12.6                                                                                                                                                                                                                                                                                                                                             |
| ID           | 21G115                                                                                                                                                                                                                                                                                                                                           |
| Go Version   | go1.21.5                                                                                                                                                                                                                                                                                                                                         |
| Platform     | darwin                                                                                                                                                                                                                                                                                                                                           |
| Architecture | arm64                                                                                                                                                                                                                                                                                                                                            |
| CPU          | Apple M1                                                                                                                                                                                                                                                                                                                                         |
| GPU          | Chipset Model: Apple M1 Type: GPU Bus: Built-In Total Number of Cores: 8 Vendor: Apple (0x106b) Metal Family: Supported, Metal GPUFamily Apple 7 Displays: Color LCD: Display Type: Built-In Retina LCD Resolution: 2560 x 1600 Retina Main Display: Yes Mirror: Off Online: Yes Automatically Adjust Brightness: No Connection Type: Internal   |
| Memory       | 8GB                                                                                                                                                                                                                                                                                                                                              |
└─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘

# Dependencies
┌──────────────────────────────────────────────────────────────────────┐
| Dependency                | Package Name | Status    | Version       |
| Xcode command line tools  | N/A          | Installed | 2395          |
| Nodejs                    | N/A          | Installed | 18.17.1       |
| npm                       | N/A          | Installed | 9.6.7         |
| *Xcode                    | N/A          | Installed | 14.0 (14A309) |
| *upx                      | N/A          | Available |               |
| *nsis                     | N/A          | Available |               |
└────────────────────── * - Optional Dependency ───────────────────────┘

# Diagnosis
Optional package(s) installation details: 
  - upx : Available at https://upx.github.io/
  - nsis : More info at https://wails.io/docs/guides/windows-installer/
```

# Checklist:

- [x] I have updated `website/src/pages/changelog.mdx` with details of this PR
- [x] My code follows the general coding style of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
