### PR TITLE
[V3] add ".html" to assetFileServer requests with no extension

### DIFF
--- a/docs/src/content/docs/changelog.mdx
+++ b/docs/src/content/docs/changelog.mdx
@@ -107,6 +107,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -  Ensure menu updates occur on the main thread by [@leaanthony](https://github.com/leaanthony)
 - The dragging and resizing mechanism is now more robust and matches expected platform behaviour more closely by [@fbbdev](https://github.com/fbbdev) in [#4100](https://github.com/wailsapp/wails/pull/4100)
 - Fixed [#4097](https://github.com/wailsapp/wails/issues/4097) Webpack/angular discards runtime init code by [@fbbdev](https://github.com/fbbdev) in [#4100](https://github.com/wailsapp/wails/pull/4100)
+- Fixed assetFileServer not serving `.html` files when non-extension request when `[request]` doesn't exist but `[request].html` does
 
 ### Changed
 

--- a/v3/internal/assetserver/asset_fileserver.go
+++ b/v3/internal/assetserver/asset_fileserver.go
@@ -71,7 +71,15 @@ func (d *assetFileServer) serveFSFile(rw http.ResponseWriter, req *http.Request,
 
 	file, err := d.fs.Open(filename)
 	if err != nil {
-		return err
+		if s := path.Ext(filename); s == "" {
+			filename = filename + ".html"
+			file, err = d.fs.Open(filename)
+			if err != nil {
+				return err
+			}
+		} else {
+			return err
+		}
 	}
 	defer file.Close()
 


### PR DESCRIPTION
<!--

*********************************************************************
*               PLEASE READ BEFORE SUBMITTING YOUR PR               *
*     YOUR PR MAY BE REJECTED IF IT DOES NOT FOLLOW THESE STEPS     *
*********************************************************************

- *DO NOT* submit PRs for v3 alpha enhancements, unless you have opened a post on the discord channel.
  All enhancements must be discussed first.
  The feedback guide for v3 is here: https://v3alpha.wails.io/getting-started/feedback/

- Before submitting your PR, please ensure you have created and linked the PR to an issue.
- If a relevant issue already exists, please reference it in your PR by including `Fixes #<issue number>` in your PR description.
- Please fill in the checklists.

-->

# Description

sveltekit by default creates routes by creating `[route].html` files in the fs root, however wails3 assetFileServer will fail on requests with no extension if a file with no extension doesn't exist. This causes multi page apps to only show the main route (`index.html`), so I added to the assetFileServer a check if `filename` doesn't exist to see if `[filename].html` exists.

## Type of change
  
Please select the option that is relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
  
*edit: forgot to add this part*
set up a new project with sveltekit template. added a second route and a button to call a func to open a new window with said route. Before my change the new window would open with a "not found" from webview, after the change the correct page opens. I also manually edited the `frontend/dist` to remove the `.html` extension and the pages still loaded properly.

- [x] Windows
- [ ] macOS
- [ ] Linux
      
If you checked Linux, please specify the distro and version.
  
## Test Configuration

```
 Wails (v3.0.0-dev)  Wails Doctor

# System

┌────────────────────────────────────────────────────────────────────────────────────────────┐
| Name              | Windows 10 Home                                                        |
| Version           | 2009 (Build: 19045)                                                    |
| ID                | 22H2                                                                   |
| Branding          | Windows 10 Home                                                        |
| Platform          | windows                                                                |
| Architecture      | amd64                                                                  |
| Go WebView2Loader | true                                                                   |
| WebView2 Version  | 133.0.3065.92                                                          |
| CPU               | Intel(R) Core(TM) i5-7200U CPU @ 2.50GHz                               |
| GPU 1             | Intel(R) HD Graphics 620 (Intel Corporation) - Driver: 25.20.100.6373  |
| Memory            | 8GB                                                                    |
└────────────────────────────────────────────────────────────────────────────────────────────┘

# Build Environment

┌─────────────────────────────────────────────────────────┐
| Wails CLI    | v3.0.0-dev                               |
| Go Version   | go1.24.1                                 |
| Revision     | 10791fabbd7397d0e2d1cd37365755f9d2b1be45 |
| Modified     | false                                    |
| -buildmode   | exe                                      |
| -compiler    | gc                                       |
| CGO_CFLAGS   |                                          |
| CGO_CPPFLAGS |                                          |
| CGO_CXXFLAGS |                                          |
| CGO_ENABLED  | 1                                        |
| CGO_LDFLAGS  |                                          |
| GOAMD64      | v1                                       |
| GOARCH       | amd64                                    |
| GOOS         | windows                                  |
| vcs          | git                                      |
| vcs.modified | false                                    |
| vcs.revision | 10791fabbd7397d0e2d1cd37365755f9d2b1be45 |
| vcs.time     | 2025-03-07T12:43:47Z                     |
└─────────────────────────────────────────────────────────┘

# Dependencies

┌───────────────────────────┐
| NSIS | v3.10              |
| npm  | 10.9.2             |
|                           |
└─ * - Optional Dependency ─┘

# Checking for issues

 SUCCESS  No issues found

# Diagnosis

 SUCCESS  Your system is ready for Wails development!
```

# Checklist:

- [x] I have updated `website/src/pages/changelog.mdx` with details of this PR
- [x] My code follows the general coding style of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
