### PR TITLE
V3 alpha feature/start window position

### DIFF
--- a/mkdocs-website/docs/en/changelog.md
+++ b/mkdocs-website/docs/en/changelog.md
@@ -20,10 +20,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Events documentation to the mkdocs webite by [atterpac](https://github.com/atterpac) in [#3867](https://github.com/wailsapp/wails/pull/3867)
 - Templates for sveltekit and sveltekit-ts that are set for non-SSR development by [atterpac](https://github.com/atterpac) in [#3829](https://github.com/wailsapp/wails/pull/3829)
-- Update build assets using new `wails3 update build-assets` command by [leaanthony](https://github.com/leaanthony).
+- Update build assets using new `wails3 update build-assets` command by [leaanthony](https://github.com/leaanthony)
 - Example to test the HTML Drag and Drop API by [FerroO2000](https://github.com/FerroO2000) in [#3856](https://github.com/wailsapp/wails/pull/3856)
 - File Association support by [leaanthony](https://github.com/leaanthony) in [#3873](https://github.com/wailsapp/wails/pull/3873)
 - New `wails3 generate runtime` command by [leaanthony](https://github.com/leaanthony)
+- New `InitialPosition` option to specify if the window should be centered or positioned at the given X/Y location by [leaanthony](https://github.com/leaanthony) in [#3885](https://github.com/wailsapp/wails/pull/3885)
 
 ### Changed
 - Taskfile refactor by [leaanthony](https://github.com/leaanthony) in [#3748](https://github.com/wailsapp/wails/pull/3748)

--- a/v3/examples/window/main.go
+++ b/v3/examples/window/main.go
@@ -189,7 +189,7 @@ func main() {
 				windowCounter++
 			})
 
-		myMenu.Add("New WebviewWindow (Position 100x100)").
+		myMenu.Add("New WebviewWindow (Position 100,100)").
 			OnClick(func(ctx *application.Context) {
 				app.NewWebviewWindowWithOptions(application.WebviewWindowOptions{
 					MaximiseButtonState: application.ButtonHidden,

--- a/v3/examples/window/main.go
+++ b/v3/examples/window/main.go
@@ -176,6 +176,32 @@ func main() {
 					Show()
 				windowCounter++
 			})
+
+		myMenu.Add("New WebviewWindow (Centered)").
+			OnClick(func(ctx *application.Context) {
+				app.NewWebviewWindowWithOptions(application.WebviewWindowOptions{
+					MaximiseButtonState: application.ButtonHidden,
+					InitialPosition:     application.WindowCentered,
+				}).
+					SetTitle("WebviewWindow " + strconv.Itoa(windowCounter)).
+					SetURL("https://wails.io").
+					Show()
+				windowCounter++
+			})
+
+		myMenu.Add("New WebviewWindow (Position 100x100)").
+			OnClick(func(ctx *application.Context) {
+				app.NewWebviewWindowWithOptions(application.WebviewWindowOptions{
+					MaximiseButtonState: application.ButtonHidden,
+					X:                   100,
+					Y:                   100,
+					InitialPosition:     application.WindowXY,
+				}).
+					SetTitle("WebviewWindow " + strconv.Itoa(windowCounter)).
+					SetURL("https://wails.io").
+					Show()
+				windowCounter++
+			})
 	}
 	if runtime.GOOS == "darwin" || runtime.GOOS == "windows" {
 		myMenu.Add("New WebviewWindow (Disable Close)").

--- a/v3/pkg/application/webview_window.go
+++ b/v3/pkg/application/webview_window.go
@@ -726,7 +726,7 @@ func (w *WebviewWindow) startResize(border string) error {
 // Center centers the window on the screen
 func (w *WebviewWindow) Center() {
 	if w.impl == nil && !w.isDestroyed() {
-		w.options.Centered = true
+		w.options.InitialPosition = WindowCentered
 		return
 	}
 	InvokeSync(w.impl.center)

--- a/v3/pkg/application/webview_window_darwin.go
+++ b/v3/pkg/application/webview_window_darwin.go
@@ -1229,7 +1229,11 @@ func (w *macosWebviewWindow) run() {
 			w.fullscreen()
 		case WindowStateNormal:
 		}
-		C.windowCenter(w.nsWindow)
+		if w.parent.options.InitialPosition == WindowCentered {
+			C.windowCenter(w.nsWindow)
+		} else {
+			w.setPosition(options.X, options.Y)
+		}
 
 		startURL, err := assetserver.GetStartURL(options.URL)
 		if err != nil {

--- a/v3/pkg/application/webview_window_darwin.go
+++ b/v3/pkg/application/webview_window_darwin.go
@@ -514,8 +514,21 @@ void windowSetAppearanceTypeByName(void* nsWindow, const char *appearanceName) {
 
 // Center window on current monitor
 void windowCenter(void* nsWindow) {
-	[(WebviewWindow*)nsWindow center];
+    WebviewWindow* window = (WebviewWindow*)nsWindow;
+    NSScreen* screen = [window screen];
+    if (screen == NULL) {
+        screen = [NSScreen mainScreen];
+    }
+
+    NSRect screenFrame = [screen frame];
+    NSRect windowFrame = [window frame];
+
+    CGFloat x = screenFrame.origin.x + (screenFrame.size.width - windowFrame.size.width) / 2;
+    CGFloat y = screenFrame.origin.y + (screenFrame.size.height - windowFrame.size.height) / 2;
+
+    [window setFrame:NSMakeRect(x, y, windowFrame.size.width, windowFrame.size.height) display:YES];
 }
+
 
 // Get the current size of the window
 void windowGetSize(void* nsWindow, int* width, int* height) {
@@ -557,11 +570,17 @@ void windowGetPosition(void* nsWindow, int* x, int* y) {
 }
 
 void windowSetPosition(void* nsWindow, int x, int y) {
-	NSRect frame = [(WebviewWindow*)nsWindow frame];
-	frame.origin.x = x;
-	frame.origin.y = y;
-	[(WebviewWindow*)nsWindow setFrame:frame display:YES];
+    WebviewWindow* window = (WebviewWindow*)nsWindow;
+    NSScreen* screen = [window screen];
+    if (screen == NULL) {
+        screen = [NSScreen mainScreen];
+    }
+    NSRect frame = [window frame];
+    frame.origin.x = x;
+    frame.origin.y = (screen.frame.size.height - frame.size.height) - y;
+    [window setFrame:frame display:YES];
 }
+
 
 // Destroy window
 void windowDestroy(void* nsWindow) {

--- a/v3/pkg/application/webview_window_linux.go
+++ b/v3/pkg/application/webview_window_linux.go
@@ -295,11 +295,12 @@ func (w *linuxWebviewWindow) run() {
 
 	w.setFrameless(w.parent.options.Frameless)
 
-	if w.parent.options.X != 0 || w.parent.options.Y != 0 {
-		w.setRelativePosition(w.parent.options.X, w.parent.options.Y)
+	if w.parent.options.InitialPosition == WindowCentered {
+		C.windowCenter(w.nsWindow)
 	} else {
-		w.center()
+		w.setPosition(options.X, options.Y)
 	}
+
 	switch w.parent.options.StartState {
 	case WindowStateMaximised:
 		w.maximise()
@@ -352,10 +353,10 @@ func (w *linuxWebviewWindow) run() {
 	}
 	if !w.parent.options.Hidden {
 		w.show()
-		if w.parent.options.X != 0 || w.parent.options.Y != 0 {
-			w.setRelativePosition(w.parent.options.X, w.parent.options.Y)
+		if w.parent.options.InitialPosition == WindowCentered {
+			w.center()
 		} else {
-			w.center() // needs to be queued until after GTK starts up!
+			w.setRelativePosition(w.parent.options.X, w.parent.options.Y)
 		}
 	}
 	if w.parent.options.DevToolsEnabled || globalApplication.isDebugMode {

--- a/v3/pkg/application/webview_window_options.go
+++ b/v3/pkg/application/webview_window_options.go
@@ -22,6 +22,13 @@ const (
 	ButtonHidden   ButtonState = 2
 )
 
+type WindowStartPosition int
+
+const (
+	WindowCentered WindowStartPosition = 0
+	WindowXY       WindowStartPosition = 1
+)
+
 type WebviewWindowOptions struct {
 	// Name is a unique identifier that can be given to a window.
 	Name string
@@ -63,9 +70,6 @@ type WebviewWindowOptions struct {
 	// Default: WindowStateNormal
 	StartState WindowState
 
-	// Centered will center the window on the screen.
-	Centered bool
-
 	// BackgroundType is the type of background to use for the window.
 	// Default: BackgroundTypeSolid
 	BackgroundType BackgroundType
@@ -81,6 +85,9 @@ type WebviewWindowOptions struct {
 
 	// CSS is the CSS to load in the window.
 	CSS string
+
+	// Initial Position
+	InitialPosition WindowStartPosition
 
 	// X is the starting X position of the window.
 	X int

--- a/v3/pkg/application/webview_window_windows.go
+++ b/v3/pkg/application/webview_window_windows.go
@@ -370,8 +370,10 @@ func (w *windowsWebviewWindow) run() {
 		w.resizeDebouncer = debounce.New(time.Duration(options.Windows.ResizeDebounceMS) * time.Millisecond)
 	}
 
-	if options.Centered {
+	if options.InitialPosition == WindowCentered {
 		w.center()
+	} else {
+		w.setPosition(options.X, options.Y)
 	}
 
 	if options.Frameless {


### PR DESCRIPTION
<!--
READ CAREFULLY: Before submitting your PR, please ensure you have created an issue for your PR.
It is essential that you do this so that we can discuss the proposed changes before you spend time on them.
If you do not create an issue, your PR may be rejected without review.
If a relevant issue already exists, please reference it in your PR by including `Fixes #<issue number>` in your PR description.
-->

# Description

This change adds a new `InitialPosition` option to `WebviewWindowOptions` to determine where the window should be initially positioned. Valid options are: 
- `WindowCentered` - Center on start
- `WindowXY` - Place the window at the position specified by the `X` and `Y` option values
