### PR TITLE
[V3 Runtime] Ensure JS package has parity with various node versions

### DIFF
--- a/v3/internal/runtime/desktop/@wailsio/runtime/package.json
+++ b/v3/internal/runtime/desktop/@wailsio/runtime/package.json
@@ -1,12 +1,18 @@
 {
   "name": "@wailsio/runtime",
-  "version": "3.0.0-alpha.27",
+  "type": "module",
+  "version": "3.0.0-alpha.28",
   "description": "Wails Runtime",
-  "main": "src/index.js",
-  "types": "types/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./types/index.d.ts",
+      "require": "./src/index.js",
+      "import": "./src/index.js"
+    }
+  },
   "repository": {
     "type": "git",
-    "url": "https://github.com/wailsapp/wails.git"
+    "url": "git+https://github.com/wailsapp/wails.git"
   },
   "scripts": {
     "prebuild:types": "rimraf ./types",


### PR DESCRIPTION
Community member brought up our v3 runtime package not being compatable with various node runtime versions and checking via [publint](https://github.com/bluwy/publint)

Current issues can be seen: [@wailsio publint](https://publint.dev/@wailsio/runtime@3.0.0-alpha.27)

PR Resolves notes given by publint to ensure parity with various node versions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated to version 3.0.0-alpha.28 of the Wails runtime, enhancing module compatibility.
	- Introduced a new module type specification for improved functionality.
	- Updated repository URL format for better integration.

These changes aim to streamline the development experience and improve compatibility with modern JavaScript module standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->