### PR TITLE
[v3] Normalize Windows paths on system Dialogs invocations

### DIFF
--- a/docs/src/content/docs/changelog.mdx
+++ b/docs/src/content/docs/changelog.mdx
@@ -111,6 +111,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed initially-hidden menu items by [@IanVS](https://github.com/IanVS) in [#4116](https://github.com/wailsapp/wails/pull/4116)
 - Fixed assetFileServer not serving `.html` files when non-extension request when `[request]` doesn't exist but `[request].html` does
 - Fixed icon generation paths by [@robin-samuel](https://github.com/robin-samuel) in [#4125](https://github.com/wailsapp/wails/pull/4125)
+- Fixed Dialogs rutime function returning escaped paths on Windows by [TheGB0077](https://github.com/TheGB0077) in [#4188](https://github.com/wailsapp/wails/pull/4188)
 
 ### Changed
 

--- a/docs/src/content/docs/changelog.mdx
+++ b/docs/src/content/docs/changelog.mdx
@@ -111,7 +111,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed initially-hidden menu items by [@IanVS](https://github.com/IanVS) in [#4116](https://github.com/wailsapp/wails/pull/4116)
 - Fixed assetFileServer not serving `.html` files when non-extension request when `[request]` doesn't exist but `[request].html` does
 - Fixed icon generation paths by [@robin-samuel](https://github.com/robin-samuel) in [#4125](https://github.com/wailsapp/wails/pull/4125)
-- Fixed Dialogs rutime function returning escaped paths on Windows by [TheGB0077](https://github.com/TheGB0077) in [#4188](https://github.com/wailsapp/wails/pull/4188)
+- Fixed Dialogs runtime function returning escaped paths on Windows by [TheGB0077](https://github.com/TheGB0077) in [#4188](https://github.com/wailsapp/wails/pull/4188)
 
 ### Changed
 

--- a/v3/pkg/application/dialogs_windows.go
+++ b/v3/pkg/application/dialogs_windows.go
@@ -234,10 +234,6 @@ func convertFilters(filters []FileFilter) []cfd.FileFilter {
 	return result
 }
 
-func normalizeWindowsPath(path string) string {
-	return strings.ReplaceAll(path, "\\", "/")
-}
-
 func showCfdDialog(newDlg func() (cfd.Dialog, error), isMultiSelect bool) (any, error) {
 	dlg, err := newDlg()
 	if err != nil {
@@ -257,7 +253,7 @@ func showCfdDialog(newDlg func() (cfd.Dialog, error), isMultiSelect bool) (any, 
 		}
 
 		for i, path := range paths {
-			paths[i] = normalizeWindowsPath(path)
+			paths[i] = filepath.Clean(path)
 		}
 		return paths, nil
 	}
@@ -266,5 +262,5 @@ func showCfdDialog(newDlg func() (cfd.Dialog, error), isMultiSelect bool) (any, 
 	if err != nil {
 		return nil, err
 	}
-	return normalizeWindowsPath(path), nil
+	return filepath.Clean(path), nil
 }

--- a/v3/pkg/application/dialogs_windows.go
+++ b/v3/pkg/application/dialogs_windows.go
@@ -234,6 +234,10 @@ func convertFilters(filters []FileFilter) []cfd.FileFilter {
 	return result
 }
 
+func normalizeWindowsPath(path string) string {
+	return strings.ReplaceAll(path, "\\", "/")
+}
+
 func showCfdDialog(newDlg func() (cfd.Dialog, error), isMultiSelect bool) (any, error) {
 	dlg, err := newDlg()
 	if err != nil {
@@ -247,7 +251,20 @@ func showCfdDialog(newDlg func() (cfd.Dialog, error), isMultiSelect bool) (any, 
 	}()
 
 	if multi, _ := dlg.(cfd.OpenMultipleFilesDialog); multi != nil && isMultiSelect {
-		return multi.ShowAndGetResults()
+		paths, err := multi.ShowAndGetResults()
+		if err != nil {
+			return nil, err
+		}
+
+		for i, path := range paths {
+			paths[i] = normalizeWindowsPath(path)
+		}
+		return paths, nil
 	}
-	return dlg.ShowAndGetResult()
+
+	path, err := dlg.ShowAndGetResult()
+	if err != nil {
+		return nil, err
+	}
+	return normalizeWindowsPath(path), nil
 }

--- a/v3/pkg/application/dialogs_windows_test.go
+++ b/v3/pkg/application/dialogs_windows_test.go
@@ -1,0 +1,57 @@
+//go:build windows
+
+package application_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/matryer/is"
+)
+
+func TestCleanPath(t *testing.T) {
+	i := is.New(t)
+	tests := []struct {
+		name      string
+		inputPath string
+		expected  string
+	}{
+		{
+			name:      "path with double separators",
+			inputPath: `C:\\temp\\folder`,
+			expected:  `C:\temp\folder`,
+		},
+		{
+			name:      "path with forward slashes",
+			inputPath: `C://temp//folder`,
+			expected:  `C:\temp\folder`,
+		},
+		{
+			name:      "path with trailing separator",
+			inputPath: `C:\\temp\\folder\\`,
+			expected:  `C:\temp\folder`,
+		},
+		{
+			name:      "path with escaped tab character",
+			inputPath: `C:\\Users\\test\\tab.txt`,
+			expected:  `C:\Users\test\tab.txt`,
+		},
+		{
+			name:      "newline character",
+			inputPath: `C:\\Users\\test\\newline\\n.txt`,
+			expected:  `C:\Users\test\newline\n.txt`,
+		},
+		{
+			name:      "UNC path with multiple separators",
+			inputPath: `\\\\\\\\host\\share\\test.txt`,
+			expected:  `\\\\host\share\test.txt`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cleaned := filepath.Clean(tt.inputPath)
+			i.Equal(cleaned, tt.expected)
+		})
+	}
+}


### PR DESCRIPTION


# Description

JS code ends up escaping Windows paths when data gets passed around from backend to the frontend, so those should be normalized beforehand.

## Type of change
  
Please select the option that is relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
  
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration using `wails doctor`.

- [x] Windows
- [ ] macOS
- [ ] Linux
      
If you checked Linux, please specify the distro and version.
  
# Checklist:

- [x] I have updated `website/src/pages/changelog.mdx` with details of this PR
- [x] My code follows the general coding style of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved file dialog reliability by enhancing error handling.
  - Ensured file paths are consistently cleaned, resulting in a more robust file selection experience.
  - Fixed Dialogs runtime function returning escaped paths on Windows.

- **Tests**
  - Introduced new tests for validating path cleaning functionality in Windows environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->