### PR TITLE
[v3] don't wrap events in slice

### DIFF
--- a/v3/pkg/application/application.go
+++ b/v3/pkg/application/application.go
@@ -381,7 +381,7 @@ func (a *App) RegisterService(service Service) {
 }
 
 // EmitEvent will emit an event
-func (a *App) EmitEvent(name string, data ...any) {
+func (a *App) EmitEvent(name string, data any) {
 	a.customEventProcessor.Emit(&CustomEvent{
 		Name: name,
 		Data: data,


### PR DESCRIPTION
This single commit removes the `variadic` operator from the input to `EmitEvent`.
Using a variadic operator for 'data' causes the `event` object to be wrapped in a single element slice which forces the consumer of the event to operate on a slice of messages even if only a single non-slice object was submitted to the function. 

If the `variadic operator` is intended it would seem that an iteration over the elements might be required and to send multiple events in that case.

Looking for clarification on desired functionality here if this is the wrong solution.
