### PR TITLE
Set MacOS window levels (`NSWindow`)

### DIFF
--- a/mkdocs-website/docs/en/changelog.md
+++ b/mkdocs-website/docs/en/changelog.md
@@ -48,7 +48,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add flag `-port` to dev command and support environment variable `WAILS_VITE_PORT` by [@abichinger](https://github.com/abichinger) in [#3429](https://github.com/wailsapp/wails/pull/3429)
 - Add tests for bound method calls by [@abichinger](https://github.com/abichinger) in [#3431](https://github.com/wailsapp/wails/pull/3431)
 - [windows] add `SetIgnoreMouseEvents` for already created window by [@bruxaodev](https://github.com/bruxaodev) in [#3667](https://github.com/wailsapp/wails/pull/3667)
-- Add ability to set MacOS window's stacking level (order) by [@OlegGulevskyy](https://github.com/OlegGulevskyy) in [#3674](https://github.com/wailsapp/wails/pull/3674)
+- [darwin] Add ability to set a window's stacking level (order) by [@OlegGulevskyy](https://github.com/OlegGulevskyy) in [#3674](https://github.com/wailsapp/wails/pull/3674)
 
 ### Fixed
 

--- a/mkdocs-website/docs/en/changelog.md
+++ b/mkdocs-website/docs/en/changelog.md
@@ -44,6 +44,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Implement `setIcon` on linux by [@abichinger](https://github.com/abichinger) in [#3354](https://github.com/wailsapp/wails/pull/3354)
 - Add flag `-port` to dev command and support environment variable `WAILS_VITE_PORT` by [@abichinger](https://github.com/abichinger) in [#3429](https://github.com/wailsapp/wails/pull/3429)
 - Add tests for bound method calls by [@abichinger](https://github.com/abichinger) in [#3431](https://github.com/wailsapp/wails/pull/3431)
+- Add ability to set MacOS window's stacking level (order) by [@OlegGulevskyy](https://github.com/OlegGulevskyy) in [#3674](https://github.com/wailsapp/wails/pull/3674)
 
 ### Fixed
 

--- a/v3/pkg/application/webview_window_darwin.go
+++ b/v3/pkg/application/webview_window_darwin.go
@@ -216,6 +216,15 @@ void windowSetAlwaysOnTop(void* nsWindow, bool alwaysOnTop) {
 	[(WebviewWindow*)nsWindow setLevel:alwaysOnTop ? NSFloatingWindowLevel : NSNormalWindowLevel];
 }
 
+void setNormalWindowLevel(void* nsWindow) { [(WebviewWindow*)nsWindow setLevel:NSNormalWindowLevel]; }
+void setFloatingWindowLevel(void* nsWindow) { [(WebviewWindow*)nsWindow setLevel:NSFloatingWindowLevel];}
+void setPopUpMenuWindowLevel(void* nsWindow) { [(WebviewWindow*)nsWindow setLevel:NSPopUpMenuWindowLevel]; }
+void setMainMenuWindowLevel(void* nsWindow) { [(WebviewWindow*)nsWindow setLevel:NSMainMenuWindowLevel]; }
+void setStatusWindowLevel(void* nsWindow) { [(WebviewWindow*)nsWindow setLevel:NSStatusWindowLevel]; }
+void setModalPanelWindowLevel(void* nsWindow) { [(WebviewWindow*)nsWindow setLevel:NSModalPanelWindowLevel]; }
+void setScreenSaverWindowLevel(void* nsWindow) { [(WebviewWindow*)nsWindow setLevel:NSScreenSaverWindowLevel]; }
+void setTornOffMenuWindowLevel(void* nsWindow) { [(WebviewWindow*)nsWindow setLevel:NSTornOffMenuWindowLevel]; }
+
 // Load URL in NSWindow
 void navigationLoadURL(void* nsWindow, char* url) {
 	// Load URL on main thread
@@ -1068,6 +1077,27 @@ func (w *macosWebviewWindow) setRelativePosition(x, y int) {
 	C.windowSetRelativePosition(w.nsWindow, C.int(x), C.int(y))
 }
 
+func (w *macosWebviewWindow) setWindowLevel(level MacWindowLevel) {
+	switch level {
+	case MacWindowLevelNormal:
+		C.setNormalWindowLevel(w.nsWindow)
+	case MacWindowLevelFloating:
+		C.setFloatingWindowLevel(w.nsWindow)
+	case MacWindowLevelTornOffMenu:
+		C.setTornOffMenuWindowLevel(w.nsWindow)
+	case MacWindowLevelModalPanel:
+		C.setModalPanelWindowLevel(w.nsWindow)
+	case MacWindowLevelMainMenu:
+		C.setMainMenuWindowLevel(w.nsWindow)
+	case MacWindowLevelStatus:
+		C.setStatusWindowLevel(w.nsWindow)
+	case MacWindowLevelPopUpMenu:
+		C.setPopUpMenuWindowLevel(w.nsWindow)
+	case MacWindowLevelScreenSaver:
+		C.setScreenSaverWindowLevel(w.nsWindow)
+	}
+}
+
 func (w *macosWebviewWindow) width() int {
 	var width C.int
 	var wg sync.WaitGroup
@@ -1153,6 +1183,11 @@ func (w *macosWebviewWindow) run() {
 			C.webviewSetTransparent(w.nsWindow)
 		case MacBackdropNormal:
 		}
+
+		if macOptions.WindowLevel == "" {
+			macOptions.WindowLevel = MacWindowLevelNormal
+		}
+		w.setWindowLevel(macOptions.WindowLevel)
 
 		// Initialise the window buttons
 		w.setMinimiseButtonState(options.MinimiseButtonState)

--- a/v3/pkg/application/webview_window_options.go
+++ b/v3/pkg/application/webview_window_options.go
@@ -380,7 +380,23 @@ type MacWindow struct {
 
 	// WebviewPreferences contains preferences for the webview
 	WebviewPreferences MacWebviewPreferences
+
+	// WindowLevel sets the window level to control the order of windows in the screen
+	WindowLevel MacWindowLevel
 }
+
+type MacWindowLevel string
+
+const (
+	MacWindowLevelNormal      MacWindowLevel = "normal"
+	MacWindowLevelFloating    MacWindowLevel = "floating"
+	MacWindowLevelTornOffMenu MacWindowLevel = "tornOffMenu"
+	MacWindowLevelModalPanel  MacWindowLevel = "modalPanel"
+	MacWindowLevelMainMenu    MacWindowLevel = "mainMenu"
+	MacWindowLevelStatus      MacWindowLevel = "status"
+	MacWindowLevelPopUpMenu   MacWindowLevel = "popUpMenu"
+	MacWindowLevelScreenSaver MacWindowLevel = "screenSaver"
+)
 
 // MacWebviewPreferences contains preferences for the Mac webview
 type MacWebviewPreferences struct {


### PR DESCRIPTION
<!--
READ CAREFULLY: Before submitting your PR, please ensure you have created an issue for your PR.
It is essential that you do this so that we can discuss the proposed changes before you spend time on them.
If you do not create an issue, your PR may be rejected without review.
If a relevant issue already exists, please reference it in your PR by including `Fixes #<issue number>` in your PR description.
-->

# Description

Adding ability to set `NSWindow` level to be able to render the window on different levels. Mainly inspired by a need of rendering a window on top of MacOS menu bar. Well, on top of any window, including menu bar + task pane.
This is an alternative of [ElectronJS option here](https://www.electronjs.org/docs/latest/api/browser-window#winsetalwaysontopflag-level-relativelevel).

Sample usage:
```go
  Mac: application.MacWindow{
    WindowLevel:  application.MacWindowLevelPopUpMenu,
  },
```
Where `MacWindowLevelPopUpMenu` allows me to render the window on top of everything else under the sun.

Fixes # (issue)

## Type of change
  
Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
  
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration using `wails doctor`.

- [ ] Windows
- [x] macOS
- [ ] Linux
  
## Test Configuration

Please paste the output of `wails doctor`. If you are unable to run this command, please describe your environment in as much detail as possible.

# Checklist:

- [ ] I have updated `website/src/pages/changelog.mdx` with details of this PR
- [ ] My code follows the general coding style of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a `-port` command-line flag for specifying the application port during development.
	- Added support for the `WAILS_VITE_PORT` environment variable for enhanced configuration.
	- New window stacking level control for macOS, improving UI management.
- **Bug Fixes**
	- Enhanced `SetIgnoreMouseEvents` functionality now works with already created windows on Windows.
- **Improvements**
	- Added multiple functions for granular control over window levels in macOS applications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->