### PR TITLE
Fixing compatibility errors w/Gin and Windows.

### DIFF
--- a/mkdocs-website/docs/en/changelog.md
+++ b/mkdocs-website/docs/en/changelog.md
@@ -80,6 +80,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - New binding code layout: output files were previously organised in folders named after their containing package; now full Go import paths are used, including the module path. By [@fbbdev](https://github.com/fbbdev) in [#3468](https://github.com/wailsapp/wails/pull/3468)
 - The struct field `application.Options.Bind` has been renamed to `application.Options.Services`. By [@fbbdev](https://github.com/fbbdev) in [#3468](https://github.com/wailsapp/wails/pull/3468)
 - New syntax for binding services: service instances must now be wrapped in a call to `application.NewService`. By [@fbbdev](https://github.com/fbbdev) in [#3468](https://github.com/wailsapp/wails/pull/3468)
+- Modified the `contentTypeSniffer` struct to include the `http.CloseNotifier` interface. Now compatible with Gin framework. By [@AnalogJ](https://github.com/AnalogJ) in [#3537](https://github.com/wailsapp/wails/pull/3537)
 
 ### Removed
 

--- a/v3/internal/assetserver/assetserver.go
+++ b/v3/internal/assetserver/assetserver.go
@@ -62,7 +62,7 @@ func NewAssetServer(options *Options) (*AssetServer, error) {
 
 func (a *AssetServer) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	start := time.Now()
-	wrapped := &contentTypeSniffer{rw: rw}
+	wrapped := newContentTypeSniffer(rw)
 
 	req = req.WithContext(contextWithLogger(req.Context(), a.options.Logger))
 	a.handler.ServeHTTP(wrapped, req)

--- a/v3/internal/assetserver/assetserver_webview.go
+++ b/v3/internal/assetserver/assetserver_webview.go
@@ -74,8 +74,8 @@ func (a *AssetServer) processWebViewRequestInternal(r webview.Request) {
 		}
 	}()
 
-	var rw http.ResponseWriter = &contentTypeSniffer{rw: wrw} // Make sure we have a Content-Type sniffer
-	defer rw.WriteHeader(http.StatusNotImplemented)           // This is a NOP when a handler has already written and set the status
+	var rw http.ResponseWriter = newContentTypeSniffer(wrw) // Make sure we have a Content-Type sniffer
+	defer rw.WriteHeader(http.StatusNotImplemented)         // This is a NOP when a handler has already written and set the status
 
 	uri, err = r.URL()
 	if err != nil {


### PR DESCRIPTION
😬  Sorry I haven't opened a issue about these yet. They've been living in my branch for more than [6months](https://github.com/fastenhealth/wails/tree/v3-alpha-analogj) at this point, made sense to move them upstream

# Description

- The `contentTypeSniffer` struct is not compatible with the Gin response, which requires the `http.CloseNotifier` interface. 
- Fixing a parsing error for syso options.

## Type of change
  
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
  
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration using `wails doctor`.

- [x] Windows
- [x] macOS

  
## Test Configuration

```

                                
          Wails Doctor          
                                

                                                                                                                                                                            
# System
┌──────────────────────────────┐
| Name          | MacOS        |
| Version       | 12.6         |
| ID            | 21G115       |
| Branding      | Monterey     |
| Platform      | darwin       |
| Architecture  | arm64        |
| Apple Silicon | true         |
| CPU           | Apple M1 Max |
| CPU           | Unknown      |
| GPU           | Unknown      |
| Memory        | Unknown      |
└──────────────────────────────┘

# Build Environment
┌─────────────────────────────────────────────────────────┐
| Wails CLI    | v3.0.0-alpha.4                           |
| Go Version   | go1.22.4                                 |
| Revision     | ab06920e74473cb0e34bf2dfffdd8bda023f3ddc |
| Modified     | false                                    |
| -buildmode   | exe                                      |
| -compiler    | gc                                       |
| CGO_CFLAGS   |                                          |
| CGO_CPPFLAGS |                                          |
| CGO_CXXFLAGS |                                          |
| CGO_ENABLED  | 1                                        |
| CGO_LDFLAGS  |                                          |
| GOARCH       | arm64                                    |
| GOOS         | darwin                                   |
| vcs          | git                                      |
| vcs.modified | false                                    |
| vcs.revision | ab06920e74473cb0e34bf2dfffdd8bda023f3ddc |
| vcs.time     | 2024-06-08T22:28:38Z                     |
└─────────────────────────────────────────────────────────┘

# Dependencies
┌────────────────────────────────────────────────────────────────────────┐
| Xcode cli tools | 2395                                                 |
| npm             | 10.5.0                                               |
| *NSIS           | Not Installed. Install with `brew install makensis`. |
└─────────────────────── * - Optional Dependency ────────────────────────┘

# Diagnosis
 SUCCESS  Your system is ready for Wails development!

```

# Checklist:

- [ ] I have updated `website/src/pages/changelog.mdx` with details of this PR
- [x] My code follows the general coding style of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
