### PR TITLE
fix resize messaging

### DIFF
--- a/mkdocs-website/docs/en/changelog.md
+++ b/mkdocs-website/docs/en/changelog.md
@@ -40,6 +40,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed resize event messaging by [atterpac](https://github.com/atterpac) in [#3606](https://github.com/wailsapp/wails/pull/3606)
 - [linux] Fixed theme handling error on NixOS by [tmclane](https://github.com/tmclane) in [#3515)(https://github.com/wailsapp/wails/pull/3515)
 - Fixed cross volume project install for windows by [atterpac](https://github.com/atterac) in [#3512](https://github.com/wailsapp/wails/pull/3512)
 - Fixed react template css to show footer by [atterpac](https://github.com/atterpac) in [#3477](https://github.com/wailsapp/wails/pull/3477)

--- a/v3/pkg/application/webview_window.go
+++ b/v3/pkg/application/webview_window.go
@@ -659,11 +659,11 @@ func (w *WebviewWindow) HandleMessage(message string) {
 	case strings.HasPrefix(message, "wails:resize:"):
 		if !w.IsFullscreen() {
 			sl := strings.Split(message, ":")
-			if len(sl) != 2 {
-				w.Error("Unknown message returned from dispatcher: %+v", message)
+			if len(sl) != 3 {
+				w.Error("Unknown message returned from dispatcher", "message", message)
 				return
 			}
-			err := w.startResize(sl[1])
+			err := w.startResize(sl[2])
 			if err != nil {
 				w.Error(err.Error())
 			}


### PR DESCRIPTION
A recent change to the messaging system broke the `wails:resize:<border>` message due to adding `wails:` prefix, this fix corrects the length check and parameter used in the resize function.

Also fixes a slog key error


# How Has This Been Tested?
- [X ] Linux
  
## Test Configuration
```
# System
┌──────────────────────────────────────────────────────────────────────────────────────────┐
| Name         | Ubuntu                                                                    |
| Version      | 24.04                                                                     |
| ID           | ubuntu                                                                    |
| Branding     | 24.04 LTS (Noble Numbat)                                                  |
| Platform     | linux                                                                     |
| Architecture | amd64                                                                     |
| CPU          | 12th Gen Intel(R) Core(TM) i5-1235U                                       |
| GPU 1        | Alder Lake-UP3 GT2 [Iris Xe Graphics] (Intel Corporation) - Driver: i915  |
| Memory       | 7GB                                                                       |
└──────────────────────────────────────────────────────────────────────────────────────────┘

# Build Environment
┌─────────────────────────────────────────────────────────┐
| Wails CLI    | v3.0.0-alpha.4                           |
| Go Version   | go1.22.4                                 |
| Revision     | 5fcebd02741eea738dfcb7fc43d8d86f139293fe |
| Modified     | true                                     |
| -buildmode   | exe                                      |
| -compiler    | gc                                       |
| CGO_CFLAGS   |                                          |
| CGO_CPPFLAGS |                                          |
| CGO_CXXFLAGS |                                          |
| CGO_ENABLED  | 1                                        |
| CGO_LDFLAGS  |                                          |
| GOAMD64      | v1                                       |
| GOARCH       | amd64                                    |
| GOOS         | linux                                    |
| vcs          | git                                      |
| vcs.modified | true                                     |
| vcs.revision | 5fcebd02741eea738dfcb7fc43d8d86f139293fe |
| vcs.time     | 2024-07-02T08:49:19Z                     |
└─────────────────────────────────────────────────────────┘

# Dependencies
┌──────────────────────────────────────────────────────────────────────────────────┐
| gcc        | 12.10ubuntu1                                                        |
| gtk3       | 3.24.41-4ubuntu1                                                    |
| npm        | 10.5.1                                                              |
| pkg-config | 1.8.1-2build1                                                       |
| webkit2gtk | not installed. Install with: sudo apt install libwebkit2gtk-4.1-dev |
└──────────────────────────── * - Optional Dependency ─────────────────────────────┘

```
