### PR TITLE
fix: pass platform and arch to GenerateBindings for cross compilation

### DIFF
--- a/v2/pkg/commands/bindings/bindings.go
+++ b/v2/pkg/commands/bindings/bindings.go
@@ -20,6 +20,8 @@ type Options struct {
 	ProjectDirectory string
 	Compiler         string
 	GoModTidy        bool
+	Platform         string
+	Arch             string
 	TsPrefix         string
 	TsSuffix         string
 	TsOutputType     string
@@ -53,7 +55,11 @@ func GenerateBindings(options Options) (string, error) {
 		}
 	}
 
-	stdout, stderr, err = shell.RunCommand(workingDirectory, options.Compiler, "build", "-tags", tagString, "-o", filename)
+	envBuild := os.Environ()
+	envBuild = shell.SetEnv(envBuild, "GOOS", options.Platform)
+	envBuild = shell.SetEnv(envBuild, "GOARCH", options.Arch)
+
+	stdout, stderr, err = shell.RunCommandWithEnv(envBuild, workingDirectory, options.Compiler, "build", "-tags", tagString, "-o", filename)
 	if err != nil {
 		return stdout, fmt.Errorf("%s\n%s\n%s", stdout, stderr, err)
 	}

--- a/v2/pkg/commands/build/build.go
+++ b/v2/pkg/commands/build/build.go
@@ -231,6 +231,8 @@ func GenerateBindings(buildOptions *Options) error {
 		Compiler:     buildOptions.Compiler,
 		Tags:         buildOptions.UserTags,
 		GoModTidy:    !buildOptions.SkipModTidy,
+		Platform:     buildOptions.Platform,
+		Arch:         buildOptions.Arch,
 		TsPrefix:     buildOptions.ProjectData.Bindings.TsGeneration.Prefix,
 		TsSuffix:     buildOptions.ProjectData.Bindings.TsGeneration.Suffix,
 		TsOutputType: buildOptions.ProjectData.Bindings.TsGeneration.OutputType,

--- a/website/src/pages/changelog.mdx
+++ b/website/src/pages/changelog.mdx
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Security` in case of vulnerabilities.
 
 ## [Unreleased]
+### Fixed
+- Fixed cross compilation failed with CGO [PR](https://github.com/wailsapp/wails/pull/3795) by [@fcying](https://github.com/fcying)
 
 ## v2.9.2 - 2024-09-18
 


### PR DESCRIPTION
# Description

cross compilation to windows with CGO, GenerateBindings get error.

Fixes #3719 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
1. wails init -t vue-ts -n wails
2. cd wails
3. add example c code to app.go
```
package main

/*
void test() {
}
*/
import "C"
```
4. wails build
5. export CC=x86_64-w64-mingw32-gcc
6. export CGO_ENABLED=1
7. wails build -platform windows


- [ ] Windows
- [ ] macOS
- [x] Linux
  
## Test Configuration
```
wails doctor
Version         | v2.9.2
Revision        | a6288c414e737296475ab2513333b0ba639d144d
Modified        | true
Package Manager | apt

# System
┌───────────────────────────────────────────────────┐                                                                                                                                                                                       | OS           | Debian GNU/Linux                   |
| Version      | 12                                 |
| ID           | debian                             |
| Go Version   | go1.23.1                           |
| Platform     | linux                              |
| Architecture | amd64                              |
| CPU          | AMD Ryzen 7 5700X 8-Core Processor |
| GPU          | Unknown                            |
| Memory       | 20GB                               |
└───────────────────────────────────────────────────┘

# Dependencies
┌──────────────────────────────────────────────────────────────────────┐                                                                                                                                                                    | Dependency | Package Name          | Status    | Version             |
| *docker    | docker.io             | Available | 20.10.24+dfsg1-1+b3 |
| gcc        | build-essential       | Installed | 12.9                |
| libgtk-3   | libgtk-3-dev          | Installed | 3.24.38-2~deb12u2   |
| libwebkit  | libwebkit2gtk-4.0-dev | Installed | 2.44.3-1~deb12u1    |
| npm        | npm                   | Installed | 10.8.2              |
| *nsis      | nsis                  | Available | 3.08-3+deb12u1      |
| pkg-config | pkg-config            | Installed | 1.8.1-1             |
└────────────────────── * - Optional Dependency ───────────────────────┘

# Diagnosis
Optional package(s) installation details:
  - docker: sudo apt install docker.io
  - nsis: sudo apt install nsis

 SUCCESS  Your system is ready for Wails development!
```
# Checklist:

- [x] I have updated `website/src/pages/changelog.mdx` with details of this PR
- [x] My code follows the general coding style of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Introduced new options for specifying target platform and architecture during binding generation.
	- Enhanced support for building universal binaries on macOS.
	- Added warning for users regarding the legacy WebView2Loader for Windows builds.
	- Implemented Drag & Drop support for Windows, Linux, and macOS.

- **Bug Fixes**
	- Resolved cross-compilation failures related to CGO.
	- Fixed CGO memory issue on Darwin.
	- Addressed JSON compatibility for author names.
	- Ensured proper file drop event handling on Windows.
	- Added nil check for Drag-and-Drop functionality on Windows.

- **Documentation**
	- Updated changelog to reflect recent fixes and improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->