### PR TITLE
bugfix : fix error on building runnable .app on MacOS when 'name' and 'outputfilename' are different.

### DIFF
--- a/v2/pkg/buildassets/build/darwin/Info.dev.plist
+++ b/v2/pkg/buildassets/build/darwin/Info.dev.plist
@@ -6,7 +6,7 @@
         <key>CFBundleName</key>
         <string>{{.Info.ProductName}}</string>
         <key>CFBundleExecutable</key>
-        <string>{{.Name}}</string>
+        <string>{{.OutputFilename}}</string>
         <key>CFBundleIdentifier</key>
         <string>com.wails.{{.Name}}</string>
         <key>CFBundleVersion</key>

--- a/v2/pkg/buildassets/build/darwin/Info.plist
+++ b/v2/pkg/buildassets/build/darwin/Info.plist
@@ -6,7 +6,7 @@
         <key>CFBundleName</key>
         <string>{{.Info.ProductName}}</string>
         <key>CFBundleExecutable</key>
-        <string>{{.Name}}</string>
+        <string>{{.OutputFilename}}</string>
         <key>CFBundleIdentifier</key>
         <string>com.wails.{{.Name}}</string>
         <key>CFBundleVersion</key>

--- a/v2/pkg/buildassets/buildassets.go
+++ b/v2/pkg/buildassets/buildassets.go
@@ -102,8 +102,9 @@ func ReadOriginalFileWithProjectDataAndSave(projectData *project.Project, file s
 }
 
 type assetData struct {
-	Name string
-	Info project.Info
+	Name           string
+	Info           project.Info
+	OutputFilename string
 }
 
 func resolveProjectData(content []byte, projectData *project.Project) ([]byte, error) {
@@ -113,8 +114,9 @@ func resolveProjectData(content []byte, projectData *project.Project) ([]byte, e
 	}
 
 	data := &assetData{
-		Name: projectData.Name,
-		Info: projectData.Info,
+		Name:           projectData.Name,
+		Info:           projectData.Info,
+		OutputFilename: projectData.OutputFilename,
 	}
 
 	var out bytes.Buffer

--- a/website/src/pages/changelog.mdx
+++ b/website/src/pages/changelog.mdx
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed dialogs in Windows when using Go 1.23 in [PR](https://github.com/wailsapp/wails/pull/3707) by [@leaanthony](https://github.com/leaanthony)
 - More syscall fixes for Go 1.23 support in [PR](https://github.com/wailsapp/wails/pull/3713) by [@leaanthony](https://github.com/leaanthony)
 - Fixed drag and drop missing cursor icon [PR](https://github.com/wailsapp/wails/pull/3703) by [@mrf345](https://github.com/mrf345)
+- Fixed a build error on macOS that occurred when the `outputfilename` and `name` fields in wails.json were different. Fixed in [PR](https://github.com/wailsapp/wails/pull/3789) by [@nickisworking](https://github.com/nickisworking)
 
 ### Changed
 - Modified docs to reflect the correct password syntax for the `gon-sign.json` file [PR](https://github.com/wailsapp/wails/pull/3620) by [@ignasbernotas](github.com/ignasbernotas)


### PR DESCRIPTION
mod : added OutputFilename field to assetData
mod : modified resolveProjectData to export OutputFilename 
mod : modified CFBundleExecutable values to .OutputFilename in info.dev.plist, info.plist

# Description
There was an issue where the executable file was not properly generated when the name and outputfilename in the existing wails.json were different. The cause of this issue was that outputfilename was not being used under pkg/buildassets. As a result, I have modified the code to properly export outputfilename and use it in CFBundleExecutable as well.

Fixes #3786 

## Type of change
  
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
  
After building Wails with the modified source code, `go build ./cmd/wails`
I built a test project using the generated binary. 

- [ ] Windows
- [x] macOS
- [ ] Linux
  
## Test Configuration

```bash
# Wails
Version | v2.9.2

# System
┌────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
| OS           | MacOS                                                                                                                       |
| Version      | 14.4.1                                                                                                                      |
| ID           | 23E224                                                                                                                      |
| Go Version   | go1.23.0                                                                                                                    |
| Platform     | darwin                                                                                                                      |
| Architecture | arm64                                                                                                                       |
| CPU          | Apple M1 Max                                                                                                                |
| GPU          | Chipset Model: Apple M1 Max Type: GPU Bus: Built-In Total Number of Cores: 24 Vendor: Apple (0x106b) Metal Support: Metal 3 |
| Memory       | 32GB                                                                                                                        |
└────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘

# Dependencies
┌─────────────────────────────────────────────────────────────────────────┐
| Dependency                | Package Name | Status    | Version          |
| Xcode command line tools  | N/A          | Installed | 2406             |
| Nodejs                    | N/A          | Installed | 16.20.2          |
| npm                       | N/A          | Installed | 8.19.4           |
| *Xcode                    | N/A          | Installed | 14.3.1 (14E300c) |
| *upx                      | N/A          | Available |                  |
| *nsis                     | N/A          | Available |                  |
└──────────────────────── * - Optional Dependency ────────────────────────┘

# Diagnosis
Optional package(s) installation details: 
  - upx : Available at https://upx.github.io/
  - nsis : More info at https://wails.io/docs/guides/windows-installer/

 SUCCESS  Your system is ready for Wails development!

 ♥   If Wails is useful to you or your company, please consider sponsoring the project:
https://github.com/sponsors/leaanthony
```

# Checklist:

- [x] I have updated `website/src/pages/changelog.mdx` with details of this PR
- [x] My code follows the general coding style of this project
- [x] I have performed a self-review of my own code
- [ ] ~I have commented my code, particularly in hard-to-understand areas~
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] ~I have added tests that prove my fix is effective or that my feature works~
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new `OutputFilename` field to enhance asset data structure.
- **Bug Fixes**
	- Resolved a build error on macOS related to discrepancies between `outputfilename` and `name` fields in the `wails.json` file.
- **Documentation**
	- Updated changelog to reflect recent fixes and enhancements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->