### PR TITLE
Fix：Adjust the first-level heading to fix the page display format

### DIFF
--- a/website/docs/community/showcase/kafka-king.mdx
+++ b/website/docs/community/showcase/kafka-king.mdx
@@ -1,4 +1,4 @@
-# [Kafka-King](https://github.com/Bronya0/Kafka-King)
+# Kafka-King
 
 ```mdx-code-block
 <p style={{ "text-align": "center" }}>

--- a/website/i18n/ja/docusaurus-plugin-content-docs/current/community/showcase/kafka-king.mdx
+++ b/website/i18n/ja/docusaurus-plugin-content-docs/current/community/showcase/kafka-king.mdx
@@ -1,4 +1,4 @@
-# [Kafka-King](https://github.com/Bronya0/Kafka-King)
+# Kafka-King
 
 ```mdx-code-block
 <p style={{ "text-align": "center" }}>

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/community/showcase/kafka-king.mdx
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/community/showcase/kafka-king.mdx
@@ -1,4 +1,4 @@
-# [Kafka-King](https://github.com/Bronya0/Kafka-King)
+# Kafka-King
 
 ```mdx-code-block
 <p style={{ "text-align": "center" }}>


### PR DESCRIPTION
Adjust the first-level heading to fix the page display format

![局部截取_20241225_135504](https://github.com/user-attachments/assets/bbf4be5a-b89f-46a9-8a61-a5fa6c86b5d6)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the "Kafka-King" documentation by removing the hyperlink from the title, presenting it as plain text.
	- Rephrased the introductory sentence for clarity while retaining the original content structure and feature descriptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->