### PR TITLE
Add "wails-lit-shoelace-esbuild-template" to community templates page

### DIFF
--- a/website/docs/community/templates.mdx
+++ b/website/docs/community/templates.mdx
@@ -67,3 +67,8 @@ If you are unsure about a template, inspect `package.json` and `wails.json` for 
 ## Pure JavaScript (Vanilla)
 
 - [wails-pure-js-template](https://github.com/KiddoV/wails-pure-js-template) - A template with nothing but just basic JavaScript, HTML, and CSS
+
+
+## Lit (web components)
+
+- [wails-lit-shoelace-esbuild-template](https://github.com/Braincompiler/wails-lit-shoelace-esbuild-template) - Wails template providing frontend with lit, Shoelace component library + pre-configured prettier and typescript.


### PR DESCRIPTION
# Description

This PR just adds the [wails-lit-shoelace-esbuild-template](https://github.com/Braincompiler/wails-lit-shoelace-esbuild-template) template to the community templates page.

## Type of change
  
- [x] Add new template to the community templates page
