### PR TITLE
[mac] fix always on top during window creation

### DIFF
--- a/mkdocs-website/docs/en/changelog.md
+++ b/mkdocs-website/docs/en/changelog.md
@@ -22,6 +22,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Upgrade to `go-webview2` v1.0.16 by [leaanthony](https://github.com/leaanthony)
 - Fixed `Screen` type to include `ID` not `Id` by [etesam913](https://github.com/etesam913) in [#3778](https://github.com/wailsapp/wails/pull/3778)
 
+### Fixed
+- Fixed `AlwaysOnTop` not working on Mac by [leaanthony](https://github.com/leaanthony)
+  in [#3841](https://github.com/wailsapp/wails/pull/3841)
+
 ## v3.0.0-alpha.7 - 2024-09-18
 
 ### Added

--- a/v3/examples/window/main.go
+++ b/v3/examples/window/main.go
@@ -154,6 +154,17 @@ func main() {
 					Show()
 				windowCounter++
 			})
+		myMenu.Add("New WebviewWindow (Always on top)").
+			OnClick(func(ctx *application.Context) {
+				app.NewWebviewWindowWithOptions(application.WebviewWindowOptions{
+					AlwaysOnTop: true,
+				}).
+					SetTitle("WebviewWindow "+strconv.Itoa(windowCounter)).
+					SetRelativePosition(rand.Intn(1000), rand.Intn(800)).
+					SetURL("https://wails.io").
+					Show()
+				windowCounter++
+			})
 		myMenu.Add("New WebviewWindow (Hide Maximise)").
 			OnClick(func(ctx *application.Context) {
 				app.NewWebviewWindowWithOptions(application.WebviewWindowOptions{

--- a/v3/pkg/application/webview_window_darwin.go
+++ b/v3/pkg/application/webview_window_darwin.go
@@ -1165,7 +1165,6 @@ func (w *macosWebviewWindow) run() {
 			w.getWebviewPreferences(),
 		)
 		w.setTitle(options.Title)
-		w.setAlwaysOnTop(options.AlwaysOnTop)
 		w.setResizable(!options.DisableResize)
 		if options.MinWidth != 0 || options.MinHeight != 0 {
 			w.setMinSize(options.MinWidth, options.MinHeight)
@@ -1251,11 +1250,13 @@ func (w *macosWebviewWindow) run() {
 				if !options.Hidden {
 					C.windowShow(w.nsWindow)
 					w.setHasShadow(!options.Mac.DisableShadow)
+					w.setAlwaysOnTop(options.AlwaysOnTop)
 				} else {
 					// We have to wait until the window is shown before we can remove the shadow
 					var cancel func()
 					cancel = w.parent.OnWindowEvent(events.Mac.WindowDidBecomeKey, func(_ *WindowEvent) {
 						w.setHasShadow(!options.Mac.DisableShadow)
+						w.setAlwaysOnTop(options.AlwaysOnTop)
 						cancel()
 					})
 				}


### PR DESCRIPTION
# Description

This PR fixes an issue with AlwaysOnTop not being applied to the window correctly during creation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new menu item: "New WebviewWindow (Always on top)" to create a window that remains on top of others.
  - Enhanced High DPI Monitor Support with a new DIP system.
  - Expanded services to support plugin functionality.

- **Bug Fixes**
  - Resolved the `AlwaysOnTop` issue on Mac.
  - Fixed compile errors on Linux and custom event processing issues.

- **Documentation**
  - Updated changelog to reflect recent changes, bug fixes, and enhancements across platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->