### PR TITLE
Use NewSingleHostReverseProxy

### DIFF
--- a/v2/pkg/assetserver/assethandler_external.go
+++ b/v2/pkg/assetserver/assethandler_external.go
@@ -3,12 +3,10 @@ package assetserver
 import (
 	"errors"
 	"fmt"
+	"github.com/wailsapp/wails/v2/pkg/options/assetserver"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
-	"runtime"
-
-	"github.com/wailsapp/wails/v2/pkg/options/assetserver"
 )
 
 func NewProxyServer(proxyURL string) http.Handler {
@@ -16,10 +14,7 @@ func NewProxyServer(proxyURL string) http.Handler {
 	if err != nil {
 		panic(err)
 	}
-	return NewExternalAssetsHandler(nil,
-		assetserver.Options{},
-		parsedURL)
-
+	return httputil.NewSingleHostReverseProxy(parsedURL)
 }
 
 func NewExternalAssetsHandler(logger Logger, options assetserver.Options, url *url.URL) http.Handler {
@@ -68,7 +63,7 @@ func NewExternalAssetsHandler(logger Logger, options assetserver.Options, url *u
 
 	var result http.Handler = http.HandlerFunc(
 		func(rw http.ResponseWriter, req *http.Request) {
-			if runtime.GOOS == "darwin" || req.Method == http.MethodGet {
+			if req.Method == http.MethodGet {
 				proxy.ServeHTTP(rw, req)
 				return
 			}


### PR DESCRIPTION
<!--
READ CAREFULLY: Before submitting your PR, please ensure you have created an issue for your PR.
It is essential that you do this so that we can discuss the proposed changes before you spend time on them.
If you do not create an issue, your PR may be rejected without review.
If a relevant issue already exists, please reference it in your PR by including `Fixes #<issue number>` in your PR description.
-->

# Description

This PR alters how the `NewProxyServer` method is implemented under the hood. It should still function as normal. This was done to revert the way default middleware would work on non-mac platforms.
