### PR TITLE
[V3] Refactor linux ignore mouse events

### DIFF
--- a/mkdocs-website/docs/en/changelog.md
+++ b/mkdocs-website/docs/en/changelog.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Services have been expanded to provide plugin functionality. By [atterpac](https://github.com/atterpac) and [leaanthony](https://github.com/leaanthony) in [#3570](https://github.com/wailsapp/wails/pull/3570)
 
 ### Fixed
+- [linux] Fixed linux compile error introduced by IgnoreMouseEvents addition by [atterpac](https://github.com/atterpac) in [#3721](https://github.com/wailsapp/wails/pull/3721)
 - [windows] Fixed syso icon file generation bug by [atterpac](https://github.com/atterpac) in [#3675](https://github.com/wailsapp/wails/pull/3675)
 - [linux] Fix to run natively in wayland incorporated from [#1811](https://github.com/wailsapp/wails/pull/1811) in [#3614](https://github.com/wailsapp/wails/pull/3614) by [@stendler](https://github.com/stendler)
 - [windows] Fixed system tray startup panic in [#3693](https://github.com/wailsapp/wails/issues/3693) by [@DeltaLaboratory](https://github.com/DeltaLaboratory)

--- a/v3/pkg/application/linux_cgo.go
+++ b/v3/pkg/application/linux_cgo.go
@@ -1373,6 +1373,14 @@ func (w *linuxWebviewWindow) position() (int, int) {
 	return int(x), int(y)
 }
 
+func (w *linuxWebviewWindow) ignoreMouse(ignore bool) {
+	if ignore {
+		C.gtk_widget_set_events((*C.GtkWidget)(unsafe.Pointer(w.window)), C.GDK_ENTER_NOTIFY_MASK|C.GDK_LEAVE_NOTIFY_MASK)
+	} else {
+		C.gtk_widget_set_events((*C.GtkWidget)(unsafe.Pointer(w.window)), C.GDK_ALL_EVENTS_MASK)
+	}
+}
+
 // FIXME Change this to reflect mouse button!
 //
 //export onButtonEvent

--- a/v3/pkg/application/webview_window_linux.go
+++ b/v3/pkg/application/webview_window_linux.go
@@ -2,8 +2,7 @@
 
 package application
 
-import "C"
-import (
+import ( 
 	"fmt"
 	"time"
 
@@ -282,7 +281,7 @@ func (w *linuxWebviewWindow) run() {
 	}
 
 	// Ignore mouse events if requested
-	w.setIgnoreMouseEvents(options.IgnoreMouseEvents)
+	w.setIgnoreMouseEvents(w.parent.options.IgnoreMouseEvents)
 
 	startURL, err := assetserver.GetStartURL(w.parent.options.URL)
 	if err != nil {
@@ -375,11 +374,5 @@ func (w *linuxWebviewWindow) isIgnoreMouseEvents() bool {
 }
 
 func (w *linuxWebviewWindow) setIgnoreMouseEvents(ignore bool) {
-	w.ignoreMouseEvents = ignore
-
-	if ignore {
-		C.gtk_widget_set_events((*C.GtkWidget)(unsafe.Pointer(w.window)), C.GDK_ENTER_NOTIFY_MASK|C.GDK_LEAVE_NOTIFY_MASK)
-	} else {
-		C.gtk_widget_set_events((*C.GtkWidget)(unsafe.Pointer(w.window)), C.GDK_ALL_EVENTS_MASK)
-	}
+	w.ignoreMouse(w.ignoreMouseEvents)
 }


### PR DESCRIPTION
# Description
Recent changes to ignoring mouse events introduced a compile time error on linux due to using GDK C calls without access to the GDK C Lib.

This PR moves the calls to linux_cgo and adds a call to the function in the webview_window_linux.go

# Fixes 
Linux compile brought up in discord

# Doctor
```
# System
┌──────────────────────────────────────────────────────────────────────────────────────────┐
| Name         | Ubuntu                                                                    |
| Version      | 24.04                                                                     |
| ID           | ubuntu                                                                    |
| Branding     | 24.04 LTS (Noble Numbat)                                                  |
| Platform     | linux                                                                     |
| Architecture | amd64                                                                     |
| CPU          | 12th Gen Intel(R) Core(TM) i5-1235U                                       |
| GPU 1        | Alder Lake-UP3 GT2 [Iris Xe Graphics] (Intel Corporation) - Driver: i915  |
| Memory       | 7GB                                                                       |
└──────────────────────────────────────────────────────────────────────────────────────────┘

# Build Environment
┌─────────────────────────────────────────────────────────┐
| Wails CLI    | v3.0.0-alpha.6                           |
| Go Version   | go1.22.4                                 |
| Revision     | 2460b570fe80dd78b83cc701421213ad8cb1d073 |
| Modified     | true                                     |
| -buildmode   | exe                                      |
| -compiler    | gc                                       |
| CGO_CFLAGS   |                                          |
| CGO_CPPFLAGS |                                          |
| CGO_CXXFLAGS |                                          |
| CGO_ENABLED  | 1                                        |
| CGO_LDFLAGS  |                                          |
| GOAMD64      | v1                                       |
| GOARCH       | amd64                                    |
| GOOS         | linux                                    |
| vcs          | git                                      |
| vcs.modified | true                                     |
| vcs.revision | 2460b570fe80dd78b83cc701421213ad8cb1d073 |
| vcs.time     | 2024-09-02T09:33:17Z                     |
└─────────────────────────────────────────────────────────┘

# Dependencies
┌──────────────────────────────────────────────────────────────────────────────────┐
| gcc        | 12.10ubuntu1                                                        |
| gtk3       | 3.24.41-4ubuntu1.1                                                  |
| npm        | 10.5.1                                                              |
| pkg-config | 1.8.1-2build1                                                       |
| webkit2gtk | not installed. Install with: sudo apt install libwebkit2gtk-4.1-dev |
└──────────────────────────── * - Optional Dependency ─────────────────────────────┘

```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced mouse event handling for the Linux application, allowing for more granular control over interactions.
	
- **Bug Fixes**
	- Resolved a Linux compile error related to mouse event handling.
	- Fixed a Windows syso icon file generation issue.
	- Improved compatibility with Wayland.
	- Addressed a system tray startup panic. 

- **Documentation**
	- Updated changelog to reflect recent bug fixes and enhancements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->