### PR TITLE
chore: fix DeskGap author link on credits page

### DIFF
--- a/website/i18n/ar/docusaurus-plugin-content-pages/credits.mdx
+++ b/website/i18n/ar/docusaurus-plugin-content-pages/credits.mdx
@@ -265,5 +265,5 @@
 - [Byron Chris](https://github.com/bh90210) - For his long term contributions to this project.
 - [Dustin Krysak](https://wiki.ubuntu.com/bashfulrobot) - His support and feedback has been invaluable.
 - [Justen Walker](https://github.com/justenwalker/) - For helping wrangle COM issues which got v2 over the line.
-- [Wang, Chi](https://github.com/patr0nus/) - The DeskGap project was a huge influence on the direction of Wails v2.
+- [Wang, Chi](https://github.com/branchseer) - The DeskGap project was a huge influence on the direction of Wails v2.
 - [Serge Zaitsev](https://github.com/zserge) - Whilst Wails does not use the Webview project, it is still a source of inspiration.

--- a/website/i18n/fr/docusaurus-plugin-content-pages/credits.mdx
+++ b/website/i18n/fr/docusaurus-plugin-content-pages/credits.mdx
@@ -265,5 +265,5 @@
 - [Byron Chris](https://github.com/bh90210) - Pour ses contributions à long terme à ce projet.
 - [Dustin Krysak](https://wiki.ubuntu.com/bashfulrobot) - Son support et ses retours ont été inestimables.
 - [Justen Walker](https://github.com/justenwalker/) - Pour aider à résoudre les problèmes COM qui ont permis de publier la v2.
-- [Wang, Chi](https://github.com/patr0nus/) - Le projet DeskGap a été une grande influence sur la direction de Wails v2.
+- [Wang, Chi](https://github.com/branchseer) - Le projet DeskGap a été une grande influence sur la direction de Wails v2.
 - [Serge Zaitsev](https://github.com/zserge) - Bien que Wails n'utilise plus le projet Webview, il est toujours une source d'inspiration.

--- a/website/i18n/ja/docusaurus-plugin-content-pages/credits.mdx
+++ b/website/i18n/ja/docusaurus-plugin-content-pages/credits.mdx
@@ -265,5 +265,5 @@
 - [Byron Chris](https://github.com/bh90210) - このプロジェクトに長期的に貢献してくれました。
 - [Dustin Krysak](https://wiki.ubuntu.com/bashfulrobot) - 彼は非常に有益なサポートおよびフィードバックをしてくれました。
 - [Justen Walker](https://github.com/justenwalker/) - v2を成功させるために、COM問題を解決してくれました。
-- [Wang, Chi](https://github.com/patr0nus/) - DeskGapプロジェクトは、Wails v2の方向性に大きな影響を与えてくれました。
+- [Wang, Chi](https://github.com/branchseer) - DeskGapプロジェクトは、Wails v2の方向性に大きな影響を与えてくれました。
 - [Serge Zaitsev](https://github.com/zserge) - WailsがWebviewを使用していない間、インスピレーションの源となっていました。

--- a/website/i18n/ko/docusaurus-plugin-content-pages/credits.mdx
+++ b/website/i18n/ko/docusaurus-plugin-content-pages/credits.mdx
@@ -265,5 +265,5 @@
 - [Byron Chris](https://github.com/bh90210) - For his long term contributions to this project.
 - [Dustin Krysak](https://wiki.ubuntu.com/bashfulrobot) - His support and feedback has been invaluable.
 - [Justen Walker](https://github.com/justenwalker/) - For helping wrangle COM issues which got v2 over the line.
-- [Wang, Chi](https://github.com/patr0nus/) - The DeskGap project was a huge influence on the direction of Wails v2.
+- [Wang, Chi](https://github.com/branchseer) - The DeskGap project was a huge influence on the direction of Wails v2.
 - [Serge Zaitsev](https://github.com/zserge) - Whilst Wails does not use the Webview project, it is still a source of inspiration.

--- a/website/i18n/pt/docusaurus-plugin-content-pages/credits.mdx
+++ b/website/i18n/pt/docusaurus-plugin-content-pages/credits.mdx
@@ -265,5 +265,5 @@
 - [Byron Chris](https://github.com/bh90210) - For his long term contributions to this project.
 - [Dustin Krysak](https://wiki.ubuntu.com/bashfulrobot) - His support and feedback has been invaluable.
 - [Justen Walker](https://github.com/justenwalker/) - For helping wrangle COM issues which got v2 over the line.
-- [Wang, Chi](https://github.com/patr0nus/) - The DeskGap project was a huge influence on the direction of Wails v2.
+- [Wang, Chi](https://github.com/branchseer) - The DeskGap project was a huge influence on the direction of Wails v2.
 - [Serge Zaitsev](https://github.com/zserge) - Whilst Wails does not use the Webview project, it is still a source of inspiration.

--- a/website/i18n/ru/docusaurus-plugin-content-pages/credits.mdx
+++ b/website/i18n/ru/docusaurus-plugin-content-pages/credits.mdx
@@ -265,5 +265,5 @@
 - [Byron Chris](https://github.com/bh90210) - For his long term contributions to this project.
 - [Dustin Krysak](https://wiki.ubuntu.com/bashfulrobot) - His support and feedback has been invaluable.
 - [Justen Walker](https://github.com/justenwalker/) - For helping wrangle COM issues which got v2 over the line.
-- [Wang, Chi](https://github.com/patr0nus/) - The DeskGap project was a huge influence on the direction of Wails v2.
+- [Wang, Chi](https://github.com/branchseer) - The DeskGap project was a huge influence on the direction of Wails v2.
 - [Serge Zaitsev](https://github.com/zserge) - Whilst Wails does not use the Webview project, it is still a source of inspiration.

--- a/website/i18n/tr/docusaurus-plugin-content-pages/credits.mdx
+++ b/website/i18n/tr/docusaurus-plugin-content-pages/credits.mdx
@@ -265,5 +265,5 @@
 - [Byron Chris](https://github.com/bh90210) - For his long term contributions to this project.
 - [Dustin Krysak](https://wiki.ubuntu.com/bashfulrobot) - His support and feedback has been invaluable.
 - [Justen Walker](https://github.com/justenwalker/) - For helping wrangle COM issues which got v2 over the line.
-- [Wang, Chi](https://github.com/patr0nus/) - The DeskGap project was a huge influence on the direction of Wails v2.
+- [Wang, Chi](https://github.com/branchseer) - The DeskGap project was a huge influence on the direction of Wails v2.
 - [Serge Zaitsev](https://github.com/zserge) - Whilst Wails does not use the Webview project, it is still a source of inspiration.

--- a/website/i18n/vi/docusaurus-plugin-content-pages/credits.mdx
+++ b/website/i18n/vi/docusaurus-plugin-content-pages/credits.mdx
@@ -265,5 +265,5 @@
 - [Byron Chris](https://github.com/bh90210) - For his long term contributions to this project.
 - [Dustin Krysak](https://wiki.ubuntu.com/bashfulrobot) - His support and feedback has been invaluable.
 - [Justen Walker](https://github.com/justenwalker/) - For helping wrangle COM issues which got v2 over the line.
-- [Wang, Chi](https://github.com/patr0nus/) - The DeskGap project was a huge influence on the direction of Wails v2.
+- [Wang, Chi](https://github.com/branchseer) - The DeskGap project was a huge influence on the direction of Wails v2.
 - [Serge Zaitsev](https://github.com/zserge) - Whilst Wails does not use the Webview project, it is still a source of inspiration.

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-pages/credits.mdx
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-pages/credits.mdx
@@ -265,5 +265,5 @@
 - [Byron Chris](https://github.com/bh90210) - 他对此项目的长期贡献。
 - [Dustin Krysak](https://wiki.ubuntu.com/bashfulrobot) - 提供了巨大的的支持和反馈。
 - [Justen Walker](https://github.com/justenwalker/) - 帮助解决 v2 上线要解决的问题。
-- [Wang, Chi](https://github.com/patr0nus/) - DeskGap 项目对 Wails v2 的方向产生了巨大影响。
+- [Wang, Chi](https://github.com/branchseer) - DeskGap 项目对 Wails v2 的方向产生了巨大影响。
 - [Serge Zaitsev](https://github.com/zserge) - 虽然 Wails 没有使用 Webview 项目，但它仍然是一个灵感来源。

--- a/website/src/pages/credits.mdx
+++ b/website/src/pages/credits.mdx
@@ -266,5 +266,5 @@
 - [Byron Chris](https://github.com/bh90210) - For his long term contributions to this project.
 - [Dustin Krysak](https://wiki.ubuntu.com/bashfulrobot) - His support and feedback has been invaluable.
 - [Justen Walker](https://github.com/justenwalker/) - For helping wrangle COM issues which got v2 over the line.
-- [Wang, Chi](https://github.com/patr0nus/) - The DeskGap project was a huge influence on the direction of Wails v2.
+- [Wang, Chi](https://github.com/branchseer) - The DeskGap project was a huge influence on the direction of Wails v2.
 - [Serge Zaitsev](https://github.com/zserge) - Whilst Wails does not use the Webview project, it is still a source of inspiration.


### PR DESCRIPTION
# Description

The DeskGap author appears to have moved from https://github.com/patr0nus/ (now a 404) to https://github.com/branchseer

## Type of change
  
Please delete options that are not relevant.

- [x] This change requires a documentation update

# How Has This Been Tested?

Visual inspection of diff.  
  
## Test Configuration

n/a

# Checklist:

- [ ] I have updated `website/src/pages/changelog.mdx` with details of this PR
- [x] My code follows the general coding style of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the GitHub link for contributor Wang, Chi across multiple language versions of the credits section to reflect the correct profile.

- **Bug Fixes**
	- Corrected the attribution link for Wang, Chi to ensure proper acknowledgment of contributions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->