### PR TITLE
fix: correct filename for Windows icon generation in Taskfile

### DIFF
--- a/docs/src/content/docs/changelog.mdx
+++ b/docs/src/content/docs/changelog.mdx
@@ -108,6 +108,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The dragging and resizing mechanism is now more robust and matches expected platform behaviour more closely by [@fbbdev](https://github.com/fbbdev) in [#4100](https://github.com/wailsapp/wails/pull/4100)
 - Fixed [#4097](https://github.com/wailsapp/wails/issues/4097) Webpack/angular discards runtime init code by [@fbbdev](https://github.com/fbbdev) in [#4100](https://github.com/wailsapp/wails/pull/4100)
 - Fixed assetFileServer not serving `.html` files when non-extension request when `[request]` doesn't exist but `[request].html` does
+- Fixed icon generation paths by [@robin-samuel](https://github.com/robin-samuel) in [#4125](https://github.com/wailsapp/wails/pull/4125)
 
 ### Changed
 

--- a/v3/internal/commands/build_assets/Taskfile.tmpl.yml
+++ b/v3/internal/commands/build_assets/Taskfile.tmpl.yml
@@ -67,9 +67,9 @@ tasks:
       - "appicon.png"
     generates:
       - "icons.icns"
-      - "icons.ico"
+      - "icon.ico"
     cmds:
-      - wails3 generate icons -input appicon.png -macfilename darwin/icons.icns -windowsfilename windows/icons.ico
+      - wails3 generate icons -input appicon.png -macfilename darwin/icons.icns -windowsfilename windows/icon.ico
 
   dev:frontend:
     summary: Runs the frontend in development mode

--- a/v3/internal/commands/build_assets/Taskfile.tmpl.yml
+++ b/v3/internal/commands/build_assets/Taskfile.tmpl.yml
@@ -66,8 +66,8 @@ tasks:
     sources:
       - "appicon.png"
     generates:
-      - "icons.icns"
-      - "icon.ico"
+      - "darwin/icons.icns"
+      - "windows/icon.ico"
     cmds:
       - wails3 generate icons -input appicon.png -macfilename darwin/icons.icns -windowsfilename windows/icon.ico
 


### PR DESCRIPTION
# Description

I noticed that generate:icons generates the windows icon to the path `windows/icons.ico` but the path used to make the syso and nsis installer is `windows/icon.ico`. This causes the app to always have the same icon if not updated manually. and there will always be an unused icons.ico file in the windows folder.

## Type of change
  
Please select the option that is relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
  
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration using `wails doctor`.

- [x] Windows
- [ ] macOS
- [ ] Linux
      
If you checked Linux, please specify the distro and version.
  
## Test Configuration

  Wails (v3.0.0-alpha.9)  Wails Doctor 

# System 

 Name              Windows 10 Pro                                                         
 Version           2009 (Build: 26100)                                                    
 ID                24H2                                                                   
 Branding          Windows 11 Pro                                                         
 Platform          windows                                                                
 Architecture      amd64                                                                  
 Go WebView2Loader true                                                                   
 WebView2 Version  133.0.3065.92                                                          
 CPU               12th Gen Intel(R) Core(TM) i9-12900K                                   
 GPU 1             Intel(R) UHD Graphics 770 (Intel Corporation) - Driver: 32.0.101.6129  
 GPU 2             NVIDIA GeForce RTX 3090 (NVIDIA) - Driver: 32.0.15.7216                
 Memory            32GB                                                                   

# Build Environment 

 Wails CLI         v3.0.0-alpha.9                                                                                                                                                                                                           
 Go Version        go1.24.0                                                                                                                                                                                                                 
 -buildmode        exe                                                                                                                                                                                                                      
 -compiler         gc                                                                                                                                                                                                                       
 CGO_ENABLED       0                                                                                                                                                                                                                        
 DefaultGODEBUG    asynctimerchan=1,gotestjsonbuildtext=1,gotypesalias=0,httpservecontentkeepheaders=1,multipathtcp=0,randseednop=0,rsa1024min=0,tls3des=1,tlsmlkem=0,x509keypairleaf=0,x509negativeserial=1,x509rsacrt=0,x509usepolicies=0 
 GOAMD64           v1                                                                                                                                                                                                                       
 GOARCH            amd64                                                                                                                                                                                                                    
 GOOS              windows                                                                                                                                                                                                                  

# Dependencies 

 NSIS              v3.10              
 npm               10.9.2   

# Diagnosis 

 SUCCESS  Your system is ready for Wails development!


# Checklist:

- [ ] I have updated `website/src/pages/changelog.mdx` with details of this PR
- [x] My code follows the general coding style of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated the Windows icon generation process to use a revised naming convention for improved consistency.
  - Modified macOS icon output to include a "darwin/" prefix for clarity.
  
- **Bug Fixes**
  - Added a changelog entry addressing the issue of icon generation paths, contributed by user `@robin-samuel`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->