### PR TITLE
[v3] actions improvements & run actions on more branches and in forks

### DIFF
--- a/.github/workflows/build-and-test-alpha.yml
+++ b/.github/workflows/build-and-test-alpha.yml
@@ -12,6 +12,7 @@ jobs:
     name: Run Go Tests
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [windows-latest, macos-latest, ubuntu-latest]
         go-version: [1.22]
@@ -80,7 +81,7 @@ jobs:
     needs: test_go
     runs-on: ${{ matrix.os }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
         template:

--- a/.github/workflows/build-and-test-alpha.yml
+++ b/.github/workflows/build-and-test-alpha.yml
@@ -19,19 +19,19 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install linux dependencies
         if: matrix.os == 'ubuntu-latest'
         run: sudo apt-get update -y && sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev javascriptcoregtk-4.1-dev build-essential pkg-config
 
       - name: Setup Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go-version }}
 
       - name: Install Task
-        uses: arduino/setup-task@v1
+        uses: arduino/setup-task@v2
         with:
           version: 3.x
           repo-token: ${{ secrets.GITHUB_TOKEN }}
@@ -61,10 +61,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
 
@@ -102,15 +102,15 @@ jobs:
         go-version: [1.22]
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go-version }}
 
       - name: Setup Golang caches
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cache/go-build

--- a/.github/workflows/build-and-test-alpha.yml
+++ b/.github/workflows/build-and-test-alpha.yml
@@ -29,6 +29,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go-version }}
+          cache-dependency-path: "v3/go.sum"
 
       - name: Install Task
         uses: arduino/setup-task@v2
@@ -108,6 +109,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go-version }}
+          cache-dependency-path: "v3/go.sum"
 
       - name: Setup Golang caches
         uses: actions/cache@v4

--- a/.github/workflows/build-and-test-alpha.yml
+++ b/.github/workflows/build-and-test-alpha.yml
@@ -2,7 +2,7 @@ name: Build + Test v3 alpha
 
 on:
   push:
-    branches: [v3-alpha]
+    branches: [v3-alpha, v3/*, v3-*]
     paths-ignore:
       - 'mkdocs-website/**/*'
   workflow_dispatch:
@@ -10,7 +10,6 @@ on:
 jobs:
   test_go:
     name: Run Go Tests
-    if: github.repository == 'wailsapp/wails'
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -54,7 +53,6 @@ jobs:
 
   test_js:
     name: Run JS Tests
-    if: github.repository == 'wailsapp/wails'
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/mkdocs-website/docs/en/changelog.md
+++ b/mkdocs-website/docs/en/changelog.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Events API change: `On`/`Emit` -> user events, `OnApplicationEvent` -> Application Events `OnWindowEvent` -> Window Events, by [leaanthony](https://github.com/leaanthony)
 - Fix for Events API on Linux by [TheGB0077](https://github.com/TheGB0077) in [#3734](https://github.com/wailsapp/wails/pull/3734)
+- [CI] improvements to actions & enable to run actions also in forks and branches prefixed with `v3/` or `v3-` by [stendler](https://github.com/stendler) in [#3747](https://github.com/wailsapp/wails/pull/3747)
 
 ### Fixed
 - Fixed bug with usage of customEventProcessor in drag-n-drop example by [etesam913](https://github.com/etesam913) in [#3742](https://github.com/wailsapp/wails/pull/3742)


### PR DESCRIPTION
<!--
READ CAREFULLY: Before submitting your PR, please ensure you have created an issue for your PR.
It is essential that you do this so that we can discuss the proposed changes before you spend time on them.
If you do not create an issue, your PR may be rejected without review.
If a relevant issue already exists, please reference it in your PR by including `Fixes #<issue number>` in your PR description.
-->

# Description

- update used actions to use newer node 20 and get rid of warnings 
- don't fail fast in OS matrix to allow seeing if only one system is affected
- also run build-and-test-alpha on branches prefixed with `v3/` or `v3-`
- enable to run in forks to make testing easier (no quota for public repos) 
- add cache dependency path for setup-go to enable caching (and get rid of the warning, that no go.sum was found in the project root)

## Type of change

- [x] CI / actions

# How Has This Been Tested?
  
As part of the actions in my fork: https://github.com/stendler/wails/actions

# Checklist:

- [x] I have updated `website/src/pages/changelog.mdx` with details of this PR
- [x] I have performed a self-review of my own code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Enhanced build and testing processes in the CI/CD pipeline.
	- Expanded workflow triggers to include more branch patterns.
	- Updated various actions to their latest versions for improved performance and efficiency.
	- Changed the `fail-fast` strategy to allow all jobs to run to completion, enhancing visibility of test results.
	- Improved Events API with clearer event handling methods and fixes for better functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->