### PR TITLE
[V3] fix windows cross volume project init

### DIFF
--- a/mkdocs-website/docs/en/changelog.md
+++ b/mkdocs-website/docs/en/changelog.md
@@ -37,6 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed cross volume project install for windows by [atterpac](https://github.com/atterac) in [#3512](https://github.com/wailsapp/wails/pull/3512)
 - Fixed react template css to show footer by [atterpac](https://github.com/atterpac) in [#3477](https://github.com/wailsapp/wails/pull/3477)
 - Fixed zombie processes when working in devmode by updating to latest refresh by [Atterpac](https://github.com/atterpac) in [#3320](https://github.com/wailsapp/wails/pull/3320).
 - Fixed appimage webkit file sourcing by [Atterpac](https://github.com/atterpac) in [#3306](https://github.com/wailsapp/wails/pull/3306).

--- a/v3/internal/templates/templates.go
+++ b/v3/internal/templates/templates.go
@@ -201,20 +201,27 @@ func getRemoteTemplate(uri string) (template *Template, err error) {
 }
 
 func Install(options *flags.Init) error {
-
+	var wd string = lo.Must(os.Getwd())
 	var projectDir string
 	if options.ProjectDir == "." || options.ProjectDir == "" {
-		projectDir = lo.Must(os.Getwd())
+		projectDir = wd
+	} else {
+		projectDir = options.ProjectDir
 	}
 	var err error
-	projectDir, err = filepath.Abs(filepath.Join(options.ProjectDir, options.ProjectName))
+	projectDir, err = filepath.Abs(filepath.Join(projectDir, options.ProjectName))
 	if err != nil {
 		return err
 	}
 
 	// Calculate relative path from project directory to LocalModulePath
 	var relativePath string
-	relativePath, err = filepath.Rel(projectDir, debug.LocalModulePath)
+	// Check if the project directory and LocalModulePath are in the same drive
+	if filepath.VolumeName(wd) != filepath.VolumeName(debug.LocalModulePath) {
+		relativePath = debug.LocalModulePath
+	} else {
+		relativePath, err = filepath.Rel(projectDir, debug.LocalModulePath)
+	}
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
# Description
Fixes an issue where if wails is installed in the `C:\` drive attempting to create a project on any other volume would result in an error due to not being able to set the relative path for the project.

This change gets the `filepath.VolumeName()` of each path and compares if they are different and hardcodes the full path if they differ

Fixes # (issue)
Raised by discord memeber.
## Type of change
  
Please delete options that are not relevant.

- [ X ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
- [X] Windows

  
## Test Configuration
```
# System
┌──────────────────────────────────────────────────────────────────────────────────────────────────┐
| Name              | Windows 10 Home                                                              |
| Version           | 2009 (Build: 22631)                                                          |
| ID                | 23H2                                                                         |
| Branding          | Windows 11 Home                                                              |
| Platform          | windows                                                                      |
| Architecture      | amd64                                                                        |
| Go WebView2Loader | true                                                                         |
| WebView2 Version  | 124.0.2478.109                                                               |
| CPU               | AMD Ryzen 7 3700X 8-Core Processor                                           |
| GPU 1             | Virtual Desktop Monitor (Virtual Desktop, Inc.) - Driver: 15.39.56.845       |
| GPU 2             | Parsec Virtual Display Adapter (Parsec Cloud, Inc.) - Driver: 0.41.0.0       |
| GPU 3             | AMD Radeon RX 5700 (Advanced Micro Devices, Inc.) - Driver: 31.0.24031.5001  |
| Memory            | 48GB                                                                         |
└──────────────────────────────────────────────────────────────────────────────────────────────────┘

# Build Environment
┌─────────────────────────────────────────────────────────┐
| Wails CLI    | v3.0.0-alpha.4                           |
| Go Version   | go1.22.2                                 |
| Revision     | 54fb385816ab7939ce94ddb184fda73f4adefb52 |
| Modified     | true                                     |
| -buildmode   | exe                                      |
| -compiler    | gc                                       |
| CGO_ENABLED  | 0                                        |
| GOAMD64      | v1                                       |
| GOARCH       | amd64                                    |
| GOOS         | windows                                  |
| vcs          | git                                      |
| vcs.modified | true                                     |
| vcs.revision | 54fb385816ab7939ce94ddb184fda73f4adefb52 |
| vcs.time     | 2024-05-24T21:01:32Z                     |
└─────────────────────────────────────────────────────────┘
```
