### PR TITLE
[v3] fix: unhandled error in dialogs.go

### DIFF
--- a/v3/pkg/application/dialogs.go
+++ b/v3/pkg/application/dialogs.go
@@ -291,6 +291,9 @@ func (d *OpenFileDialogStruct) PromptForMultipleSelection() ([]string, error) {
 	}
 
 	selections, err := InvokeSyncWithResultAndError(d.impl.show)
+	if err != nil {
+		return nil, err
+	}
 
 	var result []string
 	for filename := range selections {

--- a/website/src/pages/changelog.mdx
+++ b/website/src/pages/changelog.mdx
@@ -14,11 +14,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Fixed locking issue on Windows when multiselect dialog returns an error. Fixed in [PR](https://github.com/wailsapp/wails/pull/4156) by @johannes-luebke
+
 ## v2.9.1 - 2024-06-18
 
 ### Fixed
 - Fixed build issues on Linux for some glibc versions. Fixed in [PR](https://github.com/wailsapp/wails/pull/3545) by @leaanthony.
-- Fixed locking issue on Windows when multiselect dialog returns an error. Fixed in [PR](https://github.com/wailsapp/wails/pull/4156) by @johannes-luebke
 
 ## v2.9.0 - 2024-06-16
 

--- a/website/src/pages/changelog.mdx
+++ b/website/src/pages/changelog.mdx
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Fixed build issues on Linux for some glibc versions. Fixed in [PR](https://github.com/wailsapp/wails/pull/3545) by @leaanthony.
+- Fixed locking issue on Windows when multiselect dialog returns an error. Fixed in [PR](https://github.com/wailsapp/wails/pull/4156) by @johannes-luebke
 
 ## v2.9.0 - 2024-06-16
 


### PR DESCRIPTION
<!--

*********************************************************************
*               PLEASE READ BEFORE SUBMITTING YOUR PR               *
*     YOUR PR MAY BE REJECTED IF IT DOES NOT FOLLOW THESE STEPS     *
*********************************************************************

- *DO NOT* submit PRs for v3 alpha enhancements, unless you have opened a post on the discord channel.
  All enhancements must be discussed first.
  The feedback guide for v3 is here: https://v3alpha.wails.io/getting-started/feedback/

- Before submitting your PR, please ensure you have created and linked the PR to an issue.
- If a relevant issue already exists, please reference it in your PR by including `Fixes #<issue number>` in your PR description.
- Please fill in the checklists.

-->

# Description

The returned error from `InvokeSyncWithResultAndError` wasn't handled before and the `selections` channel could be `nil`. This leads to a deadlock, at least on Windows, if there is an error. For example if the user cancels the dialog it will deadlock.

I haven't found an issue for this problem. I hope it's fine I jumped straight to PR, otherwise I'm happy to write this down as an issue first.

## Type of change
  
Please select the option that is relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

I've tested this in my project which has a very particular setup using htmx and it actually results in a full deadlock.
But I've also reproduced the issue with the v3/examples/dialogs-basic/main.go. Here it does lock the goroutine, but because of the way the menu calls work it's hard to notice. Placing a debug print just before the return shows that it is never reached in case the user cancels the dialog.

- [x] Windows
- [ ] macOS
- [ ] Linux
  
## Test Configuration

<details><summary>Wails Doctor</summary>
<p>

# System

┌─────────────────────────────────────────────────────────────────────────────────┐
| Name              | Windows 10 Pro                                              |
| Version           | 2009 (Build: 26100)                                         |
| ID                | 24H2                                                        |
| Branding          | Windows 11 Pro                                              |
| Platform          | windows                                                     |
| Architecture      | amd64                                                       |
| Go WebView2Loader | true                                                        |
| WebView2 Version  | 134.0.3124.72                                               |
| CPU               | AMD Ryzen Threadripper PRO 5965WX 24-Cores                  |
| GPU 1             | ASPEED Graphics Family(WDDM) (ASPEED) - Driver: 9.0.10.110  |
| GPU 2             | NVIDIA GeForce RTX 4090 (NVIDIA) - Driver: 32.0.15.6636     |
| Memory            | 128GB                                                       |
└─────────────────────────────────────────────────────────────────────────────────┘

# Build Environment

┌────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
| Wails CLI      | v3.0.0-alpha.9                                                                                                            |
| Go Version     | go1.23.5                                                                                                                  |
| -buildmode     | exe                                                                                                                       |
| -compiler      | gc                                                                                                                        |
| CGO_CFLAGS     |                                                                                                                           |
| CGO_CPPFLAGS   |                                                                                                                           |
| CGO_CXXFLAGS   |                                                                                                                           |
| CGO_ENABLED    | 1                                                                                                                         |
| CGO_LDFLAGS    |                                                                                                                           |
| DefaultGODEBUG | asynctimerchan=1,gotypesalias=0,httpservecontentkeepheaders=1,tls3des=1,tlskyber=0,x509keypairleaf=0,x509negativeserial=1 |
| GOAMD64        | v1                                                                                                                        |
| GOARCH         | amd64                                                                                                                     |
| GOOS           | windows                                                                                                                   |
└────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘

# Dependencies

┌───────────────────────────┐
| npm  | 10.7.0             |
| NSIS | Not Installed      |
└─ * - Optional Dependency ─┘

# Diagnosis

 SUCCESS  Your system is ready for Wails development!
</p>
</details> 

# Checklist:

- [x] I have updated `website/src/pages/changelog.mdx` with details of this PR
- [x] My code follows the general coding style of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling in multi-selection dialogs to ensure any issues during the selection process are clearly communicated.
	- Added a changelog entry for version 2.9.1 addressing a locking issue on Windows when a multiselect dialog returns an error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->