### PR TITLE
Make exporting all exported fields an explicit config.

### DIFF
--- a/v2/cmd/wails/generate.go
+++ b/v2/cmd/wails/generate.go
@@ -48,11 +48,12 @@ func generateModule(f *flags.GenerateModule) error {
 	}
 
 	_, err = bindings.GenerateBindings(bindings.Options{
-		Compiler:     f.Compiler,
-		Tags:         buildTags,
-		TsPrefix:     projectConfig.Bindings.TsGeneration.Prefix,
-		TsSuffix:     projectConfig.Bindings.TsGeneration.Suffix,
-		TsOutputType: projectConfig.Bindings.TsGeneration.OutputType,
+		Compiler:                  f.Compiler,
+		Tags:                      buildTags,
+		TsPrefix:                  projectConfig.Bindings.TsGeneration.Prefix,
+		TsSuffix:                  projectConfig.Bindings.TsGeneration.Suffix,
+		TsOutputType:              projectConfig.Bindings.TsGeneration.OutputType,
+		GenerateAllExportedFields: projectConfig.Bindings.GenerateAllExportedFields,
 	})
 	if err != nil {
 		return err

--- a/v2/internal/app/app_bindings.go
+++ b/v2/internal/app/app_bindings.go
@@ -4,9 +4,6 @@ package app
 
 import (
 	"flag"
-	"os"
-	"path/filepath"
-
 	"github.com/leaanthony/gosod"
 	"github.com/wailsapp/wails/v2/internal/binding"
 	"github.com/wailsapp/wails/v2/internal/frontend/runtime/wrapper"
@@ -14,6 +11,9 @@ import (
 	"github.com/wailsapp/wails/v2/internal/logger"
 	"github.com/wailsapp/wails/v2/internal/project"
 	"github.com/wailsapp/wails/v2/pkg/options"
+	"os"
+	"path/filepath"
+	"strconv"
 )
 
 func (a *App) Run() error {
@@ -32,6 +32,7 @@ func (a *App) Run() error {
 	var tsPrefixFlag *string
 	var tsPostfixFlag *string
 	var tsOutputTypeFlag *string
+	var generateallexportedfieldsFlag *bool
 
 	tsPrefix := os.Getenv("tsprefix")
 	if tsPrefix == "" {
@@ -46,6 +47,17 @@ func (a *App) Run() error {
 	tsOutputType := os.Getenv("tsoutputtype")
 	if tsOutputType == "" {
 		tsOutputTypeFlag = bindingFlags.String("tsoutputtype", "", "Output type for generated typescript entities (classes|interfaces)")
+	}
+
+	generateallexportedfields := os.Getenv("generateallexportedfields")
+	if generateallexportedfields != "" {
+		value, err := strconv.ParseBool(generateallexportedfields)
+		if err != nil {
+			return err
+		}
+		generateallexportedfieldsFlag = bindingFlags.Bool("generateallexportedfields", value, "Generate bindings for all exported fields")
+	} else {
+		generateallexportedfieldsFlag = bindingFlags.Bool("generateallexportedfields", false, "Generate bindings for all exported fields")
 	}
 
 	_ = bindingFlags.Parse(os.Args[1:])
@@ -64,6 +76,7 @@ func (a *App) Run() error {
 	appBindings.SetTsPrefix(tsPrefix)
 	appBindings.SetTsSuffix(tsSuffix)
 	appBindings.SetOutputType(tsOutputType)
+	appBindings.SetGenerateAllExportedFields(*generateallexportedfieldsFlag)
 
 	err := generateBindings(appBindings)
 	if err != nil {

--- a/v2/internal/binding/binding.go
+++ b/v2/internal/binding/binding.go
@@ -33,7 +33,6 @@ type Bindings struct {
 
 // NewBindings returns a new Bindings object
 func NewBindings(logger *logger.Logger, structPointersToBind []interface{}, exemptions []interface{}, obfuscate bool, enumsToBind []interface{}) *Bindings {
-	println("*** here 1")
 	result := &Bindings{
 		db:                  newDB(),
 		logger:              logger.CustomLogger("Bindings"),
@@ -58,7 +57,6 @@ func NewBindings(logger *logger.Logger, structPointersToBind []interface{}, exem
 
 	// Add the structs to bind
 	for _, ptr := range structPointersToBind {
-		println("*** here 2")
 		err := result.Add(ptr)
 		if err != nil {
 			logger.Fatal("Error during binding: " + err.Error())
@@ -70,7 +68,6 @@ func NewBindings(logger *logger.Logger, structPointersToBind []interface{}, exem
 
 // Add the given struct methods to the Bindings
 func (b *Bindings) Add(structPtr interface{}) error {
-	println("*** here 3")
 	methods, err := b.getMethods(structPtr)
 	if err != nil {
 		return fmt.Errorf("cannot bind value to app: %s", err.Error())
@@ -97,7 +94,6 @@ func (b *Bindings) ToJSON() (string, error) {
 }
 
 func (b *Bindings) GenerateModels() ([]byte, error) {
-	println("*** here 4")
 	models := map[string]string{}
 	var seen slicer.StringSlicer
 	var seenEnumsPackages slicer.StringSlicer
@@ -143,7 +139,6 @@ func (b *Bindings) GenerateModels() ([]byte, error) {
 			}
 			seenEnumsPackages.Add(packageName)
 		}
-		println("*** here 5")
 		str, err := w.Convert(nil)
 		if err != nil {
 			return nil, err
@@ -280,7 +275,6 @@ func (b *Bindings) AddStructToGenerateTS(packageName string, structName string, 
 		}
 		kind := field.Type.Kind()
 		if kind == reflect.Struct {
-			println("here 3")
 			if !field.IsExported() {
 				continue
 			}
@@ -292,7 +286,6 @@ func (b *Bindings) AddStructToGenerateTS(packageName string, structName string, 
 			sName := sNameSplit[1]
 			pName := getPackageName(fqname)
 			a := reflect.New(field.Type)
-			println("here 2")
 			if b.hasExportedJSONFields(field.Type) {
 				s := reflect.Indirect(a).Interface()
 				b.AddStructToGenerateTS(pName, sName, s)
@@ -310,7 +303,6 @@ func (b *Bindings) AddStructToGenerateTS(packageName string, structName string, 
 			pName := getPackageName(fqname)
 			typ := field.Type.Elem()
 			a := reflect.New(typ)
-			println("here 1")
 			if b.hasExportedJSONFields(typ) {
 				s := reflect.Indirect(a).Interface()
 				b.AddStructToGenerateTS(pName, sName, s)

--- a/v2/internal/project/project.go
+++ b/v2/internal/project/project.go
@@ -238,7 +238,8 @@ type Protocol struct {
 }
 
 type Bindings struct {
-	TsGeneration TsGeneration `json:"ts_generation"`
+	TsGeneration              TsGeneration `json:"ts_generation"`
+	GenerateAllExportedFields bool         `json:"generate_all_exported_fields"`
 }
 
 type TsGeneration struct {

--- a/v2/internal/typescriptify/typescriptify.go
+++ b/v2/internal/typescriptify/typescriptify.go
@@ -105,6 +105,8 @@ type TypeScriptify struct {
 	Namespace    string
 	KnownStructs *slicer.StringSlicer
 	KnownEnums   *slicer.StringSlicer
+
+	GenerateAllExportedFields bool
 }
 
 func New() *TypeScriptify {
@@ -554,10 +556,14 @@ func (t *TypeScriptify) getFieldOptions(structType reflect.Type, field reflect.S
 func (t *TypeScriptify) getJSONFieldName(field reflect.StructField, isPtr bool) string {
 	jsonFieldName := ""
 	jsonTag, hasTag := field.Tag.Lookup("json")
-	if !hasTag && field.IsExported() {
-		jsonFieldName = field.Name
-		if isPtr {
-			jsonFieldName += "?"
+	if !hasTag {
+		// If we're generating all exported fields and the field is exported,
+		// consider it as a valid JSON field
+		if t.GenerateAllExportedFields && field.IsExported() {
+			jsonFieldName = field.Name
+			if isPtr {
+				jsonFieldName += "?"
+			}
 		}
 	}
 	if len(jsonTag) > 0 {

--- a/v2/pkg/commands/bindings/bindings.go
+++ b/v2/pkg/commands/bindings/bindings.go
@@ -15,16 +15,17 @@ import (
 
 // Options for generating bindings
 type Options struct {
-	Filename         string
-	Tags             []string
-	ProjectDirectory string
-	Compiler         string
-	GoModTidy        bool
-	Platform         string
-	Arch             string
-	TsPrefix         string
-	TsSuffix         string
-	TsOutputType     string
+	Filename                  string
+	Tags                      []string
+	ProjectDirectory          string
+	Compiler                  string
+	GoModTidy                 bool
+	Platform                  string
+	Arch                      string
+	TsPrefix                  string
+	TsSuffix                  string
+	TsOutputType              string
+	GenerateAllExportedFields bool
 }
 
 // GenerateBindings generates bindings for the Wails project in the given ProjectDirectory.
@@ -82,6 +83,7 @@ func GenerateBindings(options Options) (string, error) {
 	env = shell.SetEnv(env, "tsprefix", options.TsPrefix)
 	env = shell.SetEnv(env, "tssuffix", options.TsSuffix)
 	env = shell.SetEnv(env, "tsoutputtype", options.TsOutputType)
+	env = shell.SetEnv(env, "generateallexportedfields", fmt.Sprintf("%v", options.GenerateAllExportedFields))
 
 	stdout, stderr, err = shell.RunCommandWithEnv(env, workingDirectory, filename)
 	if err != nil {

--- a/v2/pkg/commands/build/build.go
+++ b/v2/pkg/commands/build/build.go
@@ -228,14 +228,15 @@ func GenerateBindings(buildOptions *Options) error {
 
 	// Generate Bindings
 	output, err := bindings.GenerateBindings(bindings.Options{
-		Compiler:     buildOptions.Compiler,
-		Tags:         buildOptions.UserTags,
-		GoModTidy:    !buildOptions.SkipModTidy,
-		Platform:     buildOptions.Platform,
-		Arch:         buildOptions.Arch,
-		TsPrefix:     buildOptions.ProjectData.Bindings.TsGeneration.Prefix,
-		TsSuffix:     buildOptions.ProjectData.Bindings.TsGeneration.Suffix,
-		TsOutputType: buildOptions.ProjectData.Bindings.TsGeneration.OutputType,
+		Compiler:                  buildOptions.Compiler,
+		Tags:                      buildOptions.UserTags,
+		GoModTidy:                 !buildOptions.SkipModTidy,
+		Platform:                  buildOptions.Platform,
+		Arch:                      buildOptions.Arch,
+		TsPrefix:                  buildOptions.ProjectData.Bindings.TsGeneration.Prefix,
+		TsSuffix:                  buildOptions.ProjectData.Bindings.TsGeneration.Suffix,
+		TsOutputType:              buildOptions.ProjectData.Bindings.TsGeneration.OutputType,
+		GenerateAllExportedFields: buildOptions.ProjectData.Bindings.GenerateAllExportedFields,
 	})
 	if err != nil {
 		return err

--- a/website/docs/reference/project-config.mdx
+++ b/website/docs/reference/project-config.mdx
@@ -109,6 +109,8 @@ The project config resides in the `wails.json` file in the project directory. Th
   "garbleargs": "",
   // Bindings configurations
   "bindings": {
+    // Whether to generate all exported fields regardless of if they have JSON tags
+    "generate_all_exported_fields": false,
     // model.ts file generation config
     "ts_generation": {
       // All generated JavaScript entities will be prefixed with this value

--- a/website/static/schemas/config.v2.json
+++ b/website/static/schemas/config.v2.json
@@ -256,6 +256,11 @@
             "type": "object",
             "description": "Bindings configurations",
             "properties": {
+                "generate_all_exported_fields": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "When set to true, all exported fields will be generated, even if they have no JSON tag."
+                },
                 "ts_generation": {
                     "type": "object",
                     "description": "model.ts file generation config",


### PR DESCRIPTION
<!--

*********************************************************************
*               PLEASE READ BEFORE SUBMITTING YOUR PR               *
*     YOUR PR MAY BE REJECTED IF IT DOES NOT FOLLOW THESE STEPS     *
*********************************************************************

- *DO NOT* submit PRs for v3 alpha enhancements, unless you have opened a post on the discord channel.
  All enhancements must be discussed first.
  The feedback guide for v3 is here: https://v3alpha.wails.io/getting-started/feedback/

- Before submitting your PR, please ensure you have created and linked the PR to an issue.
- If a relevant issue already exists, please reference it in your PR by including `Fixes #<issue number>` in your PR description.
- Please fill in the checklists.

-->

# Description

A breaking change was introduced in #3678 which has caused issues for some people: #3809 . This PR disables this feature by default, but adds a project option to enable it.:

New `wails.json` option:
```json5
{
  "$schema": "https://wails.io/schemas/config.v2.json",
  "name": "bindingstest",
  "outputfilename": "bindingstest",
  "frontend:install": "npm install",
  "frontend:build": "npm run build",
  "frontend:dev:watcher": "npm run dev",
  "frontend:dev:serverUrl": "auto",
  "author": {
    "name": "Lea Anthony",
    "email": "lea.anthony@gmail.com"
  },
  "bindings": {
    // This option will generate model fields for all exported fields
    "generate_all_exported_fields": true
  }
}
```

Fixes #3809 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Added option to generate all exported fields in TypeScript bindings
	- New configuration setting `generate_all_exported_fields` allows more flexible field generation

- **Documentation**
	- Updated project configuration documentation to explain new binding generation option
	- Updated JSON schema to include new configuration property

The new feature provides developers with enhanced control over TypeScript binding generation, allowing inclusion of all exported fields even without explicit JSON tags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->