### PR TITLE
[V3/Linux] swap position window function to match other OS's functionality

### DIFF
--- a/v3/pkg/application/systemtray_linux.go
+++ b/v3/pkg/application/systemtray_linux.go
@@ -221,38 +221,34 @@ func (s *linuxSystemTray) setMenu(menu *Menu) {
 }
 
 func (s *linuxSystemTray) positionWindow(window *WebviewWindow, offset int) error {
-	// Get the mouse location on the screen
-	mouseX, mouseY, currentScreen := getMousePosition()
-	screenBounds := currentScreen.Size
-
-	// Calculate new X position
-	newX := mouseX - (window.Width() / 2)
-
-	// Check if the window goes out of the screen bounds on the left side
-	if newX < 0 {
-		newX = 0
+	// Get the trayBounds of this system tray
+	trayBounds, err := s.bounds()
+	if err != nil {
+		return err
 	}
 
-	// Check if the window goes out of the screen bounds on the right side
-	if newX+window.Width() > screenBounds.Width {
-		newX = screenBounds.Width - window.Width()
+	// Get the current screen trayBounds
+	currentScreen, err := s.getScreen()
+	if err != nil {
+		return err
 	}
+	screenBounds := currentScreen.Bounds
 
-	// Calculate new Y position
-	newY := mouseY - (window.Height() / 2)
+	// Get the center height of the window
+	windowWidthCenter := window.Width() / 2
 
-	// Check if the window goes out of the screen bounds on the top
-	if newY < 0 {
-		newY = 0
+	// Get the center height of the system tray
+	systemTrayWidthCenter := trayBounds.Width / 2
+
+	// The Y will be 0 and the X will make the center of the window line up with the center of the system tray
+	windowX := trayBounds.X + systemTrayWidthCenter - windowWidthCenter
+
+	// If the end of the window goes off-screen, move it back enough to be on screen
+	if windowX+window.Width() > screenBounds.Width {
+		windowX = screenBounds.Width - window.Width()
 	}
+	window.SetRelativePosition(windowX, offset)
 
-	// Check if the window goes out of the screen bounds on the bottom
-	if newY+window.Height() > screenBounds.Height {
-		newY = screenBounds.Height - window.Height() - offset
-	}
-
-	// Set the new position of the window
-	window.SetAbsolutePosition(newX, newY)
 	return nil
 }
 


### PR DESCRIPTION
The `positionWindow` function differed in the linux version in comparison to the windows and mac versions. Both windows and mac used this to offset a systemtray from the menus location. While the linux version would create it based off the offset of the mouse position.

Fixes # (issue)
- Brought up in discord no issue.
## Type of change
  
Please delete options that are not relevant.

- [X ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
  
```
# System
┌──────────────────────────────────────────────────────────────────────────────────────────┐
| Name         | Ubuntu                                                                    |
| Version      | 24.04                                                                     |
| ID           | ubuntu                                                                    |
| Branding     | 24.04 LTS (Noble Numbat)                                                  |
| Platform     | linux                                                                     |
| Architecture | amd64                                                                     |
| CPU          | 12th Gen Intel(R) Core(TM) i5-1235U                                       |
| GPU 1        | Alder Lake-UP3 GT2 [Iris Xe Graphics] (Intel Corporation) - Driver: i915  |
| Memory       | 7GB                                                                       |
└──────────────────────────────────────────────────────────────────────────────────────────┘

# Build Environment
┌─────────────────────────────────────────────────────────┐
| Wails CLI    | v3.0.0-alpha.4                           |
| Go Version   | go1.22.2                                 |
| Revision     | 71b2edc0fef81340815c923e33b16dd2e25e2a0e |
| Modified     | false                                    |
| -buildmode   | exe                                      |
| -compiler    | gc                                       |
| CGO_CFLAGS   |                                          |
| CGO_CPPFLAGS |                                          |
| CGO_CXXFLAGS |                                          |
| CGO_ENABLED  | 1                                        |
| CGO_LDFLAGS  |                                          |
| GOAMD64      | v1                                       |
| GOARCH       | amd64                                    |
| GOOS         | linux                                    |
| vcs          | git                                      |
| vcs.modified | false                                    |
| vcs.revision | 71b2edc0fef81340815c923e33b16dd2e25e2a0e |
| vcs.time     | 2024-05-08T08:08:14Z                     |
└─────────────────────────────────────────────────────────┘

# Dependencies
┌──────────────────────────────────────────────────────────────────────────────────┐
| libgtk-3   | 3.24.41-4ubuntu1                                                    |
| libwebkit  | not installed. Install with: sudo apt install libwebkit2gtk-4.0-dev |
| npm        | 10.5.1                                                              |
| pkg-config | 1.8.1-2build1                                                       |
| gcc        | 12.10ubuntu1                                                        |
└──────────────────────────── * - Optional Dependency ─────────────────────────────┘
```