### PR TITLE
[v3] Correct detection of npm with acceptable version

### DIFF
--- a/mkdocs-website/docs/en/changelog.md
+++ b/mkdocs-website/docs/en/changelog.md
@@ -64,6 +64,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix registering events causing a nil map assignment by [@hfoxy](https://github.com/hfoxy) in [#3426](https://github.com/wailsapp/wails/pull/3426)
 - Fix unmarshaling of bound method parameters by [@fbbdev](https://github.com/fbbdev) in [#3431](https://github.com/wailsapp/wails/pull/3431)
 - Fix handling of multiple return values from bound methods by [@fbbdev](https://github.com/fbbdev) in [#3431](https://github.com/wailsapp/wails/pull/3431)
+- Fix doctor detection of npm that is not installed with system package manager by [@pekim](https://github.com/pekim) in [#3458](https://github.com/wailsapp/wails/pull/3458)
 
 ### Changed
 

--- a/v3/internal/doctor/doctor_common.go
+++ b/v3/internal/doctor/doctor_common.go
@@ -23,6 +23,8 @@ func checkCommonDependencies(result map[string]string, ok *bool) {
 			if major < 7 {
 				*ok = false
 				npmVersion = append(npmVersion, []byte(". Installed, but requires npm >= 7.0.0")...)
+			} else {
+				*ok = true
 			}
 		}
 	}


### PR DESCRIPTION
<!--
READ CAREFULLY: Before submitting your PR, please ensure you have created an issue for your PR.
It is essential that you do this so that we can discuss the proposed changes before you spend time on them.
If you do not create an issue, your PR may be rejected without review.
If a relevant issue already exists, please reference it in your PR by including `Fixes #<issue number>` in your PR description.
-->

# Description

The doctor command reports `# Diagnosis WARNING  There are some items above that need addressing!` if npm is **not found** with the system package manager, but **is found** to be available on the path with `exec.Command`.

Not only is there the warning, but there is nothing in the doctor output to indicate what the problem is. That's because there isn't really a problem, it's just that the fact that npm has been found is not propagated back to the caller of `checkCommonDependencies`.

```
# System
┌──────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
| Name         | Fedora Linux                                                                                      |
| Version      | 39                                                                                                |
| ID           | fedora                                                                                            |
| Branding     | 39 (Workstation Edition)                                                                          |
| Platform     | linux                                                                                             |
| Architecture | amd64                                                                                             |
| CPU          | AMD Ryzen 7 5800X 8-Core Processor                                                                |
| GPU 1        | Navi 24 [Radeon RX 6400/6500 XT/6500M] (Advanced Micro Devices, Inc. [AMD/ATI]) - Driver: amdgpu  |
| Memory       | 32GB                                                                                              |
└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘

# Build Environment
┌─────────────────────────────────────────────────────────────────────────────────────────────────┐
| Wails CLI      | v3.0.0-alpha.4                                                                 |
| Go Version     | go1.22.2                                                                       |
| Revision       | 2c29e1ca76b21615dd707eb17600a265e0ff3e7b                                       |
| Modified       | false                                                                          |
| -buildmode     | exe                                                                            |
| -compiler      | gc                                                                             |
| CGO_CFLAGS     |                                                                                |
| CGO_CPPFLAGS   |                                                                                |
| CGO_CXXFLAGS   |                                                                                |
| CGO_ENABLED    | 1                                                                              |
| CGO_LDFLAGS    |                                                                                |
| DefaultGODEBUG | httplaxcontentlength=1,httpmuxgo121=1,tls10server=1,tlsrsakex=1,tlsunsafeekm=1 |
| GOAMD64        | v1                                                                             |
| GOARCH         | amd64                                                                          |
| GOOS           | linux                                                                          |
| vcs            | git                                                                            |
| vcs.modified   | false                                                                          |
| vcs.revision   | 2c29e1ca76b21615dd707eb17600a265e0ff3e7b                                       |
| vcs.time       | 2024-05-05T07:27:53Z                                                           |
└─────────────────────────────────────────────────────────────────────────────────────────────────┘

# Dependencies
┌───────────────────────────┐
| gcc        | 13.2.1       |
| libgtk-3   | 3.24.41      |
| libwebkit  | 2.44.1       |
| npm        | 10.7.0       |
| pkg-config | 1.9.5        |
└─ * - Optional Dependency ─┘

# Diagnosis
 WARNING  There are some items above that need addressing!
```

## Type of change
  
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
  
Running `wails3 doctor` once the fix has been applied, result in the correct SUCCESS message.
```
# System
┌──────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
| Name         | Fedora Linux                                                                                      |
| Version      | 39                                                                                                |
| ID           | fedora                                                                                            |
| Branding     | 39 (Workstation Edition)                                                                          |
| Platform     | linux                                                                                             |
| Architecture | amd64                                                                                             |
| CPU          | AMD Ryzen 7 5800X 8-Core Processor                                                                |
| GPU 1        | Navi 24 [Radeon RX 6400/6500 XT/6500M] (Advanced Micro Devices, Inc. [AMD/ATI]) - Driver: amdgpu  |
| Memory       | 32GB                                                                                              |
└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘

# Build Environment
┌─────────────────────────────────────────────────────────────────────────────────────────────────┐
| Wails CLI      | v3.0.0-alpha.4                                                                 |
| Go Version     | go1.22.2                                                                       |
| Revision       | 097e0f19d56afb072d80bcc590aafecd942847c7                                       |
| Modified       | false                                                                          |
| -buildmode     | exe                                                                            |
| -compiler      | gc                                                                             |
| CGO_CFLAGS     |                                                                                |
| CGO_CPPFLAGS   |                                                                                |
| CGO_CXXFLAGS   |                                                                                |
| CGO_ENABLED    | 1                                                                              |
| CGO_LDFLAGS    |                                                                                |
| DefaultGODEBUG | httplaxcontentlength=1,httpmuxgo121=1,tls10server=1,tlsrsakex=1,tlsunsafeekm=1 |
| GOAMD64        | v1                                                                             |
| GOARCH         | amd64                                                                          |
| GOOS           | linux                                                                          |
| vcs            | git                                                                            |
| vcs.modified   | false                                                                          |
| vcs.revision   | 097e0f19d56afb072d80bcc590aafecd942847c7                                       |
| vcs.time       | 2024-05-05T15:04:29Z                                                           |
└─────────────────────────────────────────────────────────────────────────────────────────────────┘

# Dependencies
┌───────────────────────────┐
| libgtk-3   | 3.24.41      |
| libwebkit  | 2.44.1       |
| npm        | 10.7.0       |
| pkg-config | 1.9.5        |
| gcc        | 13.2.1       |
└─ * - Optional Dependency ─┘

# Diagnosis
 SUCCESS  Your system is ready for Wails development!
```

- [ ] Windows
- [ ] macOS
- [x] Linux
  
## Test Configuration

See the above two outputs of doctor, before and after the fix.

# Checklist:

- [x] I have updated `website/src/pages/changelog.mdx` with details of this PR
- [x] My code follows the general coding style of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
