### PR TITLE
defualt to embed all:frontend/dist

### DIFF
--- a/mkdocs-website/docs/en/changelog.md
+++ b/mkdocs-website/docs/en/changelog.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `GeneralAutofillEnabled` and `PasswordAutosaveEnabled` Windows options by [leaanthony](https://github.com/leaanthony) in [#3766](https://github.com/wailsapp/wails/pull/3766)
 
 ### Changed
+- Asset embed to include `all:frontend/dist` to support frameworks that generate subfolders by @atterpac in [#3887](https://github.com/wailsapp/wails/pull/3887)
 - Taskfile refactor by [leaanthony](https://github.com/leaanthony) in [#3748](https://github.com/wailsapp/wails/pull/3748)
 - Upgrade to `go-webview2` v1.0.16 by [leaanthony](https://github.com/leaanthony)
 - Fixed `Screen` type to include `ID` not `Id` by [etesam913](https://github.com/etesam913) in [#3778](https://github.com/wailsapp/wails/pull/3778)

--- a/v3/internal/templates/_common/main.go.tmpl
+++ b/v3/internal/templates/_common/main.go.tmpl
@@ -14,7 +14,7 @@ import (
 // made available to the frontend.
 // See https://pkg.go.dev/embed for more information.
 
-//go:embed frontend/dist
+//go:embed all:frontend/dist
 var assets embed.FS
 
 // main function serves as the application's entry point. It initializes the application, creates a window,


### PR DESCRIPTION
Changes the template to use `all:frontend/dist` instead of `frontend/dist` added sveltekit templates were not compatible due to the lack of `/dist/<subfolder>`

```
# System
┌──────────────────────────────────────────────────────────────────────────────────────────┐
| Name         | Ubuntu                                                                    |
| Version      | 24.04                                                                     |
| ID           | ubuntu                                                                    |
| Branding     | 24.04 LTS (Noble Numbat)                                                  |
| Platform     | linux                                                                     |
| Architecture | amd64                                                                     |
| CPU          | 12th Gen Intel(R) Core(TM) i5-1235U                                       |
| GPU 1        | Alder Lake-UP3 GT2 [Iris Xe Graphics] (Intel Corporation) - Driver: i915  |
| Memory       | 7GB                                                                       |
└──────────────────────────────────────────────────────────────────────────────────────────┘

# Build Environment
┌─────────────────────────────────────────────────────────┐
| Wails CLI    | v3.0.0-alpha.7                           |
| Go Version   | go1.22.4                                 |
| Revision     | 99d538ea971eb23efa3f65448ff3c5398d220902 |
| Modified     | true                                     |
| -buildmode   | exe                                      |
| -compiler    | gc                                       |
| CGO_CFLAGS   |                                          |
| CGO_CPPFLAGS |                                          |
| CGO_CXXFLAGS |                                          |
| CGO_ENABLED  | 1                                        |
| CGO_LDFLAGS  |                                          |
| GOAMD64      | v1                                       |
| GOARCH       | amd64                                    |
| GOOS         | linux                                    |
| vcs          | git                                      |
| vcs.modified | true                                     |
| vcs.revision | 99d538ea971eb23efa3f65448ff3c5398d220902 |
| vcs.time     | 2024-11-16T01:30:33Z                     |
└─────────────────────────────────────────────────────────┘

# Dependencies
┌──────────────────────────────────────┐
| webkit2gtk | 2.46.1-0ubuntu0.24.04.1 |
| gcc        | 12.10ubuntu1            |
| gtk3       | 3.24.41-4ubuntu1.2      |
| npm        | 10.5.1                  |
| pkg-config | 1.8.1-2build1           |
└────── * - Optional Dependency ───────┘
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced new commands: `wails3 update build-assets` and `wails3 generate runtime`.
	- Added `InitialPosition` option for window positioning.
	- New methods for file path management in the application package.
	- Enhanced Windows options for autofill and password autosave.

- **Bug Fixes**
	- Resolved issues with the `AlwaysOnTop` feature on macOS and compilation errors on Linux.

- **Documentation**
	- Updated changelog to reflect new features, changes, and fixes, improving user experience across platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->