### PR TITLE
Fixes #3680

### DIFF
--- a/v2/internal/frontend/desktop/windows/frontend.go
+++ b/v2/internal/frontend/desktop/windows/frontend.go
@@ -739,6 +739,9 @@ func (f *Frontend) processMessageWithAdditionalObjects(message string, sender *e
 				f.logger.Error("cannot get value at %d : %s", i, err.Error())
 				return
 			}
+			if _file == nil {
+				return
+			}
 
 			file := (*edge.ICoreWebView2File)(unsafe.Pointer(_file))
 			defer file.Release()

--- a/website/src/pages/changelog.mdx
+++ b/website/src/pages/changelog.mdx
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed file drop events on windows. Fixed in [PR](https://github.com/wailsapp/wails/pull/3595) by @FrancescoLuzzi
 - Fixed doctor command not finding pkg-config on Solus. [PR #3670](https://github.com/wailsapp/wails/pull/3670) by [@ianmjones](https://github.com/ianmjones)
 - Fixed binding for struct fields that were exported but had no json tags. [PR #3678](https://github.com/wailsapp/wails/pull/3678)
+- Fixed a bug where dropping non-file data would cause a crash. Fixed by @leaanthony in [PR #3687](https://github.com/wailsapp/wails/pull/3687)
 
 ## v2.9.1 - 2024-06-18
 


### PR DESCRIPTION

# Description

Prevents non-file content clipboard data from causing a crash. Originally proposed here: https://github.com/wailsapp/wails/issues/3680#issuecomment-2293482401

Fixes # 3680



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Bug Fixes**
	- Resolved a critical bug that caused the application to crash when non-file data was dropped, improving user experience and stability.
	- Implemented an additional check to prevent runtime errors when the file variable is `nil`, enhancing method stability and reducing potential crashes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->