### PR TITLE
[v3] Windows: catastrophic failure on cancel SaveFileDialog

### DIFF
--- a/v3/pkg/application/dialogs_windows.go
+++ b/v3/pkg/application/dialogs_windows.go
@@ -249,7 +249,7 @@ func showCfdDialog(newDlg func() (cfd.Dialog, error), isMultiSelect bool) (any, 
 	if multi, _ := dlg.(cfd.OpenMultipleFilesDialog); multi != nil && isMultiSelect {
 		paths, err := multi.ShowAndGetResults()
 		if err != nil {
-			return nil, err
+			return "", err
 		}
 
 		for i, path := range paths {
@@ -260,7 +260,7 @@ func showCfdDialog(newDlg func() (cfd.Dialog, error), isMultiSelect bool) (any, 
 
 	path, err := dlg.ShowAndGetResult()
 	if err != nil {
-		return nil, err
+		return "", err
 	}
 	return filepath.Clean(path), nil
 }


### PR DESCRIPTION
<!--

*********************************************************************
*               PLEASE READ BEFORE SUBMITTING YOUR PR               *
*     YOUR PR MAY BE REJECTED IF IT DOES NOT FOLLOW THESE STEPS     *
*********************************************************************

- *DO NOT* submit PRs for v3 alpha enhancements, unless you have opened a post on the discord channel.
  All enhancements must be discussed first.
  The feedback guide for v3 is here: https://v3alpha.wails.io/getting-started/feedback/

- Before submitting your PR, please ensure you have created and linked the PR to an issue.
- If a relevant issue already exists, please reference it in your PR by including `Fixes #<issue number>` in your PR description.
- Please fill in the checklists.

-->

# Description

This fixes a failure when closing or cancelling a SaveFileDialog on windows. The root cause is the type assertion to string of a nil variable. 

Fixes #4279

## Type of change
  
Please select the option that is relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
  
This has been tested running the reproducer on the issue and working as expected.

- [x] Windows
- [ ] macOS
- [ ] Linux

  
## Test Configuration

```
# System 

┌────────────────────────────────────────────────────────────────────────────────────────────┐
| Name              | Windows 10 Home                                                        |
| Version           | 2009 (Build: 26100)                                                    |
| ID                | 24H2                                                                   |
| Branding          | Windows 11 Home                                                        |
| Platform          | windows                                                                |
| Architecture      | amd64                                                                  |
| Go WebView2Loader | true                                                                   |
| WebView2 Version  | 136.0.3240.64                                                          |
| CPU               | 11th Gen Intel(R) Core(TM) i9-11900K @ 3.50GHz                         |
| GPU 1             | Intel(R) UHD Graphics 750 (Intel Corporation) - Driver: 32.0.101.6078  |
| GPU 2             | NVIDIA GeForce RTX 3060 Ti (NVIDIA) - Driver: 32.0.15.6624             |
| Memory            | 32GB                                                                   |
└────────────────────────────────────────────────────────────────────────────────────────────┘

# Build Environment 

┌────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
| Wails CLI      | v3.0.0-alpha.9                                                                                                            |
| Go Version     | go1.23.5                                                                                                                  |
| Revision       | c186917c34855a286227456386482fc98ca538fe                                                                                  |
| Modified       | true                                                                                                                      |
| -buildmode     | exe                                                                                                                       |
| -compiler      | gc                                                                                                                        |
| CGO_ENABLED    | 0                                                                                                                         |
| DefaultGODEBUG | asynctimerchan=1,gotypesalias=0,httpservecontentkeepheaders=1,tls3des=1,tlskyber=0,x509keypairleaf=0,x509negativeserial=1 |
| GOAMD64        | v1                                                                                                                        |
| GOARCH         | amd64                                                                                                                     |
| GOOS           | windows                                                                                                                   |
| vcs            | git                                                                                                                       |
| vcs.modified   | true                                                                                                                      |
| vcs.revision   | c186917c34855a286227456386482fc98ca538fe                                                                                  |
| vcs.time       | 2025-01-13T10:30:16Z                                                                                                      |
└────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘

# Dependencies 

┌───────────────────────────┐
| npm  | 10.9.0             |
| NSIS | Not Installed      |
└─ * - Optional Dependency ─┘

# Diagnosis 

 SUCCESS  Your system is ready for Wails development!
 ```

# Checklist:

- [ ] I have updated `website/src/pages/changelog.mdx` with details of this PR
- [ ] My code follows the general coding style of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error handling in dialogs to ensure consistent return values when an error occurs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->