### PR TITLE
https flag for dev mode

### DIFF
--- a/v3/internal/commands/dev.go
+++ b/v3/internal/commands/dev.go
@@ -17,6 +17,7 @@ type DevOptions struct {
 
 	Config   string `description:"The config file including path" default:"./build/devmode.config.yaml"`
 	VitePort int    `name:"port" description:"Specify the vite dev server port"`
+	Secure   bool   `name:"s" description:"Enable HTTPS"`
 }
 
 func Dev(options *DevOptions) error {
@@ -45,7 +46,11 @@ func Dev(options *DevOptions) error {
 	os.Setenv(wailsVitePort, strconv.Itoa(port))
 
 	// Set url of frontend dev server
-	os.Setenv("FRONTEND_DEVSERVER_URL", fmt.Sprintf("http://%s:%d", host, port))
+	if options.Secure {
+		os.Setenv("FRONTEND_DEVSERVER_URL", fmt.Sprintf("https://%s:%d", host, port))
+	} else {
+		os.Setenv("FRONTEND_DEVSERVER_URL", fmt.Sprintf("http://%s:%d", host, port))
+	}
 
 	return Watcher(&WatcherOptions{
 		Config: options.Config,


### PR DESCRIPTION
Adds `-s` flag to dev mode to allow the dev server url to be HTTPS. This is needed for NextJS to work as well as other non-vite HMR

Fixes # (issue)

## Type of change
  
- [ X ] New feature (non-breaking change which adds functionality)


# How Has This Been Tested?
- [X ] Linux
  
## Test Configuration
```
# System
┌──────────────────────────────────────────────────────────────────────────────────────────┐
| Name         | Ubuntu                                                                    |
| Version      | 24.04                                                                     |
| ID           | ubuntu                                                                    |
| Branding     | 24.04 LTS (Noble Numbat)                                                  |
| Platform     | linux                                                                     |
| Architecture | amd64                                                                     |
| CPU          | 12th Gen Intel(R) Core(TM) i5-1235U                                       |
| GPU 1        | Alder Lake-UP3 GT2 [Iris Xe Graphics] (Intel Corporation) - Driver: i915  |
| Memory       | 7GB                                                                       |
└──────────────────────────────────────────────────────────────────────────────────────────┘

# Build Environment
┌─────────────────────────────────────────────────────────┐
| Wails CLI    | v3.0.0-alpha.4                           |
| Go Version   | go1.22.4                                 |
| Revision     | 5fcebd02741eea738dfcb7fc43d8d86f139293fe |
| Modified     | true                                     |
| -buildmode   | exe                                      |
| -compiler    | gc                                       |
| CGO_CFLAGS   |                                          |
| CGO_CPPFLAGS |                                          |
| CGO_CXXFLAGS |                                          |
| CGO_ENABLED  | 1                                        |
| CGO_LDFLAGS  |                                          |
| GOAMD64      | v1                                       |
| GOARCH       | amd64                                    |
| GOOS         | linux                                    |
| vcs          | git                                      |
| vcs.modified | true                                     |
| vcs.revision | 5fcebd02741eea738dfcb7fc43d8d86f139293fe |
| vcs.time     | 2024-07-02T08:49:19Z                     |
└─────────────────────────────────────────────────────────┘

# Dependencies
┌──────────────────────────────────────────────────────────────────────────────────┐
| gcc        | 12.10ubuntu1                                                        |
| gtk3       | 3.24.41-4ubuntu1                                                    |
| npm        | 10.5.1                                                              |
| pkg-config | 1.8.1-2build1                                                       |
| webkit2gtk | not installed. Install with: sudo apt install libwebkit2gtk-4.1-dev |
└──────────────────────────── * - Optional Dependency ─────────────────────────────┘

```
