### PR TITLE
chore: update svelte CLI command

### DIFF
--- a/website/docs/guides/sveltekit.mdx
+++ b/website/docs/guides/sveltekit.mdx
@@ -1,4 +1,4 @@
-m # SvelteKit
+# SvelteKit
 
 This guide will go into:
 1. Minimal Installation Steps - The steps needed to get a minimum Wails setup working for SvelteKit.

--- a/website/docs/guides/sveltekit.mdx
+++ b/website/docs/guides/sveltekit.mdx
@@ -1,4 +1,4 @@
-# SvelteKit
+m # SvelteKit
 
 This guide will go into:
 1. Minimal Installation Steps - The steps needed to get a minimum Wails setup working for SvelteKit.
@@ -14,8 +14,8 @@ This guide will go into:
 - Navigate into your newly created myapp folder.
 - Delete the folder named "frontend"
 
-##### While in the Wails project root. Use your favorite package manager and install SvelteKit as the new frontend.  Follow the prompts.
-- `npm create svelte@latest frontend`
+##### While in the Wails project root. Use the Svelte CLI to create a SvelteKit project as the new frontend. Follow the prompts, nothing Wails specific is needed here.
+- `npx sv create`
 
 ##### Modify wails.json.
 - Add `"wailsjsdir": "./frontend/src/lib",` Do note that this is where your Go and runtime functions will appear.

--- a/website/docs/guides/sveltekit.mdx
+++ b/website/docs/guides/sveltekit.mdx
@@ -15,7 +15,7 @@ This guide will go into:
 - Delete the folder named "frontend"
 
 ##### While in the Wails project root. Use the Svelte CLI to create a SvelteKit project as the new frontend. Follow the prompts, nothing Wails specific is needed here.
-- `npx sv create`
+- `npx sv create frontend`
 
 ##### Modify wails.json.
 - Add `"wailsjsdir": "./frontend/src/lib",` Do note that this is where your Go and runtime functions will appear.


### PR DESCRIPTION
# Description
The command to create a Svelte project (previously `npm create svelte@latest`) should now be `npx sv create`.
This fixes #3911.

## Type of change
Documentation change. 

# How Has This Been Tested?
The command is a modified one from [the official Svelte docs](https://svelte.dev/docs/kit/creating-a-project).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated installation instructions for integrating SvelteKit with Wails.
	- Clarified modifications needed for the `wails.json` file.
	- Revised Bash script to reflect new project creation commands and file handling.
	- Expanded guidance on handling form submissions and error management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->