### PR TITLE
[v3 alpha] Fix deadlock of linux dialog for multiple selections

### DIFF
--- a/mkdocs-website/docs/en/changelog.md
+++ b/mkdocs-website/docs/en/changelog.md
@@ -46,6 +46,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Systray dialog now defaults to the application icon if available (Windows) by [@leaanthony](https://github.com/leaanthony)
 
 ### Fixed
+- Fixed deadlock in Linux dialog for multiple selections caused by unclosed channel variable by @michael-freling in [#3925](https://github.com/wailsapp/wails/pull/3925)
 - Fixed cross-platform cleanup for .syso files during Windows build by [ansxuman](https://github.com/ansxuman) in [#3924](https://github.com/wailsapp/wails/pull/3924)
 - Fixed amd64 appimage compile by @atterpac in [#3898](https://github.com/wailsapp/wails/pull/3898)
 - Fixed build assets update by @ansxuman in [#3901](https://github.com/wailsapp/wails/pull/3901)

--- a/v3/pkg/application/linux_cgo.go
+++ b/v3/pkg/application/linux_cgo.go
@@ -1678,6 +1678,7 @@ func runChooserDialog(window pointer, allowMultiple, createFolders, showHidden b
 					count++
 				}
 			}
+			close(selections)
 		}()
 	})
 	C.gtk_widget_destroy((*C.GtkWidget)(unsafe.Pointer(fc)))


### PR DESCRIPTION
<!--

*********************************************************************
*               PLEASE READ BEFORE SUBMITTING YOUR PR               *
*     YOUR PR MAY BE REJECTED IF IT DOES NOT FOLLOW THESE STEPS     *
*********************************************************************

- *DO NOT* submit PRs for v3 alpha enhancements, unless you have opened a post on the discord channel.
  All enhancements must be discussed first.
  The feedback guide for v3 is here: https://v3alpha.wails.io/getting-started/feedback/

- Before submitting your PR, please ensure you have created and linked the PR to an issue.
- If a relevant issue already exists, please reference it in your PR by including `Fixes #<issue number>` in your PR description.
- Please fill in the checklists.

-->

# Description

The channel variable for the selections of a dialog isn't closed on Linux.
As a result, the next statement waits a value from the channel forever.

https://github.com/wailsapp/wails/blob/8444ccf6f25ccd0104115a4e044ab03fe47fb8ed/v3/pkg/application/dialogs.go#L298-L301

I have found no issue reported about this bug.

## Type of change
  
Please select the option that is relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
  
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration using `wails doctor`.

- [ ] Windows
- [ ] macOS
- [X] Linux (WSL 2/Ubuntu 24.04)

```bash
> uname -a
Linux Desktop 5.15.167.4-microsoft-standard-WSL2 #1 SMP Tue Nov 5 00:21:55 UTC 2024 x86_64 x86_64 x86_64 GNU/Linux
```
        
## Test Configuration

Please paste the output of `wails doctor`. If you are unable to run this command, please describe your environment in as much detail as possible.

<details>
<summary>wails3 doctor output</summary>

```bash
> go run ./cmd/wails3 doctor


          Wails Doctor



# System
┌──────────────────────────────────────────────────┐
| Name         | Ubuntu                            |
| Version      | 24.04                             |
| ID           | ubuntu                            |
| Branding     | 24.04.1 LTS (Noble Numbat)        |
| Platform     | linux                             |
| Architecture | amd64                             |
| CPU          | AMD Ryzen 5 3600 6-Core Processor |
| GPU 1        | Unknown                           |
| Memory       | 40GB                              |
└──────────────────────────────────────────────────┘

# Build Environment
┌────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
| Wails CLI      | v3.0.0-alpha.7                                                                                                            |
| Go Version     | go1.23.2                                                                                                                  |
| -buildmode     | exe                                                                                                                       |
| -compiler      | gc                                                                                                                        |
| CGO_CFLAGS     |                                                                                                                           |
| CGO_CPPFLAGS   |                                                                                                                           |
| CGO_CXXFLAGS   |                                                                                                                           |
| CGO_ENABLED    | 1                                                                                                                         |
| CGO_LDFLAGS    |                                                                                                                           |
| DefaultGODEBUG | asynctimerchan=1,gotypesalias=0,httpservecontentkeepheaders=1,tls3des=1,tlskyber=0,x509keypairleaf=0,x509negativeserial=1 |
| GOAMD64        | v1                                                                                                                        |
| GOARCH         | amd64                                                                                                                     |
| GOOS           | linux                                                                                                                     |
└────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘

# Dependencies
┌───────────────────────────────────────────────────────────────────────┐
| gcc        | 12.10ubuntu1                                             |
| gtk3       | 3.24.41-4ubuntu1.2                                       |
| npm        |                                                          |
| pkg-config | not installed. Install with: sudo apt install pkg-config |
| webkit2gtk | 2.46.3-0ubuntu0.24.04.1                                  |
└─────────────────────── * - Optional Dependency ───────────────────────┘

# Diagnosis
 WARNING  There are some items above that need addressing!

Need documentation? Run: wails3 docs

 ♥   If Wails is useful to you or your company, please consider sponsoring the project: wails3 sponsor
```
</details>

# Checklist:

- [ ] I have updated `website/src/pages/changelog.mdx` with details of this PR
- [X] My code follows the general coding style of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added support for Linux packaging formats (deb, rpm, arch) and Darwin universal builds.
	- Introduced new commands for updating build assets and generating runtime.
	- New options for Windows autofill and password autosave capabilities.
	- Enhanced drag-and-drop functionality and window event handling for Linux applications.
	- Added the ability to retrieve the window calling a service method.

- **Bug Fixes**
	- Resolved a deadlock issue in the Linux dialog for multiple selections and various platform-specific application behavior fixes.

- **Changes**
	- Modified application startup behavior to improve error handling and service shutdown processes.
	- Updated systray click messaging for better user interaction alignment.
	- Refactored asset embedding and upgraded dependencies for improved performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->