### PR TITLE
[v3 alpha test] `X` and `Y` in WebviewWindowOptions do nothing

### DIFF
--- a/v3/examples/binding/main.go
+++ b/v3/examples/binding/main.go
@@ -26,6 +26,7 @@ func main() {
 	app.NewWebviewWindowWithOptions(application.WebviewWindowOptions{
 		URL:             "/",
 		DevToolsEnabled: true,
+		Centered:        true,
 	})
 
 	err := app.Run()

--- a/v3/examples/contextmenus/main.go
+++ b/v3/examples/contextmenus/main.go
@@ -25,9 +25,10 @@ func main() {
 	})
 
 	mainWindow := app.NewWebviewWindowWithOptions(application.WebviewWindowOptions{
-		Title:  "Context Menu Demo",
-		Width:  1024,
-		Height: 1024,
+		Title:    "Context Menu Demo",
+		Width:    1024,
+		Height:   1024,
+		Centered: true,
 		Mac: application.MacWindow{
 			Backdrop:                application.MacBackdropTranslucent,
 			TitleBar:                application.MacTitleBarHiddenInsetUnified,

--- a/v3/examples/dev/main.go
+++ b/v3/examples/dev/main.go
@@ -32,7 +32,8 @@ func main() {
 			TitleBar:                application.MacTitleBarHiddenInset,
 		},
 
-		URL: "/",
+		URL:      "/",
+		Centered: true,
 	})
 
 	err := app.Run()

--- a/v3/examples/drag-n-drop/main.go
+++ b/v3/examples/drag-n-drop/main.go
@@ -33,6 +33,7 @@ func main() {
 			InvisibleTitleBarHeight: 50,
 		},
 		EnableDragAndDrop: true,
+		Centered:          true,
 	})
 
 	window.OnWindowEvent(events.Common.WindowFilesDropped, func(event *application.WindowEvent) {

--- a/v3/examples/environment/main.go
+++ b/v3/examples/environment/main.go
@@ -25,9 +25,10 @@ func main() {
 	})
 
 	app.NewWebviewWindowWithOptions(application.WebviewWindowOptions{
-		Title:  "Environment Demo",
-		Width:  800,
-		Height: 600,
+		Title:    "Environment Demo",
+		Width:    800,
+		Height:   600,
+		Centered: true,
 		Mac: application.MacWindow{
 			Backdrop:                application.MacBackdropTranslucent,
 			TitleBar:                application.MacTitleBarHiddenInsetUnified,

--- a/v3/examples/events-bug/main.go
+++ b/v3/examples/events-bug/main.go
@@ -37,6 +37,7 @@ func main() {
 				window.OpenDevTools()
 			},
 		},
+		Centered: true,
 	})
 
 	app.NewWebviewWindowWithOptions(application.WebviewWindowOptions{
@@ -48,6 +49,7 @@ func main() {
 				println("Window 2: Toggle Dev Tools")
 			},
 		},
+		Centered: true,
 	})
 
 	err := app.Run()

--- a/v3/examples/events/main.go
+++ b/v3/examples/events/main.go
@@ -63,6 +63,7 @@ func main() {
 			TitleBar:                application.MacTitleBarHiddenInsetUnified,
 			InvisibleTitleBarHeight: 50,
 		},
+		Centered: true,
 	})
 
 	var countdown = 3
@@ -84,6 +85,7 @@ func main() {
 			TitleBar:                application.MacTitleBarHiddenInsetUnified,
 			InvisibleTitleBarHeight: 50,
 		},
+		Centered: true,
 	})
 
 	go func() {

--- a/v3/examples/frameless/main.go
+++ b/v3/examples/frameless/main.go
@@ -26,6 +26,7 @@ func main() {
 
 	app.NewWebviewWindowWithOptions(application.WebviewWindowOptions{
 		Frameless: true,
+		Centered:  true,
 	})
 
 	err := app.Run()

--- a/v3/examples/hide-window/main.go
+++ b/v3/examples/hide-window/main.go
@@ -25,6 +25,7 @@ func main() {
 	window := app.NewWebviewWindowWithOptions(application.WebviewWindowOptions{
 		Width:         500,
 		Height:        800,
+		Centered:      true,
 		Frameless:     false,
 		AlwaysOnTop:   false,
 		Hidden:        false,

--- a/v3/examples/ignore-mouse/main.go
+++ b/v3/examples/ignore-mouse/main.go
@@ -19,6 +19,7 @@ func main() {
 	window := app.NewWebviewWindowWithOptions(application.WebviewWindowOptions{
 		Width:             800,
 		Height:            600,
+		Centered:          true,
 		Title:             "Ignore Mouse Example",
 		URL:               "https://wails.io",
 		IgnoreMouseEvents: false,

--- a/v3/examples/keybindings/main.go
+++ b/v3/examples/keybindings/main.go
@@ -29,6 +29,7 @@ func main() {
 				window.OpenDevTools()
 			},
 		},
+		Centered: true,
 	})
 
 	app.NewWebviewWindowWithOptions(application.WebviewWindowOptions{
@@ -40,6 +41,7 @@ func main() {
 				println("Window 2: Toggle Dev Tools")
 			},
 		},
+		Centered: true,
 	})
 
 	err := app.Run()

--- a/v3/examples/plain/main.go
+++ b/v3/examples/plain/main.go
@@ -32,14 +32,16 @@ func main() {
 			Backdrop:                application.MacBackdropTranslucent,
 			TitleBar:                application.MacTitleBarHiddenInsetUnified,
 		},
-		URL: "/",
+		URL:      "/",
+		Centered: true,
 	})
 
 	app.NewWebviewWindowWithOptions(application.WebviewWindowOptions{
-		Title: "HTML TEST",
-		HTML:  "<h1>AWESOME!</h1>",
-		CSS:   `body { background-color: rgb(255, 0, 0); font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif; user-select: none; -ms-user-select: none; -webkit-user-select: none; } .main { color: white; margin: 20%; }`,
-		JS:    `window.iamhere = function() { console.log("Hello World!"); }`,
+		Title:    "HTML TEST",
+		HTML:     "<h1>AWESOME!</h1>",
+		CSS:      `body { background-color: rgb(255, 0, 0); font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif; user-select: none; -ms-user-select: none; -webkit-user-select: none; } .main { color: white; margin: 20%; }`,
+		JS:       `window.iamhere = function() { console.log("Hello World!"); }`,
+		Centered: true,
 	})
 
 	app.OnEvent("clicked", func(_ *application.CustomEvent) {
@@ -50,9 +52,10 @@ func main() {
 		time.Sleep(5 * time.Second)
 
 		app.NewWebviewWindowWithOptions(application.WebviewWindowOptions{
-			Title:  "Plain Bundle new Window from GoRoutine",
-			Width:  500,
-			Height: 500,
+			Title:    "Plain Bundle new Window from GoRoutine",
+			Width:    500,
+			Height:   500,
+			Centered: true,
 			Mac: application.MacWindow{
 				Backdrop:                application.MacBackdropTranslucent,
 				TitleBar:                application.MacTitleBarHiddenInsetUnified,

--- a/v3/examples/raw-message/main.go
+++ b/v3/examples/raw-message/main.go
@@ -34,6 +34,7 @@ func main() {
 			TitleBar:                application.MacTitleBarHiddenInsetUnified,
 			InvisibleTitleBarHeight: 50,
 		},
+		Centered: true,
 	})
 
 	err := app.Run()

--- a/v3/examples/screen/main.go
+++ b/v3/examples/screen/main.go
@@ -60,9 +60,10 @@ func main() {
 	})
 
 	app.NewWebviewWindowWithOptions(application.WebviewWindowOptions{
-		Title:  "Screen Demo",
-		Width:  800,
-		Height: 600,
+		Title:    "Screen Demo",
+		Width:    800,
+		Height:   600,
+		Centered: true,
 		Mac: application.MacWindow{
 			Backdrop:                application.MacBackdropTranslucent,
 			TitleBar:                application.MacTitleBarHiddenInsetUnified,

--- a/v3/examples/services/main.go
+++ b/v3/examples/services/main.go
@@ -55,8 +55,9 @@ func main() {
 	})
 
 	app.NewWebviewWindowWithOptions(application.WebviewWindowOptions{
-		Width:  1024,
-		Height: 768,
+		Width:    1024,
+		Height:   768,
+		Centered: true,
 	})
 
 	err := app.Run()

--- a/v3/examples/show-macos-toolbar/main.go
+++ b/v3/examples/show-macos-toolbar/main.go
@@ -27,6 +27,7 @@ func main() {
 				HideToolbarSeparator: true,
 			},
 		},
+		Centered: true,
 	})
 
 	// Create window
@@ -41,6 +42,7 @@ func main() {
 				ShowToolbarWhenFullscreen: true,
 			},
 		},
+		Centered: true,
 	})
 
 	err := app.Run()

--- a/v3/examples/systray/main.go
+++ b/v3/examples/systray/main.go
@@ -24,6 +24,7 @@ func main() {
 	_ = app.NewWebviewWindowWithOptions(application.WebviewWindowOptions{
 		Width:         500,
 		Height:        500,
+		Centered:      true,
 		Name:          "Systray Demo Window",
 		Frameless:     true,
 		AlwaysOnTop:   true,

--- a/v3/examples/video/main.go
+++ b/v3/examples/video/main.go
@@ -35,7 +35,8 @@ func main() {
 				FullscreenEnabled: application.Enabled,
 			},
 		},
-		HTML: "<video controls width=\"500\" >\n        <source\n          src=\"https://interactive-examples.mdn.mozilla.net/media/cc0-videos/flower.webm\"\n          type=\"video/webm\"\n        />\n        <source\n          src=\"https://interactive-examples.mdn.mozilla.net/media/cc0-videos/flower.mp4\"\n          type=\"video/mp4\"\n        />\n      </video>",
+		HTML:     "<video controls width=\"500\" >\n        <source\n          src=\"https://interactive-examples.mdn.mozilla.net/media/cc0-videos/flower.webm\"\n          type=\"video/webm\"\n        />\n        <source\n          src=\"https://interactive-examples.mdn.mozilla.net/media/cc0-videos/flower.mp4\"\n          type=\"video/mp4\"\n        />\n      </video>",
+		Centered: true,
 	})
 
 	err := app.Run()

--- a/v3/examples/window-api/main.go
+++ b/v3/examples/window-api/main.go
@@ -24,9 +24,10 @@ func main() {
 	})
 
 	app.NewWebviewWindowWithOptions(application.WebviewWindowOptions{
-		Title:  "JS Window API Demo",
-		Width:  1280,
-		Height: 1024,
+		Title:    "JS Window API Demo",
+		Width:    1280,
+		Height:   1024,
+		Centered: true,
 		Mac: application.MacWindow{
 			Backdrop:                application.MacBackdropTranslucent,
 			TitleBar:                application.MacTitleBarHiddenInsetUnified,

--- a/v3/examples/window/main.go
+++ b/v3/examples/window/main.go
@@ -662,6 +662,7 @@ func main() {
 		Mac: application.MacWindow{
 			DisableShadow: true,
 		},
+		Centered: true,
 	})
 
 	app.SetMenu(menu)

--- a/v3/examples/wml/main.go
+++ b/v3/examples/wml/main.go
@@ -25,9 +25,10 @@ func main() {
 	})
 
 	app.NewWebviewWindowWithOptions(application.WebviewWindowOptions{
-		Title:  "Wails ML Demo",
-		Width:  1280,
-		Height: 1024,
+		Title:    "Wails ML Demo",
+		Width:    1280,
+		Height:   1024,
+		Centered: true,
 		Mac: application.MacWindow{
 			Backdrop:                application.MacBackdropTranslucent,
 			TitleBar:                application.MacTitleBarHiddenInsetUnified,

--- a/v3/pkg/application/webview_window_darwin.go
+++ b/v3/pkg/application/webview_window_darwin.go
@@ -1166,6 +1166,7 @@ func (w *macosWebviewWindow) run() {
 		)
 		w.setTitle(options.Title)
 		w.setResizable(!options.DisableResize)
+		w.setPosition(options.X, options.Y)
 		if options.MinWidth != 0 || options.MinHeight != 0 {
 			w.setMinSize(options.MinWidth, options.MinHeight)
 		}

--- a/v3/pkg/application/webview_window_darwin.go
+++ b/v3/pkg/application/webview_window_darwin.go
@@ -1229,7 +1229,10 @@ func (w *macosWebviewWindow) run() {
 			w.fullscreen()
 		case WindowStateNormal:
 		}
-		C.windowCenter(w.nsWindow)
+
+		if options.Centered {
+			C.windowCenter(w.nsWindow)
+		}
 
 		startURL, err := assetserver.GetStartURL(options.URL)
 		if err != nil {


### PR DESCRIPTION
<!--
READ CAREFULLY: Before submitting your PR, please ensure you have created an issue for your PR.
It is essential that you do this so that we can discuss the proposed changes before you spend time on them.
If you do not create an issue, your PR may be rejected without review.
If a relevant issue already exists, please reference it in your PR by including `Fixes #<issue number>` in your PR description.
-->

# Description

In `v3/pkg/application/webview_window_darwin.go` there's no logic that involves `options.X` and `options.Y` and window is [always](https://github.com/wailsapp/wails/blob/308304b75e4e83b5aea33087e17641ac84b3bda8/v3/pkg/application/webview_window_darwin.go#L1232) centered, so `X` and `Y` in WebviewWindowOptions do nothing.

```go
app.NewWebviewWindowWithOptions(application.WebviewWindowOptions{
    Title: "Window 1",
    URL:   "/",
    // It works as if they are not set and window is always centered
    X:     320,
    Y:     240,
})
```

This PR fixes `X` `Y` issue and requires to set `Centered: true` exclusively to launch window centered. When both `X` `Y` and `Centered: true` are set the latter one is prioritized.

```go
app.NewWebviewWindowWithOptions(application.WebviewWindowOptions{
    Title:    "Window 1",
    URL:      "/",
    // X:        320, // overrode by `Centered: true`
    // Y:        240, // overrode by `Centered: true`
    Centered: true,
})
```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?
  
- [ ] Windows
- [x] macOS
- [ ] Linux
  
## Test Configuration

```
# Wails
Version | v2.9.2

# System
┌───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
| OS           | MacOS                                                                                                                  |
| Version      | 15.0.1                                                                                                                 |
| ID           | 24A348                                                                                                                 |
| Go Version   | go1.22.7                                                                                                               |
| Platform     | darwin                                                                                                                 |
| Architecture | arm64                                                                                                                  |
| CPU          | Apple M2                                                                                                               |
| GPU          | Chipset Model: Apple M2 Type: GPU Bus: Built-In Total Number of Cores: 8 Vendor: Apple (0x106b) Metal Support: Metal 3 |
| Memory       | 16GB                                                                                                                   |
└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘

# Dependencies
┌───────────────────────────────────────────────────────────────────────┐
| Dependency                | Package Name | Status    | Version        |
| Xcode command line tools  | N/A          | Installed | 2349           |
| Nodejs                    | N/A          | Installed | 22.8.0         |
| npm                       | N/A          | Installed | 10.8.2         |
| *Xcode                    | N/A          | Installed | 9.4.1 (17E189) |
| *upx                      | N/A          | Available |                |
| *nsis                     | N/A          | Available |                |
└─────────────────────── * - Optional Dependency ───────────────────────┘

# Diagnosis
Optional package(s) installation details: 
  - upx : Available at https://upx.github.io/
  - nsis : More info at https://wails.io/docs/guides/windows-installer/

 SUCCESS  Your system is ready for Wails development!

 ♥   If Wails is useful to you or your company, please consider sponsoring the project:
https://github.com/sponsors/leaanthony

```

# Checklist:

- [ ] I have updated `website/src/pages/changelog.mdx` with details of this PR
- [ ] My code follows the general coding style of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a `Centered` option to the webview window configuration, ensuring that windows open centered on the screen across various examples.
	- Introduced periodic event emission in the `events` example, enhancing interactivity.
- **Bug Fixes**
	- Adjusted formatting for consistency in window options across multiple examples. 
- **Documentation**
	- Improved clarity on window centering behavior in the user interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->