### PR TITLE
Fixed an issue where go:embed directives would generate illegal directories

### DIFF
--- a/v2/internal/staticanalysis/staticanalysis.go
+++ b/v2/internal/staticanalysis/staticanalysis.go
@@ -52,24 +52,31 @@ func GetEmbedDetailsForFile(file *ast.File, baseDir string) []*EmbedDetails {
 		for _, c := range comment.List {
 			if strings.HasPrefix(c.Text, "//go:embed") {
 				sl := strings.Split(c.Text, " ")
-				path := ""
-				all := false
 				if len(sl) == 1 {
 					continue
 				}
-				embedPath := strings.TrimSpace(sl[1])
-				switch true {
-				case strings.HasPrefix(embedPath, "all:"):
-					path = strings.TrimPrefix(embedPath, "all:")
-					all = true
-				default:
-					path = embedPath
+				// support for multiple paths in one comment
+				for _, arg := range sl[1:] {
+					embedPath := strings.TrimSpace(arg)
+					// ignores all pattern matching characters except escape sequence
+					if strings.Contains(embedPath, "*") || strings.Contains(embedPath, "?") || strings.Contains(embedPath, "[") {
+						continue
+					}
+					if strings.HasPrefix(embedPath, "all:") {
+						result = append(result, &EmbedDetails{
+							EmbedPath: strings.TrimPrefix(embedPath, "all:"),
+							All:       true,
+							BaseDir:   baseDir,
+						})
+					} else {
+						result = append(result, &EmbedDetails{
+							EmbedPath: embedPath,
+							All:       false,
+							BaseDir:   baseDir,
+						})
+					}
+
 				}
-				result = append(result, &EmbedDetails{
-					EmbedPath: path,
-					All:       all,
-					BaseDir:   baseDir,
-				})
 			}
 		}
 	}

--- a/v2/internal/staticanalysis/staticanalysis_test.go
+++ b/v2/internal/staticanalysis/staticanalysis_test.go
@@ -1,8 +1,9 @@
 package staticanalysis
 
 import (
-	"github.com/stretchr/testify/require"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestGetEmbedDetails(t *testing.T) {
@@ -24,6 +25,10 @@ func TestGetEmbedDetails(t *testing.T) {
 				{
 					EmbedPath: "frontend/dist",
 					All:       true,
+				},
+				{
+					EmbedPath: "frontend/static",
+					All:       false,
 				},
 			},
 			wantErr: false,

--- a/v2/internal/staticanalysis/test/standard/main.go
+++ b/v2/internal/staticanalysis/test/standard/main.go
@@ -8,8 +8,11 @@ import (
 	"github.com/wailsapp/wails/v2/pkg/options/assetserver"
 )
 
-//go:embed all:frontend/dist
+//go:embed all:frontend/dist frontend/static
 var assets embed.FS
+
+//go:embed frontend/src/*.json
+var srcjson embed.FS
 
 func main() {
 	// Create an instance of the app structure

--- a/v2/pkg/commands/build/build.go
+++ b/v2/pkg/commands/build/build.go
@@ -169,16 +169,19 @@ func CreateEmbedDirectories(cwd string, buildOptions *Options) error {
 
 	for _, embedDetail := range embedDetails {
 		fullPath := embedDetail.GetFullPath()
-		if _, err := os.Stat(fullPath); os.IsNotExist(err) {
-			err := os.MkdirAll(fullPath, 0o755)
-			if err != nil {
-				return err
+		// assumes path is directory only if it has no extension
+		if filepath.Ext(fullPath) == "" {
+			if _, err := os.Stat(fullPath); os.IsNotExist(err) {
+				err := os.MkdirAll(fullPath, 0755)
+				if err != nil {
+					return err
+				}
+				f, err := os.Create(filepath.Join(fullPath, "gitkeep"))
+				if err != nil {
+					return err
+				}
+				_ = f.Close()
 			}
-			f, err := os.Create(filepath.Join(fullPath, "gitkeep"))
-			if err != nil {
-				return err
-			}
-			_ = f.Close()
 		}
 	}
 

--- a/v2/pkg/commands/build/build.go
+++ b/v2/pkg/commands/build/build.go
@@ -172,7 +172,7 @@ func CreateEmbedDirectories(cwd string, buildOptions *Options) error {
 		// assumes path is directory only if it has no extension
 		if filepath.Ext(fullPath) == "" {
 			if _, err := os.Stat(fullPath); os.IsNotExist(err) {
-				err := os.MkdirAll(fullPath, 0755)
+				err := os.MkdirAll(fullPath, 0o755)
 				if err != nil {
 					return err
 				}

--- a/website/src/pages/changelog.mdx
+++ b/website/src/pages/changelog.mdx
@@ -25,7 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fixed an issue where embed comments with patterned paths would create illegal directories. Changed by [@twonull](https://github.com/twonull) in [PR](https://github.com/wailsapp/wails/pull/3445)
+- Fixed an issue where embed directives with patterned paths would create illegal directories. Changed by [@twonull](https://github.com/twonull) in [PR](https://github.com/wailsapp/wails/pull/3445)
 - Fixed an issue where certain calls to createFrom in TypeScript would fail. Changed by [@twonull](https://github.com/twonull) in [PR](https://github.com/wailsapp/wails/pull/3435)
 - Fixed some typos in comments. Changed by [@reallylowest](https://github.com/reallylowest) in [PR](https://github.com/wailsapp/wails/pull/3357)
 - Fixed an issue where the destination file was not properly closed after copying. Changed by [@testwill](https://github.com/testwill) in [PR](https://github.com/wailsapp/wails/pull/3384)

--- a/website/src/pages/changelog.mdx
+++ b/website/src/pages/changelog.mdx
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed an issue where embed comments with patterned paths would create illegal directories. Changed by [@twonull](https://github.com/twonull) in [PR](https://github.com/wailsapp/wails/pull/3445)
 - Fixed an issue where certain calls to createFrom in TypeScript would fail. Changed by [@twonull](https://github.com/twonull) in [PR](https://github.com/wailsapp/wails/pull/3435)
 - Fixed some typos in comments. Changed by [@reallylowest](https://github.com/reallylowest) in [PR](https://github.com/wailsapp/wails/pull/3357)
 - Fixed an issue where the destination file was not properly closed after copying. Changed by [@testwill](https://github.com/testwill) in [PR](https://github.com/wailsapp/wails/pull/3384)


### PR DESCRIPTION
<!--
READ CAREFULLY: Before submitting your PR, please ensure you have created an issue for your PR.
It is essential that you do this so that we can discuss the proposed changes before you spend time on them.
If you do not create an issue, your PR may be rejected without review.
If a relevant issue already exists, please reference it in your PR by including `Fixes #<issue number>` in your PR description.
-->

# Description

This PR fixes an issue where valid go:embed directives containing patterns instead of relative paths would result in illegal directories being created. The issue lies in `v2/internal/staticanalysis/staticanalysis.go`, where wails iterates through go:embed comments independently of the compiler. This list of embedded paths are read by `CreateEmbedDirectories` in `v2/pkg/commands/build/build.go` to create embedded directories if they don't exist.

I modified staticanalysis.go's `GetEmbedDetailsForFile` to check for the pattern matching characters used by filepath, excluding the escape character which may flag valid windows paths by accident. These paths are ignored. I also added a check in `CreateEmbedDirectories` to make sure the directory being created has no extension. 

I also added an iterator to `GetEmbedDetailsForFile` for the case that multiple paths are declared in a single comment.

The tests in `staticanalysis_test.go` now check for these additional edge cases of go:embed comments.

Fixes #3436

## Type of change
  
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
  
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration using `wails doctor`.

I added additional embed comments for these edge cases to the example project staticanalysis_test.go uses.

- [x] Windows
- [x] macOS
- [ ] Linux
  
## Test Configuration

```# Wails
Version  | v2.8.1                                  
Revision | b5e72633267e69e83eb0663a9f35e79b364da5e7
Modified | false                                   

# System
┌─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
| OS           | MacOS                                                                                                                                                                                                                                                                                                                                            |
| Version      | 12.6                                                                                                                                                                                                                                                                                                                                             |
| ID           | 21G115                                                                                                                                                                                                                                                                                                                                           |
| Go Version   | go1.21.5                                                                                                                                                                                                                                                                                                                                         |
| Platform     | darwin                                                                                                                                                                                                                                                                                                                                           |
| Architecture | arm64                                                                                                                                                                                                                                                                                                                                            |
| CPU          | Apple M1                                                                                                                                                                                                                                                                                                                                         |
| GPU          | Chipset Model: Apple M1 Type: GPU Bus: Built-In Total Number of Cores: 8 Vendor: Apple (0x106b) Metal Family: Supported, Metal GPUFamily Apple 7 Displays: Color LCD: Display Type: Built-In Retina LCD Resolution: 2560 x 1600 Retina Main Display: Yes Mirror: Off Online: Yes Automatically Adjust Brightness: No Connection Type: Internal   |
| Memory       | 8GB                                                                                                                                                                                                                                                                                                                                              |
└─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘

# Dependencies
┌──────────────────────────────────────────────────────────────────────┐
| Dependency                | Package Name | Status    | Version       |
| Xcode command line tools  | N/A          | Installed | 2395          |
| Nodejs                    | N/A          | Installed | 18.17.1       |
| npm                       | N/A          | Installed | 9.6.7         |
| *Xcode                    | N/A          | Installed | 14.0 (14A309) |
| *upx                      | N/A          | Available |               |
| *nsis                     | N/A          | Available |               |
└────────────────────── * - Optional Dependency ───────────────────────┘

# Diagnosis
Optional package(s) installation details: 
  - upx : Available at https://upx.github.io/
  - nsis : More info at https://wails.io/docs/guides/windows-installer/
```

# Checklist:

- [x] I have updated `website/src/pages/changelog.mdx` with details of this PR
- [x] My code follows the general coding style of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
