### PR TITLE
fix: suppress excessive console logs after updating to v2.10.1

### DIFF
--- a/website/src/pages/changelog.mdx
+++ b/website/src/pages/changelog.mdx
@@ -21,6 +21,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added "Branding" section to `wails doctor` to correctly identify Windows 11 [#3891](https://github.com/wailsapp/wails/pull/3891) by [@ronen25](https://github.com/ronen25)
 - Added `-skipembedcreate` flag to build and dev command to improve compile and recompile speed [#4143](https://github.com/wailsapp/wails/pull/4143) by @josStorer
 
+### Fixed
+- Fixed excessive console logging after updating to v2.10.1 by @superDingda in [#4111](https://github.com/wailsapp/wails/issues/4111)
 
 ## v2.10.1 - 2025-02-24
 


### PR DESCRIPTION
---

## **Description**  
This PR fixes excessive console logging after updating to Wails v2.10.1 Previously, any Go backend function call results were automatically printed to the console, making it difficult to read actual logs. This update suppresses those unnecessary logs unless explicitly enabled.  

Fixes [#4111](https://github.com/wailsapp/wails/issues/4111).  

---

## **Type of change**  
- [x] Bug fix (non-breaking change which fixes an issue)  

---

## **How Has This Been Tested?**  
This fix has been tested on the following platforms:  
- [x] Windows  
- [] macOS  
- [x] Linux (Ubuntu 20.04)  

### **Test Configuration:**  
```sh
# Wails
Version         | v2.10.1
Package Manager | apt    


# System
WARNING: failed to read int from file: open /sys/devices/system/cpu/cpu0/online: no such file or directory
┌──────────────────────────────────────────────────────────┐
| OS           | Ubuntu                                    |
| Version      | 20.04                                     |
| ID           | ubuntu                                    |
| Go Version   | go1.24.1                                  |
| Platform     | linux                                     |
| Architecture | amd64                                     |
| CPU          | 13th Gen Intel(R) Core(TM) i9-13900H      |
| GPU          | SVGA II Adapter (VMware) - Driver: vmwgfx |
| Memory       | 8GB                                       |
└──────────────────────────────────────────────────────────┘

# Dependencies
┌──────────────────────────────────────────────────────────────────────────┐
| Dependency | Package Name          | Status    | Version                 |
| *docker    | docker.io             | Available | 26.1.3-0ubuntu1~20.04.1 |
| gcc        | build-essential       | Installed | 12.8ubuntu1.1           |
| libgtk-3   | libgtk-3-dev          | Installed | 3.24.20-0ubuntu1.2      |
| libwebkit  | libwebkit2gtk-4.0-dev | Installed | 2.38.6-0ubuntu0.20.04.1 |
| npm        | npm                   | Installed | 10.9.2                  |
| *nsis      | nsis                  | Available | 3.05-2                  |
| pkg-config | pkg-config            | Installed | 0.29.1-0ubuntu4         |
|                                                                          |
└──────────────────────── * - Optional Dependency ─────────────────────────┘

# Diagnosis
Optional package(s) installation details: 
  - docker: sudo apt install docker.io
  - nsis: sudo apt install nsis

 SUCCESS  Your system is ready for Wails development!
```
Steps to reproduce and verify the fix:  
1. Run `wails dev` on Wails v2.10.1 
2. Observe excessive console logs whenever a frontend call is made to the Go backend.  
3. Apply this fix and rerun `wails dev -loglevel Info` .  
4. Verify that only expected logs are printed.  

---

## **Checklist**  
- [x] I have updated `website/src/pages/changelog.mdx` with details of this PR.  
- [x] My code follows the general coding style of this project.  
- [x] I have performed a self-review of my own code.  
- [x] I have commented my code, particularly in hard-to-understand areas.  
- [x] My changes generate no new warnings.  
- [x] I have added tests that prove my fix is effective.  
- [x] New and existing unit tests pass locally with my changes.  

---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

These updates improve the application's logging behavior, resulting in a cleaner console output and more consistent error reporting.

- **Bug Fixes**
	- Fixed excessive console logging following the recent update.
	- Streamlined log level handling to ensure a smoother and more reliable experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->