### PR TITLE
[v3] Fix systemTray.setIcon crashing on Linux

### DIFF
--- a/mkdocs-website/docs/en/changelog.md
+++ b/mkdocs-website/docs/en/changelog.md
@@ -73,6 +73,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix handling of multiple return values from bound methods by [@fbbdev](https://github.com/fbbdev) in [#3431](https://github.com/wailsapp/wails/pull/3431)
 - Fix doctor detection of npm that is not installed with system package manager by [@pekim](https://github.com/pekim) in [#3458](https://github.com/wailsapp/wails/pull/3458)
 - Fix missing MicrosoftEdgeWebview2Setup.exe. Thanks to [@robin-samuel](https://github.com/robin-samuel).
+- Fix systemTray.setIcon crashing on Linux by [@windom](https://github.com/windom/) in [#3636](https://github.com/wailsapp/wails/pull/3636).
 
 ### Changed
 

--- a/v3/pkg/application/systemtray_linux.go
+++ b/v3/pkg/application/systemtray_linux.go
@@ -375,7 +375,7 @@ func (s *linuxSystemTray) setIcon(icon []byte) {
 		globalApplication.error("systray error: failed to convert icon to PX: %s\n", err)
 		return
 	}
-	s.props.SetMust("org.kde.StatusNotifierItem", "IconPixmap", iconPx)
+	s.props.SetMust("org.kde.StatusNotifierItem", "IconPixmap", []PX{iconPx})
 
 	if s.conn == nil {
 		return


### PR DESCRIPTION
<!--
READ CAREFULLY: Before submitting your PR, please ensure you have created an issue for your PR.
It is essential that you do this so that we can discuss the proposed changes before you spend time on them.
If you do not create an issue, your PR may be rejected without review.
If a relevant issue already exists, please reference it in your PR by including `Fixes #<issue number>` in your PR description.
-->

# Description

Changing the system tray icon, after the application has started results in the panic listed below. 
To reproduce add the following code just before calling `app.Run()`  in `v3/examples/systray/main.go`:

```
app.On(events.Common.ApplicationStarted, func(event *application.Event) {
	systemTray.SetIcon(icons.SystrayDark)
})
```

```
panic: dbus.Store: type mismatch: cannot convert application.PX to []application.PX

goroutine 1 [running, locked to thread]:
github.com/godbus/dbus/v5/prop.(*Properties).SetMust(0xc000230200, {0xa447a1, 0x1a}, {0xa37fd7, 0xa}, {0x9d1d80, 0xc0001fc7e0})
	/home/windom/go/pkg/mod/github.com/godbus/dbus/v5@v5.1.0/prop/prop.go:346 +0xec
github.com/wailsapp/wails/v3/pkg/application.(*linuxSystemTray).setIcon(0xc00021c080, {0xee5500?, 0xc00003d5d0?, 0x42197f?})
	/home/windom/uprock/wails/v3/pkg/application/systemtray_linux.go:378 +0x169
github.com/wailsapp/wails/v3/pkg/application.(*SystemTray).SetIcon.func1()
	/home/windom/uprock/wails/v3/pkg/application/systemtray.go:136 +0x32
github.com/wailsapp/wails/v3/pkg/application.InvokeSync.func1()
	/home/windom/uprock/wails/v3/pkg/application/mainthread.go:28 +0x42
github.com/wailsapp/wails/v3/pkg/application.executeOnMainThread(0x2)
	/home/windom/uprock/wails/v3/pkg/application/mainthread_linux.go:17 +0xef
github.com/wailsapp/wails/v3/pkg/application.dispatchOnMainThreadCallback(...)
	/home/windom/uprock/wails/v3/pkg/application/linux_cgo.go:295
github.com/wailsapp/wails/v3/pkg/application._Cfunc_g_application_run(0x2f94670, 0x0, 0x0)
	_cgo_gotypes.go:1226 +0x4b
github.com/wailsapp/wails/v3/pkg/application.appRun.func4(0x2f94670)
	/home/windom/uprock/wails/v3/pkg/application/linux_cgo.go:373 +0x45
github.com/wailsapp/wails/v3/pkg/application.appRun(0x2f94670)
	/home/windom/uprock/wails/v3/pkg/application/linux_cgo.go:373 +0x7d
github.com/wailsapp/wails/v3/pkg/application.(*linuxApp).run(0xc00016ea00)
	/home/windom/uprock/wails/v3/pkg/application/application_linux.go:100 +0x52
github.com/wailsapp/wails/v3/pkg/application.(*App).Run(0xc0001e6308)
	/home/windom/uprock/wails/v3/pkg/application/application.go:553 +0x408
main.main()
	/home/windom/uprock/wails/v3/examples/systray/main.go:102 +0x8df
exit status 2
```

Fixes # (issue)

## Type of change
  
Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
  
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration using `wails doctor`.

- [ ] Windows
- [ ] macOS
- [X] Linux
  
## Test Configuration

```
# System
┌───────────────────────────────────────────────────────────────────────────────────────────┐
| Name         | Ubuntu                                                                     |
| Version      | 24.04                                                                      |
| ID           | ubuntu                                                                     |
| Branding     | 24.04 LTS (Noble Numbat)                                                   |
| Platform     | linux                                                                      |
| Architecture | amd64                                                                      |
| CPU          | Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz                                   |
| GPU 1        | TU116M [GeForce GTX 1660 Ti Mobile] (NVIDIA Corporation) - Driver: nvidia  |
| GPU 2        | CoffeeLake-H GT2 [UHD Graphics 630] (Intel Corporation) - Driver: i915     |
| Memory       | 16GB                                                                       |
└───────────────────────────────────────────────────────────────────────────────────────────┘

# Build Environment
┌─────────────────────────────────────────────────────────┐
| Wails CLI    | v3.0.0-alpha.4                           |
| Go Version   | go1.22.4                                 |
| Revision     | f0cec1cf376978f047d23a75b1da727111d358f6 |
| Modified     | false                                    |
| -buildmode   | exe                                      |
| -compiler    | gc                                       |
| CGO_ENABLED  | 0                                        |
| GOAMD64      | v1                                       |
| GOARCH       | amd64                                    |
| GOOS         | linux                                    |
| vcs          | git                                      |
| vcs.modified | false                                    |
| vcs.revision | f0cec1cf376978f047d23a75b1da727111d358f6 |
| vcs.time     | 2024-07-16T20:44:46Z                     |
└─────────────────────────────────────────────────────────┘

# Dependencies
┌──────────────────────────────────────┐
| webkit2gtk | 2.44.2-0ubuntu0.24.04.2 |
| gcc        | 12.10ubuntu1            |
| gtk3       | 3.24.41-4ubuntu1.1      |
| npm        | 10.8.2                  |
| pkg-config | 1.8.1-2build1           |
└────── * - Optional Dependency ───────┘
```

# Checklist:

- [ ] I have updated `website/src/pages/changelog.mdx` with details of this PR
- [ ] My code follows the general coding style of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
