### PR TITLE
If a field is exported, generate json even in the absence of tags

### DIFF
--- a/v2/internal/binding/binding.go
+++ b/v2/internal/binding/binding.go
@@ -350,7 +350,10 @@ func (b *Bindings) hasExportedJSONFields(typeOf reflect.Type) bool {
 	for i := 0; i < typeOf.NumField(); i++ {
 		jsonFieldName := ""
 		f := typeOf.Field(i)
-		jsonTag := f.Tag.Get("json")
+		jsonTag, hasTag := f.Tag.Lookup("json")
+		if !hasTag && f.IsExported() {
+			return true
+		}
 		if len(jsonTag) == 0 {
 			continue
 		}

--- a/v2/internal/binding/binding_test/binding_notags_test.go
+++ b/v2/internal/binding/binding_test/binding_notags_test.go
@@ -1,0 +1,59 @@
+package binding_test
+
+type NoFieldTags struct {
+	Name    string
+	Address string
+	Zip     *string
+	Spouse  *NoFieldTags
+}
+
+func (n NoFieldTags) Get() NoFieldTags {
+	return n
+}
+
+var NoFieldTagsTest = BindingTest{
+	name: "NoFieldTags",
+	structs: []interface{}{
+		&NoFieldTags{},
+	},
+	exemptions:  nil,
+	shouldError: false,
+	want: `
+export namespace binding_test {
+	export class NoFieldTags {
+		Name: string;
+		Address: string;
+		Zip?: string;
+		Spouse?: NoFieldTags;
+		static createFrom(source: any = {}) {
+			return new NoFieldTags(source);
+		}
+		constructor(source: any = {}) {
+			if ('string' === typeof source) source = JSON.parse(source);
+			this.Name = source["Name"];
+			this.Address = source["Address"];
+			this.Zip = source["Zip"];
+			this.Spouse = this.convertValues(source["Spouse"], NoFieldTags);
+		}
+			
+		convertValues(a: any, classs: any, asMap: boolean = false): any {
+			if (!a) {
+					return a;
+			}
+			if (a.slice && a.map) {
+					return (a as any[]).map(elem => this.convertValues(elem, classs));
+			} else if ("object" === typeof a) {
+					if (asMap) {
+							for (const key of Object.keys(a)) {
+									a[key] = new classs(a[key]);
+							}
+							return a;
+					}
+					return new classs(a);
+			}
+			return a;
+		}
+	}
+}
+`,
+}

--- a/v2/internal/binding/binding_test/binding_test.go
+++ b/v2/internal/binding/binding_test/binding_test.go
@@ -50,6 +50,7 @@ func TestBindings_GenerateModels(t *testing.T) {
 		EntityWithDiffNamespacesTest,
 		SpecialCharacterFieldTest,
 		WithoutFieldsTest,
+		NoFieldTagsTest,
 	}
 
 	testLogger := &logger.Logger{}

--- a/v2/internal/typescriptify/typescriptify.go
+++ b/v2/internal/typescriptify/typescriptify.go
@@ -553,7 +553,13 @@ func (t *TypeScriptify) getFieldOptions(structType reflect.Type, field reflect.S
 
 func (t *TypeScriptify) getJSONFieldName(field reflect.StructField, isPtr bool) string {
 	jsonFieldName := ""
-	jsonTag := field.Tag.Get("json")
+	jsonTag, hasTag := field.Tag.Lookup("json")
+	if !hasTag && field.IsExported() {
+		jsonFieldName = field.Name
+		if isPtr {
+			jsonFieldName += "?"
+		}
+	}
 	if len(jsonTag) > 0 {
 		jsonTagParts := strings.Split(jsonTag, ",")
 		if len(jsonTagParts) > 0 {

--- a/website/src/pages/changelog.mdx
+++ b/website/src/pages/changelog.mdx
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed MacOS build to use `outputfilename` from wails.json. [#3200](https://github.com/wailsapp/wails/issues/3200)
 - Fixed file drop events on windows. Fixed in [PR](https://github.com/wailsapp/wails/pull/3595) by @FrancescoLuzzi
 - Fixed doctor command not finding pkg-config on Solus. [PR #3670](https://github.com/wailsapp/wails/pull/3670) by [@ianmjones](https://github.com/ianmjones)
+- Fixed binding for struct fields that were exported but had no json tags. [PR #3678](https://github.com/wailsapp/wails/pull/3678)
 
 ## v2.9.1 - 2024-06-18
 


### PR DESCRIPTION
# Description

Fixes #945 - generate typescript models for structs that do not contain json tags, using similar logic as Go's JSON interfaces (e.g. in the absence of json tags, if the field is exported then include it as-is).

## Type of change
  
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
  
I'm not sure the "proper" way to test, but I vendored wails in my app with these changes and looked at the resulting `models.ts` output.
  
## Test Configuration

For brevity I will skip `wails doctor` output here but I can include if necessary.

# Checklist:

- [x] I have updated `website/src/pages/changelog.mdx` with details of this PR
- [x] My code follows the general coding style of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Improved handling of exported fields in JSON serialization, ensuring those without a JSON tag are recognized appropriately.
	- Enhanced TypeScript definition generation to reflect accurate JSON field names and optionality for fields that are pointers.

- **Bug Fixes**
	- Corrected logic for checking JSON field names, leading to more accurate serialization and TypeScript definitions.

- **Documentation**
	- Updated changelog to document the fixes related to binding struct fields without associated JSON tags, improving data integrity and usability.
  
- **Tests**
	- Added new test cases to validate the behavior of model generation for entities without field tags, expanding test coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->