### PR TITLE
Fix window position inconsistency in MacOS

### DIFF
--- a/v2/internal/frontend/desktop/darwin/WailsContext.m
+++ b/v2/internal/frontend/desktop/darwin/WailsContext.m
@@ -55,7 +55,7 @@ typedef void (^schemeTaskCaller)(id<WKURLSchemeTask>);
     
     NSScreen* screen = [self getCurrentScreen];
     NSRect windowFrame = [self.mainWindow frame];
-    NSRect screenFrame = [screen frame];
+    NSRect screenFrame = [screen visibleFrame];
     windowFrame.origin.x = screenFrame.origin.x + (float)x;
     windowFrame.origin.y = (screenFrame.origin.y + screenFrame.size.height) - windowFrame.size.height - (float)y;
     

--- a/website/src/pages/changelog.mdx
+++ b/website/src/pages/changelog.mdx
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Fixed optional type generation where an extra `?` would be placed inside the field name instead of outside the name `"field?"?` vs `"field"?`. Fixed  by [@atterpac](https://github.com/atterpac) in [#3476](https://github.com/wailsapp/wails/pull/3476)
+- Fixed an issue where `WindowGetPosition` and `WindowSetPosition` values were inconsistent on MacOS. Fixed by [@cenan](https://github.com/wailsapp/wails/pull/3479)
 
 ## v2.8.2 - 2024-05-08
 


### PR DESCRIPTION
<!--
READ CAREFULLY: Before submitting your PR, please ensure you have created an issue for your PR.
It is essential that you do this so that we can discuss the proposed changes before you spend time on them.
If you do not create an issue, your PR may be rejected without review.
If a relevant issue already exists, please reference it in your PR by including `Fixes #<issue number>` in your PR description.
-->

# Description

There is an inconsistency of window position values on MacOS. When getting the window position using `runtime.WindowGetPosition()` and setting it back using `runtime.WindowSetPosition()` the `y` value decrements. This is caused by using different screen frame sizes while reading and writing window positions.

We are using `[screen frame]` while setting the position and using `[screen visibleFrame]` while reading it.

`frame` property returns the fullscreen rectangle of the screen, while `visibleFrame` returns the area not occupied by dock and menubar.

I have changed `[screen frame]` to `[screen visibleFrame]` in `v2/internal/frontend/desktop/darwin/WailsContext.m` and the issue seems to be fixed on my tests.

Fixes #3478 

## Type of change
  
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
  
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration using `wails doctor`.

- [ ] Windows
- [x] macOS
- [ ] Linux
  
## Test Configuration

```
# Wails
Version  | v2.8.2
Revision | 43f0dd6624ba477bc9aba75cef63790e8928b6e5
Modified | true

# System
┌────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
| OS           | MacOS                                                                                                                       |
| Version      | 14.4.1                                                                                                                      |
| ID           | 23E224                                                                                                                      |
| Go Version   | go1.22.2                                                                                                                    |
| Platform     | darwin                                                                                                                      |
| Architecture | arm64                                                                                                                       |
| CPU          | Apple M1 Pro                                                                                                                |
| GPU          | Chipset Model: Apple M1 Pro Type: GPU Bus: Built-In Total Number of Cores: 14 Vendor: Apple (0x106b) Metal Support: Metal 3 |
| Memory       | 16GB                                                                                                                        |
└────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘

# Dependencies
┌───────────────────────────────────────────────────────────────────────┐
| Dependency                | Package Name | Status    | Version        |
| Xcode command line tools  | N/A          | Installed | 2406           |
| Nodejs                    | N/A          | Installed | 20.11.1        |
| npm                       | N/A          | Installed | 10.2.4         |
| *Xcode                    | N/A          | Installed | 15.3 (15E204a) |
| *upx                      | N/A          | Available |                |
| *nsis                     | N/A          | Available |                |
└─────────────────────── * - Optional Dependency ───────────────────────┘

# Diagnosis
Optional package(s) installation details:
  - upx : Available at https://upx.github.io/
  - nsis : More info at https://wails.io/docs/guides/windows-installer/

 SUCCESS  Your system is ready for Wails development!
```

# Checklist:

- [x] I have updated `website/src/pages/changelog.mdx` with details of this PR
- [x] My code follows the general coding style of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
