### PR TITLE
recover from process message instead crash the whole app

### DIFF
--- a/v2/internal/frontend/dispatcher/dispatcher.go
+++ b/v2/internal/frontend/dispatcher/dispatcher.go
@@ -2,6 +2,7 @@ package dispatcher
 
 import (
 	"context"
+	"fmt"
 	"github.com/pkg/errors"
 	"github.com/wailsapp/wails/v2/internal/binding"
 	"github.com/wailsapp/wails/v2/internal/frontend"
@@ -29,7 +30,20 @@ func NewDispatcher(ctx context.Context, log *logger.Logger, bindings *binding.Bi
 	}
 }
 
-func (d *Dispatcher) ProcessMessage(message string, sender frontend.Frontend) (string, error) {
+func (d *Dispatcher) ProcessMessage(message string, sender frontend.Frontend) (_ string, err error) {
+	defer func() {
+		if e := recover(); e != nil {
+			if errPanic, ok := e.(error); ok {
+				err = errPanic
+			} else {
+				err = fmt.Errorf("%v", e)
+			}
+		}
+		if err != nil {
+			d.log.Error("process message error: %s -> %s", message, err)
+		}
+	}()
+
 	if message == "" {
 		return "", errors.New("No message to process")
 	}

--- a/website/src/pages/changelog.mdx
+++ b/website/src/pages/changelog.mdx
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [windows] Fixed frameless window flickering when minimizing/restoring by preventing unnecessary redraws [#3951](https://github.com/wailsapp/wails/issues/3951)
 - Fixed failed models.ts build due to non-json-encodable Go types [PR](https://github.com/wailsapp/wails/pull/3975) by [@pbnjay](https://github.com/pbnjay)
 - Fixed more binding and typescript export bugs [PR](https://github.com/wailsapp/wails/pull/3978) by [@pbnjay](https://github.com/pbnjay)
+- Fixed Dispatcher.ProcessMessage crash process instead of return error [PR](https://github.com/wailsapp/wails/pull/4016) [#4015](https://github.com/wailsapp/wails/issues/4015) by [@ronaldinho_x86](https://github.com/RonaldinhoL)
 
 ### Changed
 - Allow to specify macos-min-version externally. Implemented by @APshenkin in [PR](https://github.com/wailsapp/wails/pull/3756)


### PR DESCRIPTION
Fixes https://github.com/wailsapp/wails/issues/4015

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced error handling in message processing to improve system stability and error tracking.
	- Added comprehensive panic recovery mechanism for more robust error management.
	- Updated documentation to clarify changes in error handling and improve user guidance regarding the Mac App Store.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->