### PR TITLE
[WEP] Customise Window Titlebars

### DIFF
--- a/mkdocs-website/docs/en/learn/guides/customising-windows.md
+++ b/mkdocs-website/docs/en/learn/guides/customising-windows.md
@@ -1,0 +1,77 @@
+# Controlling Window Buttons in Wails
+
+Wails provides an API to control the appearance and functionality of the window buttons (minimise, maximise, and close) on the titlebar. This functionality is available on Windows and macOS, but not on Linux.
+
+## Button States
+
+The button states are defined by the `ButtonState` enum:
+
+```go
+type ButtonState int
+
+const (
+    ButtonEnabled   ButtonState = 0
+    ButtonDisabled ButtonState = 1
+    ButtonHidden   ButtonState = 2
+)
+```
+
+- `ButtonEnabled`: The button is enabled and visible.
+- `ButtonDisabled`: The button is visible but disabled (grayed out).
+- `ButtonHidden`: The button is hidden from the titlebar.
+
+## Setting Button States
+
+The button states can be set during window creation or at runtime.
+
+### Setting Button States During Window Creation
+
+When creating a new window, you can set the initial state of the buttons using the `WebviewWindowOptions` struct:
+
+```go
+package main
+
+import (
+	"github.com/wailsapp/wails/v3/pkg/application"
+)
+
+func main() {
+    app := application.New(application.Options{
+		Name:        "My Application",
+	})
+	
+    app.NewWebviewWindowWithOptions(application.WebviewWindowOptions{
+        MinimiseButtonState: application.ButtonHidden,
+        MaximiseButtonState: application.ButtonDisabled,
+        CloseButtonState:    application.ButtonEnabled,
+	})
+	
+	app.Run()
+```
+
+In the example above, the minimise button is hidden, the maximise button is inactive (grayed out), and the close button is active.
+
+### Setting Button States at Runtime
+
+You can also change the button states at runtime using the following methods on the `Window` interface:
+
+```go
+window.SetMinimiseButtonState(wails.ButtonHidden)
+window.SetMaximiseButtonState(wails.ButtonEnabled)
+window.SetCloseButtonState(wails.ButtonDisabled)
+```
+
+## Platform Differences
+
+The button state functionality behaves slightly differently on Windows and macOS:
+
+|                       | Windows                | Mac                    |
+|-----------------------|------------------------|------------------------|
+| Disable Min/Max/Close | Disables Min/Max/Close | Disables Min/Max/Close |
+| Hide Min              | Disables Min           | Hides Min button       |
+| Hide Max              | Disables Max           | Hides Max button       |
+| Hide Close            | Hides all controls     | Hides Close            |
+
+Note: On Windows, it is not possible to hide the Min/Max buttons individually.
+However, disabling both will hide both of the controls and only show the
+close button.

--- a/mkdocs-website/docs/en/learn/guides/customising-windows.md
+++ b/mkdocs-website/docs/en/learn/guides/customising-windows.md
@@ -1,8 +1,9 @@
-# Controlling Window Buttons in Wails
+# Customising Window Controls in Wails
 
-Wails provides an API to control the appearance and functionality of the window buttons (minimise, maximise, and close) on the titlebar. This functionality is available on Windows and macOS, but not on Linux.
+Wails provides an API to control the appearance and functionality of the controls of a window. 
+This functionality is available on Windows and macOS, but not on Linux.
 
-## Button States
+## Setting the Window Button States
 
 The button states are defined by the `ButtonState` enum:
 
@@ -19,8 +20,6 @@ const (
 - `ButtonEnabled`: The button is enabled and visible.
 - `ButtonDisabled`: The button is visible but disabled (grayed out).
 - `ButtonHidden`: The button is hidden from the titlebar.
-
-## Setting Button States
 
 The button states can be set during window creation or at runtime.
 
@@ -47,6 +46,7 @@ func main() {
 	})
 	
 	app.Run()
+}
 ```
 
 In the example above, the minimise button is hidden, the maximise button is inactive (grayed out), and the close button is active.
@@ -61,7 +61,7 @@ window.SetMaximiseButtonState(wails.ButtonEnabled)
 window.SetCloseButtonState(wails.ButtonDisabled)
 ```
 
-## Platform Differences
+### Platform Differences
 
 The button state functionality behaves slightly differently on Windows and macOS:
 
@@ -75,3 +75,37 @@ The button state functionality behaves slightly differently on Windows and macOS
 Note: On Windows, it is not possible to hide the Min/Max buttons individually.
 However, disabling both will hide both of the controls and only show the
 close button.
+
+### Controlling Window Style (Windows)
+
+To control the style of the titlebar on Windows, you can use the `ExStyle` field in the `WebviewWindowOptions` struct:
+
+Example:
+```go
+package main
+
+import (
+	"github.com/wailsapp/wails/v3/pkg/application"
+	"github.com/wailsapp/wails/v3/pkg/w32"
+)
+
+func main() {
+    app := application.New(application.Options{
+		Name: "My Application",
+	})
+	
+    app.NewWebviewWindowWithOptions(application.WebviewWindowOptions{
+        Windows: application.WindowsWindow{
+            ExStyle: w32.WS_EX_TOOLWINDOW | w32.WS_EX_NOREDIRECTIONBITMAP | w32.WS_EX_TOPMOST,
+        },
+	})
+	
+	app.Run()
+}
+```
+
+Other options that affect the Extended Style of a window will be overridden by this setting:
+- HiddenOnTaskbar
+- AlwaysOnTop
+- IgnoreMouseEvents
+- BackgroundType

--- a/mkdocs-website/mkdocs.yml
+++ b/mkdocs-website/mkdocs.yml
@@ -142,6 +142,8 @@ nav:
     - Learn More:
         - Runtime: learn/runtime.md
         - Plugins: learn/plugins.md
+        - Guides:
+            - Customising Windows: learn/guides/customising-windows.md
     - Feedback: getting-started/feedback.md
   - Feedback: getting-started/feedback.md
   - What's New in v3?: whats-new.md

--- a/v3/examples/window/main.go
+++ b/v3/examples/window/main.go
@@ -64,12 +64,7 @@ func main() {
 		myMenu.Add("New WebviewWindow (Disable Minimise)").
 			OnClick(func(ctx *application.Context) {
 				app.NewWebviewWindowWithOptions(application.WebviewWindowOptions{
-					Windows: application.WindowsWindow{
-						DisableMinimiseButton: true,
-					},
-					Mac: application.MacWindow{
-						DisableMinimiseButton: true,
-					},
+					MinimiseButtonState: application.ButtonInactive,
 				}).
 					SetTitle("WebviewWindow "+strconv.Itoa(windowCounter)).
 					SetRelativePosition(rand.Intn(1000), rand.Intn(800)).
@@ -80,12 +75,29 @@ func main() {
 		myMenu.Add("New WebviewWindow (Disable Maximise)").
 			OnClick(func(ctx *application.Context) {
 				app.NewWebviewWindowWithOptions(application.WebviewWindowOptions{
-					Windows: application.WindowsWindow{
-						DisableMaximiseButton: true,
-					},
-					Mac: application.MacWindow{
-						DisableMaximiseButton: true,
-					},
+					MaximiseButtonState: application.ButtonInactive,
+				}).
+					SetTitle("WebviewWindow "+strconv.Itoa(windowCounter)).
+					SetRelativePosition(rand.Intn(1000), rand.Intn(800)).
+					SetURL("https://wails.io").
+					Show()
+				windowCounter++
+			})
+		myMenu.Add("New WebviewWindow (Hide Minimise)").
+			OnClick(func(ctx *application.Context) {
+				app.NewWebviewWindowWithOptions(application.WebviewWindowOptions{
+					MinimiseButtonState: application.ButtonHidden,
+				}).
+					SetTitle("WebviewWindow "+strconv.Itoa(windowCounter)).
+					SetRelativePosition(rand.Intn(1000), rand.Intn(800)).
+					SetURL("https://wails.io").
+					Show()
+				windowCounter++
+			})
+		myMenu.Add("New WebviewWindow (Hide Maximise)").
+			OnClick(func(ctx *application.Context) {
+				app.NewWebviewWindowWithOptions(application.WebviewWindowOptions{
+					MaximiseButtonState: application.ButtonHidden,
 				}).
 					SetTitle("WebviewWindow "+strconv.Itoa(windowCounter)).
 					SetRelativePosition(rand.Intn(1000), rand.Intn(800)).
@@ -98,9 +110,18 @@ func main() {
 		myMenu.Add("New WebviewWindow (Disable Close)").
 			OnClick(func(ctx *application.Context) {
 				app.NewWebviewWindowWithOptions(application.WebviewWindowOptions{
-					Mac: application.MacWindow{
-						DisableCloseButton: true,
-					},
+					CloseButtonState: application.ButtonInactive,
+				}).
+					SetTitle("WebviewWindow "+strconv.Itoa(windowCounter)).
+					SetRelativePosition(rand.Intn(1000), rand.Intn(800)).
+					SetURL("https://wails.io").
+					Show()
+				windowCounter++
+			})
+		myMenu.Add("New WebviewWindow (Hide Close)").
+			OnClick(func(ctx *application.Context) {
+				app.NewWebviewWindowWithOptions(application.WebviewWindowOptions{
+					CloseButtonState: application.ButtonHidden,
 				}).
 					SetTitle("WebviewWindow "+strconv.Itoa(windowCounter)).
 					SetRelativePosition(rand.Intn(1000), rand.Intn(800)).
@@ -278,12 +299,12 @@ func main() {
 			w.SetMinSize(200, 200)
 		})
 	})
-	sizeMenu.Add("Set Max Size (600,600)").OnClick(func(ctx *application.Context) {
-		currentWindow(func(w *application.WebviewWindow) {
-			w.SetFullscreenButtonEnabled(false)
-			w.SetMaxSize(600, 600)
-		})
-	})
+	//sizeMenu.Add("Set Max Size (600,600)").OnClick(func(ctx *application.Context) {
+	//	currentWindow(func(w *application.WebviewWindow) {
+	//		w.SetFullscreenButtonEnabled(false)
+	//		w.SetMaxSize(600, 600)
+	//	})
+	//})
 	sizeMenu.Add("Get Current WebviewWindow Size").OnClick(func(ctx *application.Context) {
 		currentWindow(func(w *application.WebviewWindow) {
 			width, height := w.Size()
@@ -297,12 +318,12 @@ func main() {
 		})
 	})
 
-	sizeMenu.Add("Reset Max Size").OnClick(func(ctx *application.Context) {
-		currentWindow(func(w *application.WebviewWindow) {
-			w.SetMaxSize(0, 0)
-			w.SetFullscreenButtonEnabled(true)
-		})
-	})
+	//sizeMenu.Add("Reset Max Size").OnClick(func(ctx *application.Context) {
+	//	currentWindow(func(w *application.WebviewWindow) {
+	//		w.SetMaxSize(0, 0)
+	//		w.SetFullscreenButtonEnabled(true)
+	//	})
+	//})
 	positionMenu := menu.AddSubmenu("Position")
 	positionMenu.Add("Set Relative Position (0,0)").OnClick(func(ctx *application.Context) {
 		currentWindow(func(w *application.WebviewWindow) {

--- a/v3/examples/window/main.go
+++ b/v3/examples/window/main.go
@@ -106,7 +106,7 @@ func main() {
 				windowCounter++
 			})
 	}
-	if runtime.GOOS == "darwin" {
+	if runtime.GOOS == "darwin" || runtime.GOOS == "windows" {
 		myMenu.Add("New WebviewWindow (Disable Close)").
 			OnClick(func(ctx *application.Context) {
 				app.NewWebviewWindowWithOptions(application.WebviewWindowOptions{

--- a/v3/examples/window/main.go
+++ b/v3/examples/window/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	_ "embed"
 	"fmt"
+	"github.com/wailsapp/wails/v3/pkg/w32"
 	"log"
 	"math/rand"
 	"runtime"
@@ -130,6 +131,22 @@ func main() {
 				windowCounter++
 			})
 
+	}
+	if runtime.GOOS == "windows" {
+		myMenu.Add("New WebviewWindow (Custom ExStyle)").
+			OnClick(func(ctx *application.Context) {
+				app.NewWebviewWindowWithOptions(application.WebviewWindowOptions{
+					Windows: application.WindowsWindow{
+						DisableMenu: true,
+						ExStyle:     w32.WS_EX_TOOLWINDOW | w32.WS_EX_NOREDIRECTIONBITMAP | w32.WS_EX_TOPMOST,
+					},
+				}).
+					SetTitle("WebviewWindow "+strconv.Itoa(windowCounter)).
+					SetRelativePosition(rand.Intn(1000), rand.Intn(800)).
+					SetURL("https://wails.io").
+					Show()
+				windowCounter++
+			})
 	}
 
 	myMenu.Add("New WebviewWindow (Hides on Close one time)").

--- a/v3/examples/window/main.go
+++ b/v3/examples/window/main.go
@@ -299,12 +299,6 @@ func main() {
 			w.SetMinSize(200, 200)
 		})
 	})
-	//sizeMenu.Add("Set Max Size (600,600)").OnClick(func(ctx *application.Context) {
-	//	currentWindow(func(w *application.WebviewWindow) {
-	//		w.SetFullscreenButtonEnabled(false)
-	//		w.SetMaxSize(600, 600)
-	//	})
-	//})
 	sizeMenu.Add("Get Current WebviewWindow Size").OnClick(func(ctx *application.Context) {
 		currentWindow(func(w *application.WebviewWindow) {
 			width, height := w.Size()
@@ -318,12 +312,6 @@ func main() {
 		})
 	})
 
-	//sizeMenu.Add("Reset Max Size").OnClick(func(ctx *application.Context) {
-	//	currentWindow(func(w *application.WebviewWindow) {
-	//		w.SetMaxSize(0, 0)
-	//		w.SetFullscreenButtonEnabled(true)
-	//	})
-	//})
 	positionMenu := menu.AddSubmenu("Position")
 	positionMenu.Add("Set Relative Position (0,0)").OnClick(func(ctx *application.Context) {
 		currentWindow(func(w *application.WebviewWindow) {
@@ -365,6 +353,52 @@ func main() {
 	positionMenu.Add("Center").OnClick(func(ctx *application.Context) {
 		currentWindow(func(w *application.WebviewWindow) {
 			w.Center()
+		})
+	})
+	titleBarMenu := menu.AddSubmenu("TitleBar")
+	titleBarMenu.Add("Disable Minimise").OnClick(func(ctx *application.Context) {
+		currentWindow(func(w *application.WebviewWindow) {
+			w.SetMinimiseButtonState(application.ButtonInactive)
+		})
+	})
+	titleBarMenu.Add("Enable Minimise").OnClick(func(ctx *application.Context) {
+		currentWindow(func(w *application.WebviewWindow) {
+			w.SetMinimiseButtonState(application.ButtonActive)
+		})
+	})
+	titleBarMenu.Add("Hide Minimise").OnClick(func(ctx *application.Context) {
+		currentWindow(func(w *application.WebviewWindow) {
+			w.SetMinimiseButtonState(application.ButtonHidden)
+		})
+	})
+	titleBarMenu.Add("Disable Maximise").OnClick(func(ctx *application.Context) {
+		currentWindow(func(w *application.WebviewWindow) {
+			w.SetMaximiseButtonState(application.ButtonInactive)
+		})
+	})
+	titleBarMenu.Add("Enable Maximise").OnClick(func(ctx *application.Context) {
+		currentWindow(func(w *application.WebviewWindow) {
+			w.SetMaximiseButtonState(application.ButtonActive)
+		})
+	})
+	titleBarMenu.Add("Hide Maximise").OnClick(func(ctx *application.Context) {
+		currentWindow(func(w *application.WebviewWindow) {
+			w.SetMaximiseButtonState(application.ButtonHidden)
+		})
+	})
+	titleBarMenu.Add("Disable Close").OnClick(func(ctx *application.Context) {
+		currentWindow(func(w *application.WebviewWindow) {
+			w.SetCloseButtonState(application.ButtonInactive)
+		})
+	})
+	titleBarMenu.Add("Enable Close").OnClick(func(ctx *application.Context) {
+		currentWindow(func(w *application.WebviewWindow) {
+			w.SetCloseButtonState(application.ButtonActive)
+		})
+	})
+	titleBarMenu.Add("Hide Close").OnClick(func(ctx *application.Context) {
+		currentWindow(func(w *application.WebviewWindow) {
+			w.SetCloseButtonState(application.ButtonHidden)
 		})
 	})
 	stateMenu := menu.AddSubmenu("State")

--- a/v3/examples/window/main.go
+++ b/v3/examples/window/main.go
@@ -64,7 +64,7 @@ func main() {
 		myMenu.Add("New WebviewWindow (Disable Minimise)").
 			OnClick(func(ctx *application.Context) {
 				app.NewWebviewWindowWithOptions(application.WebviewWindowOptions{
-					MinimiseButtonState: application.ButtonInactive,
+					MinimiseButtonState: application.ButtonDisabled,
 				}).
 					SetTitle("WebviewWindow "+strconv.Itoa(windowCounter)).
 					SetRelativePosition(rand.Intn(1000), rand.Intn(800)).
@@ -75,7 +75,7 @@ func main() {
 		myMenu.Add("New WebviewWindow (Disable Maximise)").
 			OnClick(func(ctx *application.Context) {
 				app.NewWebviewWindowWithOptions(application.WebviewWindowOptions{
-					MaximiseButtonState: application.ButtonInactive,
+					MaximiseButtonState: application.ButtonDisabled,
 				}).
 					SetTitle("WebviewWindow "+strconv.Itoa(windowCounter)).
 					SetRelativePosition(rand.Intn(1000), rand.Intn(800)).
@@ -110,7 +110,7 @@ func main() {
 		myMenu.Add("New WebviewWindow (Disable Close)").
 			OnClick(func(ctx *application.Context) {
 				app.NewWebviewWindowWithOptions(application.WebviewWindowOptions{
-					CloseButtonState: application.ButtonInactive,
+					CloseButtonState: application.ButtonDisabled,
 				}).
 					SetTitle("WebviewWindow "+strconv.Itoa(windowCounter)).
 					SetRelativePosition(rand.Intn(1000), rand.Intn(800)).
@@ -355,15 +355,15 @@ func main() {
 			w.Center()
 		})
 	})
-	titleBarMenu := menu.AddSubmenu("TitleBar")
+	titleBarMenu := menu.AddSubmenu("Controls")
 	titleBarMenu.Add("Disable Minimise").OnClick(func(ctx *application.Context) {
 		currentWindow(func(w *application.WebviewWindow) {
-			w.SetMinimiseButtonState(application.ButtonInactive)
+			w.SetMinimiseButtonState(application.ButtonDisabled)
 		})
 	})
 	titleBarMenu.Add("Enable Minimise").OnClick(func(ctx *application.Context) {
 		currentWindow(func(w *application.WebviewWindow) {
-			w.SetMinimiseButtonState(application.ButtonActive)
+			w.SetMinimiseButtonState(application.ButtonEnabled)
 		})
 	})
 	titleBarMenu.Add("Hide Minimise").OnClick(func(ctx *application.Context) {
@@ -373,12 +373,12 @@ func main() {
 	})
 	titleBarMenu.Add("Disable Maximise").OnClick(func(ctx *application.Context) {
 		currentWindow(func(w *application.WebviewWindow) {
-			w.SetMaximiseButtonState(application.ButtonInactive)
+			w.SetMaximiseButtonState(application.ButtonDisabled)
 		})
 	})
 	titleBarMenu.Add("Enable Maximise").OnClick(func(ctx *application.Context) {
 		currentWindow(func(w *application.WebviewWindow) {
-			w.SetMaximiseButtonState(application.ButtonActive)
+			w.SetMaximiseButtonState(application.ButtonEnabled)
 		})
 	})
 	titleBarMenu.Add("Hide Maximise").OnClick(func(ctx *application.Context) {
@@ -388,12 +388,12 @@ func main() {
 	})
 	titleBarMenu.Add("Disable Close").OnClick(func(ctx *application.Context) {
 		currentWindow(func(w *application.WebviewWindow) {
-			w.SetCloseButtonState(application.ButtonInactive)
+			w.SetCloseButtonState(application.ButtonDisabled)
 		})
 	})
 	titleBarMenu.Add("Enable Close").OnClick(func(ctx *application.Context) {
 		currentWindow(func(w *application.WebviewWindow) {
-			w.SetCloseButtonState(application.ButtonActive)
+			w.SetCloseButtonState(application.ButtonEnabled)
 		})
 	})
 	titleBarMenu.Add("Hide Close").OnClick(func(ctx *application.Context) {

--- a/v3/pkg/application/messageprocessor_window.go
+++ b/v3/pkg/application/messageprocessor_window.go
@@ -249,14 +249,6 @@ func (m *MessageProcessor) processWindowMethod(method int, rw http.ResponseWrite
 		}
 		window.SetFrameless(*frameless)
 		m.ok(rw)
-	//case WindowSetFullscreenButtonEnabled:
-	//	enabled := args.Bool("enabled")
-	//	if enabled == nil {
-	//		m.Error("Invalid SetFullscreenButtonEnabled Message: 'enabled' value required")
-	//		return
-	//	}
-	//	window.SetFullscreenButtonEnabled(*enabled)
-	//	m.ok(rw)
 	case WindowSetMaxSize:
 		width := args.Int("width")
 		if width == nil {

--- a/v3/pkg/application/messageprocessor_window.go
+++ b/v3/pkg/application/messageprocessor_window.go
@@ -249,14 +249,14 @@ func (m *MessageProcessor) processWindowMethod(method int, rw http.ResponseWrite
 		}
 		window.SetFrameless(*frameless)
 		m.ok(rw)
-	case WindowSetFullscreenButtonEnabled:
-		enabled := args.Bool("enabled")
-		if enabled == nil {
-			m.Error("Invalid SetFullscreenButtonEnabled Message: 'enabled' value required")
-			return
-		}
-		window.SetFullscreenButtonEnabled(*enabled)
-		m.ok(rw)
+	//case WindowSetFullscreenButtonEnabled:
+	//	enabled := args.Bool("enabled")
+	//	if enabled == nil {
+	//		m.Error("Invalid SetFullscreenButtonEnabled Message: 'enabled' value required")
+	//		return
+	//	}
+	//	window.SetFullscreenButtonEnabled(*enabled)
+	//	m.ok(rw)
 	case WindowSetMaxSize:
 		width := args.Int("width")
 		if width == nil {

--- a/v3/pkg/application/webview_window.go
+++ b/v3/pkg/application/webview_window.go
@@ -71,9 +71,6 @@ type (
 		isNormal() bool
 		isVisible() bool
 		isFocused() bool
-		setFullscreenButtonEnabled(enabled bool)
-		setMinimiseButtonEnabled(enabled bool)
-		setMaximiseButtonEnabled(enabled bool)
 		focus()
 		show()
 		hide()
@@ -90,6 +87,9 @@ type (
 		flash(enabled bool)
 		handleKeyEvent(acceleratorString string)
 		getBorderSizes() *LRTB
+		setMinimiseButtonState(state ButtonState)
+		setMaximiseButtonState(state ButtonState)
+		setCloseButtonState(state ButtonState)
 	}
 )
 
@@ -540,31 +540,31 @@ func (w *WebviewWindow) Fullscreen() Window {
 	return w
 }
 
-func (w *WebviewWindow) SetFullscreenButtonEnabled(enabled bool) Window {
-	w.options.FullscreenButtonEnabled = enabled
+func (w *WebviewWindow) SetMinimiseButtonState(state ButtonState) Window {
+	w.options.MinimiseButtonState = state
 	if w.impl != nil {
 		InvokeSync(func() {
-			w.impl.setFullscreenButtonEnabled(enabled)
+			w.impl.setMinimiseButtonState(state)
 		})
 	}
 	return w
 }
 
-func (w *WebviewWindow) SetMinimiseButtonEnabled(enabled bool) Window {
-	w.options.FullscreenButtonEnabled = enabled
+func (w *WebviewWindow) SetMaximiseButtonState(state ButtonState) Window {
+	w.options.MaximiseButtonState = state
 	if w.impl != nil {
 		InvokeSync(func() {
-			w.impl.setMinimiseButtonEnabled(enabled)
+			w.impl.setMaximiseButtonState(state)
 		})
 	}
 	return w
 }
 
-func (w *WebviewWindow) SetMaximiseButtonEnabled(enabled bool) Window {
-	w.options.FullscreenButtonEnabled = enabled
+func (w *WebviewWindow) SetCloseButtonState(state ButtonState) Window {
+	w.options.CloseButtonState = state
 	if w.impl != nil {
 		InvokeSync(func() {
-			w.impl.setMaximiseButtonEnabled(enabled)
+			w.impl.setCloseButtonState(state)
 		})
 	}
 	return w

--- a/v3/pkg/application/webview_window_darwin.go
+++ b/v3/pkg/application/webview_window_darwin.go
@@ -642,8 +642,8 @@ static void windowHide(void *window) {
 }
 
 // setButtonState sets the state of the given button
-// 0 = active
-// 1 = inactive
+// 0 = enabled
+// 1 = disabled
 // 2 = hidden
 static void setButtonState(void *button, int state) {
 	if (button == nil) {

--- a/v3/pkg/application/webview_window_darwin.go
+++ b/v3/pkg/application/webview_window_darwin.go
@@ -641,22 +641,38 @@ static void windowHide(void *window) {
 	[(WebviewWindow*)window orderOut:nil];
 }
 
-static void enableMinimiseButton(void *window, bool enabled) {
+// setButtonState sets the state of the given button
+// 0 = active
+// 1 = inactive
+// 2 = hidden
+static void setButtonState(void *button, int state) {
+	if (button == nil) {
+		return;
+	}
+	NSButton *nsbutton = (NSButton*)button;
+	nsbutton.hidden = state == 2;
+	nsbutton.enabled = state != 1;
+}
+
+// setMinimiseButtonState sets the minimise button state
+static void setMinimiseButtonState(void *window, int state) {
 	WebviewWindow* nsWindow = (WebviewWindow*)window;
 	NSButton *minimiseButton = [nsWindow standardWindowButton:NSWindowMiniaturizeButton];
-	minimiseButton.enabled = enabled;
+	setButtonState(minimiseButton, state);
 }
 
-static void enableMaximiseButton(void *window, bool enabled) {
+// setMaximiseButtonState sets the maximise button state
+static void setMaximiseButtonState(void *window, int state) {
 	WebviewWindow* nsWindow = (WebviewWindow*)window;
 	NSButton *maximiseButton = [nsWindow standardWindowButton:NSWindowZoomButton];
-	maximiseButton.enabled = enabled;
+	setButtonState(maximiseButton, state);
 }
 
-static void enableCloseButton(void *window, bool enabled) {
+// setCloseButtonState sets the close button state
+static void setCloseButtonState(void *window, int state) {
 	WebviewWindow* nsWindow = (WebviewWindow*)window;
 	NSButton *closeButton = [nsWindow standardWindowButton:NSWindowCloseButton];
-	closeButton.enabled = enabled;
+	setButtonState(closeButton, state);
 }
 
 // windowShowMenu opens an NSMenu at the given coordinates
@@ -1131,15 +1147,10 @@ func (w *macosWebviewWindow) run() {
 		case MacBackdropNormal:
 		}
 
-		if macOptions.DisableMinimiseButton {
-			w.setMinimiseButtonEnabled(false)
-		}
-		if macOptions.DisableMaximiseButton {
-			w.setMaximiseButtonEnabled(false)
-		}
-		if macOptions.DisableCloseButton {
-			w.setCloseButtonEnabled(false)
-		}
+		// Initialise the window buttons
+		w.setMinimiseButtonState(options.MinimiseButtonState)
+		w.setMaximiseButtonState(options.MaximiseButtonState)
+		w.setCloseButtonState(options.CloseButtonState)
 
 		if options.IgnoreMouseEvents {
 			C.windowIgnoreMouseEvents(w.nsWindow, C.bool(true))
@@ -1270,14 +1281,14 @@ func (w *macosWebviewWindow) startDrag() error {
 	return nil
 }
 
-func (w *macosWebviewWindow) setMinimiseButtonEnabled(enabled bool) {
-	C.enableMinimiseButton(w.nsWindow, C.bool(enabled))
+func (w *macosWebviewWindow) setMinimiseButtonState(state ButtonState) {
+	C.setMinimiseButtonState(w.nsWindow, C.int(state))
 }
 
-func (w *macosWebviewWindow) setMaximiseButtonEnabled(enabled bool) {
-	C.enableMaximiseButton(w.nsWindow, C.bool(enabled))
+func (w *macosWebviewWindow) setMaximiseButtonState(state ButtonState) {
+	C.setMaximiseButtonState(w.nsWindow, C.int(state))
 }
 
-func (w *macosWebviewWindow) setCloseButtonEnabled(enabled bool) {
-	C.enableCloseButton(w.nsWindow, C.bool(enabled))
+func (w *macosWebviewWindow) setCloseButtonState(state ButtonState) {
+	C.setCloseButtonState(w.nsWindow, C.int(state))
 }

--- a/v3/pkg/application/webview_window_linux.go
+++ b/v3/pkg/application/webview_window_linux.go
@@ -337,3 +337,18 @@ func (w *linuxWebviewWindow) handleKeyEvent(acceleratorString string) {
 	// }
 	w.parent.processKeyBinding(acceleratorString)
 }
+
+// SetMinimiseButtonState is unsupported on Linux
+func (w *linuxWebviewWindow) SetMinimiseButtonState(state ButtonState) Window {
+	return w
+}
+
+// SetMaximiseButtonState is unsupported on Linux
+func (w *linuxWebviewWindow) SetMaximiseButtonState(state ButtonState) Window {
+	return w
+}
+
+// SetFullscreenButtonState is unsupported on Linux
+func (w *linuxWebviewWindow) SetCloseButtonState(state ButtonState) Window {
+	return w
+}

--- a/v3/pkg/application/webview_window_options.go
+++ b/v3/pkg/application/webview_window_options.go
@@ -14,6 +14,14 @@ const (
 	WindowStateFullscreen
 )
 
+type ButtonState int
+
+const (
+	ButtonActive   ButtonState = 0
+	ButtonInactive ButtonState = 1
+	ButtonHidden   ButtonState = 2
+)
+
 type WebviewWindowOptions struct {
 	// Name is a unique identifier that can be given to a window.
 	Name string
@@ -107,6 +115,11 @@ type WebviewWindowOptions struct {
 
 	// Linux options
 	Linux LinuxWindow
+
+	// Toolbar button states
+	MinimiseButtonState ButtonState
+	MaximiseButtonState ButtonState
+	CloseButtonState    ButtonState
 
 	// ShouldClose is called when the window is about to close.
 	// Return true to allow the window to close, or false to prevent it from closing.
@@ -283,12 +296,6 @@ type WindowsWindow struct {
 
 	// Permissions map for WebView2. If empty, default permissions will be granted.
 	Permissions map[CoreWebView2PermissionKind]CoreWebView2PermissionState
-
-	// Disables the minimise button
-	DisableMinimiseButton bool
-
-	// Disables the maximise button
-	DisableMaximiseButton bool
 }
 
 type Theme int
@@ -370,15 +377,6 @@ type MacWindow struct {
 
 	// WebviewPreferences contains preferences for the webview
 	WebviewPreferences MacWebviewPreferences
-
-	// Disables the minimise button
-	DisableMinimiseButton bool
-
-	// Disables the maximise button
-	DisableMaximiseButton bool
-
-	// Disables the close button
-	DisableCloseButton bool
 }
 
 // MacWebviewPreferences contains preferences for the Mac webview

--- a/v3/pkg/application/webview_window_options.go
+++ b/v3/pkg/application/webview_window_options.go
@@ -17,8 +17,8 @@ const (
 type ButtonState int
 
 const (
-	ButtonActive   ButtonState = 0
-	ButtonInactive ButtonState = 1
+	ButtonEnabled  ButtonState = 0
+	ButtonDisabled ButtonState = 1
 	ButtonHidden   ButtonState = 2
 )
 

--- a/v3/pkg/application/webview_window_options.go
+++ b/v3/pkg/application/webview_window_options.go
@@ -296,6 +296,9 @@ type WindowsWindow struct {
 
 	// Permissions map for WebView2. If empty, default permissions will be granted.
 	Permissions map[CoreWebView2PermissionKind]CoreWebView2PermissionState
+
+	// ExStyle is the extended window style
+	ExStyle int
 }
 
 type Theme int

--- a/v3/pkg/application/webview_window_windows.go
+++ b/v3/pkg/application/webview_window_windows.go
@@ -192,8 +192,7 @@ func (w *windowsWebviewWindow) run() {
 
 	w.chromium = edge.NewChromium()
 
-	var exStyle uint
-	exStyle = w32.WS_EX_CONTROLPARENT
+	exStyle := w32.WS_EX_CONTROLPARENT
 	if options.BackgroundType != BackgroundTypeSolid {
 		exStyle |= w32.WS_EX_NOREDIRECTIONBITMAP
 		if w.parent.options.IgnoreMouseEvents {
@@ -208,6 +207,10 @@ func (w *windowsWebviewWindow) run() {
 		exStyle |= w32.WS_EX_TOOLWINDOW
 	} else {
 		exStyle |= w32.WS_EX_APPWINDOW
+	}
+
+	if options.Windows.ExStyle != 0 {
+		exStyle = options.Windows.ExStyle
 	}
 
 	// ToDo: X, Y should also be scaled, should it be always relative to the main monitor?
@@ -234,7 +237,7 @@ func (w *windowsWebviewWindow) run() {
 	var style uint = w32.WS_OVERLAPPEDWINDOW
 
 	w.hwnd = w32.CreateWindowEx(
-		exStyle,
+		uint(exStyle),
 		windowClassName,
 		w32.MustStringToUTF16Ptr(options.Title),
 		style,

--- a/v3/pkg/application/webview_window_windows.go
+++ b/v3/pkg/application/webview_window_windows.go
@@ -1684,11 +1684,10 @@ func NewIconFromResource(instance w32.HINSTANCE, resId uint16) (w32.HICON, error
 
 func (w *windowsWebviewWindow) setMinimiseButtonState(state ButtonState) {
 	switch state {
-	case ButtonInactive:
+	case ButtonDisabled, ButtonHidden:
 		w.setStyle(false, w32.WS_MINIMIZEBOX)
-	case ButtonHidden:
-		w.setGWLStyle(w32.WS_SYSMENU | w32.WS_CAPTION)
-	case ButtonActive:
+	case ButtonEnabled:
+		w.setStyle(true, w32.WS_SYSMENU)
 		w.setStyle(true, w32.WS_MINIMIZEBOX)
 
 	}
@@ -1696,22 +1695,22 @@ func (w *windowsWebviewWindow) setMinimiseButtonState(state ButtonState) {
 
 func (w *windowsWebviewWindow) setMaximiseButtonState(state ButtonState) {
 	switch state {
-	case ButtonInactive:
+	case ButtonDisabled, ButtonHidden:
 		w.setStyle(false, w32.WS_MAXIMIZEBOX)
-	case ButtonHidden:
-		w.setGWLStyle(w32.WS_SYSMENU | w32.WS_CAPTION)
-	case ButtonActive:
+	case ButtonEnabled:
+		w.setStyle(true, w32.WS_SYSMENU)
 		w.setStyle(true, w32.WS_MAXIMIZEBOX)
 	}
 }
 
 func (w *windowsWebviewWindow) setCloseButtonState(state ButtonState) {
 	switch state {
-	case ButtonActive:
-		// Enable the close button
-		w32.EnableCloseButton(w.hwnd)
-	case ButtonInactive:
-		w32.DisableCloseButton(w.hwnd)
+	case ButtonEnabled:
+		w.setStyle(true, w32.WS_SYSMENU)
+		_ = w32.EnableCloseButton(w.hwnd)
+	case ButtonDisabled:
+		w.setStyle(true, w32.WS_SYSMENU)
+		_ = w32.DisableCloseButton(w.hwnd)
 	case ButtonHidden:
 		w.setStyle(false, w32.WS_SYSMENU)
 	}

--- a/v3/pkg/application/webview_window_windows.go
+++ b/v3/pkg/application/webview_window_windows.go
@@ -255,9 +255,10 @@ func (w *windowsWebviewWindow) run() {
 
 	w.setupChromium()
 
-	// Min/max buttons
-	w.setMinimiseButtonEnabled(!options.Windows.DisableMinimiseButton)
-	w.setMaximiseButtonEnabled(!options.Windows.DisableMaximiseButton)
+	// Initialise the window buttons
+	w.setMinimiseButtonState(options.MinimiseButtonState)
+	w.setMaximiseButtonState(options.MaximiseButtonState)
+	w.setCloseButtonState(options.CloseButtonState)
 
 	// Register the window with the application
 	getNativeApplication().registerWindow(w)
@@ -1679,4 +1680,43 @@ func NewIconFromResource(instance w32.HINSTANCE, resId uint16) (w32.HICON, error
 		err = errors.New(fmt.Sprintf("Cannot load icon from resource with id %v", resId))
 	}
 	return result, err
+}
+
+func (w *windowsWebviewWindow) setMinimiseButtonState(state ButtonState) {
+	switch state {
+	case ButtonInactive:
+		w.setStyle(false, w32.WS_MINIMIZEBOX)
+	case ButtonHidden:
+		w.setGWLStyle(w32.WS_SYSMENU | w32.WS_CAPTION)
+	case ButtonActive:
+		w.setStyle(true, w32.WS_MINIMIZEBOX)
+
+	}
+}
+
+func (w *windowsWebviewWindow) setMaximiseButtonState(state ButtonState) {
+	switch state {
+	case ButtonInactive:
+		w.setStyle(false, w32.WS_MAXIMIZEBOX)
+	case ButtonHidden:
+		w.setGWLStyle(w32.WS_SYSMENU | w32.WS_CAPTION)
+	case ButtonActive:
+		w.setStyle(true, w32.WS_MAXIMIZEBOX)
+	}
+}
+
+func (w *windowsWebviewWindow) setCloseButtonState(state ButtonState) {
+	switch state {
+	case ButtonActive:
+		// Enable the close button
+		w32.EnableCloseButton(w.hwnd)
+	case ButtonInactive:
+		w32.DisableCloseButton(w.hwnd)
+	case ButtonHidden:
+		w.setStyle(false, w32.WS_SYSMENU)
+	}
+}
+
+func (w *windowsWebviewWindow) setGWLStyle(style int) {
+	w32.SetWindowLong(w.hwnd, w32.GWL_STYLE, uint32(style))
 }

--- a/v3/pkg/application/window.go
+++ b/v3/pkg/application/window.go
@@ -55,8 +55,10 @@ type Window interface {
 	SetAlwaysOnTop(b bool) Window
 	SetBackgroundColour(colour RGBA) Window
 	SetFrameless(frameless bool) Window
-	SetFullscreenButtonEnabled(enabled bool) Window
 	SetHTML(html string) Window
+	SetMinimiseButtonState(state ButtonState) Window
+	SetMaximiseButtonState(state ButtonState) Window
+	SetCloseButtonState(state ButtonState) Window
 	SetMaxSize(maxWidth, maxHeight int) Window
 	SetMinSize(minWidth, minHeight int) Window
 	SetRelativePosition(x, y int) Window

--- a/v3/pkg/w32/window.go
+++ b/v3/pkg/w32/window.go
@@ -14,6 +14,21 @@ import (
 )
 
 const (
+	SC_CLOSE    = 0xF060
+	SC_MOVE     = 0xF010
+	SC_MAXIMIZE = 0xF030
+	SC_MINIMIZE = 0xF020
+	SC_SIZE     = 0xF000
+	SC_RESTORE  = 0xF120
+)
+
+var (
+	user32         = syscall.NewLazyDLL("user32.dll")
+	getSystemMenu  = user32.NewProc("GetSystemMenu")
+	enableMenuItem = user32.NewProc("EnableMenuItem")
+)
+
+const (
 	GCLP_HBRBACKGROUND int32 = -10
 	GCLP_HICON         int32 = -14
 )
@@ -250,4 +265,32 @@ func FlashWindow(hwnd HWND, enabled bool) {
 func EnumChildWindows(hwnd HWND, callback func(hwnd HWND, lparam LPARAM) LRESULT) LRESULT {
 	r, _, _ := procEnumChildWindows.Call(hwnd, syscall.NewCallback(callback), 0)
 	return r
+}
+
+func DisableCloseButton(hwnd HWND) error {
+	hSysMenu, _, err := getSystemMenu.Call(hwnd, 0)
+	if hSysMenu == 0 {
+		return err
+	}
+
+	r1, _, err := enableMenuItem.Call(hSysMenu, SC_CLOSE, MF_BYCOMMAND|MF_DISABLED|MF_GRAYED)
+	if r1 == 0 {
+		return err
+	}
+
+	return nil
+}
+
+func EnableCloseButton(hwnd HWND) error {
+	hSysMenu, _, err := getSystemMenu.Call(hwnd, 0)
+	if hSysMenu == 0 {
+		return err
+	}
+
+	r1, _, err := enableMenuItem.Call(hSysMenu, SC_CLOSE, MF_BYCOMMAND|MF_ENABLED)
+	if r1 == 0 {
+		return err
+	}
+
+	return nil
 }

--- a/v3/wep/proposals/titlebar-buttons/proposal.md
+++ b/v3/wep/proposals/titlebar-buttons/proposal.md
@@ -22,8 +22,8 @@ We currently do not fully support the ability to hide or disable the window butt
       type ButtonState int
 
       const (
-          ButtonActive   ButtonState = 0
-          ButtonInactive ButtonState = 1
+          ButtonEnabled  ButtonState = 0
+          ButtonDisabled ButtonState = 1
           ButtonHidden   ButtonState = 2
       )
 ```
@@ -57,22 +57,27 @@ The following options will be removed from the `MacWindow` options:
 
 The settings translate to the following functionality on each platform:
 
-|                       | Windows                      | Mac                    |
-|-----------------------|------------------------------|------------------------|
-| Disable Min/Max/Close | Disables Min/Max/Close       | Disables Min/Max/Close |
-| Hide Min              | Hides both Min + Max buttons | Hides Min button       |
-| Hide Max              | Hides both Min + Max buttons | Hides Max button       |
-| Hide Close            | Hides all buttons            | Hides Close            |
+|                       | Windows                | Mac                    |
+|-----------------------|------------------------|------------------------|
+| Disable Min/Max/Close | Disables Min/Max/Close | Disables Min/Max/Close |
+| Hide Min              | Disables Min           | Hides Min button       |
+| Hide Max              | Disables Max           | Hides Max button       |
+| Hide Close            | Hides all controls     | Hides Close            |
+
+Note: On Windows, it is not possible to hide the Min/Max buttons individually.
+However, disabling both will hide both of the controls and only show the 
+close button. 
 
 ## Pros/Cons
 
 ### Pros
 
-1. We can support everything that's possible on both macOS and Windows
+- We can support everything that's possible on both macOS and Windows
 
 ### Cons
 
-1. Windows works slightly different to macOS
+- Windows works slightly different to macOS
+- No Linux support (doesn't look like it's possible regardless of the solution)
 
 ## Alternatives Considered
 
@@ -80,11 +85,11 @@ The alternative is to draw your own titlebar, but this is a lot of work and ofte
 
 ## Backwards Compatibility
 
-This is not backwards compatible as we remove the old `Disable*Button` options.
+This is not backwards compatible as we remove the old button disable options.
 
 ## Test Plan
 
-As part of the implementation, an example will be created in `v3/examples` to test the functionality.
+As part of the implementation, the window example will be updated to test the functionality.
 
 ## Reference Implementation
 

--- a/v3/wep/proposals/titlebar-buttons/proposal.md
+++ b/v3/wep/proposals/titlebar-buttons/proposal.md
@@ -2,20 +2,17 @@
 
 ## Title
 
-**Author**: Lea Anthony 
+**Author**: Lea Anthony
 **Created**: 2024-05-20
 
 ## Summary
 
 Create a better API for controlling the appearance and functionality of window buttons in Wails.
+This will only be available on Windows and macOS.
 
 ## Motivation
 
-Currently, it's only possible to control the visibility of the window buttons (minimize, maximize, close) in Wails. 
-This proposal aims to enhance the control over titlebar buttons for applications on Windows and macOS by introducing a 
-tri-state system (active, inactive, hidden) for each button. This feature will allow developers to have granular 
-control over the appearance and functionality of window buttons, enhancing the customization capabilities of desktop 
-applications built with Wails
+We currently do not fully support the ability to hide or disable the window buttons on the titlebar. 
 
 ## Detailed Design
 
@@ -25,9 +22,9 @@ applications built with Wails
       type ButtonState int
 
       const (
-      ButtonActive ButtonState   = 0
-      ButtonInactive ButtonState = 1
-      ButtonHidden ButtonState   = 2
+          ButtonActive   ButtonState = 0
+          ButtonInactive ButtonState = 1
+          ButtonHidden   ButtonState = 2
       )
 ```
 
@@ -38,6 +35,7 @@ applications built with Wails
    MaximiseButtonState ButtonState
    CloseButtonState    ButtonState
 ```
+
 The following options will be removed from the `WindowsWindow` options:
 
 - DisableMinimiseButton
@@ -57,46 +55,32 @@ The following options will be removed from the `MacWindow` options:
    SetCloseButtonState(state ButtonState)
 ```
 
+The settings translate to the following functionality on each platform:
+
+|                       | Windows                      | Mac                    |
+|-----------------------|------------------------------|------------------------|
+| Disable Min/Max/Close | Disables Min/Max/Close       | Disables Min/Max/Close |
+| Hide Min              | Hides both Min + Max buttons | Hides Min button       |
+| Hide Max              | Hides both Min + Max buttons | Hides Max button       |
+| Hide Close            | Hides all buttons            | Hides Close            |
 
 ## Pros/Cons
 
 ### Pros
 
-1. Enhanced Customization
-Provides developers with the ability to tailor the window controls (minimize, maximize, close) to the specific needs 
-of their application. This can improve the user interface by aligning the window's behavior with the application's 
-design and functional requirements.
-
-2. Improved User Experience
-By controlling the state of window buttons, applications can prevent user actions that might not make sense in certain 
-contexts, such as disabling the minimize button during a critical operation, thereby enhancing the overall user experience.
-
-3. Cross-Platform Consistency
-The proposal includes handling for both Windows and macOS, ensuring that applications behave consistently across these 
-platforms. This reduces the complexity for developers aiming to provide a uniform experience on different operating 
-systems.
+1. We can support everything that's possible on both macOS and Windows
 
 ### Cons
 
-1. Platform-Specific Bugs
-
-The proposal includes handling for both Windows and macOS. There may well be subtle differences in how the controls
-are handled on each platform. 
-
-2. Top Level Options
-
-Having the options at the top level of the `WebviewWindowOptions` option struct may be confusing for developers
-as it suggests it works on Linux. However, the options are only relevant to macOS and Windows. The reason for this
-is to provide a better API for calling these methods at runtime.
+1. Windows works slightly different to macOS
 
 ## Alternatives Considered
 
-Original design used booleans but we'd like to give the option for disabling as well as hiding.
+The alternative is to draw your own titlebar, but this is a lot of work and often doesn't look good.
 
 ## Backwards Compatibility
 
-The new features are optional and do not affect existing applications unless they opt to use them. This ensures that
-current applications built with Wails will continue to function as before without any modifications.
+This is not backwards compatible as we remove the old `Disable*Button` options.
 
 ## Test Plan
 
@@ -114,74 +98,3 @@ This feature will be maintained and supported by the Wails developers.
 
 This API would be a leap forward in giving developers greater control over their application window appearances.
 
-
-
-### Wails Enhancement Proposal (WEP)
-
-#### Title
-Implementing Tri-State Titlebar Button Control in Wails
-
-#### Abstract
-This proposal aims to enhance the control over titlebar buttons (minimize, maximize, close) in the Wails framework for applications on Windows and macOS by introducing a tri-state system (active, inactive, hidden) for each button. This feature will allow developers to have granular control over the appearance and functionality of window buttons, enhancing the customization capabilities of desktop applications built with Wails.
-
-#### Specification
-1. **Platform Detection**:
-    - Detect the operating system at runtime using Go's `runtime` package to apply platform-specific logic for window controls.
-
-2. **Window Struct Extension**:
-    - Extend the `Window` struct in Wails to include properties for the state of the titlebar buttons using an enum to represent the three states:
-      BACKTICKSgo
-      type ButtonState int
-
-      const (
-      ButtonActive ButtonState = iota
-      ButtonInactive
-      ButtonHidden
-      )
-
-      type Window struct {
-      ...
-      BACKTICKS
-    - This extension allows the window's titlebar buttons to be dynamically controlled through the Wails application.
-
-3. **Interfacing with Native APIs**:
-    - **Windows**: Use the Windows API to manipulate window styles (`WS_MINIMIZEBOX`, `WS_MAXIMIZEBOX`, `WS_SYSMENU`) and system commands to reflect the desired button states.
-    - **macOS**: Utilize Cocoa APIs through Objective-C bridging to manipulate properties of `NSWindow` buttons, including their visibility and enabled states.
-
-4. **API Functions**:
-    - Implement Go functions that interface with native code to set the state of the window buttons. Example functions could be:
-      BACKTICKSgo
-      func (w *Window) SetMinimizeButtonState(state ButtonState) {
-      // Platform-specific logic to set the minimize button state
-      }
-
-      func (w *Window) SetMaximizeButtonState(state ButtonState) {
-      // Platform-specific logic to set the maximize button state
-      }
-
-      func (w *Window) SetCloseButtonState(state ButtonState) {
-      // Platform-specific logic to set the close button state
-      }
-      BACKTICKS
-
-5. **Binding to Frontend**:
-    - Expose these functions to the frontend via Wails' bindings so they can be called from the JavaScript context. This allows frontend code to control the appearance of the window based on application state or user interactions.
-
-#### Motivation
-The ability to control the state of window titlebar buttons (active, inactive, hidden) is crucial for creating polished, user-friendly desktop applications. This feature will provide Wails developers with the tools needed to tailor the window controls to fit the design and functionality requirements of their applications, improving both aesthetics and usability.
-
-#### Rationale
-Implementing this feature as described will leverage existing platform-specific APIs to provide a consistent and reliable way to manage window button states across different operating systems, thereby enhancing the Wails framework's capabilities and appeal to developers looking for advanced UI customization options.
-
-#### Backwards Compatibility
-This proposal introduces new functionality that does not affect existing applications unless they opt to use the new features. Therefore, it is fully backward compatible.
-
-#### Reference Implementation
-A reference implementation will be provided as part of the development process, demonstrating the use of the new window button state controls in a sample Wails application.
-
-#### Open Issues
-- Detailed error handling strategies need to be discussed and implemented to ensure robust application behavior.
-- Consideration of how these controls interact with other window management features in Wails.
-
-#### Future Possibilities
-Further enhancements could include more detailed customization options for the appearance of the buttons themselves, potentially allowing for completely custom designs and interactions.

--- a/v3/wep/proposals/titlebar-buttons/proposal.md
+++ b/v3/wep/proposals/titlebar-buttons/proposal.md
@@ -1,0 +1,187 @@
+# Wails Enhancement Proposal (WEP)
+
+## Title
+
+**Author**: Lea Anthony 
+**Created**: 2024-05-20
+
+## Summary
+
+Create a better API for controlling the appearance and functionality of window buttons in Wails.
+
+## Motivation
+
+Currently, it's only possible to control the visibility of the window buttons (minimize, maximize, close) in Wails. 
+This proposal aims to enhance the control over titlebar buttons for applications on Windows and macOS by introducing a 
+tri-state system (active, inactive, hidden) for each button. This feature will allow developers to have granular 
+control over the appearance and functionality of window buttons, enhancing the customization capabilities of desktop 
+applications built with Wails
+
+## Detailed Design
+
+1. A new enum will be added:
+
+```go
+      type ButtonState int
+
+      const (
+      ButtonActive ButtonState   = 0
+      ButtonInactive ButtonState = 1
+      ButtonHidden ButtonState   = 2
+      )
+```
+
+2. The following options will be added to the `WebviewWindowOptions` option struct:
+
+```go
+   MinimiseButtonState ButtonState
+   MaximiseButtonState ButtonState
+   CloseButtonState    ButtonState
+```
+The following options will be removed from the `WindowsWindow` options:
+
+- DisableMinimiseButton
+- DisableMaximiseButton
+
+The following options will be removed from the `MacWindow` options:
+
+- DisableMinimiseButton
+- DisableMaximiseButton
+- DisableCloseButton
+
+3. The following methods will be added to the `Window` interface:
+
+```go
+   SetMinimizeButtonState(state ButtonState)
+   SetMaximizeButtonState(state ButtonState)
+   SetCloseButtonState(state ButtonState)
+```
+
+
+## Pros/Cons
+
+### Pros
+
+1. Enhanced Customization
+Provides developers with the ability to tailor the window controls (minimize, maximize, close) to the specific needs 
+of their application. This can improve the user interface by aligning the window's behavior with the application's 
+design and functional requirements.
+
+2. Improved User Experience
+By controlling the state of window buttons, applications can prevent user actions that might not make sense in certain 
+contexts, such as disabling the minimize button during a critical operation, thereby enhancing the overall user experience.
+
+3. Cross-Platform Consistency
+The proposal includes handling for both Windows and macOS, ensuring that applications behave consistently across these 
+platforms. This reduces the complexity for developers aiming to provide a uniform experience on different operating 
+systems.
+
+### Cons
+
+1. Platform-Specific Bugs
+
+The proposal includes handling for both Windows and macOS. There may well be subtle differences in how the controls
+are handled on each platform. 
+
+2. Top Level Options
+
+Having the options at the top level of the `WebviewWindowOptions` option struct may be confusing for developers
+as it suggests it works on Linux. However, the options are only relevant to macOS and Windows. The reason for this
+is to provide a better API for calling these methods at runtime.
+
+## Alternatives Considered
+
+Original design used booleans but we'd like to give the option for disabling as well as hiding.
+
+## Backwards Compatibility
+
+The new features are optional and do not affect existing applications unless they opt to use them. This ensures that
+current applications built with Wails will continue to function as before without any modifications.
+
+## Test Plan
+
+As part of the implementation, an example will be created in `v3/examples` to test the functionality.
+
+## Reference Implementation
+
+There is a reference implementation as part of this proposal.
+
+## Maintenance Plan
+
+This feature will be maintained and supported by the Wails developers.
+
+## Conclusion
+
+This API would be a leap forward in giving developers greater control over their application window appearances.
+
+
+
+### Wails Enhancement Proposal (WEP)
+
+#### Title
+Implementing Tri-State Titlebar Button Control in Wails
+
+#### Abstract
+This proposal aims to enhance the control over titlebar buttons (minimize, maximize, close) in the Wails framework for applications on Windows and macOS by introducing a tri-state system (active, inactive, hidden) for each button. This feature will allow developers to have granular control over the appearance and functionality of window buttons, enhancing the customization capabilities of desktop applications built with Wails.
+
+#### Specification
+1. **Platform Detection**:
+    - Detect the operating system at runtime using Go's `runtime` package to apply platform-specific logic for window controls.
+
+2. **Window Struct Extension**:
+    - Extend the `Window` struct in Wails to include properties for the state of the titlebar buttons using an enum to represent the three states:
+      BACKTICKSgo
+      type ButtonState int
+
+      const (
+      ButtonActive ButtonState = iota
+      ButtonInactive
+      ButtonHidden
+      )
+
+      type Window struct {
+      ...
+      BACKTICKS
+    - This extension allows the window's titlebar buttons to be dynamically controlled through the Wails application.
+
+3. **Interfacing with Native APIs**:
+    - **Windows**: Use the Windows API to manipulate window styles (`WS_MINIMIZEBOX`, `WS_MAXIMIZEBOX`, `WS_SYSMENU`) and system commands to reflect the desired button states.
+    - **macOS**: Utilize Cocoa APIs through Objective-C bridging to manipulate properties of `NSWindow` buttons, including their visibility and enabled states.
+
+4. **API Functions**:
+    - Implement Go functions that interface with native code to set the state of the window buttons. Example functions could be:
+      BACKTICKSgo
+      func (w *Window) SetMinimizeButtonState(state ButtonState) {
+      // Platform-specific logic to set the minimize button state
+      }
+
+      func (w *Window) SetMaximizeButtonState(state ButtonState) {
+      // Platform-specific logic to set the maximize button state
+      }
+
+      func (w *Window) SetCloseButtonState(state ButtonState) {
+      // Platform-specific logic to set the close button state
+      }
+      BACKTICKS
+
+5. **Binding to Frontend**:
+    - Expose these functions to the frontend via Wails' bindings so they can be called from the JavaScript context. This allows frontend code to control the appearance of the window based on application state or user interactions.
+
+#### Motivation
+The ability to control the state of window titlebar buttons (active, inactive, hidden) is crucial for creating polished, user-friendly desktop applications. This feature will provide Wails developers with the tools needed to tailor the window controls to fit the design and functionality requirements of their applications, improving both aesthetics and usability.
+
+#### Rationale
+Implementing this feature as described will leverage existing platform-specific APIs to provide a consistent and reliable way to manage window button states across different operating systems, thereby enhancing the Wails framework's capabilities and appeal to developers looking for advanced UI customization options.
+
+#### Backwards Compatibility
+This proposal introduces new functionality that does not affect existing applications unless they opt to use the new features. Therefore, it is fully backward compatible.
+
+#### Reference Implementation
+A reference implementation will be provided as part of the development process, demonstrating the use of the new window button state controls in a sample Wails application.
+
+#### Open Issues
+- Detailed error handling strategies need to be discussed and implemented to ensure robust application behavior.
+- Consideration of how these controls interact with other window management features in Wails.
+
+#### Future Possibilities
+Further enhancements could include more detailed customization options for the appearance of the buttons themselves, potentially allowing for completely custom designs and interactions.

--- a/v3/wep/proposals/titlebar-buttons/proposal.md
+++ b/v3/wep/proposals/titlebar-buttons/proposal.md
@@ -1,20 +1,22 @@
 # Wails Enhancement Proposal (WEP)
 
-## Title
+## Customising Window Controls in Wails
 
 **Author**: Lea Anthony
 **Created**: 2024-05-20
 
 ## Summary
 
-Create a better API for controlling the appearance and functionality of window buttons in Wails.
+This is a proposal for an API to control the appearance and functionality of window controls in Wails.
 This will only be available on Windows and macOS.
 
 ## Motivation
 
-We currently do not fully support the ability to hide or disable the window buttons on the titlebar. 
+We currently do not fully support the ability to customise window controls. 
 
 ## Detailed Design
+
+### Controlling Button State
 
 1. A new enum will be added:
 
@@ -28,7 +30,7 @@ We currently do not fully support the ability to hide or disable the window butt
       )
 ```
 
-2. The following options will be added to the `WebviewWindowOptions` option struct:
+2. These options will be added to the `WebviewWindowOptions` option struct:
 
 ```go
    MinimiseButtonState ButtonState
@@ -36,18 +38,13 @@ We currently do not fully support the ability to hide or disable the window butt
    CloseButtonState    ButtonState
 ```
 
-The following options will be removed from the `WindowsWindow` options:
-
-- DisableMinimiseButton
-- DisableMaximiseButton
-
-The following options will be removed from the `MacWindow` options:
+3. These options will be removed from the current Windows/Mac options:
 
 - DisableMinimiseButton
 - DisableMaximiseButton
 - DisableCloseButton
 
-3. The following methods will be added to the `Window` interface:
+4. These methods will be added to the `Window` interface:
 
 ```go
    SetMinimizeButtonState(state ButtonState)
@@ -68,11 +65,46 @@ Note: On Windows, it is not possible to hide the Min/Max buttons individually.
 However, disabling both will hide both of the controls and only show the 
 close button. 
 
+### Controlling Window Style (Windows)
+
+As Windows currently does not have much in the way of controlling the style of the
+titlebar, a new option will be added to the `WebviewWindowOptions` option struct:
+
+```go
+   ExStyle int
+```
+
+If this is set, then the new Window will use the style specified in the `ExStyle` field.
+
+Example:
+```go
+package main
+
+import (
+	"github.com/wailsapp/wails/v3/pkg/application"
+	"github.com/wailsapp/wails/v3/pkg/w32"
+)
+
+func main() {
+    app := application.New(application.Options{
+		Name:        "My Application",
+	})
+	
+    app.NewWebviewWindowWithOptions(application.WebviewWindowOptions{
+        Windows: application.WindowsWindow{
+            ExStyle: w32.WS_EX_TOOLWINDOW | w32.WS_EX_NOREDIRECTIONBITMAP | w32.WS_EX_TOPMOST,
+        },
+	})
+	
+	app.Run()
+}
+```
+
 ## Pros/Cons
 
 ### Pros
 
-- We can support everything that's possible on both macOS and Windows
+- We bring much needed customisation capabilities to both macOS and Windows
 
 ### Cons
 
@@ -85,7 +117,7 @@ The alternative is to draw your own titlebar, but this is a lot of work and ofte
 
 ## Backwards Compatibility
 
-This is not backwards compatible as we remove the old button disable options.
+This is not backwards compatible as we remove the old "disable button" options.
 
 ## Test Plan
 


### PR DESCRIPTION
# Wails Enhancement Proposal (WEP)

## Customising Window Controls in Wails

**Author**: Lea Anthony
**Created**: 2024-05-20

## Summary

This is a proposal for an API to control the appearance and functionality of window controls in Wails.
This will only be available on Windows and macOS.

## Motivation

We currently do not fully support the ability to customise window controls. 

## Detailed Design

### Controlling Button State

1. A new enum will be added:

```go
      type ButtonState int

      const (
          ButtonEnabled  ButtonState = 0
          ButtonDisabled ButtonState = 1
          ButtonHidden   ButtonState = 2
      )
```

2. These options will be added to the `WebviewWindowOptions` option struct:

```go
   MinimiseButtonState ButtonState
   MaximiseButtonState ButtonState
   CloseButtonState    ButtonState
```

3. These options will be removed from the current Windows/Mac options:

- DisableMinimiseButton
- DisableMaximiseButton
- DisableCloseButton

4. These methods will be added to the `Window` interface:

```go
   SetMinimizeButtonState(state ButtonState)
   SetMaximizeButtonState(state ButtonState)
   SetCloseButtonState(state ButtonState)
```

The settings translate to the following functionality on each platform:

|                       | Windows                | Mac                    |
|-----------------------|------------------------|------------------------|
| Disable Min/Max/Close | Disables Min/Max/Close | Disables Min/Max/Close |
| Hide Min              | Disables Min           | Hides Min button       |
| Hide Max              | Disables Max           | Hides Max button       |
| Hide Close            | Hides all controls     | Hides Close            |

Note: On Windows, it is not possible to hide the Min/Max buttons individually.
However, disabling both will hide both of the controls and only show the 
close button. 

### Controlling Window Style (Windows)

As Windows currently does not have much in the way of controlling the style of the
titlebar, a new option will be added to the `WebviewWindowOptions` option struct:

```go
   ExStyle int
```

If this is set, then the new Window will use the style specified in the `ExStyle` field.

Example:
```go
package main

import (
	"github.com/wailsapp/wails/v3/pkg/application"
	"github.com/wailsapp/wails/v3/pkg/w32"
)

func main() {
    app := application.New(application.Options{
	Name: "My Application",
    })

    app.NewWebviewWindowWithOptions(application.WebviewWindowOptions{
        Windows: application.WindowsWindow{
            ExStyle: w32.WS_EX_TOOLWINDOW | w32.WS_EX_NOREDIRECTIONBITMAP | w32.WS_EX_TOPMOST,
        },
    })

    app.Run()
}
```

## Pros/Cons

### Pros

- We bring much needed customisation capabilities to both macOS and Windows

### Cons

- Windows works slightly different to macOS
- No Linux support (doesn't look like it's possible regardless of the solution)

## Alternatives Considered

The alternative is to draw your own titlebar, but this is a lot of work and often doesn't look good.

## Backwards Compatibility

This is not backwards compatible as we remove the old "disable button" options.

## Test Plan

As part of the implementation, the window example will be updated to test the functionality.

## Reference Implementation

There is a reference implementation as part of this proposal.

## Maintenance Plan

This feature will be maintained and supported by the Wails developers.

## Conclusion

This API would be a leap forward in giving developers greater control over their application window appearances.