### PR TITLE
Fix build for Linux/v2.9.0

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Run tests (Ubuntu 24.04)
         if: matrix.os == 'ubuntu-24.04'
         working-directory: ./v2
-        run: go test -v ./...-tags webkit2_41
+        run: go test -v ./... -tags webkit2_41
 
   test_js:
     name: Run JS Tests

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest, macos-11]
+        os: [ubuntu-22.04, windows-latest, macos-latest, macos-11]
         go-version: ['1.21']
 
     steps:
@@ -77,7 +77,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest, ubuntu-24.04]
+        os: [ubuntu-22.04, windows-latest, macos-latest, ubuntu-24.04]
         template:
           [
             svelte,

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Run tests (Ubuntu 24.04)
         if: matrix.os == 'ubuntu-24.04'
         working-directory: ./v2
-        run: go test -v ./... -tags webkit2_41
+        run: go test -v -tags webkit2_41 ./...
 
   test_js:
     name: Run JS Tests

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -19,13 +19,17 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Install linux dependencies ( 22.04 )
+      - uses: awalsh128/cache-apt-pkgs-action@latest
         if: matrix.os == 'ubuntu-22.04'
-        run: sudo apt-get update -y && sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.0-dev build-essential pkg-config
+        with:
+          packages: libgtk-3-dev libwebkit2gtk-4.0-dev build-essential pkg-config
+          version: 1.0
 
-      - name: Install linux dependencies ( 24.04 )
+      - uses: awalsh128/cache-apt-pkgs-action@latest
         if: matrix.os == 'ubuntu-24.04'
-        run: sudo apt-get update -y && sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev build-essential pkg-config
+        with:
+          packages: libgtk-3-dev libwebkit2gtk-4.1-dev build-essential pkg-config
+          version: 1.0
 
       - name: Setup Go
         uses: actions/setup-go@v4

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -124,5 +124,15 @@ jobs:
           mkdir -p ./test-${{ matrix.template }}
           cd ./test-${{ matrix.template }}
           wails init -n ${{ matrix.template }} -t ${{ matrix.template }} -ci
+
+      - name: Build template '${{ matrix.template }}'
+        if: matrix.os != 'ubuntu-24.04'
+        run: |
           cd ${{ matrix.template }}
           wails build -v 2
+
+      - name: Build template '${{ matrix.template }}' (Ubuntu 24.04)
+        if: matrix.os == 'ubuntu-24.04'
+        run: |
+          cd ${{ matrix.template }}
+          wails build -v 2 -tags webkit2_41

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-22.04, windows-latest, macos-latest, macos-11]
+        os: [ubuntu-22.04, ubuntu-24.04, windows-latest, macos-latest, macos-11]
         go-version: ['1.21']
 
     steps:
@@ -77,7 +77,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: [ubuntu-22.04, windows-latest, macos-latest, ubuntu-24.04]
+        os: [ubuntu-22.04, windows-latest, macos-latest, ubuntu-24.04, macos-11]
         template:
           [
             svelte,

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -124,20 +124,21 @@ jobs:
         if: matrix.os == 'ubuntu-24.04'
         run: sudo apt-get update -y && sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev build-essential pkg-config
 
-      - name: Generate template '${{ matrix.template }}'
+      - name: Generate & Build template '${{ matrix.template }}'
+        if: matrix.os != 'ubuntu-24.04'
         run: |
           mkdir -p ./test-${{ matrix.template }}
           cd ./test-${{ matrix.template }}
           wails init -n ${{ matrix.template }} -t ${{ matrix.template }} -ci
-
-      - name: Build template '${{ matrix.template }}'
-        if: matrix.os != 'ubuntu-24.04'
-        run: |
           cd ${{ matrix.template }}
           wails build -v 2
 
-      - name: Build template '${{ matrix.template }}' (Ubuntu 24.04)
+      - name: Generate & Build template '${{ matrix.template }}' (ubuntu-24.04)
         if: matrix.os == 'ubuntu-24.04'
         run: |
+          mkdir -p ./test-${{ matrix.template }}
+          cd ./test-${{ matrix.template }}
+          wails init -n ${{ matrix.template }} -t ${{ matrix.template }} -ci
           cd ${{ matrix.template }}
           wails build -v 2 -tags webkit2_41
+

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -41,9 +41,14 @@ jobs:
         run: go test -v ./...
 
       - name: Run tests (!mac)
-        if: matrix.os != 'macos-latest' && matrix.os != 'macos-11'
+        if: matrix.os != 'macos-latest' && matrix.os != 'macos-11' && matrix.os != 'ubuntu-24.04'
         working-directory: ./v2
         run: go test -v ./...
+
+      - name: Run tests (Ubuntu 24.04)
+        if: matrix.os == 'ubuntu-24.04'
+        working-directory: ./v2
+        run: go test -v ./...-tags webkit2_41
 
   test_js:
     name: Run JS Tests

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -19,9 +19,13 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Install linux dependencies
-        if: matrix.os == 'ubuntu-latest'
+      - name: Install linux dependencies ( 22.04 )
+        if: matrix.os == 'ubuntu-22.04'
         run: sudo apt-get update -y && sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.0-dev build-essential pkg-config
+
+      - name: Install linux dependencies ( 24.04 )
+        if: matrix.os == 'ubuntu-24.04'
+        run: sudo apt-get update -y && sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev build-essential pkg-config
 
       - name: Setup Go
         uses: actions/setup-go@v4
@@ -73,7 +77,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest, ubuntu-24.04]
         template:
           [
             svelte,
@@ -107,9 +111,13 @@ jobs:
           go install
           wails -help
 
-      - name: Install linux dependencies
-        if: matrix.os == 'ubuntu-latest'
+      - name: Install linux dependencies ( 22.04 )
+        if: matrix.os == 'ubuntu-22.04'
         run: sudo apt-get update -y && sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.0-dev build-essential pkg-config
+
+      - name: Install linux dependencies ( 24.04 )
+        if: matrix.os == 'ubuntu-24.04'
+        run: sudo apt-get update -y && sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev build-essential pkg-config
 
       - name: Generate template '${{ matrix.template }}'
         run: |

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -56,7 +56,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-22.04, windows-latest, macos-latest, ubuntu-24.04]
-        go-version: ['1.22']
+        go-version: ['1.21']
 
     steps:
       - name: Checkout code

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -62,9 +62,13 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
-      - name: Install linux dependencies
-        if: matrix.os == 'ubuntu-latest'
+      - name: Install linux dependencies ( 22.04 )
+        if: matrix.os == 'ubuntu-22.04'
         run: sudo apt-get update -y && sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.0-dev build-essential pkg-config
+
+      - name: Install linux dependencies ( 24.04 )
+        if: matrix.os == 'ubuntu-24.04'
+        run: sudo apt-get update -y && sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev build-essential pkg-config
 
       - name: Setup Go
         uses: actions/setup-go@v3

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -83,6 +83,11 @@ jobs:
         run: go test -v ./...
 
       - name: Run tests (!mac)
-        if: matrix.os != 'macos-latest'
+        if: matrix.os != 'macos-latest' && matrix.os != 'ubuntu-24.04'
         working-directory: ./v2
         run: go test -v ./...
+
+      - name: Run tests (Ubuntu 24.04)
+        if: matrix.os == 'ubuntu-24.04'
+        working-directory: ./v2
+        run: go test -v -tags webkit2_41 ./...

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -55,7 +55,7 @@ jobs:
     if: github.event.review.state == 'approved'
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-22.04, windows-latest, macos-latest, ubuntu-24.04]
         go-version: ['1.22']
 
     steps:

--- a/v2/internal/frontend/desktop/linux/window.c
+++ b/v2/internal/frontend/desktop/linux/window.c
@@ -507,7 +507,7 @@ GtkWidget *SetupWebview(void *contentManager, GtkWindow *window, int hideWindowO
 
     if(disableWebViewDragAndDrop)
     {
-        gtk_drag_dest_unset(G_OBJECT(webview));
+        gtk_drag_dest_unset(webview);
     }
 
     if(enableDragAndDrop)


### PR DESCRIPTION

# Description

This PR adds a fix for compilation errors on Linux. Pipelines updated to test on both 22.04 and 24.04.

Fixes #3542 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated continuous integration workflows to include support for `ubuntu-22.04` and `ubuntu-24.04`.
  - Added steps to install Linux dependencies and run tests for new Ubuntu versions.
  - Modified job execution matrix to replace `ubuntu-latest` with `ubuntu-22.04` and `ubuntu-24.04`.
  - Updated Go version to `1.21` in workflow configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->