### PR TITLE
linux: theme handling bugfix

### DIFF
--- a/mkdocs-website/docs/en/changelog.md
+++ b/mkdocs-website/docs/en/changelog.md
@@ -37,6 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- [linux] Fixed theme handling error on NixOS by [tmclane](https://github.com/tmclane) in [#3515)(https://github.com/wailsapp/wails/pull/3515)
 - Fixed cross volume project install for windows by [atterpac](https://github.com/atterac) in [#3512](https://github.com/wailsapp/wails/pull/3512)
 - Fixed react template css to show footer by [atterpac](https://github.com/atterpac) in [#3477](https://github.com/wailsapp/wails/pull/3477)
 - Fixed zombie processes when working in devmode by updating to latest refresh by [Atterpac](https://github.com/atterpac) in [#3320](https://github.com/wailsapp/wails/pull/3320).

--- a/v3/pkg/application/application_linux.go
+++ b/v3/pkg/application/application_linux.go
@@ -156,10 +156,10 @@ func (a *linuxApp) monitorThemeChanges() {
 			if len(body) < 2 {
 				return "", false
 			}
-			if body[0].(string) != "org.gnome.desktop.interface" {
+			if entry, ok := body[0].(string); !ok || entry != "org.gnome.desktop.interface" {
 				return "", false
 			}
-			if body[1].(string) == "color-scheme" {
+			if entry, ok := body[1].(string); ok && entry == "color-scheme" {
 				return body[2].(dbus.Variant).Value().(string), true
 			}
 			return "", false


### PR DESCRIPTION
This change addresses an issue encountered on NixOS where the data passed in from the `Body` element contains data other than an `[]interface{} of string values`.  
Updating the code to do a safe type assertion instead of blindly asserting it is a string.   
This seems to resolve the crash but further investigation should be done to see what other types of values might be included in the `dbus.Signal.Body` field.
