### PR TITLE
[V3/Windows] Fix Windows Dialog crash on invalid folder path

### DIFF
--- a/v3/internal/go-common-file-dialog/cfd/DialogConfig.go
+++ b/v3/internal/go-common-file-dialog/cfd/DialogConfig.go
@@ -2,6 +2,10 @@
 
 package cfd
 
+import (
+	"os"
+)
+
 type FileFilter struct {
 	// The display name of the filter (That is shown to the user)
 	DisplayName string
@@ -67,6 +71,10 @@ func (config *DialogConfig) apply(dialog Dialog) (err error) {
 	}
 
 	if config.Folder != "" {
+		_, err = os.Stat(config.Folder)
+		if err != nil {
+			return
+		}
 		err = dialog.SetFolder(config.Folder)
 		if err != nil {
 			return
@@ -74,6 +82,10 @@ func (config *DialogConfig) apply(dialog Dialog) (err error) {
 	}
 
 	if config.DefaultFolder != "" {
+		_, err = os.Stat(config.DefaultFolder)
+		if err != nil {
+			return
+		}
 		err = dialog.SetDefaultFolder(config.DefaultFolder)
 		if err != nil {
 			return


### PR DESCRIPTION
Windows crashes when setting a file dialog directory to one that does not exist
Adds os.Stat errors before creating the dialog 

```
# System
┌──────────────────────────────────────────────────────────────────────────────────────────┐
| Name         | Ubuntu                                                                    |
| Version      | 24.04                                                                     |
| ID           | ubuntu                                                                    |
| Branding     | 24.04 LTS (Noble Numbat)                                                  |
| Platform     | linux                                                                     |
| Architecture | amd64                                                                     |
| CPU          | 12th Gen Intel(R) Core(TM) i5-1235U                                       |
| GPU 1        | Alder Lake-UP3 GT2 [Iris Xe Graphics] (Intel Corporation) - Driver: i915  |
| Memory       | 7GB                                                                       |
└──────────────────────────────────────────────────────────────────────────────────────────┘

# Build Environment
┌─────────────────────────────────────────────────────────┐
| Wails CLI    | v3.0.0-alpha.4                           |
| Go Version   | go1.22.4                                 |
| Revision     | d684599d755807392b728dc5794fcd662bfb9b72 |
| Modified     | true                                     |
| -buildmode   | exe                                      |
| -compiler    | gc                                       |
| CGO_CFLAGS   |                                          |
| CGO_CPPFLAGS |                                          |
| CGO_CXXFLAGS |                                          |
| CGO_ENABLED  | 1                                        |
| CGO_LDFLAGS  |                                          |
| GOAMD64      | v1                                       |
| GOARCH       | amd64                                    |
| GOOS         | linux                                    |
| vcs          | git                                      |
| vcs.modified | true                                     |
| vcs.revision | d684599d755807392b728dc5794fcd662bfb9b72 |
| vcs.time     | 2024-06-26T11:03:57Z                     |
└─────────────────────────────────────────────────────────┘

# Dependencies
┌──────────────────────────────────────────────────────────────────────────────────┐
| gcc        | 12.10ubuntu1                                                        |
| gtk3       | 3.24.41-4ubuntu1                                                    |
| npm        | 10.5.1                                                              |
| pkg-config | 1.8.1-2build1                                                       |
| webkit2gtk | not installed. Install with: sudo apt install libwebkit2gtk-4.1-dev |
└──────────────────────────── * - Optional Dependency ─────────────────────────────┘
```