### PR TITLE
[v3] Bundling/signing

### DIFF
--- a/docs/src/content/docs/changelog.mdx
+++ b/docs/src/content/docs/changelog.mdx
@@ -139,6 +139,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Built-in service types are now consistently called `Service` by [@fbbdev](https://github.com/fbbdev) in [#4067](https://github.com/wailsapp/wails/pull/4067)
 - Built-in service creation functions with options are now consistently called `NewWithConfig` by [@fbbdev](https://github.com/fbbdev) in [#4067](https://github.com/wailsapp/wails/pull/4067)
 - `Select` method on `sqlite` service is now named `Query` for consistency with Go APIs by [@fbbdev](https://github.com/fbbdev) in [#4067](https://github.com/wailsapp/wails/pull/4067)
+- Creates and ad-hoc signs app bundles in dev to enable certain macOS APIs by [@popaprozac] in [#4171](https://github.com/wailsapp/wails/pull/4171)
 
 ## v3.0.0-alpha.9 - 2025-01-13
 

--- a/docs/src/content/docs/guides/signing.mdx
+++ b/docs/src/content/docs/guides/signing.mdx
@@ -86,7 +86,7 @@ This guide covers how to sign your Wails applications for both macOS and Windows
 3. **Configure Notarization**
    ```json title="gon-sign.json"
    {
-     "source": ["./build/bin/app"],
+     "source": ["./build/bin/release/app"],
      "bundle_id": "com.company.app",
      "apple_id": {
        "username": "dev@company.com",

--- a/docs/src/content/docs/guides/signing.mdx
+++ b/docs/src/content/docs/guides/signing.mdx
@@ -86,7 +86,7 @@ This guide covers how to sign your Wails applications for both macOS and Windows
 3. **Configure Notarization**
    ```json title="gon-sign.json"
    {
-     "source": ["./build/bin/release/app"],
+     "source": ["./build/bin/app"],
      "bundle_id": "com.company.app",
      "apple_id": {
        "username": "dev@company.com",

--- a/docs/src/content/docs/learn/build.mdx
+++ b/docs/src/content/docs/learn/build.mdx
@@ -123,6 +123,7 @@ the application on macOS. Key features include:
 - Building binaries for amd64, arm64 and universal (both) architectures
 - Generating `.icns` icon file
 - Creating an `.app` bundle for distributing
+- Ad-hoc signing `.app` bundles
 - Setting macOS-specific build flags and environment variables
 
 ## Task Execution and Command Aliases

--- a/v3/internal/commands/build_assets/darwin/Taskfile.yml
+++ b/v3/internal/commands/build_assets/darwin/Taskfile.yml
@@ -19,7 +19,7 @@ tasks:
       - go build {{.BUILD_FLAGS}} -o {{.OUTPUT}}
     vars:
       BUILD_FLAGS: '{{if eq .PRODUCTION "true"}}-tags production -trimpath -buildvcs=false -ldflags="-w -s"{{else}}-buildvcs=false -gcflags=all="-l"{{end}}'
-      DEFAULT_OUTPUT: '{{.BIN_DIR}}/{{.APP_NAME}}'
+      DEFAULT_OUTPUT: '{{.BIN_DIR}}/build/{{.APP_NAME}}'
       OUTPUT: '{{ .OUTPUT | default .DEFAULT_OUTPUT }}'
     env:
       GOOS: darwin
@@ -36,14 +36,14 @@ tasks:
       - task: build
         vars:
           ARCH: amd64
-          OUTPUT: "{{.BIN_DIR}}/{{.APP_NAME}}-amd64"
+          OUTPUT: "{{.BIN_DIR}}/build/{{.APP_NAME}}-amd64"
       - task: build
         vars:
           ARCH: arm64
-          OUTPUT: "{{.BIN_DIR}}/{{.APP_NAME}}-arm64"
+          OUTPUT: "{{.BIN_DIR}}/build/{{.APP_NAME}}-arm64"
     cmds:
-      - lipo -create -output "{{.BIN_DIR}}/{{.APP_NAME}}" "{{.BIN_DIR}}/{{.APP_NAME}}-amd64" "{{.BIN_DIR}}/{{.APP_NAME}}-arm64"
-      - rm "{{.BIN_DIR}}/{{.APP_NAME}}-amd64" "{{.BIN_DIR}}/{{.APP_NAME}}-arm64"
+      - lipo -create -output "{{.BIN_DIR}}/build/{{.APP_NAME}}" "{{.BIN_DIR}}/build/{{.APP_NAME}}-amd64" "{{.BIN_DIR}}/build/{{.APP_NAME}}-arm64"
+      - rm "{{.BIN_DIR}}/build/{{.APP_NAME}}-amd64" "{{.BIN_DIR}}/build/{{.APP_NAME}}-arm64"
 
   package:
     summary: Packages a production build of the application into a `.app` bundle
@@ -65,11 +65,17 @@ tasks:
   create:app:bundle:
     summary: Creates an `.app` bundle
     cmds:
-      - mkdir -p {{.BIN_DIR}}/{{.APP_NAME}}.app/Contents/{MacOS,Resources}
-      - cp build/darwin/icons.icns {{.BIN_DIR}}/{{.APP_NAME}}.app/Contents/Resources
-      - cp {{.BIN_DIR}}/{{.APP_NAME}} {{.BIN_DIR}}/{{.APP_NAME}}.app/Contents/MacOS
-      - cp build/darwin/Info.plist {{.BIN_DIR}}/{{.APP_NAME}}.app/Contents
+      - mkdir -p {{.BIN_DIR}}/release/{{.APP_NAME}}.app/Contents/{MacOS,Resources}
+      - cp build/darwin/icons.icns {{.BIN_DIR}}/release/{{.APP_NAME}}.app/Contents/Resources
+      - cp {{.BIN_DIR}}/build/{{.APP_NAME}} {{.BIN_DIR}}/release/{{.APP_NAME}}.app/Contents/MacOS
+      - cp build/darwin/Info.plist {{.BIN_DIR}}/release/{{.APP_NAME}}.app/Contents
+      - codesign --force --deep --sign - {{.BIN_DIR}}/release/{{.APP_NAME}}.app
 
   run:
     cmds:
-      - '{{.BIN_DIR}}/{{.APP_NAME}}'
+      - mkdir -p {{.BIN_DIR}}/dev/{{.APP_NAME}}.app/Contents/{MacOS,Resources}
+      - cp build/darwin/icons.icns {{.BIN_DIR}}/dev/{{.APP_NAME}}.app/Contents/Resources
+      - cp {{.BIN_DIR}}/build/{{.APP_NAME}} {{.BIN_DIR}}/dev/{{.APP_NAME}}.app/Contents/MacOS
+      - cp build/darwin/Info.dev.plist {{.BIN_DIR}}/dev/{{.APP_NAME}}.app/Contents/Info.plist
+      - codesign --force --deep --sign - {{.BIN_DIR}}/dev/{{.APP_NAME}}.app
+      - '{{.BIN_DIR}}/dev/{{.APP_NAME}}.app/Contents/MacOS/{{.APP_NAME}}'

--- a/v3/internal/commands/build_assets/darwin/Taskfile.yml
+++ b/v3/internal/commands/build_assets/darwin/Taskfile.yml
@@ -19,7 +19,7 @@ tasks:
       - go build {{.BUILD_FLAGS}} -o {{.OUTPUT}}
     vars:
       BUILD_FLAGS: '{{if eq .PRODUCTION "true"}}-tags production -trimpath -buildvcs=false -ldflags="-w -s"{{else}}-buildvcs=false -gcflags=all="-l"{{end}}'
-      DEFAULT_OUTPUT: '{{.BIN_DIR}}/build/{{.APP_NAME}}'
+      DEFAULT_OUTPUT: '{{.BIN_DIR}}/{{.APP_NAME}}'
       OUTPUT: '{{ .OUTPUT | default .DEFAULT_OUTPUT }}'
     env:
       GOOS: darwin
@@ -36,14 +36,14 @@ tasks:
       - task: build
         vars:
           ARCH: amd64
-          OUTPUT: "{{.BIN_DIR}}/build/{{.APP_NAME}}-amd64"
+          OUTPUT: "{{.BIN_DIR}}/{{.APP_NAME}}-amd64"
       - task: build
         vars:
           ARCH: arm64
-          OUTPUT: "{{.BIN_DIR}}/build/{{.APP_NAME}}-arm64"
+          OUTPUT: "{{.BIN_DIR}}/{{.APP_NAME}}-arm64"
     cmds:
-      - lipo -create -output "{{.BIN_DIR}}/build/{{.APP_NAME}}" "{{.BIN_DIR}}/build/{{.APP_NAME}}-amd64" "{{.BIN_DIR}}/build/{{.APP_NAME}}-arm64"
-      - rm "{{.BIN_DIR}}/build/{{.APP_NAME}}-amd64" "{{.BIN_DIR}}/build/{{.APP_NAME}}-arm64"
+      - lipo -create -output "{{.BIN_DIR}}/{{.APP_NAME}}" "{{.BIN_DIR}}/{{.APP_NAME}}-amd64" "{{.BIN_DIR}}/{{.APP_NAME}}-arm64"
+      - rm "{{.BIN_DIR}}/{{.APP_NAME}}-amd64" "{{.BIN_DIR}}/{{.APP_NAME}}-arm64"
 
   package:
     summary: Packages a production build of the application into a `.app` bundle
@@ -65,17 +65,17 @@ tasks:
   create:app:bundle:
     summary: Creates an `.app` bundle
     cmds:
-      - mkdir -p {{.BIN_DIR}}/release/{{.APP_NAME}}.app/Contents/{MacOS,Resources}
-      - cp build/darwin/icons.icns {{.BIN_DIR}}/release/{{.APP_NAME}}.app/Contents/Resources
-      - cp {{.BIN_DIR}}/build/{{.APP_NAME}} {{.BIN_DIR}}/release/{{.APP_NAME}}.app/Contents/MacOS
-      - cp build/darwin/Info.plist {{.BIN_DIR}}/release/{{.APP_NAME}}.app/Contents
-      - codesign --force --deep --sign - {{.BIN_DIR}}/release/{{.APP_NAME}}.app
+      - mkdir -p {{.BIN_DIR}}/{{.APP_NAME}}.app/Contents/{MacOS,Resources}
+      - cp build/darwin/icons.icns {{.BIN_DIR}}/{{.APP_NAME}}.app/Contents/Resources
+      - cp {{.BIN_DIR}}/{{.APP_NAME}} {{.BIN_DIR}}/{{.APP_NAME}}.app/Contents/MacOS
+      - cp build/darwin/Info.plist {{.BIN_DIR}}/{{.APP_NAME}}.app/Contents
+      - codesign --force --deep --sign - {{.BIN_DIR}}/{{.APP_NAME}}.app
 
   run:
     cmds:
-      - mkdir -p {{.BIN_DIR}}/dev/{{.APP_NAME}}.app/Contents/{MacOS,Resources}
-      - cp build/darwin/icons.icns {{.BIN_DIR}}/dev/{{.APP_NAME}}.app/Contents/Resources
-      - cp {{.BIN_DIR}}/build/{{.APP_NAME}} {{.BIN_DIR}}/dev/{{.APP_NAME}}.app/Contents/MacOS
-      - cp build/darwin/Info.dev.plist {{.BIN_DIR}}/dev/{{.APP_NAME}}.app/Contents/Info.plist
-      - codesign --force --deep --sign - {{.BIN_DIR}}/dev/{{.APP_NAME}}.app
-      - '{{.BIN_DIR}}/dev/{{.APP_NAME}}.app/Contents/MacOS/{{.APP_NAME}}'
+      - mkdir -p {{.BIN_DIR}}/{{.APP_NAME}}.dev.app/Contents/{MacOS,Resources}
+      - cp build/darwin/icons.icns {{.BIN_DIR}}/{{.APP_NAME}}.dev.app/Contents/Resources
+      - cp {{.BIN_DIR}}/{{.APP_NAME}} {{.BIN_DIR}}/{{.APP_NAME}}.dev.app/Contents/MacOS
+      - cp build/darwin/Info.dev.plist {{.BIN_DIR}}/{{.APP_NAME}}.dev.app/Contents/Info.plist
+      - codesign --force --deep --sign - {{.BIN_DIR}}/{{.APP_NAME}}.dev.app
+      - '{{.BIN_DIR}}/{{.APP_NAME}}.dev.app/Contents/MacOS/{{.APP_NAME}}'


### PR DESCRIPTION
# Description

This PR makes changes to the macOS build tasks to bundle and sign Wails binaries to enable new macOS APIs.
Upcoming Notifications API (https://github.com/wailsapp/wails/pull/4098) on macOS requires the app to be bundled with a bundle identifier and signed to work properly. 

Fixes (https://github.com/wailsapp/wails/pull/4098)

**Changes**
| `dev` | `build` | `package` |
|---|---|---|
| <ul> <li>Creates an app bundle with `.dev` appended.</li> <li>Copies the `build` binary from `bin`, dev bundle identifier from `build/darwin/Info.dev.plist`, and the icons from `build/darwin/icons.icns`.</li> <li>Ad-hoc/self-signs the app bundle for local testing.</li> </ul> | No changes | <ul> <li>Ad-hoc/self-signs the app bundle for local use.</li> </ul> |

It will be important to document that the ad-hoc signing will **not work** for distributing the app and is only sufficient for local testing/use. Signing and notarizing is required for distribution. 

## Type of change
  
Please select the option that is relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?
  
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration using `wails doctor`.

- [ ] Windows
- [x] macOS
- [ ] Linux
      
If you checked Linux, please specify the distro and version.
  
## Test Configuration

Please paste the output of `wails doctor`. If you are unable to run this command, please describe your environment in as much detail as possible.

```
 Wails (v3.0.0-dev)  Wails Doctor

# System

┌──────────────────────────────────────────────────┐
| Name          | MacOS                            |
| Version       | 15.3.2                           |
| ID            | 24D2082                          |
| Branding      | Sequoia                          |
| Platform      | darwin                           |
| Architecture  | arm64                            |
| Apple Silicon | true                             |
| CPU           | Apple M4 Max                     |
| CPU 1         | Apple M4 Max                     |
| CPU 2         | Apple M4 Max                     |
| GPU           | 32 cores, Metal Support: Metal 3 |
| Memory        | 36 GB                            |
└──────────────────────────────────────────────────┘

# Build Environment

┌─────────────────────────────────────────────────────────┐
| Wails CLI    | v3.0.0-dev                               |
| Go Version   | go1.24.1                                 |
| Revision     | 4a2dc2875f1a2215cfd74c1099be8e4ef0f5cf96 |
| Modified     | true                                     |
| -buildmode   | exe                                      |
| -compiler    | gc                                       |
| CGO_CFLAGS   |                                          |
| CGO_CPPFLAGS |                                          |
| CGO_CXXFLAGS |                                          |
| CGO_ENABLED  | 1                                        |
| CGO_LDFLAGS  |                                          |
| GOARCH       | arm64                                    |
| GOARM64      | v8.0                                     |
| GOOS         | darwin                                   |
| vcs          | git                                      |
| vcs.modified | true                                     |
| vcs.revision | 4a2dc2875f1a2215cfd74c1099be8e4ef0f5cf96 |
| vcs.time     | 2025-03-16T01:37:50Z                     |
└─────────────────────────────────────────────────────────┘

# Dependencies

┌────────────────────────────────────────────────────────────────────────┐
| npm             | 10.9.2                                               |
| *NSIS           | Not Installed. Install with `brew install makensis`. |
| Xcode cli tools | 2409                                                 |
|                                                                        |
└─────────────────────── * - Optional Dependency ────────────────────────┘

# Checking for issues

 SUCCESS  No issues found

# Diagnosis

 SUCCESS  Your system is ready for Wails development!
```

# Checklist:

- [x] I have updated `website/src/pages/changelog.mdx` with details of this PR
- [x] My code follows the general coding style of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced the macOS application bundling process with automatic signing for both production and development builds, improving security and compatibility.
  
- **Documentation**
  - Updated the changelog and build guides to describe the new macOS bundling and ad-hoc signing capabilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->