### PR TITLE
Add fatalHandler() stubs to fix non-windows builds

### DIFF
--- a/v3/pkg/application/application.go
+++ b/v3/pkg/application/application.go
@@ -4,7 +4,6 @@ import (
 	"embed"
 	"encoding/json"
 	"fmt"
-	"github.com/wailsapp/wails/v3/pkg/w32"
 	"io"
 	"log"
 	"log/slog"
@@ -59,7 +58,7 @@ func New(appOptions Options) *App {
 
 	result := newApplication(appOptions)
 	globalApplication = result
-	w32.Fatal = result.handleFatalError
+	fatalHandler(result.handleFatalError)
 
 	if result.Logger == nil {
 		if result.isDebugMode {

--- a/v3/pkg/application/application_darwin.go
+++ b/v3/pkg/application/application_darwin.go
@@ -359,3 +359,8 @@ func (a *App) logPlatformInfo() {
 func (a *App) platformEnvironment() map[string]any {
 	return map[string]any{}
 }
+
+
+func fatalHandler(errFunc func(error)) {
+	return 
+}

--- a/v3/pkg/application/application_linux.go
+++ b/v3/pkg/application/application_linux.go
@@ -253,3 +253,8 @@ func (a *App) platformEnvironment() map[string]any {
 	)
 	return result
 }
+
+func fatalHandler(errFunc func(error)) {
+	// Stub for windows function
+	return
+}

--- a/v3/pkg/application/application_windows.go
+++ b/v3/pkg/application/application_windows.go
@@ -358,3 +358,8 @@ func (a *App) platformEnvironment() map[string]any {
 	result["WebView2"] = webviewVersion
 	return result
 }
+
+func fatalHandler(errFunc func(error)) {
+	w32.Fatal = errFunc
+	return 
+}


### PR DESCRIPTION
Recent changes to application.go broke non-windows builds by calling w32 directly. This PR adds a `fatalHandler(errFunc func(error))` to stub out the process for non-windows builds and keep the `w32.Fatal` setting only in a `application_windows.go`


 ## Test Configuration
```

          Wails Doctor



# System
┌──────────────────────────────────────────────────────────────────────────────────────────┐
| Name         | Ubuntu                                                                    |
| Version      | 24.04                                                                     |
| ID           | ubuntu                                                                    |
| Branding     | 24.04 LTS (Noble Numbat)                                                  |
| Platform     | linux                                                                     |
| Architecture | amd64                                                                     |
| CPU          | 12th Gen Intel(R) Core(TM) i5-1235U                                       |
| GPU 1        | Alder Lake-UP3 GT2 [Iris Xe Graphics] (Intel Corporation) - Driver: i915  |
| Memory       | 7GB                                                                       |
└──────────────────────────────────────────────────────────────────────────────────────────┘

# Build Environment
┌─────────────────────────────────────────────────────────┐
| Wails CLI    | v3.0.0-alpha.4                           |
| Go Version   | go1.22.4                                 |
| Revision     | 6e43657221cf464a1511946a85b0419f22e0b43a |
| Modified     | true                                     |
| -buildmode   | exe                                      |
| -compiler    | gc                                       |
| CGO_CFLAGS   |                                          |
| CGO_CPPFLAGS |                                          |
| CGO_CXXFLAGS |                                          |
| CGO_ENABLED  | 1                                        |
| CGO_LDFLAGS  |                                          |
| GOAMD64      | v1                                       |
| GOARCH       | amd64                                    |
| GOOS         | linux                                    |
| vcs          | git                                      |
| vcs.modified | true                                     |
| vcs.revision | 6e43657221cf464a1511946a85b0419f22e0b43a |
| vcs.time     | 2024-07-21T15:33:19Z                     |
└─────────────────────────────────────────────────────────┘

# Dependencies
┌──────────────────────────────────────────────────────────────────────────────────┐
| gcc        | 12.10ubuntu1                                                        |
| gtk3       | 3.24.41-4ubuntu1.1                                                  |
| npm        | 10.5.1                                                              |
| pkg-config | 1.8.1-2build1                                                       |
| webkit2gtk | not installed. Install with: sudo apt install libwebkit2gtk-4.1-dev |
└──────────────────────────── * - Optional Dependency ─────────────────────────────┘

# Diagnosis
 SUCCESS  Your system is ready for Wails development!
```