### PR TITLE
fix: restore hidden menuitem at correct position

### DIFF
--- a/docs/src/content/docs/changelog.mdx
+++ b/docs/src/content/docs/changelog.mdx
@@ -124,8 +124,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed transparency issue for frameless windows by [@leaanthony](https://github.com/leaanthony) based on work by @kron.
 - Fixed focus calls when window is disabled or minimised by [@leaanthony](https://github.com/leaanthony) based on work by @kron.
 - Fixed system trays not showing after taskbar restarts by [@leaanthony](https://github.com/leaanthony) based on work by @kron.
-- Fixed fallbackResponseWriter not implementing Flush() in
-[#4245](https://github.com/wailsapp/wails/pull/4245)
+- Fixed fallbackResponseWriter not implementing Flush() in [#4245](https://github.com/wailsapp/wails/pull/4245)
+- Fixed fallbackResponseWriter not implementing Flush() by [@superDingda] in [#4236](https://github.com/wailsapp/wails/issues/4236)
 
 ### Changed
 

--- a/v3/examples/menu/main.go
+++ b/v3/examples/menu/main.go
@@ -113,6 +113,37 @@ func main() {
 			ctx.ClickedMenuItem().SetLabel("Unhide the beatles!")
 		}
 	})
+
+	myMenu.AddSeparator()
+
+	coffee := myMenu.Add("Request Coffee").OnClick(func(*application.Context) {
+		println("Coffee dispatched. Productivity +10!")
+	})
+
+	myMenu.Add("Toggle coffee availability").OnClick(func(*application.Context) {
+		if coffee.Enabled() {
+			coffee.SetEnabled(false)
+			coffee.SetLabel("Coffee Machine Broken")
+			println("Alert: Developer morale critically low.")
+		} else {
+			coffee.SetEnabled(true)
+			coffee.SetLabel("Request Coffee")
+			println("All systems nominal. Coffee restored.")
+		}
+	})
+
+	myMenu.Add("Hide the coffee option").OnClick(func(ctx *application.Context) {
+		if coffee.Hidden() {
+			ctx.ClickedMenuItem().SetLabel("Hide the coffee option")
+			coffee.SetHidden(false)
+			println("Coffee menu item has been resurrected!")
+		} else {
+			coffee.SetHidden(true)
+			ctx.ClickedMenuItem().SetLabel("Unhide the coffee option")
+			println("The coffee option has vanished into the void.")
+		}
+	})
+
 	app.SetMenu(menu)
 
 	window := app.NewWebviewWindow().SetBackgroundColour(application.NewRGB(33, 37, 41))

--- a/v3/pkg/application/menuitem_windows.go
+++ b/v3/pkg/application/menuitem_windows.go
@@ -12,45 +12,32 @@ type windowsMenuItem struct {
 	parent   *Menu
 	menuItem *MenuItem
 
-	hMenu     w32.HMENU
-	id        int
-	label     string
-	disabled  bool
-	checked   bool
-	itemType  menuItemType
-	hidden    bool
-	submenu   w32.HMENU
-	itemAfter *MenuItem
+	hMenu    w32.HMENU
+	id       int
+	label    string
+	disabled bool
+	checked  bool
+	itemType menuItemType
+	hidden   bool
+	submenu  w32.HMENU
 }
 
 func (m *windowsMenuItem) setHidden(hidden bool) {
 	if hidden && !m.hidden {
 		m.hidden = true
-		// iterate the parent items and find the menu item after us
-		for i, item := range m.parent.items {
-			if item == m.menuItem {
-				if i < len(m.parent.items)-1 {
-					m.itemAfter = m.parent.items[i+1]
-				} else {
-					m.itemAfter = nil
-				}
-				break
-			}
-		}
 		// Remove from parent menu
 		w32.RemoveMenu(m.hMenu, m.id, w32.MF_BYCOMMAND)
 	} else if !hidden && m.hidden {
 		m.hidden = false
-		// Add to parent menu before the "itemAfter"
+		// Reinsert into parent menu at correct visible position
 		var pos int
-		if m.itemAfter != nil {
-			for i, item := range m.parent.items {
-				if item == m.itemAfter {
-					pos = i - 1
-					break
-				}
+		for _, item := range m.parent.items {
+			if item == m.menuItem {
+				break
 			}
-			m.itemAfter = nil
+			if item.hidden == false {
+				pos++
+			}
 		}
 		w32.InsertMenuItem(m.hMenu, uint32(pos), true, m.getMenuInfo())
 	}


### PR DESCRIPTION
<!--

*********************************************************************
*               PLEASE READ BEFORE SUBMITTING YOUR PR               *
*     YOUR PR MAY BE REJECTED IF IT DOES NOT FOLLOW THESE STEPS     *
*********************************************************************

- *DO NOT* submit PRs for v3 alpha enhancements, unless you have opened a post on the discord channel.
  All enhancements must be discussed first.
  The feedback guide for v3 is here: https://v3alpha.wails.io/getting-started/feedback/

- Before submitting your PR, please ensure you have created and linked the PR to an issue.
- If a relevant issue already exists, please reference it in your PR by including `Fixes #<issue number>` in your PR description.
- Please fill in the checklists.

-->

# Description

Currently, when a menuitem is hidden and then shown again, it is not restored to its correct original position.
This issue becomes worse when multiple items are hidden, as the relative ordering becomes completely incorrect.

Instead of using a stale `itemAfter` pointer, this patch dynamically recalculates the menuitem's correct position based on the current `m.parent.items` slice at the time of reinsertion.

Fixes #4236 

## Type of change
  
Please select the option that is relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
  
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration using `wails doctor`.

- [X] Windows
- [ ] macOS
- [ ] Linux
      
If you checked Linux, please specify the distro and version.

# Checklist:

- [X] I have updated `website/src/pages/changelog.mdx` with details of this PR
- [X] My code follows the general coding style of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
