### PR TITLE
[v3] Make Windows window class configurable

### DIFF
--- a/mkdocs-website/docs/en/changelog.md
+++ b/mkdocs-website/docs/en/changelog.md
@@ -17,6 +17,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- [windows] Window class name option by [windom](https://github.com/windom/) in [#3682](https://github.com/wailsapp/wails/pull/3682) 
+
 ### Fixed
 - [windows] Fixed syso icon file generation bug by [atterpac](https://github.com/atterpac) in [#3675](https://github.com/wailsapp/wails/pull/3675)
 

--- a/v3/pkg/application/application.go
+++ b/v3/pkg/application/application.go
@@ -168,6 +168,9 @@ func mergeApplicationDefaults(o *Options) {
 	if o.Description == "" {
 		o.Description = "An application written using Wails"
 	}
+	if o.Windows.WndClass == "" {
+		o.Windows.WndClass = "WailsWebviewWindow"
+	}
 }
 
 type (

--- a/v3/pkg/application/application_options.go
+++ b/v3/pkg/application/application_options.go
@@ -182,6 +182,10 @@ type MacOptions struct {
 // WindowsOptions contains options for Windows applications.
 type WindowsOptions struct {
 
+	// Window class name
+	// Default: WailsWebviewWindow
+	WndClass string
+
 	// WndProcInterceptor is a function that will be called for every message sent in the application.
 	// Use this to hook into the main message loop. This is useful for handling custom window messages.
 	// If `shouldReturn` is `true` then `returnCode` will be returned by the main message loop.

--- a/v3/pkg/application/application_windows.go
+++ b/v3/pkg/application/application_windows.go
@@ -16,11 +16,7 @@ import (
 
 	"github.com/wailsapp/wails/v3/pkg/events"
 	"github.com/wailsapp/wails/v3/pkg/w32"
-
-	"github.com/samber/lo"
 )
-
-var windowClassName = lo.Must(syscall.UTF16PtrFromString("WailsWebviewWindow"))
 
 type windowsApp struct {
 	parent *App
@@ -212,7 +208,7 @@ func (m *windowsApp) init() {
 	m.windowClass.Background = w32.COLOR_BTNFACE + 1
 	m.windowClass.Icon = icon
 	m.windowClass.Cursor = w32.LoadCursorWithResourceID(0, w32.IDC_ARROW)
-	m.windowClass.ClassName = windowClassName
+	m.windowClass.ClassName = w32.MustStringToUTF16Ptr(m.parent.options.Windows.WndClass)
 	m.windowClass.MenuName = nil
 	m.windowClass.IconSm = icon
 

--- a/v3/pkg/application/mainthread_windows.go
+++ b/v3/pkg/application/mainthread_windows.go
@@ -34,7 +34,7 @@ func (m *windowsApp) initMainLoop() {
 	// > Because the system directs messages to individual windows in an application, a thread must create at least one window before starting its message loop.
 	m.mainThreadWindowHWND = w32.CreateWindowEx(
 		0,
-		windowClassName,
+		w32.MustStringToUTF16Ptr(m.parent.options.Windows.WndClass),
 		w32.MustStringToUTF16Ptr("__wails_hidden_mainthread"),
 		w32.WS_DISABLED,
 		w32.CW_USEDEFAULT,

--- a/v3/pkg/application/systemtray_windows.go
+++ b/v3/pkg/application/systemtray_windows.go
@@ -150,7 +150,7 @@ func (s *windowsSystemTray) setMenu(menu *Menu) {
 func (s *windowsSystemTray) run() {
 	s.hwnd = w32.CreateWindowEx(
 		0,
-		windowClassName,
+		w32.MustStringToUTF16Ptr(globalApplication.options.Windows.WndClass),
 		nil,
 		0,
 		0,

--- a/v3/pkg/application/webview_window_windows.go
+++ b/v3/pkg/application/webview_window_windows.go
@@ -249,7 +249,7 @@ func (w *windowsWebviewWindow) run() {
 
 	w.hwnd = w32.CreateWindowEx(
 		uint(exStyle),
-		windowClassName,
+		w32.MustStringToUTF16Ptr(globalApplication.options.Windows.WndClass),
 		w32.MustStringToUTF16Ptr(options.Title),
 		style,
 		startX,


### PR DESCRIPTION
<!--
READ CAREFULLY: Before submitting your PR, please ensure you have created an issue for your PR.
It is essential that you do this so that we can discuss the proposed changes before you spend time on them.
If you do not create an issue, your PR may be rejected without review.
If a relevant issue already exists, please reference it in your PR by including `Fixes #<issue number>` in your PR description.
-->

# Description

This patch makes the window class configurable on Windows. Kept the current hard-coded value as default.
This can come handy for example in NSIS installer scripts, where we want to check if an instance of the app is running using FindWindow with an own window class.

Fixes # (issue)

## Type of change
  
Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
  
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration using `wails doctor`.

- [ ] Windows
- [ ] macOS
- [ ] Linux
  
## Test Configuration

Please paste the output of `wails doctor`. If you are unable to run this command, please describe your environment in as much detail as possible.

# Checklist:

- [ ] I have updated `website/src/pages/changelog.mdx` with details of this PR
- [ ] My code follows the general coding style of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced a configurable `WndClass` property to enhance the flexibility of Windows application options.
	- Improved the initialization of the window class name to be dynamically determined from application configuration.

- **Bug Fixes**
	- Addressed issues related to the generation of the syso icon file.

- **Documentation**
	- Updated the changelog to include new configuration options for Windows applications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->