### PR TITLE
Update options docs to clarify linux webview gpu defaults

### DIFF
--- a/website/src/pages/changelog.mdx
+++ b/website/src/pages/changelog.mdx
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Updated recommendation for Svelte router in [#4085](https://github.com/wailsapp/wails/pull/4085) by [@benmccann](https://github.com/benmccann)
+- Updated documentation to clarify `WebviewGpuPolicy` default behavior on Linux in [#4162](https://github.com/wailsapp/wails/pull/4162) by [@brianetaveras](https://github.com/brianetaveras)
 
 ### Added
 - Added "Branding" section to `wails doctor` to correctly identify Windows 11 [#3891](https://github.com/wailsapp/wails/pull/3891) by [@ronen25](https://github.com/ronen25)

--- a/website/versioned_docs/version-v2.10/reference/options.mdx
+++ b/website/versioned_docs/version-v2.10/reference/options.mdx
@@ -126,7 +126,7 @@ func main() {
         Linux: &linux.Options{
             Icon: icon,
             WindowIsTranslucent: false,
-            WebviewGpuPolicy: linux.WebviewGpuPolicyAlways,
+            WebviewGpuPolicy: linux.WebviewGpuPolicyNever,
             ProgramName: "wails"
         },
         Debug: options.Debug{
@@ -1066,7 +1066,8 @@ This option is used for determining the webview's hardware acceleration policy.
 
 Name: WebviewGpuPolicy<br/>
 Type: [`options.WebviewGpuPolicy`](#webviewgpupolicy-type)<br/>
-Default: `WebviewGpuPolicyAlways`
+Default (Windows, macOS): `WebviewGpuPolicyAlways`<br/>
+Default (Linux): `WebviewGpuPolicyNever`<br/>
 
 ##### WebviewGpuPolicy type
 

--- a/website/versioned_docs/version-v2.10/reference/options.mdx
+++ b/website/versioned_docs/version-v2.10/reference/options.mdx
@@ -1067,7 +1067,9 @@ This option is used for determining the webview's hardware acceleration policy.
 Name: WebviewGpuPolicy<br/>
 Type: [`options.WebviewGpuPolicy`](#webviewgpupolicy-type)<br/>
 Default (Windows, macOS): `WebviewGpuPolicyAlways`<br/>
-Default (Linux): `WebviewGpuPolicyNever`<br/>
+Default (Linux): Due to [#2977](https://github.com/wailsapp/wails/issues/2977,), if `options.Linux` is nil 
+	    in the call to `wails.Run()`, `WebviewGpuPolicy` is set by default to `WebviewGpuPolicyNever`. You can override this behavior by passing a non-nil `Options` and set `WebviewGpuPolicy` as needed.
+
 
 ##### WebviewGpuPolicy type
 


### PR DESCRIPTION
# Description

I noticed a significant performance degradation when working with Pixi.js on my wails app vs the browser. Community members on [Discord](https://discord.com/channels/1042734330029547630/1353553377354584064) helped me figure out that hardware acceleration is disabled by default for linux builts - this is documented in code but not reflected on the docs. 

https://github.com/user-attachments/assets/fa51202c-e6e5-47dc-8483-e8fa82c7c889

Please let me know if I need to include more details.

Fixes # (issue)

N/A

## Type of change
  
Please select the option that is relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Documentation update 

# How Has This Been Tested?
  
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration using `wails doctor`.

- [ ] Windows
- [ ] macOS
- [ ] Linux
- [x] N/A: Docs Change
      
If you checked Linux, please specify the distro and version.
  
## Test Configuration

Please paste the output of `wails doctor`. If you are unable to run this command, please describe your environment in as much detail as possible.

N/A: Docs Change

# Checklist:

- [ ] I have updated `website/src/pages/changelog.mdx` with details of this PR
- [ ] My code follows the general coding style of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Adjusted Linux behavior so that GPU hardware acceleration is now disabled by default, ensuring a consistent experience across platforms.
- **Documentation**
  - Updated settings guidance to clearly reflect the default GPU preferences for Linux, Windows, and macOS.
  - Added a changelog entry detailing the changes to the `WebviewGpuPolicy` for Linux, referencing pull request #4162.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->