### PR TITLE
Documentation: Add guide on TypeScript type generation

### DIFF
--- a/website/docs/guides/troubleshooting.mdx
+++ b/website/docs/guides/troubleshooting.mdx
@@ -119,11 +119,11 @@ go env -w GOPROXY=https://goproxy.cn,direct
 
 Source: https://github.com/wailsapp/wails/issues/1233
 
-## The generated TypeScript doesn't have the correct types
+## TypeScript generation fails or has incorrect types
 
-Sometimes the generated TypeScript doesn't have the correct types. To mitigate this,
-it is possible to specify what types should be generated using the `ts_type` struct tag. For
-more details, please read [this](https://github.com/tkrajina/typescriptify-golang-structs#custom-types).
+Sometimes Wails' TypeScript generator encounters a type it is unable to handle properly. 
+To mitigate this, it is possible to specify what types should be generated using the `ts_type` struct tag. 
+For more information please read the [TypeScript guide](https://wails.io/docs/guides/typescript).
 
 ## When I navigate away from `index.html`, I am unable to call methods on the frontend
 

--- a/website/docs/guides/troubleshooting.mdx
+++ b/website/docs/guides/troubleshooting.mdx
@@ -123,7 +123,7 @@ Source: https://github.com/wailsapp/wails/issues/1233
 
 Sometimes Wails' TypeScript generator encounters a type it is unable to handle properly. 
 To mitigate this, it is possible to specify what types should be generated using the `ts_type` struct tag. 
-For more information please read the [TypeScript guide](https://wails.io/docs/guides/typescript).
+For more information please read the [TypeScript guide](https://wails.io/docs/guides/typescript-generation).
 
 ## When I navigate away from `index.html`, I am unable to call methods on the frontend
 

--- a/website/docs/guides/typescript-generation.mdx
+++ b/website/docs/guides/typescript-generation.mdx
@@ -1,4 +1,4 @@
-# TypeScript
+# TypeScript Generation
 
 This guide provides tips to generate TypeScript types for your bound Go structs.
 

--- a/website/docs/guides/typescript.mdx
+++ b/website/docs/guides/typescript.mdx
@@ -1,0 +1,94 @@
+# TypeScript
+
+This guide provides tips to generate TypeScript types for your bound Go structs.
+
+## Background
+
+As described in [How does it work?](https://wails.io/docs/howdoesitwork), structs can be passed from Go functions to the frontend 
+and vice versa. These structs take the form of JSON objects in transit. In order to take advantage of TypeScript's type safety features, 
+Wails will generate equivalent TypeScript classes for each struct during compilation. These generated classes can be imported from 
+`frontend/wailsjs/go/models.ts`.
+
+## TypeScript Generator
+
+Wails includes a TypeScript type generator based on [typescriptify](https://github.com/tkrajina/typescriptify-golang-structs). 
+Go's numerics, booleans, and strings as well as slices, arrays, structs, and maps will be automatically converted to their
+TypeScript equivalents. The following is a dictionary of common Go types:
+
+| Go Type                             | TypeScript Equivalent |
+| ----------------------------------- | --------------------- |
+| int, int8, int16, int32, int64      | number                |
+| uint, uint8, uint16, uint32, uint64 | number                |
+| byte, rune                          | number                |
+| float32, float64                    | number                |
+| bool                                | boolean               |
+| string                              | string                |
+| interface{}                         | any                   |
+| map[string]T                        | {[key: string]: T}    |
+| []T  (slice)                        | T[]                   |
+| [n]T (array)                        | T[]                   |
+| struct                              | class                 |
+
+:::warning
+
+The numerics `complex64` and `complex128` are currently unsupported and any structs containing 
+these types will fail to generate. You must use the [**ts type**](#ts_type) struct tag on these fields.
+
+:::
+
+The majority of structs will generate appropriate TypeScript bindings without modification. 
+For custom types or types that require additional transformations when converted from JSON, Wails provides two struct tags.
+
+## Struct Tags
+
+### ts_type
+
+If your struct field needs a custom TypeScript type but can be constructed from JSON as-is, you can use the `ts_type` tag. 
+For example: 
+
+```go
+type Data struct {
+    Counters map[string]int `json:"counters" ts_type:"CustomType"`
+}
+```
+
+will generate:
+
+```ts
+export class Data {
+    counters: CustomType;
+}
+```
+
+### ts_transform
+
+If your struct field needs special handling to be converted to a JavaScript object such as a call to the object's contructor, 
+you can use the `ts_transform` tag. 
+For example:
+
+```go
+type Data struct {
+    Time time.Time `json:"time" ts_type:"Date" ts_transform:"new Date(__VALUE__)"`
+}
+```
+
+will generate:
+
+```ts
+export class Date {
+	time: Date;
+
+    constructor(source: any = {}) {
+        if ('string' === typeof source) source = JSON.parse(source);
+        this.time = new Date(source["time"]);
+    }
+}
+```
+
+There is currently no way to import external TypeScript types or functions to your bindings.
+
+## Additional Considerations
+
+We've just discussed how to modify the unmarshalling behavior from Go to your TypeScript bindings, but what if you want to change 
+the unmarshalling behavior from JS/TypeScript to your Go structs? This can be done by implementing an override for the function 
+`UnmarshalJSON()` as defined in [encoding/json](https://pkg.go.dev/encoding/json).

--- a/website/src/pages/changelog.mdx
+++ b/website/src/pages/changelog.mdx
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added docs on TypeScript generation/Typescriptify struct tags. Added by [@twonull](https://github.com/twonull) in [PR](https://github.com/wailsapp/wails/pull/3445)
 - Added docs help to indicate that in IDE options you can choose between vscode and goland. Added by @DiegPS in [PR](https://github.com/wailsapp/wails/pull/3419)
 - Added docs to help fix NixOs/Wayland font-size css issue. Added by @atterpac in [PR](https://github.com/wailsapp/wails/pull/3268)
 - Added -m (skip `go mod tidy`) flag to dev command by @te5se in [PR](https://github.com/wailsapp/wails/pull/3275)

--- a/website/src/pages/changelog.mdx
+++ b/website/src/pages/changelog.mdx
@@ -26,7 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Added docs on TypeScript generation/Typescriptify struct tags. Added by [@twonull](https://github.com/twonull) in [PR](https://github.com/wailsapp/wails/pull/3445)
+- Added docs on TypeScript generation/Typescriptify struct tags. Added by [@twonull](https://github.com/twonull) in [PR](https://github.com/wailsapp/wails/pull/3460)
 - Added docs help to indicate that in IDE options you can choose between vscode and goland. Added by @DiegPS in [PR](https://github.com/wailsapp/wails/pull/3419)
 - Added docs to help fix NixOs/Wayland font-size css issue. Added by @atterpac in [PR](https://github.com/wailsapp/wails/pull/3268)
 - Added -m (skip `go mod tidy`) flag to dev command by @te5se in [PR](https://github.com/wailsapp/wails/pull/3275)


### PR DESCRIPTION
<!--
READ CAREFULLY: Before submitting your PR, please ensure you have created an issue for your PR.
It is essential that you do this so that we can discuss the proposed changes before you spend time on them.
If you do not create an issue, your PR may be rejected without review.
If a relevant issue already exists, please reference it in your PR by including `Fixes #<issue number>` in your PR description.
-->

# Description

Wails' TypeScript generator has a number of quirks that make types like slices of arrays, complex primitives, and times/dates not generate as expected. While it's difficult for the generator to handle every edge case, Typescriptify (and Wails' Typescriptify fork) provides struct tags for developers to specify their own TS types and Go->TS conversions. The docs previously linked the Typescriptify readme from within the troubleshooting section, but a dedicated guide is preferable because Typescriptify's main branch diverges from the features available in Wails.

The TypeScript Generation page includes a table of default conversion behavior, as well as a section explaining the functionality of the `ts_type` and `ts_transform` struct tags. If more features such as `AddImport` or `ts_doc` are implemented, they can be added to this section of the guide.

Fixes Incomplete Documentation

## Type of change
  
Please delete options that are not relevant.

- [x] This change requires a documentation update

# How Has This Been Tested?
  
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration using `wails doctor`.

- [ ] Windows
- [x] macOS
- [ ] Linux
  
## Test Configuration

Not relevant

# Checklist:

- [x] I have updated `website/src/pages/changelog.mdx` with details of this PR
- [x] My code follows the general coding style of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
