### PR TITLE
Fix: Ensure Window Frame is Applied on First Call in setFrameless Function

### DIFF
--- a/mkdocs-website/docs/en/changelog.md
+++ b/mkdocs-website/docs/en/changelog.md
@@ -19,8 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## v3.0.0-alpha.6 - 2024-07-30
 
-### Fixed 
-- Module issues 
+### Fixed
+- Module issues
 
 ## v3.0.0-alpha.5 - 2024-07-30
 
@@ -82,6 +82,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix missing MicrosoftEdgeWebview2Setup.exe. Thanks to [@robin-samuel](https://github.com/robin-samuel).
 - Fix random crash on linux due to window ID handling by @leaanthony. Based on PR [#3466](https://github.com/wailsapp/wails/pull/3622) by [@5aaee9](https://github.com/5aaee9).
 - Fix systemTray.setIcon crashing on Linux by [@windom](https://github.com/windom/) in [#3636](https://github.com/wailsapp/wails/pull/3636).
+- Fix Ensure Window Frame is Applied on First Call in `setFrameless` Function on Windows by [@bruxaodev](https://github.com/bruxaodev/) in [#3691](https://github.com/wailsapp/wails/pull/3691).
 
 ### Changed
 

--- a/v3/pkg/application/webview_window_windows.go
+++ b/v3/pkg/application/webview_window_windows.go
@@ -857,6 +857,7 @@ func (w *windowsWebviewWindow) setFrameless(b bool) {
 	} else {
 		w32.SetWindowLong(w.hwnd, w32.GWL_STYLE, w32.WS_VISIBLE|w32.WS_OVERLAPPEDWINDOW)
 	}
+	w32.SetWindowPos(w.hwnd, 0, 0, 0, 0, 0, w32.SWP_NOMOVE|w32.SWP_NOSIZE|w32.SWP_NOZORDER|w32.SWP_FRAMECHANGED)
 }
 
 func newWindowImpl(parent *WebviewWindow) *windowsWebviewWindow {


### PR DESCRIPTION
This pull request addresses the issue where the window frame does not appear on the first call to `setFrameless(false)` after being opened in frameless mode. The problem was that `SetWindowLong ` alone did not immediately apply the style change, requiring a second call to update the window correctly.

Issue Link: [Issue #3690](https://github.com/wailsapp/wails/issues/3690)

#Changes:

- Added a call to `SetWindowPos ` with the `SWP_FRAMECHANGED` flag after setting the window style. This forces the window to apply the style changes immediately.

#Testing:

- Verified that the frame is correctly applied on the first call to setFrameless(false).
- Tested both frameless and framed modes to ensure no regression in behavior.

![overlay-fix](https://github.com/user-attachments/assets/af6f11fb-5b0d-4e06-bf89-d5c9198153d3)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced window management functionality to ensure visual updates of window frame styles are reflected immediately.

- **Bug Fixes**
	- Improved behavior of frameless window display, ensuring frame changes are applied correctly on the first call.
	
- **Documentation**
	- Updated changelog for versioning documentation, correcting formatting and adding details about the frameless function fix on Windows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->