### PR TITLE
[V3] Add MacOS 15 "Sequoia" to `OSInfo.Branding`

### DIFF
--- a/docs/src/content/docs/changelog.mdx
+++ b/docs/src/content/docs/changelog.mdx
@@ -52,7 +52,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `//wails:ignore` directive to prevent binding generation for chosen service methods by [@fbbdev](https://github.com/fbbdev) in [#4045](https://github.com/wailsapp/wails/pull/4045)
 - Add `//wails:internal` directive on services and models to allow for types that are exported in Go but not in JS/TS by [@fbbdev](https://github.com/fbbdev) in [#4045](https://github.com/wailsapp/wails/pull/4045)
 - Add binding generator support for constants of alias type to allow for weakly typed enums by [@fbbdev](https://github.com/fbbdev) in [#4045](https://github.com/wailsapp/wails/pull/4045)
-- Add MacOS 15 "Sequoia" to `OSInfo.Branding` in [#4065](https://github.com/wailsapp/wails/pull/4065)
+- Add support for macOS 15 "Sequoia" to `OSInfo.Branding` for improved OS version detection in [#4065](https://github.com/wailsapp/wails/pull/4065)
 
 ### Fixed
 

--- a/docs/src/content/docs/changelog.mdx
+++ b/docs/src/content/docs/changelog.mdx
@@ -52,6 +52,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `//wails:ignore` directive to prevent binding generation for chosen service methods by [@fbbdev](https://github.com/fbbdev) in [#4045](https://github.com/wailsapp/wails/pull/4045)
 - Add `//wails:internal` directive on services and models to allow for types that are exported in Go but not in JS/TS by [@fbbdev](https://github.com/fbbdev) in [#4045](https://github.com/wailsapp/wails/pull/4045)
 - Add binding generator support for constants of alias type to allow for weakly typed enums by [@fbbdev](https://github.com/fbbdev) in [#4045](https://github.com/wailsapp/wails/pull/4045)
+- Add MacOS 15 "Sequoia" to `OSInfo.Branding` in [#4065](https://github.com/wailsapp/wails/pull/4065)
 
 ### Fixed
 

--- a/v3/internal/operatingsystem/os_darwin.go
+++ b/v3/internal/operatingsystem/os_darwin.go
@@ -18,6 +18,7 @@ var macOSNames = map[string]string{
 	"12":    "Monterey",
 	"13":    "Ventura",
 	"14":    "Sonoma",
+	"15":    "Sequoia",
 	// Add newer versions as they are released...
 }
 


### PR DESCRIPTION
# Description

This is a tiny PR, sorry I did not open a discussion first, it seemed like it would be unnecessary.

All this does is add macOS 15 to the list of names.

Fixes # NA

## Type of change
  
Please select the option that is relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
 
Tested in the "environment" example:

|Before|After|
|---|---|
|<img width="911" alt="image" src="https://github.com/user-attachments/assets/fbc62daf-2b25-4a3c-8d4e-100785329e80" />|<img width="911" alt="image" src="https://github.com/user-attachments/assets/327b8ac8-027e-4977-bab0-28dc10389d73" />|


- [ ] Windows
- [X] macOS
- [ ] Linux
      
If you checked Linux, please specify the distro and version.
  
## Test Configuration

Please paste the output of `wails doctor`. If you are unable to run this command, please describe your environment in as much detail as possible.

# Checklist:

- [X] I have updated `website/src/pages/changelog.mdx` with details of this PR
- [X] My code follows the general coding style of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Expanded macOS version mapping by adding support for version 15, now identified as "Sequoia," ensuring that systems display the correct operating system name.
  - Users will experience improved recognition of their macOS version, with accurate version details reflected in system dialogs and interfaces.
  - This enhancement also benefits device information displays and compatibility checks by reflecting the most up-to-date system details.

- **Documentation**
  - Updated changelog to include "macOS 15 'Sequoia'" under the supported operating systems.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->