### PR TITLE
[v3 alpha test]  example of minsize bug under Linux (LMDE 6)

### DIFF
--- a/v3/examples/linux-minsize-bug/main.go
+++ b/v3/examples/linux-minsize-bug/main.go
@@ -1,4 +1,4 @@
-ypackage main
+package main
 
 import (
     "log"

--- a/v3/examples/linux-minsize-bug/main.go
+++ b/v3/examples/linux-minsize-bug/main.go
@@ -1,0 +1,28 @@
+ypackage main
+
+import (
+    "log"
+
+    "github.com/wailsapp/wails/v3/pkg/application"
+)
+
+func main() {
+
+    app := application.New(application.Options{
+	Name: "v3-alpha8.3-minsize-linux-bug",
+    })
+
+    app.NewWebviewWindowWithOptions(application.WebviewWindowOptions{
+	Title:     "v3-alpha8.3-minsize-linux-bug",
+	URL:       "/",
+	Width:     1024,
+	Height:    768,
+	MinWidth:  1024,
+	MinHeight: 768,
+    })
+
+    err := app.Run()
+    if err != nil {
+	log.Fatal(err)
+    }
+}


### PR DESCRIPTION
<!--

*********************************************************************
*               PLEASE READ BEFORE SUBMITTING YOUR PR               *
*     YOUR PR MAY BE REJECTED IF IT DOES NOT FOLLOW THESE STEPS     *
*********************************************************************

- *DO NOT* submit PRs for v3 alpha enhancements, unless you have opened a post on the discord channel.
  All enhancements must be discussed first.
  The feedback guide for v3 is here: https://v3alpha.wails.io/getting-started/feedback/

- Before submitting your PR, please ensure you have created and linked the PR to an issue.
- If a relevant issue already exists, please reference it in your PR by including `Fixes #<issue number>` in your PR description.
- Please fill in the checklists.

-->

# Description

Discord feedback link: https://discord.com/channels/1042734330029547630/1323287764887666759/1323287764887666759

As descripted in https://v3alpha.wails.io/feedback/ I created a example in v3/examples/linux-minsize-bug/main.go (to see under "Files changed") and a pull request because with alpha 8.3 the minWidth and minHeight params of a window have no effect under Linux. 

## What I have already found out:
- The options seems correctly, the MinWidth and MinHeight parameters are set in the application.WebviewWindowOptions
- Its WORKING on Windows Server 2022
- Its NOT working on LMDE 6
- Its NOT working on Debian 12
- Its NOT working on Ubuntu 24.10

So it seems to be a Linux only problem so far.
I don't have access to a mac at the moment. Maybe someone can test it on mac?

## Type of change
  
Please select the option that is relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
  
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration using `wails doctor`.

- [x] Windows
- [ ] macOS
- [x] Linux
      
If you checked Linux, please specify the distro and version.

LMDE 6 (Faye) x86_64 
Debian 12 (Bookworm) x86_64 
Ubuntu 24.10 (Oracular Oriole) x86_64 

  
## Test Configuration

Please paste the output of `wails doctor`. If you are unable to run this command, please describe your environment in as much detail as possible.

Wails3 doctor:

System
WARNING: failed to read int from file: open /sys/devices/system/cpu/cpu0/online: no such file or directory

 Name  LMDE
 Version  6
 ID linuxmint
 Branding 6 (faye)
 Platform linux
 Architecture amd64
 CPU AMD Ryzen 7 7800X3D 8-Core Processor
 GPU 1  Navi 31 [Radeon RX 7900 XT/7900 XTX] (Advanced Micro Devices, Inc. [AMD/ATI]) - Driver: amdgpu 
 Memory  31GB
Build Environment
 Wails CLI   v3.0.0-alpha.8.3
 Go Version  go1.23.4
 -buildmode  exe 
 -compiler  gc
 CGO_CFLAGS 
 CGO_CPPFLAGS 
 CGO_CXXFLAGS
 CGO_ENABLED  1
 CGO_LDFLAGS
 DefaultGODEBUG | asynctimerchan=1,gotypesalias=0,httpservecontentkeepheaders=1,tls3des=1,tlskyber=0,x509keypairleaf=0,x509negativeserial=1 
 GOAMD64  v1 
 GOARCH amd64
 GOOS linu
Dependencies
 gtk3 3.24.38-2-deb12u3 
 npm 10.9.0
 pkg-config 1.8.1-1
 webkit2gtk 2.46.5-1-deb12u1
 gcc 12.9
Optional Dependency
Diagnosis
 SUCCESS  Your system is ready for Wails development!

# Result
I can still drag the window below the specified size by far.
![wails_min_size_bug](https://github.com/user-attachments/assets/16fbcbde-e838-48bb-b66c-54514aa7375a)
