### PR TITLE
Fix invalid path for windows dialogs

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -56,7 +56,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-22.04, windows-latest, macos-latest, ubuntu-24.04]
-        go-version: ['1.21']
+        go-version: ['1.23']
 
     steps:
       - name: Checkout code

--- a/v2/internal/go-common-file-dialog/cfd/CommonFileDialog_nonWindows.go
+++ b/v2/internal/go-common-file-dialog/cfd/CommonFileDialog_nonWindows.go
@@ -5,24 +5,24 @@ package cfd
 
 import "fmt"
 
-var errUnsupported = fmt.Errorf("common file dialogs are only available on windows")
+var unsupportedError = fmt.Errorf("common file dialogs are only available on windows")
 
 // TODO doc
 func NewOpenFileDialog(config DialogConfig) (OpenFileDialog, error) {
-	return nil, errUnsupported
+	return nil, unsupportedError
 }
 
 // TODO doc
 func NewOpenMultipleFilesDialog(config DialogConfig) (OpenMultipleFilesDialog, error) {
-	return nil, errUnsupported
+	return nil, unsupportedError
 }
 
 // TODO doc
 func NewSelectFolderDialog(config DialogConfig) (SelectFolderDialog, error) {
-	return nil, errUnsupported
+	return nil, unsupportedError
 }
 
 // TODO doc
 func NewSaveFileDialog(config DialogConfig) (SaveFileDialog, error) {
-	return nil, errUnsupported
+	return nil, unsupportedError
 }

--- a/v2/internal/go-common-file-dialog/cfd/DialogConfig.go
+++ b/v2/internal/go-common-file-dialog/cfd/DialogConfig.go
@@ -2,7 +2,11 @@
 
 package cfd
 
-import "fmt"
+import (
+	"fmt"
+	"os"
+	"reflect"
+)
 
 type FileFilter struct {
 	// The display name of the filter (That is shown to the user)
@@ -10,6 +14,9 @@ type FileFilter struct {
 	// The filter pattern. Eg. "*.txt;*.png" to select all txt and png files, "*.*" to select any files, etc.
 	Pattern string
 }
+
+// Never obfuscate the FileFilter type.
+var _ = reflect.TypeOf(FileFilter{})
 
 type DialogConfig struct {
 	// The title of the dialog
@@ -69,6 +76,10 @@ func (config *DialogConfig) apply(dialog Dialog) (err error) {
 	}
 
 	if config.Folder != "" {
+		_, err = os.Stat(config.Folder)
+		if err != nil {
+			return
+		}
 		err = dialog.SetFolder(config.Folder)
 		if err != nil {
 			return
@@ -76,6 +87,10 @@ func (config *DialogConfig) apply(dialog Dialog) (err error) {
 	}
 
 	if config.DefaultFolder != "" {
+		_, err = os.Stat(config.DefaultFolder)
+		if err != nil {
+			return
+		}
 		err = dialog.SetDefaultFolder(config.DefaultFolder)
 		if err != nil {
 			return

--- a/v2/internal/go-common-file-dialog/cfd/errors.go
+++ b/v2/internal/go-common-file-dialog/cfd/errors.go
@@ -2,4 +2,6 @@ package cfd
 
 import "errors"
 
-var ErrCancelled = errors.New("cancelled by user")
+var (
+	ErrorCancelled = errors.New("cancelled by user")
+)

--- a/v2/internal/go-common-file-dialog/cfd/iFileOpenDialog.go
+++ b/v2/internal/go-common-file-dialog/cfd/iFileOpenDialog.go
@@ -5,7 +5,7 @@ package cfd
 
 import (
 	"github.com/go-ole/go-ole"
-	"github.com/wailsapp/wails/v2/internal/go-common-file-dialog/util"
+	"github.com/google/uuid"
 	"syscall"
 	"unsafe"
 )
@@ -106,7 +106,7 @@ func (fileOpenDialog *iFileOpenDialog) SetFileFilters(filter []FileFilter) error
 }
 
 func (fileOpenDialog *iFileOpenDialog) SetRole(role string) error {
-	return fileOpenDialog.vtbl.setClientGuid(unsafe.Pointer(fileOpenDialog), util.StringToUUID(role))
+	return fileOpenDialog.vtbl.setClientGuid(unsafe.Pointer(fileOpenDialog), StringToUUID(role))
 }
 
 // This should only be callable when the user asks for a multi select because
@@ -177,7 +177,7 @@ func (vtbl *iFileOpenDialogVtbl) getResultsStrings(objPtr unsafe.Pointer) ([]str
 		return nil, err
 	}
 	if shellItemArray == nil {
-		return nil, ErrCancelled
+		return nil, ErrorCancelled
 	}
 	defer shellItemArray.vtbl.release(unsafe.Pointer(shellItemArray))
 	count, err := shellItemArray.vtbl.getCount(unsafe.Pointer(shellItemArray))
@@ -193,4 +193,8 @@ func (vtbl *iFileOpenDialogVtbl) getResultsStrings(objPtr unsafe.Pointer) ([]str
 		results = append(results, newItem)
 	}
 	return results, nil
+}
+
+func StringToUUID(str string) *ole.GUID {
+	return ole.NewGUID(uuid.NewSHA1(uuid.Nil, []byte(str)).String())
 }

--- a/v2/internal/go-common-file-dialog/cfd/iFileSaveDialog.go
+++ b/v2/internal/go-common-file-dialog/cfd/iFileSaveDialog.go
@@ -5,7 +5,6 @@ package cfd
 
 import (
 	"github.com/go-ole/go-ole"
-	"github.com/wailsapp/wails/v2/internal/go-common-file-dialog/util"
 	"unsafe"
 )
 
@@ -77,7 +76,7 @@ func (fileSaveDialog *iFileSaveDialog) SetFileFilters(filter []FileFilter) error
 }
 
 func (fileSaveDialog *iFileSaveDialog) SetRole(role string) error {
-	return fileSaveDialog.vtbl.setClientGuid(unsafe.Pointer(fileSaveDialog), util.StringToUUID(role))
+	return fileSaveDialog.vtbl.setClientGuid(unsafe.Pointer(fileSaveDialog), StringToUUID(role))
 }
 
 func (fileSaveDialog *iFileSaveDialog) SetDefaultExtension(defaultExtension string) error {

--- a/v2/internal/go-common-file-dialog/cfd/iShellItemArray.go
+++ b/v2/internal/go-common-file-dialog/cfd/iShellItemArray.go
@@ -4,6 +4,7 @@
 package cfd
 
 import (
+	"fmt"
 	"github.com/go-ole/go-ole"
 	"syscall"
 	"unsafe"
@@ -57,7 +58,7 @@ func (vtbl *iShellItemArrayVtbl) getItemAt(objPtr unsafe.Pointer, index uintptr)
 		return "", err
 	}
 	if shellItem == nil {
-		return "", ErrCancelled
+		return "", fmt.Errorf("shellItem is nil")
 	}
 	defer shellItem.vtbl.release(unsafe.Pointer(shellItem))
 	return shellItem.vtbl.getDisplayName(unsafe.Pointer(shellItem))

--- a/v2/internal/go-common-file-dialog/cfd/vtblCommonFunc.go
+++ b/v2/internal/go-common-file-dialog/cfd/vtblCommonFunc.go
@@ -168,7 +168,7 @@ func (vtbl *iFileDialogVtbl) getResultString(objPtr unsafe.Pointer) (string, err
 		return "", err
 	}
 	if shellItem == nil {
-		return "", ErrCancelled
+		return "", fmt.Errorf("shellItem is nil")
 	}
 	defer shellItem.vtbl.release(unsafe.Pointer(shellItem))
 	return shellItem.vtbl.getDisplayName(unsafe.Pointer(shellItem))

--- a/v2/internal/go-common-file-dialog/cfdutil/CFDUtil.go
+++ b/v2/internal/go-common-file-dialog/cfdutil/CFDUtil.go
@@ -10,9 +10,7 @@ func ShowOpenFileDialog(config cfd.DialogConfig) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	defer func() {
-		_ = dialog.Release()
-	}()
+	defer dialog.Release()
 	return dialog.ShowAndGetResult()
 }
 
@@ -22,9 +20,7 @@ func ShowOpenMultipleFilesDialog(config cfd.DialogConfig) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer func() {
-		_ = dialog.Release()
-	}()
+	defer dialog.Release()
 	return dialog.ShowAndGetResults()
 }
 
@@ -34,9 +30,7 @@ func ShowPickFolderDialog(config cfd.DialogConfig) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	defer func() {
-		_ = dialog.Release()
-	}()
+	defer dialog.Release()
 	return dialog.ShowAndGetResult()
 }
 
@@ -46,8 +40,6 @@ func ShowSaveFileDialog(config cfd.DialogConfig) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	defer func() {
-		_ = dialog.Release()
-	}()
+	defer dialog.Release()
 	return dialog.ShowAndGetResult()
 }

--- a/website/src/pages/changelog.mdx
+++ b/website/src/pages/changelog.mdx
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed failed models.ts build due to non-json-encodable Go types [PR](https://github.com/wailsapp/wails/pull/3975) by [@pbnjay](https://github.com/pbnjay)
 - Fixed more binding and typescript export bugs [PR](https://github.com/wailsapp/wails/pull/3978) by [@pbnjay](https://github.com/pbnjay)
 - Fixed Dispatcher.ProcessMessage crash process instead of return error [PR](https://github.com/wailsapp/wails/pull/4016) [#4015](https://github.com/wailsapp/wails/issues/4015) by [@ronaldinho_x86](https://github.com/RonaldinhoL)
+- Fixed Windows SaveDialog crash by [@leaanthony](https://github.com/leaanthony) 
 
 ### Changed
 - Allow to specify macos-min-version externally. Implemented by @APshenkin in [PR](https://github.com/wailsapp/wails/pull/3756)


### PR DESCRIPTION
# Description

Updates the file dialog code so that invalid default paths don't crash the app.

Fixes #3804


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added option to set window class name on Windows

- **Bug Fixes**
	- Resolved Windows SaveDialog crash
	- Fixed cross-compilation failures
	- Addressed native webview2loader problems
	- Corrected incorrect TypeScript definitions

- **Documentation**
	- Updated Mac App Store guide to support app names with spaces
	- Updated changelog documentation

- **Style**
	- Reformatted import statements for consistency

- **Chores**
	- Updated Go version in testing workflow from `1.21` to `1.23`
	- Commented out the linter job in the workflow
<!-- end of auto-generated comment: release notes by coderabbit.ai -->