### PR TITLE
V3/mac menu fixes

### DIFF
--- a/v3/examples/menu/main.go
+++ b/v3/examples/menu/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	_ "embed"
+	"fmt"
 	"log"
 	"runtime"
 
@@ -468,24 +469,30 @@ func main() {
 
 	// Add a button to update the submenu label in the Demo menu
 	labelOperations.Add("Update Demo Submenu Label").OnClick(func(*application.Context) {
-		// Find the submenu item in the Demo menu
-		submenuItem := myMenu.FindByLabel("Submenu")
-		if submenuItem != nil {
-			// Change the label
-			submenuItem.SetLabel("Updated Submenu Label")
-			// Update the menu to reflect the changes
-			menu.Update()
-			println("Submenu label changed to: Updated Submenu Label")
+		// Use the direct reference 'myDemoMenuItemForSubmenu' captured when the menu was created.
+		if submenu != nil {
+			oldLabel := submenu.Label()
+			targetNewLabel := "Updated Submenu Label"
 
-			// Verify the change
-			updatedItem := myMenu.FindByLabel("Updated Submenu Label")
-			if updatedItem != nil {
-				println("Verification: Found submenu with updated label:", updatedItem.Label())
+			if oldLabel == targetNewLabel {
+				fmt.Printf("Demo submenu ('%s') label in myMenu is already: %s\n", oldLabel, targetNewLabel)
+				return
+			}
+
+			submenu.SetLabel(targetNewLabel)
+			menu.Update() // Global update
+
+			fmt.Printf("Submenu label in myMenu changed from '%s' to: '%s'\n", oldLabel, submenu.Label())
+
+			// Verification (using the direct reference)
+			if submenu.Label() == targetNewLabel {
+				fmt.Printf("Verification: Submenu MenuItem in myMenu now has label: %s\n", submenu.Label())
 			} else {
-				println("Verification failed: Could not find submenu with updated label")
+				fmt.Printf("Verification FAILED: Submenu MenuItem in myMenu has label: %s, but expected %s\n", submenu.Label(), targetNewLabel)
 			}
 		} else {
-			println("Submenu not found!")
+			// This means myDemoMenuItemForSubmenu was nil when captured (myMenu.GetItemByLabel("Submenu") failed during setup).
+			fmt.Println("Error: The 'myDemoMenuItemForSubmenu' variable is nil (was not found during menu setup).")
 		}
 	})
 
@@ -519,47 +526,61 @@ func main() {
 
 	// Add a button to the nested submenu to change its own label
 	nestedSubmenu.Add("Change My Own Label").OnClick(func(*application.Context) {
-		// Find the nested submenu item
-		submenuItem := labelOperations.FindByLabel("Nested Submenu")
-		if submenuItem != nil {
-			// Change the label
-			submenuItem.SetLabel("Self-Updated Submenu")
-			// Update the menu to reflect the changes
-			menu.Update()
-			println("Nested submenu changed its own label to: Self-Updated Submenu")
+		// 'nestedSubmenu' is the Go variable pointing to the menu whose label we want to change.
+		// It's captured by this closure.
+		if nestedSubmenu != nil {
+			oldLabel := nestedSubmenu.Label()
+			targetNewLabel := "Self-Updated Submenu"
 
-			// Verify the change
-			updatedItem := labelOperations.FindByLabel("Self-Updated Submenu")
-			if updatedItem != nil {
-				println("Verification: Found nested submenu with self-updated label:", updatedItem.Label())
+			// Avoid re-setting if already set, to prevent redundant updates/logs if clicked multiple times
+			if oldLabel == targetNewLabel {
+				fmt.Printf("Nested submenu (self) label is already: %s\n", targetNewLabel)
+				return
+			}
+
+			nestedSubmenu.SetLabel(targetNewLabel)
+			menu.Update() // Or app.Update()
+
+			fmt.Printf("Nested submenu (self) changed label from '%s' to: %s\n", oldLabel, nestedSubmenu.Label())
+
+			// Verification
+			if nestedSubmenu.Label() == targetNewLabel {
+				fmt.Printf("Verification: Nested submenu (self) object now has label: %s\n", nestedSubmenu.Label())
 			} else {
-				println("Verification failed: Could not find nested submenu with self-updated label")
+				fmt.Printf("Verification FAILED: Nested submenu (self) object has label: %s, but expected %s\n", nestedSubmenu.Label(), targetNewLabel)
 			}
 		} else {
-			println("Nested submenu not found!")
+			println("Error: The 'nestedSubmenu' variable is nil in the 'Change My Own Label' click handler scope.")
 		}
 	})
 
 	// Add a button to update the nested submenu's label
 	labelOperations.Add("Update Nested Submenu Label").OnClick(func(*application.Context) {
-		// Find the nested submenu item
-		submenuItem := labelOperations.FindByLabel("Nested Submenu")
-		if submenuItem != nil {
-			// Change the label
-			submenuItem.SetLabel("Updated Nested Submenu")
-			// Update the menu to reflect the changes
-			menu.Update()
-			println("Nested submenu label changed to: Updated Nested Submenu")
+		// 'nestedSubmenu' is the Go variable pointing to the target menu.
+		// It's captured by this closure.
+		if nestedSubmenu != nil {
+			oldLabel := nestedSubmenu.Label()
+			targetNewLabel := "Updated Nested Submenu"
 
-			// Verify the change
-			updatedItem := labelOperations.FindByLabel("Updated Nested Submenu")
-			if updatedItem != nil {
-				println("Verification: Found nested submenu with updated label:", updatedItem.Label())
+			// Avoid re-setting if already set
+			if oldLabel == targetNewLabel {
+				fmt.Printf("Nested submenu label is already: %s\n", targetNewLabel)
+				return
+			}
+
+			nestedSubmenu.SetLabel(targetNewLabel)
+			menu.Update() // Or app.Update()
+
+			fmt.Printf("Nested submenu label changed from '%s' to: %s\n", oldLabel, nestedSubmenu.Label())
+
+			// Verification
+			if nestedSubmenu.Label() == targetNewLabel {
+				fmt.Printf("Verification: Nested submenu object now has label: %s\n", nestedSubmenu.Label())
 			} else {
-				println("Verification failed: Could not find nested submenu with updated label")
+				fmt.Printf("Verification FAILED: Nested submenu object has label: %s, but expected %s\n", nestedSubmenu.Label(), targetNewLabel)
 			}
 		} else {
-			println("Nested submenu not found!")
+			println("Error: The 'nestedSubmenu' variable is nil in the 'Update Nested Submenu Label' click handler scope.")
 		}
 	})
 

--- a/v3/pkg/application/menu.go
+++ b/v3/pkg/application/menu.go
@@ -176,6 +176,13 @@ func (m *Menu) SetLabel(label string) {
 	m.updateParentMenuItemLabel(label)
 }
 
+// Label returns the menu's internal label.
+// For a submenu, this is the label it was created with.
+// The displayed label of a submenu is determined by the label of the MenuItem that points to it.
+func (m *Menu) Label() string {
+	return m.label
+}
+
 // updateParentMenuItemLabel finds and updates the parent MenuItem that contains this submenu
 func (m *Menu) updateParentMenuItemLabel(label string) {
 	// Find all menu items that have this menu as their submenu

--- a/v3/pkg/application/menu.go
+++ b/v3/pkg/application/menu.go
@@ -1,9 +1,39 @@
 package application
 
-import "sync"
+import (
+	"fmt"
+	"sync"
+	"sync/atomic"
+)
 
 type menuImpl interface {
 	update()
+}
+
+// MenuElementInterface defines the common interface for both Menu and MenuItem
+type MenuElementInterface interface {
+	// Identity methods
+	ID() string
+	Label() string
+	SetLabel(string) MenuElementInterface
+
+	// State methods
+	SetEnabled(bool) MenuElementInterface
+	Enabled() bool
+	SetHidden(bool) MenuElementInterface
+	Hidden() bool
+
+	// Behavior methods
+	OnClick(func(*Context)) MenuElementInterface
+	SetAccelerator(string) MenuElementInterface
+	GetAccelerator() string
+
+	// Submenu capability
+	IsSubmenu() bool
+	GetSubmenu() *Menu
+
+	// For updating the menu system
+	Update() MenuElementInterface
 }
 
 type ContextMenu struct {
@@ -29,56 +59,214 @@ func (m *ContextMenu) Destroy() {
 	globalApplication.unregisterContextMenu(m.name)
 }
 
+// Menu represents a menu that can also act as a MenuItem
 type Menu struct {
-	items []*MenuItem
+	id    string
 	label string
+	items []MenuElementInterface
 
-	impl menuImpl
+	// MenuItem properties when this menu acts as a menu item
+	enabled     bool
+	hidden      bool
+	accelerator *accelerator
+	callback    func(*Context)
+	role        Role
+
+	impl        menuImpl
+	parentMenu  *Menu
+	contextData *ContextMenuData
 
 	// Track which windows this menu is attached to
 	attachedWindows     map[uint]bool
 	attachedWindowsLock sync.RWMutex
+
+	// ID management
+	itemRegistry  map[string]MenuElementInterface
+	registryMutex sync.RWMutex
+}
+
+// Global registry for quick lookups
+var (
+	globalMenuRegistry      = make(map[string]MenuElementInterface)
+	globalMenuRegistryMutex sync.RWMutex
+	globalElementIDCounter  uint64
+)
+
+// Helper functions for ID generation
+func generateElementID() string {
+	return fmt.Sprintf("element_%d", atomic.AddUint64(&globalElementIDCounter, 1))
+}
+
+func registerElement(element MenuElementInterface) {
+	globalMenuRegistryMutex.Lock()
+	defer globalMenuRegistryMutex.Unlock()
+	globalMenuRegistry[element.ID()] = element
+}
+
+func unregisterElement(id string) {
+	globalMenuRegistryMutex.Lock()
+	defer globalMenuRegistryMutex.Unlock()
+	delete(globalMenuRegistry, id)
+}
+
+func GetElementByID(id string) MenuElementInterface {
+	globalMenuRegistryMutex.RLock()
+	defer globalMenuRegistryMutex.RUnlock()
+	return globalMenuRegistry[id]
+}
+
+func GetElementByLabel(label string) MenuElementInterface {
+	globalMenuRegistryMutex.RLock()
+	defer globalMenuRegistryMutex.RUnlock()
+	for _, element := range globalMenuRegistry {
+		if element.Label() == label {
+			return element
+		}
+	}
+	return nil
 }
 
 func NewMenu() *Menu {
-	return &Menu{
+	menu := &Menu{
+		id:              generateElementID(),
+		enabled:         true,
 		attachedWindows: make(map[uint]bool),
+		itemRegistry:    make(map[string]MenuElementInterface),
 	}
+	registerElement(menu)
+	return menu
+}
+
+// Menu implementation of MenuElementInterface
+
+func (m *Menu) ID() string {
+	return m.id
+}
+
+func (m *Menu) Label() string {
+	return m.label
+}
+
+func (m *Menu) SetLabel(label string) MenuElementInterface {
+	m.label = label
+	return m
+}
+
+func (m *Menu) SetEnabled(enabled bool) MenuElementInterface {
+	m.enabled = enabled
+	return m
+}
+
+func (m *Menu) Enabled() bool {
+	return m.enabled
+}
+
+func (m *Menu) SetHidden(hidden bool) MenuElementInterface {
+	m.hidden = hidden
+	return m
+}
+
+func (m *Menu) Hidden() bool {
+	return m.hidden
+}
+
+func (m *Menu) OnClick(callback func(*Context)) MenuElementInterface {
+	m.callback = callback
+	return m
+}
+
+func (m *Menu) SetAccelerator(shortcut string) MenuElementInterface {
+	accelerator, err := parseAccelerator(shortcut)
+	if err != nil {
+		globalApplication.error("invalid accelerator: %w", err)
+		return m
+	}
+	m.accelerator = accelerator
+	return m
+}
+
+func (m *Menu) GetAccelerator() string {
+	if m.accelerator == nil {
+		return ""
+	}
+	return m.accelerator.String()
+}
+
+func (m *Menu) IsSubmenu() bool {
+	return true // Menus are always submenus when used as menu items
+}
+
+func (m *Menu) GetSubmenu() *Menu {
+	return m // A menu returns itself as the submenu
 }
 
 func (m *Menu) Add(label string) *MenuItem {
 	result := NewMenuItem(label)
-	m.items = append(m.items, result)
+	m.AddElement(result)
 	return result
+}
+
+// AddElement adds an existing menu element (item or submenu)
+func (m *Menu) AddElement(element MenuElementInterface) *Menu {
+	m.registryMutex.Lock()
+	defer m.registryMutex.Unlock()
+
+	m.items = append(m.items, element)
+	m.itemRegistry[element.ID()] = element
+
+	// Set parent reference
+	if menu, ok := element.(*Menu); ok {
+		menu.parentMenu = m
+	}
+
+	return m
 }
 
 func (m *Menu) AddSeparator() {
 	result := NewMenuItemSeparator()
-	m.items = append(m.items, result)
+	m.AddElement(result)
 }
 
 func (m *Menu) AddCheckbox(label string, enabled bool) *MenuItem {
 	result := NewMenuItemCheckbox(label, enabled)
-	m.items = append(m.items, result)
+	m.AddElement(result)
 	return result
 }
 
 func (m *Menu) AddRadio(label string, enabled bool) *MenuItem {
 	result := NewMenuItemRadio(label, enabled)
-	m.items = append(m.items, result)
+	m.AddElement(result)
 	return result
+}
+
+// AddSubmenu creates and adds a new submenu, returning the submenu for chaining
+func (m *Menu) AddSubmenu(s string) *Menu {
+	submenu := NewMenu()
+	submenu.SetLabel(s)
+	m.AddElement(submenu)
+	return submenu
+}
+
+func (m *Menu) AddRole(role Role) *Menu {
+	result := NewRole(role)
+	if result != nil {
+		m.AddElement(result)
+	}
+	return m
 }
 
 // Update updates the menu and propagates the changes to the application and all windows
 // that have the menu attached.
-//
-// The propagate parameter is kept for backward compatibility but is ignored.
-// Changes are always propagated to the application and all windows that have the menu attached.
-func (m *Menu) Update() *Menu {
+func (m *Menu) Update() MenuElementInterface {
+	// Update all child items
+	for _, item := range m.items {
+		item.Update()
+	}
+
 	// Process radio groups and update the menu
 	m.processRadioGroups()
 	if m.impl == nil {
-		m.impl = newMenuImpl(m)
+		m.impl = newMenuImpl(m.convertToOldMenu())
 	}
 	m.impl.update()
 
@@ -98,7 +286,7 @@ func (m *Menu) Update() *Menu {
 	// Check if this menu is the application menu (ID 0)
 	if attachedWindowsCopy[0] {
 		// Update the application menu
-		globalApplication.SetMenu(m)
+		globalApplication.SetMenu(m.convertToOldMenu())
 	}
 
 	// Update all windows that use this menu
@@ -107,116 +295,51 @@ func (m *Menu) Update() *Menu {
 
 	for id, window := range globalApplication.windows {
 		if attachedWindowsCopy[id] {
-			window.SetMenu(m)
+			window.SetMenu(m.convertToOldMenu())
 		}
 	}
 
 	return m
 }
 
-// Clear all menu items
-func (m *Menu) Clear() {
+// FindByID finds an element by its ID
+func (m *Menu) FindByID(id string) MenuElementInterface {
+	m.registryMutex.RLock()
+	defer m.registryMutex.RUnlock()
+
+	if element, exists := m.itemRegistry[id]; exists {
+		return element
+	}
+
+	// Search recursively in submenus
 	for _, item := range m.items {
-		removeMenuItemByID(item.id)
-	}
-	m.items = nil
-}
-
-func (m *Menu) Destroy() {
-	for _, item := range m.items {
-		item.Destroy()
-	}
-	m.items = nil
-}
-
-func (m *Menu) AddSubmenu(s string) *Menu {
-	result := NewSubMenuItem(s)
-	m.items = append(m.items, result)
-	return result.submenu
-}
-
-func (m *Menu) AddRole(role Role) *Menu {
-	result := NewRole(role)
-	if result != nil {
-		m.items = append(m.items, result)
-	}
-	return m
-}
-
-func (m *Menu) processRadioGroups() {
-	var radioGroup []*MenuItem
-
-	closeOutRadioGroups := func() {
-		if len(radioGroup) > 0 {
-			for _, item := range radioGroup {
-				item.radioGroupMembers = radioGroup
-			}
-			radioGroup = []*MenuItem{}
-		}
-	}
-
-	for _, item := range m.items {
-		if item.itemType != radio {
-			closeOutRadioGroups()
-		}
-		if item.itemType == submenu {
-			item.submenu.processRadioGroups()
-			continue
-		}
-		if item.itemType == radio {
-			radioGroup = append(radioGroup, item)
-		}
-	}
-	closeOutRadioGroups()
-}
-
-func (m *Menu) SetLabel(label string) {
-	m.label = label
-	// If this menu is a submenu, update the parent MenuItem's label as well
-	m.updateParentMenuItemLabel(label)
-}
-
-// Label returns the menu's internal label.
-// For a submenu, this is the label it was created with.
-// The displayed label of a submenu is determined by the label of the MenuItem that points to it.
-func (m *Menu) Label() string {
-	return m.label
-}
-
-// updateParentMenuItemLabel finds and updates the parent MenuItem that contains this submenu
-func (m *Menu) updateParentMenuItemLabel(label string) {
-	// Find all menu items that have this menu as their submenu
-	menuItemMapLock.Lock()
-	defer menuItemMapLock.Unlock()
-
-	for _, item := range menuItemMap {
-		if item.submenu == m {
-			item.SetLabel(label)
-			break // There should only be one parent MenuItem per submenu
-		}
-	}
-}
-
-func (m *Menu) setContextData(data *ContextMenuData) {
-	for _, item := range m.items {
-		item.setContextData(data)
-	}
-}
-
-// FindByLabel recursively searches for a menu item with the given label
-// and returns the first match, or nil if not found.
-func (m *Menu) FindByLabel(label string) *MenuItem {
-	for _, item := range m.items {
-		if item.label == label {
-			return item
-		}
-		if item.submenu != nil {
-			found := item.submenu.FindByLabel(label)
-			if found != nil {
+		if submenu := item.GetSubmenu(); submenu != nil && submenu != item {
+			if found := submenu.FindByID(id); found != nil {
 				return found
 			}
 		}
 	}
+
+	return nil
+}
+
+// FindByLabel finds an element by its label - updated to use MenuElementInterface
+func (m *Menu) FindByLabel(label string) MenuElementInterface {
+	m.registryMutex.RLock()
+	defer m.registryMutex.RUnlock()
+
+	for _, item := range m.items {
+		if item.Label() == label {
+			return item
+		}
+		// Search recursively in submenus
+		if submenu := item.GetSubmenu(); submenu != nil && submenu != item {
+			if found := submenu.FindByLabel(label); found != nil {
+				return found
+			}
+		}
+	}
+
 	return nil
 }
 
@@ -224,11 +347,13 @@ func (m *Menu) FindByLabel(label string) *MenuItem {
 // and returns the first match, or nil if not found.
 func (m *Menu) FindByRole(role Role) *MenuItem {
 	for _, item := range m.items {
-		if item.role == role {
-			return item
+		if menuItem, ok := item.(*MenuItem); ok {
+			if menuItem.role == role {
+				return menuItem
+			}
 		}
-		if item.submenu != nil {
-			found := item.submenu.FindByRole(role)
+		if submenu := item.GetSubmenu(); submenu != nil && submenu != item {
+			found := submenu.FindByRole(role)
 			if found != nil {
 				return found
 			}
@@ -237,38 +362,41 @@ func (m *Menu) FindByRole(role Role) *MenuItem {
 	return nil
 }
 
-func (m *Menu) RemoveMenuItem(target *MenuItem) {
+// RemoveByID removes an element by ID
+func (m *Menu) RemoveByID(id string) bool {
+	m.registryMutex.Lock()
+	defer m.registryMutex.Unlock()
+
 	for i, item := range m.items {
-		if item == target {
-			// Remove the item from the slice
+		if item.ID() == id {
+			// Remove from slice
 			m.items = append(m.items[:i], m.items[i+1:]...)
-			break
-		}
-		if item.submenu != nil {
-			item.submenu.RemoveMenuItem(target)
+			// Remove from registry
+			delete(m.itemRegistry, id)
+			unregisterElement(id)
+			return true
 		}
 	}
+	return false
 }
 
-// ItemAt returns the menu item at the given index, or nil if the index is out of bounds.
-func (m *Menu) ItemAt(index int) *MenuItem {
-	if index < 0 || index >= len(m.items) {
-		return nil
+// RemoveByLabel removes an element by label
+func (m *Menu) RemoveByLabel(label string) bool {
+	if element := m.FindByLabel(label); element != nil {
+		return m.RemoveByID(element.ID())
 	}
-	return m.items[index]
+	return false
 }
 
-// InsertAt inserts a new menu item with the given label at the specified index.
-// Returns the newly created menu item.
-func (m *Menu) InsertAt(index int, label string) *MenuItem {
-	result := NewMenuItem(label)
-	m.InsertItemAt(index, result)
-	return result
+func (m *Menu) RemoveMenuItem(target *MenuItem) {
+	m.RemoveByID(target.ID())
 }
 
-// InsertItemAt inserts an existing menu item at the specified index.
-// Returns the menu for chaining.
-func (m *Menu) InsertItemAt(index int, item *MenuItem) *Menu {
+// InsertAtIndex inserts an element at a specific index
+func (m *Menu) InsertAtIndex(index int, element MenuElementInterface) *Menu {
+	m.registryMutex.Lock()
+	defer m.registryMutex.Unlock()
+
 	if index < 0 {
 		index = 0
 	}
@@ -277,12 +405,86 @@ func (m *Menu) InsertItemAt(index int, item *MenuItem) *Menu {
 	}
 
 	if index == len(m.items) {
-		m.items = append(m.items, item)
+		m.items = append(m.items, element)
 	} else {
-		// Create a new slice with the item inserted at the specified index
-		m.items = append(m.items[:index], append([]*MenuItem{item}, m.items[index:]...)...)
+		m.items = append(m.items[:index], append([]MenuElementInterface{element}, m.items[index:]...)...)
 	}
 
+	m.itemRegistry[element.ID()] = element
+
+	// Set parent reference
+	if item, ok := element.(*MenuItem); ok {
+		item.parentMenu = m
+	} else if menu, ok := element.(*Menu); ok {
+		menu.parentMenu = m
+	}
+
+	return m
+}
+
+// InsertBeforeID inserts an element before the element with the given ID
+func (m *Menu) InsertBeforeID(beforeID string, element MenuElementInterface) bool {
+	for i, item := range m.items {
+		if item.ID() == beforeID {
+			m.InsertAtIndex(i, element)
+			return true
+		}
+	}
+	return false
+}
+
+// InsertAfterID inserts an element after the element with the given ID
+func (m *Menu) InsertAfterID(afterID string, element MenuElementInterface) bool {
+	for i, item := range m.items {
+		if item.ID() == afterID {
+			m.InsertAtIndex(i+1, element)
+			return true
+		}
+	}
+	return false
+}
+
+// InsertBeforeLabel inserts an element before the element with the given label
+func (m *Menu) InsertBeforeLabel(beforeLabel string, element MenuElementInterface) bool {
+	if target := m.FindByLabel(beforeLabel); target != nil {
+		return m.InsertBeforeID(target.ID(), element)
+	}
+	return false
+}
+
+// InsertAfterLabel inserts an element after the element with the given label
+func (m *Menu) InsertAfterLabel(afterLabel string, element MenuElementInterface) bool {
+	if target := m.FindByLabel(afterLabel); target != nil {
+		return m.InsertAfterID(target.ID(), element)
+	}
+	return false
+}
+
+// Legacy methods that still work
+
+// ItemAt returns the menu item at the given index, or nil if the index is out of bounds.
+func (m *Menu) ItemAt(index int) *MenuItem {
+	if index < 0 || index >= len(m.items) {
+		return nil
+	}
+	if item, ok := m.items[index].(*MenuItem); ok {
+		return item
+	}
+	return nil
+}
+
+// InsertAt inserts a new menu item with the given label at the specified index.
+// Returns the newly created menu item.
+func (m *Menu) InsertAt(index int, label string) *MenuItem {
+	result := NewMenuItem(label)
+	m.InsertAtIndex(index, result)
+	return result
+}
+
+// InsertItemAt inserts an existing menu item at the specified index.
+// Returns the menu for chaining.
+func (m *Menu) InsertItemAt(index int, item *MenuItem) *Menu {
+	m.InsertAtIndex(index, item)
 	return m
 }
 
@@ -290,14 +492,15 @@ func (m *Menu) InsertItemAt(index int, item *MenuItem) *Menu {
 // Returns the menu for chaining.
 func (m *Menu) InsertSeparatorAt(index int) *Menu {
 	result := NewMenuItemSeparator()
-	return m.InsertItemAt(index, result)
+	m.InsertAtIndex(index, result)
+	return m
 }
 
 // InsertCheckboxAt inserts a checkbox menu item at the specified index.
 // Returns the newly created menu item.
 func (m *Menu) InsertCheckboxAt(index int, label string, enabled bool) *MenuItem {
 	result := NewMenuItemCheckbox(label, enabled)
-	m.InsertItemAt(index, result)
+	m.InsertAtIndex(index, result)
 	return result
 }
 
@@ -305,26 +508,58 @@ func (m *Menu) InsertCheckboxAt(index int, label string, enabled bool) *MenuItem
 // Returns the newly created menu item.
 func (m *Menu) InsertRadioAt(index int, label string, enabled bool) *MenuItem {
 	result := NewMenuItemRadio(label, enabled)
-	m.InsertItemAt(index, result)
+	m.InsertAtIndex(index, result)
 	return result
 }
 
 // InsertSubmenuAt inserts a submenu at the specified index.
 // Returns the newly created submenu.
 func (m *Menu) InsertSubmenuAt(index int, label string) *Menu {
-	result := NewSubMenuItem(label)
-	m.InsertItemAt(index, result)
-	return result.submenu
+	submenu := NewMenu()
+	submenu.SetLabel(label)
+	m.InsertAtIndex(index, submenu)
+	return submenu
+}
+
+// Clear all menu items
+func (m *Menu) Clear() {
+	for _, item := range m.items {
+		if menuItem, ok := item.(*MenuItem); ok {
+			removeMenuItemByID(menuItem.id)
+		}
+		unregisterElement(item.ID())
+	}
+	m.items = nil
+}
+
+func (m *Menu) Destroy() {
+	for _, item := range m.items {
+		if menuItem, ok := item.(*MenuItem); ok {
+			menuItem.Destroy()
+		} else if submenu, ok := item.(*Menu); ok {
+			submenu.Destroy()
+		}
+	}
+	m.items = nil
 }
 
 // Clone recursively clones the menu and all its submenus.
 func (m *Menu) Clone() *Menu {
 	result := &Menu{
+		id:              generateElementID(),
 		label:           m.label,
 		attachedWindows: make(map[uint]bool),
+		itemRegistry:    make(map[string]MenuElementInterface),
 	}
+	registerElement(result)
 	for _, item := range m.items {
-		result.items = append(result.items, item.Clone())
+		if menuItem, ok := item.(*MenuItem); ok {
+			clonedItem := menuItem.Clone()
+			result.items = append(result.items, clonedItem)
+		} else if submenu, ok := item.(*Menu); ok {
+			clonedSubmenu := submenu.Clone()
+			result.items = append(result.items, clonedSubmenu)
+		}
 	}
 	return result
 }
@@ -334,7 +569,9 @@ func (m *Menu) Append(in *Menu) {
 	if in == nil {
 		return
 	}
-	m.items = append(m.items, in.items...)
+	for _, item := range in.items {
+		m.AddElement(item)
+	}
 }
 
 // AppendItem appends a menu item to the menu
@@ -342,7 +579,7 @@ func (m *Menu) AppendItem(item *MenuItem) *Menu {
 	if item == nil {
 		return m
 	}
-	m.items = append(m.items, item)
+	m.AddElement(item)
 	return m
 }
 
@@ -351,8 +588,60 @@ func (m *Menu) Remove(index int) *Menu {
 	if index < 0 || index >= len(m.items) {
 		return m
 	}
-	m.items = append(m.items[:index], m.items[index+1:]...)
+	itemToRemove := m.items[index]
+	m.RemoveByID(itemToRemove.ID())
 	return m
+}
+
+func (m *Menu) processRadioGroups() {
+	var radioGroup []MenuElementInterface
+
+	closeOutRadioGroups := func() {
+		if len(radioGroup) > 0 {
+			for _, item := range radioGroup {
+				if radioItem, ok := item.(*MenuItem); ok {
+					// Convert MenuElementInterface slice to MenuItem slice for compatibility
+					radioMembers := make([]*MenuItem, 0, len(radioGroup))
+					for _, member := range radioGroup {
+						if menuItem, ok := member.(*MenuItem); ok {
+							radioMembers = append(radioMembers, menuItem)
+						}
+					}
+					radioItem.radioGroupMembers = radioMembers
+				}
+			}
+			radioGroup = []MenuElementInterface{}
+		}
+	}
+
+	for _, item := range m.items {
+		if menuItem, ok := item.(*MenuItem); ok {
+			if menuItem.itemType != radio {
+				closeOutRadioGroups()
+			}
+			if menuItem.itemType == radio {
+				radioGroup = append(radioGroup, item)
+			}
+		} else {
+			closeOutRadioGroups()
+		}
+
+		// Process submenus recursively
+		if submenu := item.GetSubmenu(); submenu != nil && submenu != item {
+			submenu.processRadioGroups()
+		}
+	}
+	closeOutRadioGroups()
+}
+
+func (m *Menu) setContextData(data *ContextMenuData) {
+	for _, item := range m.items {
+		if menuItem, ok := item.(*MenuItem); ok {
+			menuItem.setContextData(data)
+		} else if submenu, ok := item.(*Menu); ok {
+			submenu.setContextData(data)
+		}
+	}
 }
 
 // registerWindow registers a window as using this menu
@@ -369,36 +658,56 @@ func (m *Menu) unregisterWindow(windowID uint) {
 	delete(m.attachedWindows, windowID)
 }
 
+// updateParentMenuItemLabel finds and updates the parent MenuItem that contains this submenu
+func (m *Menu) updateParentMenuItemLabel(label string) {
+	// This is no longer needed as menus can update their own labels directly
+	m.SetLabel(label)
+}
+
 // UpdateAll updates the menu and propagates the changes to the application and all windows
 // This is a convenience method that handles all the necessary update steps after modifying a menu
 //
 // Deprecated: Use Update() instead as it now always propagates changes.
 func (m *Menu) UpdateAll() *Menu {
-	return m.Update()
+	m.Update()
+	return m
 }
 
 // Prepend menu before an existing menu
 func (m *Menu) Prepend(in *Menu) {
-	m.items = append(in.items, m.items...)
+	if in == nil {
+		return
+	}
+	// Insert all items from 'in' at the beginning
+	for i, item := range in.items {
+		m.InsertAtIndex(i, item)
+	}
+}
+
+// Conversion methods to maintain compatibility with existing platform implementations
+func (m *Menu) convertToOldMenu() *Menu {
+	// For now, return self since we're replacing the old system
+	// This method may need platform-specific implementations
+	return m
 }
 
 func (a *App) NewMenu() *Menu {
-	return &Menu{
-		attachedWindows: make(map[uint]bool),
-	}
+	return NewMenu()
 }
 
 func NewMenuFromItems(item *MenuItem, items ...*MenuItem) *Menu {
-	result := &Menu{
-		items:           []*MenuItem{item},
-		attachedWindows: make(map[uint]bool),
+	result := NewMenu()
+	result.AddElement(item)
+	for _, itm := range items {
+		result.AddElement(itm)
 	}
-	result.items = append(result.items, items...)
 	return result
 }
 
 func NewSubmenu(s string, items *Menu) *MenuItem {
-	result := NewSubMenuItem(s)
+	// This creates a MenuItem that wraps a Menu - for backward compatibility
+	result := NewMenuItem(s)
+	result.itemType = submenu
 	result.submenu = items
 	return result
 }

--- a/v3/pkg/application/menuitem.go
+++ b/v3/pkg/application/menuitem.go
@@ -50,6 +50,7 @@ type menuItemImpl interface {
 
 type MenuItem struct {
 	id              uint
+	elementID       string // New ID for MenuElementInterface
 	label           string
 	tooltip         string
 	disabled        bool
@@ -65,61 +66,320 @@ type MenuItem struct {
 
 	impl              menuItemImpl
 	radioGroupMembers []*MenuItem
+
+	// Parent reference
+	parentMenu *Menu
 }
 
 func NewMenuItem(label string) *MenuItem {
 	result := &MenuItem{
-		id:       uint(atomic.AddUintptr(&menuItemID, 1)),
-		label:    label,
-		itemType: text,
+		id:        uint(atomic.AddUintptr(&menuItemID, 1)),
+		elementID: generateElementID(),
+		label:     label,
+		itemType:  text,
 	}
 	addToMenuItemMap(result)
+	registerElement(result)
 	return result
 }
 
 func NewMenuItemSeparator() *MenuItem {
 	result := &MenuItem{
-		id:       uint(atomic.AddUintptr(&menuItemID, 1)),
-		itemType: separator,
+		id:        uint(atomic.AddUintptr(&menuItemID, 1)),
+		elementID: generateElementID(),
+		itemType:  separator,
 	}
+	registerElement(result)
 	return result
 }
 
 func NewMenuItemCheckbox(label string, checked bool) *MenuItem {
 	result := &MenuItem{
-		id:       uint(atomic.AddUintptr(&menuItemID, 1)),
-		label:    label,
-		checked:  checked,
-		itemType: checkbox,
+		id:        uint(atomic.AddUintptr(&menuItemID, 1)),
+		elementID: generateElementID(),
+		label:     label,
+		checked:   checked,
+		itemType:  checkbox,
 	}
 	addToMenuItemMap(result)
+	registerElement(result)
 	return result
 }
 
 func NewMenuItemRadio(label string, checked bool) *MenuItem {
 	result := &MenuItem{
-		id:       uint(atomic.AddUintptr(&menuItemID, 1)),
-		label:    label,
-		checked:  checked,
-		itemType: radio,
+		id:        uint(atomic.AddUintptr(&menuItemID, 1)),
+		elementID: generateElementID(),
+		label:     label,
+		checked:   checked,
+		itemType:  radio,
 	}
 	addToMenuItemMap(result)
+	registerElement(result)
 	return result
 }
 
 func NewSubMenuItem(label string) *MenuItem {
 	result := &MenuItem{
-		id:       uint(atomic.AddUintptr(&menuItemID, 1)),
-		label:    label,
-		itemType: submenu,
+		id:        uint(atomic.AddUintptr(&menuItemID, 1)),
+		elementID: generateElementID(),
+		label:     label,
+		itemType:  submenu,
 		submenu: &Menu{
 			label: label,
 		},
 	}
 	addToMenuItemMap(result)
+	registerElement(result)
 	return result
 }
 
+// MenuItem implementation of MenuElementInterface
+
+func (m *MenuItem) ID() string {
+	return m.elementID
+}
+
+func (m *MenuItem) Label() string {
+	return m.label
+}
+
+func (m *MenuItem) SetLabel(s string) MenuElementInterface {
+	m.label = s
+	if m.impl != nil {
+		m.impl.setLabel(s)
+	}
+	// If this is a submenu, update the submenu's label as well
+	if m.itemType == submenu && m.submenu != nil {
+		m.submenu.label = s
+	}
+	return m
+}
+
+func (m *MenuItem) SetEnabled(enabled bool) MenuElementInterface {
+	m.disabled = !enabled
+	if m.impl != nil {
+		m.impl.setDisabled(m.disabled)
+	}
+	return m
+}
+
+func (m *MenuItem) Enabled() bool {
+	return !m.disabled
+}
+
+func (m *MenuItem) SetHidden(hidden bool) MenuElementInterface {
+	m.hidden = hidden
+	if m.impl != nil {
+		m.impl.setHidden(m.hidden)
+	}
+	return m
+}
+
+func (m *MenuItem) Hidden() bool {
+	return m.hidden
+}
+
+func (m *MenuItem) OnClick(f func(*Context)) MenuElementInterface {
+	m.callback = f
+	return m
+}
+
+func (m *MenuItem) SetAccelerator(shortcut string) MenuElementInterface {
+	accelerator, err := parseAccelerator(shortcut)
+	if err != nil {
+		globalApplication.error("invalid accelerator: %w", err)
+		return m
+	}
+	m.accelerator = accelerator
+	if m.impl != nil {
+		m.impl.setAccelerator(accelerator)
+	}
+	return m
+}
+
+func (m *MenuItem) GetAccelerator() string {
+	if m.accelerator == nil {
+		return ""
+	}
+	return m.accelerator.String()
+}
+
+func (m *MenuItem) IsSubmenu() bool {
+	return m.itemType == submenu
+}
+
+func (m *MenuItem) GetSubmenu() *Menu {
+	return m.submenu
+}
+
+func (m *MenuItem) Update() MenuElementInterface {
+	if m.impl != nil {
+		// Update platform-specific implementation
+		m.impl.setLabel(m.label)
+		m.impl.setDisabled(m.disabled)
+		m.impl.setHidden(m.hidden)
+		m.impl.setChecked(m.checked)
+		if m.accelerator != nil {
+			m.impl.setAccelerator(m.accelerator)
+		}
+	}
+	// Update submenu if this is a submenu
+	if m.itemType == submenu && m.submenu != nil {
+		m.submenu.Update()
+	}
+	return m
+}
+
+// Legacy MenuItem methods that still work
+
+func (m *MenuItem) handleClick() {
+	var ctx = newContext().
+		withClickedMenuItem(m).
+		withContextMenuData(m.contextMenuData)
+	if m.itemType == checkbox {
+		m.checked = !m.checked
+		ctx.withChecked(m.checked)
+		if m.impl != nil {
+			m.impl.setChecked(m.checked)
+		}
+	}
+	if m.itemType == radio {
+		for _, member := range m.radioGroupMembers {
+			member.checked = false
+			if member.impl != nil {
+				member.impl.setChecked(false)
+			}
+		}
+		m.checked = true
+		ctx.withChecked(true)
+		if m.impl != nil {
+			m.impl.setChecked(true)
+		}
+	}
+	if m.callback != nil {
+		go func() {
+			defer handlePanic()
+			m.callback(ctx)
+		}()
+	}
+}
+
+func (m *MenuItem) RemoveAccelerator() {
+	m.accelerator = nil
+}
+
+func (m *MenuItem) SetTooltip(s string) *MenuItem {
+	m.tooltip = s
+	if m.impl != nil {
+		m.impl.setTooltip(s)
+	}
+	return m
+}
+
+func (m *MenuItem) SetRole(role Role) *MenuItem {
+	m.role = role
+	return m
+}
+
+func (m *MenuItem) SetBitmap(bitmap []byte) *MenuItem {
+	m.bitmap = bitmap
+	if m.impl != nil {
+		m.impl.setBitmap(bitmap)
+	}
+	return m
+}
+
+func (m *MenuItem) SetChecked(checked bool) *MenuItem {
+	m.checked = checked
+	if m.impl != nil {
+		m.impl.setChecked(m.checked)
+	}
+	return m
+}
+
+func (m *MenuItem) Checked() bool {
+	return m.checked
+}
+
+func (m *MenuItem) IsSeparator() bool {
+	return m.itemType == separator
+}
+
+func (m *MenuItem) IsCheckbox() bool {
+	return m.itemType == checkbox
+}
+
+func (m *MenuItem) IsRadio() bool {
+	return m.itemType == radio
+}
+
+func (m *MenuItem) Tooltip() string {
+	return m.tooltip
+}
+
+func (m *MenuItem) setContextData(data *ContextMenuData) {
+	m.contextMenuData = data
+	if m.submenu != nil {
+		m.submenu.setContextData(data)
+	}
+}
+
+// Clone returns a deep copy of the MenuItem
+func (m *MenuItem) Clone() *MenuItem {
+	result := &MenuItem{
+		id:        uint(atomic.AddUintptr(&menuItemID, 1)),
+		elementID: generateElementID(),
+		label:     m.label,
+		tooltip:   m.tooltip,
+		disabled:  m.disabled,
+		checked:   m.checked,
+		hidden:    m.hidden,
+		bitmap:    m.bitmap,
+		callback:  m.callback,
+		itemType:  m.itemType,
+		role:      m.role,
+	}
+	if m.submenu != nil {
+		result.submenu = m.submenu.Clone()
+	}
+	if m.accelerator != nil {
+		result.accelerator = m.accelerator.clone()
+	}
+	if m.contextMenuData != nil {
+		result.contextMenuData = m.contextMenuData.clone()
+	}
+	addToMenuItemMap(result)
+	registerElement(result)
+	return result
+}
+
+func (m *MenuItem) Destroy() {
+	removeMenuItemByID(m.id)
+	unregisterElement(m.elementID)
+
+	// Clean up resources
+	if m.impl != nil {
+		m.impl.destroy()
+	}
+	if m.submenu != nil {
+		m.submenu.Destroy()
+		m.submenu = nil
+	}
+
+	if m.contextMenuData != nil {
+		m.contextMenuData = nil
+	}
+
+	if m.accelerator != nil {
+		m.accelerator = nil
+	}
+
+	m.callback = nil
+	m.radioGroupMembers = nil
+}
+
+// NewRole creates menu items based on predefined roles
 func NewRole(role Role) *MenuItem {
 	var result *MenuItem
 	switch role {
@@ -240,221 +500,58 @@ func NewServicesMenu() *MenuItem {
 	return serviceMenu
 }
 
-func (m *MenuItem) handleClick() {
-	var ctx = newContext().
-		withClickedMenuItem(m).
-		withContextMenuData(m.contextMenuData)
-	if m.itemType == checkbox {
-		m.checked = !m.checked
-		ctx.withChecked(m.checked)
-		if m.impl != nil {
-			m.impl.setChecked(m.checked)
-		}
+// AsMenuItem is a helper function to cast MenuElementInterface back to *MenuItem
+// Returns nil if the element is not a MenuItem
+func AsMenuItem(element MenuElementInterface) *MenuItem {
+	if menuItem, ok := element.(*MenuItem); ok {
+		return menuItem
 	}
-	if m.itemType == radio {
-		for _, member := range m.radioGroupMembers {
-			member.checked = false
-			if member.impl != nil {
-				member.impl.setChecked(false)
-			}
-		}
-		m.checked = true
-		ctx.withChecked(true)
-		if m.impl != nil {
-			m.impl.setChecked(true)
-		}
-	}
-	if m.callback != nil {
-		go func() {
-			defer handlePanic()
-			m.callback(ctx)
-		}()
-	}
+	return nil
 }
 
-func (m *MenuItem) SetAccelerator(shortcut string) *MenuItem {
-	accelerator, err := parseAccelerator(shortcut)
-	if err != nil {
-		globalApplication.error("invalid accelerator: %w", err)
-		return m
+// AsMenu is a helper function to cast MenuElementInterface back to *Menu
+// Returns nil if the element is not a Menu
+func AsMenu(element MenuElementInterface) *Menu {
+	if menu, ok := element.(*Menu); ok {
+		return menu
 	}
-	m.accelerator = accelerator
-	if m.impl != nil {
-		m.impl.setAccelerator(accelerator)
-	}
+	return nil
+}
+
+// Convenience methods for MenuItem to allow fluent chaining while returning *MenuItem
+
+// SetLabelItem sets the label and returns *MenuItem for chaining
+func (m *MenuItem) SetLabelItem(label string) *MenuItem {
+	m.SetLabel(label)
 	return m
 }
 
-func (m *MenuItem) GetAccelerator() string {
-	if m.accelerator == nil {
-		return ""
-	}
-	return m.accelerator.String()
-}
-
-func (m *MenuItem) RemoveAccelerator() {
-	m.accelerator = nil
-}
-
-func (m *MenuItem) SetTooltip(s string) *MenuItem {
-	m.tooltip = s
-	if m.impl != nil {
-		m.impl.setTooltip(s)
-	}
+// SetEnabledItem sets the enabled state and returns *MenuItem for chaining
+func (m *MenuItem) SetEnabledItem(enabled bool) *MenuItem {
+	m.SetEnabled(enabled)
 	return m
 }
 
-func (m *MenuItem) SetRole(role Role) *MenuItem {
-	m.role = role
+// SetHiddenItem sets the hidden state and returns *MenuItem for chaining
+func (m *MenuItem) SetHiddenItem(hidden bool) *MenuItem {
+	m.SetHidden(hidden)
 	return m
 }
 
-func (m *MenuItem) SetLabel(s string) *MenuItem {
-	m.label = s
-	if m.impl != nil {
-		m.impl.setLabel(s)
-	}
-	// If this is a submenu, update the submenu's label as well
-	if m.itemType == submenu && m.submenu != nil {
-		m.submenu.label = s
-	}
+// OnClickItem sets the click callback and returns *MenuItem for chaining
+func (m *MenuItem) OnClickItem(callback func(*Context)) *MenuItem {
+	m.OnClick(callback)
 	return m
 }
 
-func (m *MenuItem) SetEnabled(enabled bool) *MenuItem {
-	m.disabled = !enabled
-	if m.impl != nil {
-		m.impl.setDisabled(m.disabled)
-	}
+// SetAcceleratorItem sets the accelerator and returns *MenuItem for chaining
+func (m *MenuItem) SetAcceleratorItem(shortcut string) *MenuItem {
+	m.SetAccelerator(shortcut)
 	return m
 }
 
-func (m *MenuItem) SetBitmap(bitmap []byte) *MenuItem {
-	m.bitmap = bitmap
-	if m.impl != nil {
-		m.impl.setBitmap(bitmap)
-	}
+// SetRoleItem sets the role and returns *MenuItem for chaining
+func (m *MenuItem) SetRoleItem(role Role) *MenuItem {
+	m.SetRole(role)
 	return m
-}
-
-func (m *MenuItem) SetChecked(checked bool) *MenuItem {
-	m.checked = checked
-	if m.impl != nil {
-		m.impl.setChecked(m.checked)
-	}
-	return m
-}
-
-func (m *MenuItem) SetHidden(hidden bool) *MenuItem {
-	m.hidden = hidden
-	if m.impl != nil {
-		m.impl.setHidden(m.hidden)
-	}
-	return m
-}
-
-// GetSubmenu returns the submenu of the MenuItem.
-// If the MenuItem is not a submenu, it returns nil.
-func (m *MenuItem) GetSubmenu() *Menu {
-	return m.submenu
-}
-
-func (m *MenuItem) Checked() bool {
-	return m.checked
-}
-
-func (m *MenuItem) IsSeparator() bool {
-	return m.itemType == separator
-}
-
-func (m *MenuItem) IsSubmenu() bool {
-	return m.itemType == submenu
-}
-
-func (m *MenuItem) IsCheckbox() bool {
-	return m.itemType == checkbox
-}
-
-func (m *MenuItem) IsRadio() bool {
-	return m.itemType == radio
-}
-
-func (m *MenuItem) Hidden() bool {
-	return m.hidden
-}
-
-func (m *MenuItem) OnClick(f func(*Context)) *MenuItem {
-	m.callback = f
-	return m
-}
-
-func (m *MenuItem) Label() string {
-	return m.label
-}
-
-func (m *MenuItem) Tooltip() string {
-	return m.tooltip
-}
-
-func (m *MenuItem) Enabled() bool {
-	return !m.disabled
-}
-
-func (m *MenuItem) setContextData(data *ContextMenuData) {
-	m.contextMenuData = data
-	if m.submenu != nil {
-		m.submenu.setContextData(data)
-	}
-}
-
-// Clone returns a deep copy of the MenuItem
-func (m *MenuItem) Clone() *MenuItem {
-	result := &MenuItem{
-		id:       m.id,
-		label:    m.label,
-		tooltip:  m.tooltip,
-		disabled: m.disabled,
-		checked:  m.checked,
-		hidden:   m.hidden,
-		bitmap:   m.bitmap,
-		callback: m.callback,
-		itemType: m.itemType,
-		role:     m.role,
-	}
-	if m.submenu != nil {
-		result.submenu = m.submenu.Clone()
-	}
-	if m.accelerator != nil {
-		result.accelerator = m.accelerator.clone()
-	}
-	if m.contextMenuData != nil {
-		result.contextMenuData = m.contextMenuData.clone()
-	}
-	return result
-}
-
-func (m *MenuItem) Destroy() {
-
-	removeMenuItemByID(m.id)
-
-	// Clean up resources
-	if m.impl != nil {
-		m.impl.destroy()
-	}
-	if m.submenu != nil {
-		m.submenu.Destroy()
-		m.submenu = nil
-	}
-
-	if m.contextMenuData != nil {
-		m.contextMenuData = nil
-	}
-
-	if m.accelerator != nil {
-		m.accelerator = nil
-	}
-
-	m.callback = nil
-	m.radioGroupMembers = nil
-
 }

--- a/v3/pkg/application/menuitem_dev.go
+++ b/v3/pkg/application/menuitem_dev.go
@@ -4,8 +4,8 @@ package application
 
 func NewOpenDevToolsMenuItem() *MenuItem {
 	return NewMenuItem("Open Developer Tools").
-		SetAccelerator("Alt+Command+I").
-		OnClick(func(ctx *Context) {
+		SetAcceleratorItem("Alt+Command+I").
+		OnClickItem(func(ctx *Context) {
 			currentWindow := globalApplication.CurrentWindow()
 			if currentWindow != nil {
 				currentWindow.OpenDevTools()

--- a/v3/pkg/application/menuitem_roles.go
+++ b/v3/pkg/application/menuitem_roles.go
@@ -13,14 +13,14 @@ func NewSpeechMenu() *MenuItem {
 
 func NewHideMenuItem() *MenuItem {
 	return NewMenuItem("Hide " + globalApplication.options.Name).
-		SetAccelerator("CmdOrCtrl+h").
-		SetRole(Hide)
+		SetAcceleratorItem("CmdOrCtrl+h").
+		SetRoleItem(Hide)
 }
 
 func NewHideOthersMenuItem() *MenuItem {
 	return NewMenuItem("Hide Others").
-		SetAccelerator("CmdOrCtrl+OptionOrAlt+h").
-		SetRole(HideOthers)
+		SetAcceleratorItem("CmdOrCtrl+OptionOrAlt+h").
+		SetRoleItem(HideOthers)
 }
 
 func NewFrontMenuItem() *MenuItem {
@@ -33,9 +33,9 @@ func NewUnhideMenuItem() *MenuItem {
 
 func NewUndoMenuItem() *MenuItem {
 	result := NewMenuItem("Undo").
-		SetAccelerator("CmdOrCtrl+z")
+		SetAcceleratorItem("CmdOrCtrl+z")
 	if runtime.GOOS != "darwin" {
-		result.OnClick(func(ctx *Context) {
+		result.OnClickItem(func(ctx *Context) {
 			currentWindow := globalApplication.CurrentWindow()
 			if currentWindow != nil {
 				currentWindow.undo()
@@ -48,9 +48,9 @@ func NewUndoMenuItem() *MenuItem {
 // NewRedoMenuItem creates a new menu item for redoing the last action
 func NewRedoMenuItem() *MenuItem {
 	result := NewMenuItem("Redo").
-		SetAccelerator("CmdOrCtrl+Shift+z")
+		SetAcceleratorItem("CmdOrCtrl+Shift+z")
 	if runtime.GOOS != "darwin" {
-		result.OnClick(func(ctx *Context) {
+		result.OnClickItem(func(ctx *Context) {
 			currentWindow := globalApplication.CurrentWindow()
 			if currentWindow != nil {
 				currentWindow.redo()
@@ -62,10 +62,10 @@ func NewRedoMenuItem() *MenuItem {
 
 func NewCutMenuItem() *MenuItem {
 	result := NewMenuItem("Cut").
-		SetAccelerator("CmdOrCtrl+x")
+		SetAcceleratorItem("CmdOrCtrl+x")
 
 	if runtime.GOOS != "darwin" {
-		result.OnClick(func(ctx *Context) {
+		result.OnClickItem(func(ctx *Context) {
 			currentWindow := globalApplication.CurrentWindow()
 			if currentWindow != nil {
 				currentWindow.cut()
@@ -77,10 +77,10 @@ func NewCutMenuItem() *MenuItem {
 
 func NewCopyMenuItem() *MenuItem {
 	result := NewMenuItem("Copy").
-		SetAccelerator("CmdOrCtrl+c")
+		SetAcceleratorItem("CmdOrCtrl+c")
 
 	if runtime.GOOS != "darwin" {
-		result.OnClick(func(ctx *Context) {
+		result.OnClickItem(func(ctx *Context) {
 			currentWindow := globalApplication.CurrentWindow()
 			if currentWindow != nil {
 				currentWindow.copy()
@@ -92,10 +92,10 @@ func NewCopyMenuItem() *MenuItem {
 
 func NewPasteMenuItem() *MenuItem {
 	result := NewMenuItem("Paste").
-		SetAccelerator("CmdOrCtrl+v")
+		SetAcceleratorItem("CmdOrCtrl+v")
 
 	if runtime.GOOS != "darwin" {
-		result.OnClick(func(ctx *Context) {
+		result.OnClickItem(func(ctx *Context) {
 			currentWindow := globalApplication.CurrentWindow()
 			if currentWindow != nil {
 				currentWindow.paste()
@@ -107,15 +107,15 @@ func NewPasteMenuItem() *MenuItem {
 
 func NewPasteAndMatchStyleMenuItem() *MenuItem {
 	return NewMenuItem("Paste and Match Style").
-		SetAccelerator("CmdOrCtrl+OptionOrAlt+Shift+v")
+		SetAcceleratorItem("CmdOrCtrl+OptionOrAlt+Shift+v")
 }
 
 func NewDeleteMenuItem() *MenuItem {
 	result := NewMenuItem("Delete").
-		SetAccelerator("backspace")
+		SetAcceleratorItem("backspace")
 
 	if runtime.GOOS != "darwin" {
-		result.OnClick(func(ctx *Context) {
+		result.OnClickItem(func(ctx *Context) {
 			currentWindow := globalApplication.CurrentWindow()
 			if currentWindow != nil {
 				currentWindow.delete()
@@ -133,18 +133,18 @@ func NewQuitMenuItem() *MenuItem {
 		}
 	}
 	return NewMenuItem(label).
-		SetAccelerator("CmdOrCtrl+q").
-		OnClick(func(ctx *Context) {
+		SetAcceleratorItem("CmdOrCtrl+q").
+		OnClickItem(func(ctx *Context) {
 			globalApplication.Quit()
 		})
 }
 
 func NewSelectAllMenuItem() *MenuItem {
 	result := NewMenuItem("Select All").
-		SetAccelerator("CmdOrCtrl+a")
+		SetAcceleratorItem("CmdOrCtrl+a")
 
 	if runtime.GOOS != "darwin" {
-		result.OnClick(func(ctx *Context) {
+		result.OnClickItem(func(ctx *Context) {
 			currentWindow := globalApplication.CurrentWindow()
 			if currentWindow != nil {
 				currentWindow.selectAll()
@@ -160,15 +160,15 @@ func NewAboutMenuItem() *MenuItem {
 		label += " " + globalApplication.options.Name
 	}
 	return NewMenuItem(label).
-		OnClick(func(ctx *Context) {
+		OnClickItem(func(ctx *Context) {
 			globalApplication.ShowAboutDialog()
 		})
 }
 
 func NewCloseMenuItem() *MenuItem {
 	return NewMenuItem("Close").
-		SetAccelerator("CmdOrCtrl+w").
-		OnClick(func(ctx *Context) {
+		SetAcceleratorItem("CmdOrCtrl+w").
+		OnClickItem(func(ctx *Context) {
 			currentWindow := globalApplication.CurrentWindow()
 			if currentWindow != nil {
 				currentWindow.Close()
@@ -178,8 +178,8 @@ func NewCloseMenuItem() *MenuItem {
 
 func NewReloadMenuItem() *MenuItem {
 	return NewMenuItem("Reload").
-		SetAccelerator("CmdOrCtrl+r").
-		OnClick(func(ctx *Context) {
+		SetAcceleratorItem("CmdOrCtrl+r").
+		OnClickItem(func(ctx *Context) {
 			currentWindow := globalApplication.CurrentWindow()
 			if currentWindow != nil {
 				currentWindow.Reload()
@@ -189,8 +189,8 @@ func NewReloadMenuItem() *MenuItem {
 
 func NewForceReloadMenuItem() *MenuItem {
 	return NewMenuItem("Force Reload").
-		SetAccelerator("CmdOrCtrl+Shift+r").
-		OnClick(func(ctx *Context) {
+		SetAcceleratorItem("CmdOrCtrl+Shift+r").
+		OnClickItem(func(ctx *Context) {
 			currentWindow := globalApplication.CurrentWindow()
 			if currentWindow != nil {
 				currentWindow.ForceReload()
@@ -200,15 +200,15 @@ func NewForceReloadMenuItem() *MenuItem {
 
 func NewToggleFullscreenMenuItem() *MenuItem {
 	result := NewMenuItem("Toggle Full Screen").
-		SetAccelerator("Ctrl+Command+F").
-		OnClick(func(ctx *Context) {
+		SetAcceleratorItem("Ctrl+Command+F").
+		OnClickItem(func(ctx *Context) {
 			currentWindow := globalApplication.CurrentWindow()
 			if currentWindow != nil {
 				currentWindow.ToggleFullscreen()
 			}
 		})
 	if runtime.GOOS != "darwin" {
-		result.SetAccelerator("F11")
+		result.SetAcceleratorItem("F11")
 	}
 	return result
 }
@@ -216,8 +216,8 @@ func NewToggleFullscreenMenuItem() *MenuItem {
 func NewZoomResetMenuItem() *MenuItem {
 	// reset zoom menu item
 	return NewMenuItem("Actual Size").
-		SetAccelerator("CmdOrCtrl+0").
-		OnClick(func(ctx *Context) {
+		SetAcceleratorItem("CmdOrCtrl+0").
+		OnClickItem(func(ctx *Context) {
 			currentWindow := globalApplication.CurrentWindow()
 			if currentWindow != nil {
 				currentWindow.ZoomReset()
@@ -227,8 +227,8 @@ func NewZoomResetMenuItem() *MenuItem {
 
 func NewZoomInMenuItem() *MenuItem {
 	return NewMenuItem("Zoom In").
-		SetAccelerator("CmdOrCtrl+plus").
-		OnClick(func(ctx *Context) {
+		SetAcceleratorItem("CmdOrCtrl+plus").
+		OnClickItem(func(ctx *Context) {
 			currentWindow := globalApplication.CurrentWindow()
 			if currentWindow != nil {
 				currentWindow.ZoomIn()
@@ -238,8 +238,8 @@ func NewZoomInMenuItem() *MenuItem {
 
 func NewZoomOutMenuItem() *MenuItem {
 	return NewMenuItem("Zoom Out").
-		SetAccelerator("CmdOrCtrl+-").
-		OnClick(func(ctx *Context) {
+		SetAcceleratorItem("CmdOrCtrl+-").
+		OnClickItem(func(ctx *Context) {
 			currentWindow := globalApplication.CurrentWindow()
 			if currentWindow != nil {
 				currentWindow.ZoomOut()
@@ -249,8 +249,8 @@ func NewZoomOutMenuItem() *MenuItem {
 
 func NewMinimiseMenuItem() *MenuItem {
 	return NewMenuItem("Minimize").
-		SetAccelerator("CmdOrCtrl+M").
-		OnClick(func(ctx *Context) {
+		SetAcceleratorItem("CmdOrCtrl+M").
+		OnClickItem(func(ctx *Context) {
 			currentWindow := globalApplication.CurrentWindow()
 			if currentWindow != nil {
 				currentWindow.Minimise()
@@ -260,7 +260,7 @@ func NewMinimiseMenuItem() *MenuItem {
 
 func NewZoomMenuItem() *MenuItem {
 	return NewMenuItem("Zoom").
-		OnClick(func(ctx *Context) {
+		OnClickItem(func(ctx *Context) {
 			currentWindow := globalApplication.CurrentWindow()
 			if currentWindow != nil {
 				currentWindow.Zoom()
@@ -270,7 +270,7 @@ func NewZoomMenuItem() *MenuItem {
 
 func NewFullScreenMenuItem() *MenuItem {
 	return NewMenuItem("Fullscreen").
-		OnClick(func(ctx *Context) {
+		OnClickItem(func(ctx *Context) {
 			currentWindow := globalApplication.CurrentWindow()
 			if currentWindow != nil {
 				currentWindow.Fullscreen()
@@ -280,12 +280,12 @@ func NewFullScreenMenuItem() *MenuItem {
 
 func NewPrintMenuItem() *MenuItem {
 	return NewMenuItem("Print").
-		SetAccelerator("CmdOrCtrl+p")
+		SetAcceleratorItem("CmdOrCtrl+p")
 }
 
 func NewPageLayoutMenuItem() *MenuItem {
 	return NewMenuItem("Page Setup...").
-		SetAccelerator("CmdOrCtrl+Shift+p")
+		SetAcceleratorItem("CmdOrCtrl+Shift+p")
 }
 
 func NewShowAllMenuItem() *MenuItem {
@@ -298,61 +298,61 @@ func NewBringAllToFrontMenuItem() *MenuItem {
 
 func NewNewFileMenuItem() *MenuItem {
 	return NewMenuItem("New File").
-		SetAccelerator("CmdOrCtrl+n")
+		SetAcceleratorItem("CmdOrCtrl+n")
 }
 
 func NewOpenMenuItem() *MenuItem {
 	return NewMenuItem("Open...").
-		SetAccelerator("CmdOrCtrl+o").
-		SetRole(Open)
+		SetAcceleratorItem("CmdOrCtrl+o").
+		SetRoleItem(Open)
 }
 
 func NewSaveMenuItem() *MenuItem {
 	return NewMenuItem("Save").
-		SetAccelerator("CmdOrCtrl+s")
+		SetAcceleratorItem("CmdOrCtrl+s")
 }
 
 func NewSaveAsMenuItem() *MenuItem {
 	return NewMenuItem("Save As...").
-		SetAccelerator("CmdOrCtrl+Shift+s")
+		SetAcceleratorItem("CmdOrCtrl+Shift+s")
 }
 
 func NewStartSpeakingMenuItem() *MenuItem {
 	return NewMenuItem("Start Speaking").
-		SetAccelerator("CmdOrCtrl+OptionOrAlt+Shift+.")
+		SetAcceleratorItem("CmdOrCtrl+OptionOrAlt+Shift+.")
 }
 
 func NewStopSpeakingMenuItem() *MenuItem {
 	return NewMenuItem("Stop Speaking").
-		SetAccelerator("CmdOrCtrl+OptionOrAlt+Shift+,")
+		SetAcceleratorItem("CmdOrCtrl+OptionOrAlt+Shift+,")
 }
 
 func NewRevertMenuItem() *MenuItem {
 	return NewMenuItem("Revert").
-		SetAccelerator("CmdOrCtrl+r")
+		SetAcceleratorItem("CmdOrCtrl+r")
 }
 
 func NewFindMenuItem() *MenuItem {
 	return NewMenuItem("Find...").
-		SetAccelerator("CmdOrCtrl+f")
+		SetAcceleratorItem("CmdOrCtrl+f")
 }
 
 func NewFindAndReplaceMenuItem() *MenuItem {
 	return NewMenuItem("Find and Replace...").
-		SetAccelerator("CmdOrCtrl+Shift+f")
+		SetAcceleratorItem("CmdOrCtrl+Shift+f")
 }
 
 func NewFindNextMenuItem() *MenuItem {
 	return NewMenuItem("Find Next").
-		SetAccelerator("CmdOrCtrl+g")
+		SetAcceleratorItem("CmdOrCtrl+g")
 }
 
 func NewFindPreviousMenuItem() *MenuItem {
 	return NewMenuItem("Find Previous").
-		SetAccelerator("CmdOrCtrl+Shift+g")
+		SetAcceleratorItem("CmdOrCtrl+Shift+g")
 }
 
 func NewHelpMenuItem() *MenuItem {
 	return NewMenuItem("Help").
-		SetAccelerator("CmdOrCtrl+?")
+		SetAcceleratorItem("CmdOrCtrl+?")
 }

--- a/v3/pkg/application/menuitem_test.go
+++ b/v3/pkg/application/menuitem_test.go
@@ -14,7 +14,7 @@ func TestMenuItem_GetAccelerator(t *testing.T) {
 	}{
 		{
 			name:        "Get existing accelerator",
-			menuItem:    application.NewMenuItem("Item 1").SetAccelerator("ctrl+a"),
+			menuItem:    application.NewMenuItem("Item 1").SetAcceleratorItem("ctrl+a"),
 			expectedAcc: "Ctrl+A",
 		},
 		{
@@ -41,7 +41,7 @@ func TestMenuItem_RemoveAccelerator(t *testing.T) {
 	}{
 		{
 			name:     "Remove existing accelerator",
-			menuItem: application.NewMenuItem("Item 1").SetAccelerator("Ctrl+A"),
+			menuItem: application.NewMenuItem("Item 1").SetAcceleratorItem("Ctrl+A"),
 		},
 		{
 			name:     "Remove non-existing accelerator",


### PR DESCRIPTION
Fixes infinite loop on startup and fixes example to match changes to API



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a unified interface for menu elements, enabling consistent handling of menus and menu items with unique IDs and global registration.
	- Added advanced menu element management methods for insertion, removal, lookup, cloning, and recursive updates.
	- Extended menu items with unique IDs, parent references, and fluent API methods for improved customization and lifecycle management.

- **Bug Fixes**
	- Improved submenu label updates to ensure changes are only applied when necessary, with better error handling and status messages.
	- Enhanced application menu setup on macOS to ensure menus are fully initialized before being set, with added error reporting for unexpected states.

- **Refactor**
	- Refined native menu construction on macOS to differentiate submenu and item processing, improving platform-specific menu handling.
	- Updated method calls on menu items to use new fluent chaining methods for accelerators, roles, and click handlers, ensuring API consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->