### PR TITLE
[v3 Darwin] Fix NewEditMenu, remove duplicate PasteAndMatchStyle item

### DIFF
--- a/mkdocs-website/docs/en/changelog.md
+++ b/mkdocs-website/docs/en/changelog.md
@@ -23,8 +23,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed `Screen` type to include `ID` not `Id` by [etesam913](https://github.com/etesam913) in [#3778](https://github.com/wailsapp/wails/pull/3778)
 
 ### Fixed
-- Fixed `AlwaysOnTop` not working on Mac by [leaanthony](https://github.com/leaanthony)
-  in [#3841](https://github.com/wailsapp/wails/pull/3841)
+- Fixed `AlwaysOnTop` not working on Mac by [leaanthony](https://github.com/leaanthony) in [#3841](https://github.com/wailsapp/wails/pull/3841)
+- [darwin]  Fixed `application.NewEditMenu` including a duplicate `PasteAndMatchStyle` role in the edit menu on Darwin by [johnmccabe](https://github.com/johnmccabe) in [#3839](https://github.com/wailsapp/wails/pull/3839)
 
 ## v3.0.0-alpha.7 - 2024-09-18
 

--- a/v3/pkg/application/roles.go
+++ b/v3/pkg/application/roles.go
@@ -122,7 +122,6 @@ func NewEditMenu() *MenuItem {
 	editMenu.AddRole(Paste)
 	if runtime.GOOS == "darwin" {
 		editMenu.AddRole(PasteAndMatchStyle)
-		editMenu.AddRole(PasteAndMatchStyle)
 		editMenu.AddRole(Delete)
 		editMenu.AddRole(SelectAll)
 		editMenu.AddSeparator()


### PR DESCRIPTION
# Description

What looks to be a simple copy paste error in the V3 `application.NewEditMenu()` function where the `PasteAndMatchStyle` role in the Edit menu has been duplicated. Noticed when running the V3 examples and having ported a personal app across.

Given the trivial nature of the change I've skipped the issue creation, can swing back and create if you wish.

## Type of change
  
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Running the V3 binding example before and after the change to confirm the presence and then absence of the duplicated menu item. Change is within a `darwin` only conditional so I've skipped Windows and Linux validation.

- [ ] Windows
- [x] macOS
- [ ] Linux
  
## Test Configuration

Freshly checked out `v3-alpha` branch on MacOS `14.7`, Go `1.23.2`.

# Checklist:

- [ ] I have updated `website/src/pages/changelog.mdx` with details of this PR. *I skipped this as there doesn't seem to be any other entries for V3 prior to its release.*
- [x] My code follows the general coding style of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation. *Change does not warrant a documentation change*
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Simplified the handling of the 'Paste and Match Style' role in the edit menu for macOS, enhancing menu consistency.
	- Fixed the `AlwaysOnTop` functionality on macOS.
	- Resolved issues with custom event processing in drag-and-drop examples and Linux compile errors.
	- Addressed syso icon file generation bugs on Windows.

- **New Features**
	- Introduced a new DIP system for Enhanced High DPI Monitor Support on Windows.
	- Expanded services for plugin functionality.
	- Updated Events API for improved user event handling.

These changes improve the user experience by ensuring a more streamlined menu interface on macOS and enhancing support across various platforms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->