### PR TITLE
[V3] Fix windows syso icon processing 

### DIFF
--- a/mkdocs-website/docs/en/changelog.md
+++ b/mkdocs-website/docs/en/changelog.md
@@ -17,6 +17,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- [windows] Fixed syso icon file generation bug by [atterpac](https://github.com/atterpac) in [#3675](https://github.com/wailsapp/wails/pull/3675)
+
 ## v3.0.0-alpha.6 - 2024-07-30
 
 ### Fixed 

--- a/v3/internal/commands/syso.go
+++ b/v3/internal/commands/syso.go
@@ -44,7 +44,7 @@ func GenerateSyso(options *SysoOptions) (err error) {
 	}
 	defer func() {
 		err2 := iconFile.Close()
-		if err == nil {
+		if err2 != nil {
 			err = errors.Wrap(err, "error closing icon file: "+err2.Error())
 		}
 	}()


### PR DESCRIPTION
A recent bug was added due the syso generation in [this commit](https://github.com/wailsapp/wails/commit/1cba1416a1e673236c81ddd456e020076e7605b8) due to evaluating the incorrect error in a nil check.

Fixes # (issue)
- Raised by user in discord
## Type of change
  
Please delete options that are not relevant.

- [ X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a "Fixed" subsection in the changelog to improve clarity on recent bug fixes.
  
- **Bug Fixes**
	- Resolved an issue related to the generation of the syso icon file on Windows systems, enhancing user experience.

- **Documentation**
	- Updated changelog documentation to include recent bug fixes for better user awareness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->