### PR TITLE
More syscall fixes

### DIFF
--- a/v2/internal/frontend/desktop/windows/winc/w32/user32.go
+++ b/v2/internal/frontend/desktop/windows/winc/w32/user32.go
@@ -639,7 +639,7 @@ func GetSysColorBrush(nIndex int) HBRUSH {
 
 		return HBRUSH(ret)
 	*/
-	ret, _, _ := syscall.Syscall(getSysColorBrush, 1,
+	ret, _, _ := syscall.SyscallN(getSysColorBrush,
 		uintptr(nIndex),
 		0,
 		0)
@@ -792,11 +792,9 @@ func CreateMenu() HMENU {
 }
 
 func SetMenu(hWnd HWND, hMenu HMENU) bool {
-	ret, _, _ := syscall.Syscall(setMenu, 2,
+	ret, _, _ := syscall.SyscallN(setMenu,
 		uintptr(hWnd),
-		uintptr(hMenu),
-		0)
-
+		uintptr(hMenu))
 	return ret != 0
 }
 
@@ -834,11 +832,7 @@ func TrackPopupMenuEx(hMenu HMENU, fuFlags uint32, x, y int32, hWnd HWND, lptpm 
 }
 
 func DrawMenuBar(hWnd HWND) bool {
-	ret, _, _ := syscall.Syscall(drawMenuBar, 1,
-		uintptr(hWnd),
-		0,
-		0)
-
+	ret, _, _ := syscall.SyscallN(drawMenuBar, hWnd)
 	return ret != 0
 }
 
@@ -1231,11 +1225,8 @@ func CallNextHookEx(hhk HHOOK, nCode int, wParam WPARAM, lParam LPARAM) LRESULT 
 }
 
 func GetKeyState(nVirtKey int32) int16 {
-	ret, _, _ := syscall.Syscall(getKeyState, 1,
-		uintptr(nVirtKey),
-		0,
-		0)
-
+	ret, _, _ := syscall.SyscallN(getKeyState,
+		uintptr(nVirtKey))
 	return int16(ret)
 }
 
@@ -1249,17 +1240,15 @@ func DestroyMenu(hMenu HMENU) bool {
 }
 
 func GetWindowPlacement(hWnd HWND, lpwndpl *WINDOWPLACEMENT) bool {
-	ret, _, _ := syscall.Syscall(getWindowPlacement, 2,
-		uintptr(hWnd),
-		uintptr(unsafe.Pointer(lpwndpl)),
-		0)
-
+	ret, _, _ := syscall.SyscallN(getWindowPlacement,
+		hWnd,
+		uintptr(unsafe.Pointer(lpwndpl)))
 	return ret != 0
 }
 
 func SetWindowPlacement(hWnd HWND, lpwndpl *WINDOWPLACEMENT) bool {
-	ret, _, _ := syscall.Syscall(setWindowPlacement, 2,
-		uintptr(hWnd),
+	ret, _, _ := syscall.SyscallN(setWindowPlacement,
+		hWnd,
 		uintptr(unsafe.Pointer(lpwndpl)),
 		0)
 
@@ -1279,7 +1268,7 @@ func SetScrollInfo(hwnd HWND, fnBar int32, lpsi *SCROLLINFO, fRedraw bool) int32
 }
 
 func GetScrollInfo(hwnd HWND, fnBar int32, lpsi *SCROLLINFO) bool {
-	ret, _, _ := syscall.Syscall(getScrollInfo, 3,
+	ret, _, _ := syscall.SyscallN(getScrollInfo,
 		hwnd,
 		uintptr(fnBar),
 		uintptr(unsafe.Pointer(lpsi)))

--- a/v2/internal/frontend/desktop/windows/winc/w32/utils.go
+++ b/v2/internal/frontend/desktop/windows/winc/w32/utils.go
@@ -75,7 +75,7 @@ func UTF16PtrToString(cstr *uint16) string {
 }
 
 func ComAddRef(unknown *IUnknown) int32 {
-	ret, _, _ := syscall.Syscall(unknown.lpVtbl.pAddRef, 1,
+	ret, _, _ := syscall.SyscallN(unknown.lpVtbl.pAddRef,
 		uintptr(unsafe.Pointer(unknown)),
 		0,
 		0)
@@ -83,7 +83,7 @@ func ComAddRef(unknown *IUnknown) int32 {
 }
 
 func ComRelease(unknown *IUnknown) int32 {
-	ret, _, _ := syscall.Syscall(unknown.lpVtbl.pRelease, 1,
+	ret, _, _ := syscall.SyscallN(unknown.lpVtbl.pRelease,
 		uintptr(unsafe.Pointer(unknown)),
 		0,
 		0)
@@ -92,7 +92,7 @@ func ComRelease(unknown *IUnknown) int32 {
 
 func ComQueryInterface(unknown *IUnknown, id *GUID) *IDispatch {
 	var disp *IDispatch
-	hr, _, _ := syscall.Syscall(unknown.lpVtbl.pQueryInterface, 3,
+	hr, _, _ := syscall.SyscallN(unknown.lpVtbl.pQueryInterface,
 		uintptr(unsafe.Pointer(unknown)),
 		uintptr(unsafe.Pointer(id)),
 		uintptr(unsafe.Pointer(&disp)))

--- a/v2/internal/frontend/desktop/windows/winc/w32/uxtheme.go
+++ b/v2/internal/frontend/desktop/windows/winc/w32/uxtheme.go
@@ -83,7 +83,7 @@ func init() {
 }
 
 func CloseThemeData(hTheme HTHEME) HRESULT {
-	ret, _, _ := syscall.Syscall(closeThemeData, 1,
+	ret, _, _ := syscall.SyscallN(closeThemeData,
 		uintptr(hTheme),
 		0,
 		0)
@@ -134,7 +134,7 @@ func GetThemeTextExtent(hTheme HTHEME, hdc HDC, iPartId, iStateId int32, pszText
 }
 
 func OpenThemeData(hwnd HWND, pszClassList *uint16) HTHEME {
-	ret, _, _ := syscall.Syscall(openThemeData, 2,
+	ret, _, _ := syscall.SyscallN(openThemeData,
 		uintptr(hwnd),
 		uintptr(unsafe.Pointer(pszClassList)),
 		0)
@@ -143,7 +143,7 @@ func OpenThemeData(hwnd HWND, pszClassList *uint16) HTHEME {
 }
 
 func SetWindowTheme(hwnd HWND, pszSubAppName, pszSubIdList *uint16) HRESULT {
-	ret, _, _ := syscall.Syscall(setWindowTheme, 3,
+	ret, _, _ := syscall.SyscallN(setWindowTheme,
 		uintptr(hwnd),
 		uintptr(unsafe.Pointer(pszSubAppName)),
 		uintptr(unsafe.Pointer(pszSubIdList)))

--- a/v2/internal/go-common-file-dialog/cfd/iFileOpenDialog.go
+++ b/v2/internal/go-common-file-dialog/cfd/iFileOpenDialog.go
@@ -164,8 +164,7 @@ func (fileOpenDialog *iFileOpenDialog) setIsMultiselect(isMultiselect bool) erro
 
 func (vtbl *iFileOpenDialogVtbl) getResults(objPtr unsafe.Pointer) (*iShellItemArray, error) {
 	var shellItemArray *iShellItemArray
-	ret, _, _ := syscall.Syscall(vtbl.GetResults,
-		1,
+	ret, _, _ := syscall.SyscallN(vtbl.GetResults,
 		uintptr(objPtr),
 		uintptr(unsafe.Pointer(&shellItemArray)),
 		0)

--- a/website/src/pages/changelog.mdx
+++ b/website/src/pages/changelog.mdx
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed typos in various .mdx files. [PR #3628](https://github.com/wailsapp/wails/pull/3628) by [@deining](https://github.com/deining)
 - Fixed `notifyListeners()` race condition when terminated mid-emission [PR](https://github.com/wailsapp/wails/pull/3695) by [@mrf345](https://github.com/mrf345)
 - Fixed dialogs in Windows when using Go 1.23 in [PR](https://github.com/wailsapp/wails/pull/3707) by [@leaanthony](https://github.com/leaanthony)
+- More syscall fixes for Go 1.23 support in [PR](https://github.com/wailsapp/wails/pull/3713) by [@leaanthony](https://github.com/leaanthony)
 - Fixed drag and drop missing cursor icon [PR](https://github.com/wailsapp/wails/pull/3703) by [@mrf345](https://github.com/mrf345)
 
 ### Changed


### PR DESCRIPTION

<!--
READ CAREFULLY: Before submitting your PR, please ensure you have created an issue for your PR.
It is essential that you do this so that we can discuss the proposed changes before you spend time on them.
If you do not create an issue, your PR may be rejected without review.
If a relevant issue already exists, please reference it in your PR by including `Fixes #<issue number>` in your PR description.
-->

# Description

More syscall fixes for Windows. Should prevent issues on Go 1.23.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced system call handling for improved flexibility and performance across various functions.
	- Updated `getResults` method to support dynamic argument counts for better compatibility and error management.

- **Bug Fixes**
	- Added syscall fixes to improve compatibility with Go 1.23.

- **Documentation**
	- New entry in the changelog detailing recent syscall improvements and ongoing compatibility efforts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->