### PR TITLE
Ignore internal service methods when binding

### DIFF
--- a/mkdocs-website/docs/en/changelog.md
+++ b/mkdocs-website/docs/en/changelog.md
@@ -24,6 +24,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - [windows] Fixed syso icon file generation bug by [atterpac](https://github.com/atterpac) in [#3675](https://github.com/wailsapp/wails/pull/3675)
 - [linux] Fix to run natively in wayland incorporated from [#1811](https://github.com/wailsapp/wails/pull/1811) in [#3614](https://github.com/wailsapp/wails/pull/3614) by [@stendler](https://github.com/stendler)
+- Do not bind internal service methods in [#3720](https://github.com/wailsapp/wails/pull/3720)
+  by [leaanthony](https://github.com/leaanthony)
 
 ## v3.0.0-alpha.6 - 2024-07-30
 

--- a/v3/examples/services/hashes/hashes.go
+++ b/v3/examples/services/hashes/hashes.go
@@ -1,10 +1,12 @@
 package hashes
 
 import (
+	"context"
 	"crypto/md5"
 	"crypto/sha1"
 	"crypto/sha256"
 	"encoding/hex"
+	"github.com/wailsapp/wails/v3/pkg/application"
 )
 
 type Hashes struct {
@@ -35,6 +37,6 @@ func (h *Hashes) Name() string {
 	return "Hashes Service"
 }
 
-func (h *Hashes) OnStartup() error {
+func (h *Hashes) OnStartup(_ context.Context, _ application.ServiceOptions) error {
 	return nil
 }

--- a/v3/examples/services/main.go
+++ b/v3/examples/services/main.go
@@ -11,6 +11,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"runtime"
 )
 
 //go:embed assets/*
@@ -18,7 +19,13 @@ var assets embed.FS
 
 func main() {
 
-	rootPath, _ := filepath.Abs("./files")
+	// Get the local directory of this source file
+	// This isn't needed when running the example with `go run .`
+	// but is needed when running the example from an IDE
+	_, thisFile, _, _ := runtime.Caller(0)
+	localDir := filepath.Dir(thisFile)
+
+	rootPath := filepath.Join(localDir, "files")
 	app := application.New(application.Options{
 		Name:        "Services Demo",
 		Description: "A demo of the services API",

--- a/v3/internal/assetserver/assetserver.go
+++ b/v3/internal/assetserver/assetserver.go
@@ -112,8 +112,6 @@ func (a *AssetServer) serveHTTP(rw http.ResponseWriter, req *http.Request, userH
 		for route, handler := range a.services {
 			if strings.HasPrefix(reqPath, route) {
 				req.URL.Path = strings.TrimPrefix(reqPath, route)
-				// Strip leading slash
-				req.URL.Path = strings.TrimPrefix(req.URL.Path, "/")
 				handler.ServeHTTP(rw, req)
 				return
 			}

--- a/v3/pkg/application/bindings.go
+++ b/v3/pkg/application/bindings.go
@@ -101,7 +101,7 @@ func NewBindings(instances []Service, aliases map[uint32]uint32) (*Bindings, err
 
 // Add the given named type pointer methods to the Bindings
 func (b *Bindings) Add(namedPtr interface{}) error {
-	methods, err := b.getMethods(namedPtr, false)
+	methods, err := b.getMethods(namedPtr)
 	if err != nil {
 		return fmt.Errorf("cannot bind value to app: %s", err.Error())
 	}
@@ -153,7 +153,7 @@ func (b *BoundMethod) String() string {
 	return fmt.Sprintf("%s.%s.%s", b.PackagePath, b.TypeName, b.Name)
 }
 
-func (b *Bindings) getMethods(value interface{}, isPlugin bool) ([]*BoundMethod, error) {
+func (b *Bindings) getMethods(value interface{}) ([]*BoundMethod, error) {
 	// Create result placeholder
 	var result []*BoundMethod
 
@@ -188,6 +188,10 @@ func (b *Bindings) getMethods(value interface{}, isPlugin bool) ([]*BoundMethod,
 		methodName := methodDef.Name
 		method := namedValue.MethodByName(methodName)
 
+		if b.internalMethod(methodDef) {
+			continue
+		}
+
 		// Create new method
 		boundMethod := &BoundMethod{
 			Name:        methodName,
@@ -204,16 +208,15 @@ func (b *Bindings) getMethods(value interface{}, isPlugin bool) ([]*BoundMethod,
 			return nil, err
 		}
 
-		if !isPlugin {
-			args := []any{"name", boundMethod, "id", boundMethod.ID}
-			if b.methodAliases != nil {
-				alias, found := lo.FindKey(b.methodAliases, boundMethod.ID)
-				if found {
-					args = append(args, "alias", alias)
-				}
+		args := []any{"name", boundMethod, "id", boundMethod.ID}
+		if b.methodAliases != nil {
+			alias, found := lo.FindKey(b.methodAliases, boundMethod.ID)
+			if found {
+				args = append(args, "alias", alias)
 			}
-			globalApplication.debug("Adding method:", args...)
 		}
+		globalApplication.debug("Adding method:", args...)
+
 		// Iterate inputs
 		methodType := method.Type()
 		inputParamCount := methodType.NumIn()
@@ -243,6 +246,33 @@ func (b *Bindings) getMethods(value interface{}, isPlugin bool) ([]*BoundMethod,
 
 	}
 	return result, nil
+}
+
+func (b *Bindings) internalMethod(def reflect.Method) bool {
+	// Get the receiver type
+	receiverType := def.Type.In(0)
+
+	// Create a new instance of the receiver type
+	instance := reflect.New(receiverType.Elem()).Interface()
+
+	// Check if the instance implements any of our service interfaces
+	// and if the method matches the interface method
+	switch def.Name {
+	case "Name":
+		if _, ok := instance.(ServiceName); ok {
+			return true
+		}
+	case "OnStartup":
+		if _, ok := instance.(ServiceStartup); ok {
+			return true
+		}
+	case "OnShutdown":
+		if _, ok := instance.(ServiceShutdown); ok {
+			return true
+		}
+	}
+
+	return false
 }
 
 var errorType = reflect.TypeFor[error]()

--- a/v3/pkg/services/fileserver/fileserver.go
+++ b/v3/pkg/services/fileserver/fileserver.go
@@ -47,6 +47,5 @@ func (s *Service) OnStartup(ctx context.Context, options application.ServiceOpti
 
 func (s *Service) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// Create a new file server rooted at the given path
-	// Strip the base path out of the request path
 	s.fs.ServeHTTP(w, r)
 }


### PR DESCRIPTION

# Description

This PR includes:
- Ignoring internal service methods when binding
- Updated example to bring the hashes service up to date
- Use path relative to source file in services example

## Type of change
  
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
  
Manually.

- [x] Windows
- [ ] macOS
- [ ] Linux
  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced service initialization with context-aware operations and service options.
	- Dynamic resolution of the root directory based on the executing file's location for improved flexibility.

- **Bug Fixes**
	- Updated request handling to ensure proper processing of URLs without stripping leading slashes, improving routing accuracy.

- **Refactor**
	- Simplified method signatures in the Bindings struct by removing unnecessary parameters and introducing a dedicated method for internal checks.

- **Documentation**
	- Added a changelog entry highlighting the shift in managing internal service methods for better modularity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->