### PR TITLE
Fix assetserver_webview.go request cancelation on MacOS

### DIFF
--- a/v2/internal/frontend/desktop/darwin/WailsContext.m
+++ b/v2/internal/frontend/desktop/darwin/WailsContext.m
@@ -463,6 +463,7 @@ typedef void (^schemeTaskCaller)(id<WKURLSchemeTask>);
 }
 
 - (void)webView:(nonnull WKWebView *)webView stopURLSchemeTask:(nonnull id<WKURLSchemeTask>)urlSchemeTask {
+    processURLRequestStop(self, urlSchemeTask);
     NSInputStream *stream = urlSchemeTask.request.HTTPBodyStream;
     if (stream) {
         NSStreamStatus status = stream.streamStatus;

--- a/v2/internal/frontend/desktop/darwin/frontend.go
+++ b/v2/internal/frontend/desktop/darwin/frontend.go
@@ -463,6 +463,17 @@ func processURLRequest(_ unsafe.Pointer, wkURLSchemeTask unsafe.Pointer) {
 	requestBuffer <- webview.NewRequest(wkURLSchemeTask)
 }
 
+//export processURLRequestStop
+func processURLRequestStop(_ unsafe.Pointer, wkURLSchemeTask unsafe.Pointer) {
+	r := webview.NewRequest(wkURLSchemeTask)
+	requestID, err := r.URL()
+	if err != nil {
+		fmt.Println(err.Error())
+	}
+
+	assetserver.CancelRequest(requestID)
+}
+
 //export HandleOpenFile
 func HandleOpenFile(filePath *C.char) {
 	goFilepath := C.GoString(filePath)

--- a/v2/internal/frontend/desktop/darwin/message.h
+++ b/v2/internal/frontend/desktop/darwin/message.h
@@ -16,6 +16,7 @@ extern "C"
 
 void processMessage(const char *);
 void processURLRequest(void *, void*);
+void processURLRequestStop(void *, void*);
 void processMessageDialogResponse(int);
 void processOpenFileDialogResponse(const char*);
 void processSaveFileDialogResponse(const char*);


### PR DESCRIPTION
# Description

I am using custom Middleware with go-chi router for IPC between ui & go (need this to pass large amounts of data), and sometimes wish to cancel the request from UI before it is completed. It works for remote dev server (opening from browser via http://localhost:34115/ ) - canceling fetch request from javascript will cancel the request.Context. But this does not work from Webview - http.Request is created with empty Context. 

This is my fix / proposal for MacOS
Current solution only uses request.URL() for RequestID, thinking about replacing it by extending `type Request interface` with something like RequestID() method that will return a pointer to WKURLSchemeTask

@leaanthony what do you think about this approach ?

## Type of change
  
- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
  
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration using `wails doctor`.

- [X] macOS
- [ ] Windows
- [ ] Linux
  
## Test Configuration
```                                                                                                                                                                                         
# Wails
Version | v2.8.2

# System
┌────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
| OS           | MacOS                                                                                                                       |
| Version      | 14.5                                                                                                                        |
| ID           | 23F79                                                                                                                       |
| Go Version   | go1.22.2                                                                                                                    |
| Platform     | darwin                                                                                                                      |
| Architecture | arm64                                                                                                                       |
| CPU          | Apple M1 Pro                                                                                                                |
| GPU          | Chipset Model: Apple M1 Pro Type: GPU Bus: Built-In Total Number of Cores: 16 Vendor: Apple (0x106b) Metal Support: Metal 3 |
| Memory       | 16GB                                                                                                                        |
└────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘

# Dependencies
┌──────────────────────────────────────────────────────────────────────┐
| Dependency                | Package Name | Status    | Version       |
| Xcode command line tools  | N/A          | Installed | 2408          |
| Nodejs                    | N/A          | Installed | 20.13.1       |
| npm                       | N/A          | Installed | 10.5.2        |
| *Xcode                    | N/A          | Installed | 15.4 (15F31d) |
| *upx                      | N/A          | Available |               |
| *nsis                     | N/A          | Available |               |
└────────────────────── * - Optional Dependency ───────────────────────┘

# Diagnosis
Optional package(s) installation details: 
  - upx : Available at https://upx.github.io/
  - nsis : More info at https://wails.io/docs/guides/windows-installer/
```
# Checklist:

- [ ] I have updated `website/src/pages/changelog.mdx` with details of this PR
- [X] My code follows the general coding style of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
    - Enhanced request handling with the introduction of a mechanism to stop ongoing URL requests, improving resource management.
    - Added a cancellation functionality to manage long-running HTTP requests effectively.

- **Improvements**
    - Robust handling of URL scheme tasks, allowing for better cleanup and processing when stopping tasks.
    - Integrated cancellation context for HTTP requests, enhancing the responsiveness of the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->