### PR TITLE
fix: correct Windows filename in generate:icons task

### DIFF
--- a/v3/cmd/wails3/README.md
+++ b/v3/cmd/wails3/README.md
@@ -21,13 +21,13 @@ It can be used to generate many things including:
 
 The `icon` command generates icons for your project. 
 
-| Flag               | Type   | Description                                          | Default               |
-|--------------------|--------|------------------------------------------------------|-----------------------|
-| `-example`         | bool   | Generates example icon file (appicon.png)            |                       |
-| `-input`           | string | The input image file                                 |                       |
+| Flag               | Type   | Description                                          | Default              |
+|--------------------|--------|------------------------------------------------------|----------------------|
+| `-example`         | bool   | Generates example icon file (appicon.png)            |                      |
+| `-input`           | string | The input image file                                 |                      |
 | `-sizes`           | string | The sizes to generate in .ico file (comma separated) | "256,128,64,48,32,16" |
-| `-windowsFilename` | string | The output filename for the Windows icon             | icons.ico             |
-| `-macFilename`     | string | The output filename for the Mac icon bundle          | icons.icns            |
+| `-windowsFilename` | string | The output filename for the Windows icon             | icon.ico             |
+| `-macFilename`     | string | The output filename for the Mac icon bundle          | icons.icns           |
 
 ```bash
 wails3 generate icon -input myicon.png -sizes "32,64,128" -windowsFilename myicon.ico -macFilename myicon.icns       

--- a/v3/examples/file-association/build/Taskfile.common.yml
+++ b/v3/examples/file-association/build/Taskfile.common.yml
@@ -56,7 +56,7 @@ tasks:
       - "appicon.png"
     generates:
       - "icons.icns"
-      - "icons.ico"
+      - "icon.ico"
     cmds:
       - wails3 generate icons -input appicon.png
 


### PR DESCRIPTION
# Description

`wails3 task common:generate:icons` will now generate **icon.ico** instead of **icons.ico**

Fixes #4217


## Type of change
  
Please select the option that is relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
  
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration using `wails doctor`.

- [x] Windows
- [ ] macOS
- [ ] Linux
      
If you checked Linux, please specify the distro and version.
  
## Test Configuration

Please paste the output of `wails doctor`. If you are unable to run this command, please describe your environment in as much detail as possible.

# Checklist:

- [ ] I have updated `website/src/pages/changelog.mdx` with details of this PR
- [ ] My code follows the general coding style of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
