### PR TITLE
Update example for macOS Menu

### DIFF
--- a/website/versioned_docs/version-v2.9.0/reference/menus.mdx
+++ b/website/versioned_docs/version-v2.9.0/reference/menus.mdx
@@ -15,6 +15,9 @@ An example of how to create a menu:
     app := NewApp()
 
     AppMenu := menu.NewMenu()
+	if runtime.GOOS == "darwin" { // On macOS platform, this must be done right after `NewMenu()`
+		AppMenu.Append(menu.AppMenu())
+	}
     FileMenu := AppMenu.AddSubmenu("File")
     FileMenu.AddText("&Open", keys.CmdOrCtrl("o"), openFile)
     FileMenu.AddSeparator()
@@ -22,9 +25,9 @@ An example of how to create a menu:
         runtime.Quit(app.ctx)
     })
 
-    if runtime.GOOS == "darwin" {
-	AppMenu.Append(menu.EditMenu())  // on macos platform, we should append EditMenu to enable Cmd+C,Cmd+V,Cmd+Z... shortcut
-    }
+	if runtime.GOOS == "darwin" {
+		AppMenu.Append(menu.EditMenu()) // On macos platform, EditMenu should be appended enable Cmd+C, Cmd+V, Cmd+Z... shortcuts
+	}
 
     err := wails.Run(&options.App{
         Title:             "Menus Demo",


### PR DESCRIPTION
<!--
READ CAREFULLY: Before submitting your PR, please ensure you have created an issue for your PR.
It is essential that you do this so that we can discuss the proposed changes before you spend time on them.
If you do not create an issue, your PR may be rejected without review.
If a relevant issue already exists, please reference it in your PR by including `Fixes #<issue number>` in your PR description.
-->

# Description

Example in [menus](https://wails.io/docs/reference/menus/) are not correctly written. This PR corrects code for macOS to add menus properly.

```go
AppMenu := menu.NewMenu()
if runtime.GOOS == "darwin" { // On macOS platform, this must be done right after `NewMenu()`
	AppMenu.Append(menu.AppMenu())
}
FileMenu := AppMenu.AddSubmenu("File")
FileMenu.AddText("&Open", keys.CmdOrCtrl("o"), openFile)
FileMenu.AddSeparator()
FileMenu.AddText("Quit", keys.CmdOrCtrl("q"), func(_ *menu.CallbackData) {
	rt.Quit(app.ctx)
})
if runtime.GOOS == "darwin" {
	AppMenu.Append(menu.EditMenu()) // On macos platform, EditMenu should be appended enable Cmd+C, Cmd+V, Cmd+Z... shortcuts
}
```

Writing `AppMenu.Append()` twice and separately looks weird but this do matters to menus be added in `File` `Edit` order. For instance, the following code results menus to be added in `Edit` `File` order.

```go
AppMenu := menu.NewMenu()
if runtime.GOOS == "darwin" { // On macOS platform, this must be done right after `NewMenu()`
	AppMenu.Append(menu.AppMenu())
	AppMenu.Append(menu.EditMenu()) // On macos platform, EditMenu should be appended enable Cmd+C, Cmd+V, Cmd+Z... shortcuts
}
```

![image](https://github.com/user-attachments/assets/cf69afc9-5c46-41d0-8e58-f77a4f0ae677)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated documentation for the Wails framework regarding application menus.
	- Added conditional logic for macOS in example code to clarify menu creation.
	- Rephrased comments to enhance clarity on appending the edit menu for standard shortcuts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->