### PR TITLE
Fix AMD64 appimage generation

### DIFF
--- a/mkdocs-website/docs/en/changelog.md
+++ b/mkdocs-website/docs/en/changelog.md
@@ -41,6 +41,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Consolidated dev config into `config.yml` by [leaanthony](https://github.com/leaanthony)
 
 ### Fixed
+- Fixed amd64 appimage compile by @atterpac in [#3898](https://github.com/wailsapp/wails/pull/3898)
 - Fixed Linux systray `OnClick` and `OnRightClick` implementation by @atterpac in [#3886](https://github.com/wailsapp/wails/pull/3886)
 - Fixed `AlwaysOnTop` not working on Mac by [leaanthony](https://github.com/leaanthony) in [#3841](https://github.com/wailsapp/wails/pull/3841)
 - [darwin]  Fixed `application.NewEditMenu` including a duplicate `PasteAndMatchStyle` role in the edit menu on Darwin by [johnmccabe](https://github.com/johnmccabe) in [#3839](https://github.com/wailsapp/wails/pull/3839)

--- a/v3/internal/commands/appimage.go
+++ b/v3/internal/commands/appimage.go
@@ -76,6 +76,7 @@ func generateAppImage(options *GenerateAppImageOptions) error {
 	// Architecture-specific variables using a map
 	archDetails := map[string]string{
 		"arm64":  "aarch64",
+		"amd64":  "x86_64",
 		"x86_64": "x86_64",
 	}
 


### PR DESCRIPTION
#3854 introduced a bug for compiling appimage for amd64 CPUs this PR adds the amd64 to the archdeatilas map to remedy the issue.

```
# System
┌──────────────────────────────────────────────────────────────────────────────────────────┐
| Name         | Ubuntu                                                                    |
| Version      | 24.04                                                                     |
| ID           | ubuntu                                                                    |
| Branding     | 24.04.1 LTS (Noble Numbat)                                                |
| Platform     | linux                                                                     |
| Architecture | amd64                                                                     |
| CPU          | 12th Gen Intel(R) Core(TM) i5-1235U                                       |
| GPU 1        | Alder Lake-UP3 GT2 [Iris Xe Graphics] (Intel Corporation) - Driver: i915  |
| Memory       | 7GB                                                                       |
└──────────────────────────────────────────────────────────────────────────────────────────┘

# Build Environment
┌─────────────────────────────────────────────────────────┐
| Wails CLI    | v3.0.0-alpha.7                           |
| Go Version   | go1.22.4                                 |
| Revision     | 699743dbe2e247a6c7e9bdfd08f3c4f48809e8a8 |
| Modified     | false                                    |
| -buildmode   | exe                                      |
| -compiler    | gc                                       |
| CGO_CFLAGS   |                                          |
| CGO_CPPFLAGS |                                          |
| CGO_CXXFLAGS |                                          |
| CGO_ENABLED  | 1                                        |
| CGO_LDFLAGS  |                                          |
| GOAMD64      | v1                                       |
| GOARCH       | amd64                                    |
| GOOS         | linux                                    |
| vcs          | git                                      |
| vcs.modified | false                                    |
| vcs.revision | 699743dbe2e247a6c7e9bdfd08f3c4f48809e8a8 |
| vcs.time     | 2024-11-21T16:11:02Z                     |
└─────────────────────────────────────────────────────────┘

# Dependencies
┌──────────────────────────────────────┐
| gtk3       | 3.24.41-4ubuntu1.2      |
| npm        | 10.5.1                  |
| pkg-config | 1.8.1-2build1           |
| webkit2gtk | 2.46.3-0ubuntu0.24.04.1 |
| gcc        | 12.10ubuntu1            |
└────── * - Optional Dependency ───────┘
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added documentation for events on the mkdocs website.
	- Introduced new templates for SvelteKit.
	- Added `wails3 update build-assets` and `wails3 generate runtime` commands.
	- New `InitialPosition` option for window positioning.
	- Added options for autofill and password autosave on Windows.
	- Introduced new methods `Path` and `Paths` in the application package.
	- Added ability to retrieve the window calling a service method.

- **Bug Fixes**
	- Resolved issues with amd64 AppImage compilation and Linux systray handling.
	- Fixed `AlwaysOnTop` functionality on macOS and various platform-specific issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->