### PR TITLE
[V3] Fix docs change detection in npm CI

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -39,7 +39,7 @@ jobs:
           files: |
             v3/internal/runtime/desktop/@wailsio/runtime/src/*.js
             v3/internal/runtime/desktop/@wailsio/runtime/types/*.d.ts
-            v3/internal/runtime/desktop/@wailsio/runtime/docs/*.*
+            v3/internal/runtime/desktop/@wailsio/runtime/docs/**/*.*
 
       - name: test action
         if: steps.verify-changed-files.outputs.files_changed == 'true'


### PR DESCRIPTION
Runtime changes in #4066 were not picked up because a) I committed the wrong files and b) the docs path in the verify changes action is missing a segment.

This is a quick fix to get the npm package up to date.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated our package release workflow to improve detection of documentation changes across all subdirectories. This update streamlines quality assurance by ensuring that all documentation updates are reliably captured and verified before a package release. End users benefit from a more thoroughly vetted release process without any impact on everyday functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->