### PR TITLE
Bump Go to 1.22 in pipelines

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest, macos-11]
-        go-version: ['1.20']
+        go-version: ['1.22']
 
     steps:
       - name: Checkout code
@@ -90,7 +90,7 @@ jobs:
             vanilla-ts,
             plain,
           ]
-        go-version: ['1.20']
+        go-version: ['1.22']
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/website/src/pages/changelog.mdx
+++ b/website/src/pages/changelog.mdx
@@ -17,6 +17,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Support for compiling with `libwebkit2gtk-4.1` instead of `4.0` to support latest Ubuntu release by [atterpac](https://github.com/atterpac) in [#3465](https://github.com/wailsapp/wails/pull/3465)
 
+### Changed
+- Upgraded Go version in CI to 1.22 by [@leaanthony](https://github.com/leaanthony) in [#3473](https://github.com/wailsapp/wails/pull/3473).
+
 ## v2.8.2 - 2024-05-08
 
 ### Breaking Change


### PR DESCRIPTION

# Description

Fix pipeline build errors by bumping to Go 1.22