### PR TITLE
Add wails-template-nuxt

### DIFF
--- a/website/versioned_docs/version-v2.9.0/community/templates.mdx
+++ b/website/versioned_docs/version-v2.9.0/community/templates.mdx
@@ -27,6 +27,7 @@ If you are unsure about a template, inspect `package.json` and `wails.json` for 
 - [wails-template-quasar-js](https://github.com/sgosiaco/wails-template-quasar-js) - A template using JavaScript + Quasar V2 (Vue 3, Vite, Sass, Pinia, ESLint, Prettier)
 - [wails-template-quasar-ts](https://github.com/sgosiaco/wails-template-quasar-ts) - A template using TypeScript + Quasar V2 (Vue 3, Vite, Sass, Pinia, ESLint, Prettier, Composition API with &lt;script setup&gt;)
 - [wails-template-naive](https://github.com/tk103331/wails-template-naive) - Wails template based on Naive UI (A Vue 3 Component Library)
+- [wails-template-nuxt](https://github.com/gornius/wails-template-nuxt) - Wails template using clean Nuxt3 and TypeScript with auto-imports for wails js runtime
 
 ## Angular
 


### PR DESCRIPTION
# Description
I've created template with Nuxt3.

## Type of change

- [x] This change requires a documentation update

# How Has This Been Tested?

- [x] Windows
- [ ] macOS
- [x] Linux


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new Wails template called `wails-template-nuxt`. This template features clean Nuxt3 and TypeScript with auto-imports for the Wails JS runtime.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->