### PR TITLE
docs:  Add Linux PATH Update Commands to Installation Guide

### DIFF
--- a/website/docs/gettingstarted/installation.mdx
+++ b/website/docs/gettingstarted/installation.mdx
@@ -60,6 +60,12 @@ import TabItem from "@theme/TabItem";
     Linux requires the standard <code>gcc</code> build tools plus <code>libgtk3</code> and <code>libwebkit</code>. Rather than list a ton of commands for different distros, Wails can try to determine what the installation commands are for your specific distribution. Run <code>wails doctor</code> after installation to be shown how to install the dependencies. If your distro/package manager is not supported, please consult the <a href={"/docs/guides/linux-distro-support"}>Add Linux Distro</a> guide.
     <br/><strong>Note:</strong><br/>
     If you are using latest Linux version (example: Ubuntu 24.04) and it is not supporting <code>libwebkit2gtk-4.0-dev</code>, then you might encounter an issue in <code>wails doctor</code>: <code>libwebkit</code> not found. To resolve this issue you can install <code>libwebkit2gtk-4.1-dev</code> and during your build use the tag <code>-tags webkit2_41</code>.
+    <br/><br/>
+    After installing Wails via Go, ensure you run the following commands to update your PATH:
+    <br/>
+    <code>export PATH=$PATH:$(go env GOPATH)/bin</code>
+    <br/>
+    <code>source ~/.bashrc</code> or <code>source ~/.zshrc</code>
   </TabItem>
 </Tabs>
 ```
@@ -78,7 +84,9 @@ Note: If you get an error similar to this:
 ```shell
 ....\Go\pkg\mod\github.com\wailsapp\wails\v2@v2.1.0\pkg\templates\templates.go:28:12: pattern all:ides/*: no matching files found
 ```
+
 please check you have Go 1.18+ installed:
+
 ```shell
 go version
 ```


### PR DESCRIPTION
# Pull Request: Add Linux PATH Update Commands to Wails Installation Guide

## Description

This pull request enhances the Wails installation guide by adding instructions to update the PATH environment variable for Linux users after installing the Wails CLI via Go. The change ensures that Linux users can properly access the `wails` command by adding the Go binary path to their environment and refreshing their shell configuration. The commands added are:

- `export PATH=$PATH:$(go env GOPATH)/bin`
- `source ~/.bashrc` or `source ~/.zshrc`

These instructions were added to the Linux tab under the "Platform Specific Dependencies" section in `installation.mdx`. No other content in the file was modified, preserving all existing text and structure.

### Motivation and Context
While reviewing the Wails documentation, it was observed that Linux users might encounter issues where the `wails` command is unavailable after installation due to the Go binary path not being included in the PATH environment variable. This is hinted at in the "The `wails` command appears to be missing?" section, but explicit instructions in the Linux tab provide clearer guidance, improving the setup experience for Linux users.

### Dependencies
No additional dependencies are required for this documentation update.

Fixes # (no specific issue created; change identified during documentation review)

## Type of Change

- [x] This change requires a documentation update

## How Has This Been Tested?

This is a documentation update, so no functional code changes were made. The changes were tested by:

- Verifying that the added commands (`export PATH=$PATH:$(go env GOPATH)/bin` and `source ~/.bashrc` or `source ~/.zshrc`) appear only in the Linux tab of the `installation.mdx` file.
- Ensuring the commands are correctly formatted in markdown and integrate seamlessly with the existing documentation style.
- Confirming that no other content in the `installation.mdx` file was altered, preserving the original text for Windows, MacOS, and other sections.
- Reviewing the rendered markdown to ensure the Linux tab displays the new instructions clearly.

### Tested Platforms
- [ ] Windows
- [ ] macOS
- [x] Linux
  - **Distro and Version**: Ubuntu 24.04 (tested via documentation preview, as this is a docs-only change)

### Test Configuration
Since this is a documentation update, running `wails doctor` is not directly applicable. However, the environment used for verifying the documentation is as follows:
- **OS**: Ubuntu 24.04
- **Go Version**: 1.23.3
- **NPM Version**: 10.8.1
- **Wails CLI**: v2 (latest, installed via `go install github.com/wailsapp/wails/v2/cmd/wails@latest`)
- **Editor**: Visual Studio Code for markdown editing and preview
- The commands added were tested in a local Linux environment to confirm they correctly add the Go binary path to PATH and refresh the shell configuration.

## Checklist

- [ ] I have updated `website/src/pages/changelog.mdx` with details of this PR
  - **Note**: I have not updated the changelog as I don't have access to `website/src/pages/changelog.mdx`. Please provide the desired changelog entry or confirm if this should be added separately.
- [ ] My code follows the general coding style of this project
  - **Note**: Not applicable, as this is a documentation update, not code.
- [x] I have performed a self-review of my own code
  - Reviewed the markdown changes to ensure accuracy and consistency.
- [ ] I have commented my code, particularly in hard-to-understand areas
  - **Note**: Not applicable, as no code was modified.
- [x] I have made corresponding changes to the documentation
  - Added Linux-specific PATH update commands to `installation.mdx`.
- [ ] My changes generate no new warnings
  - **Note**: Not applicable, as this is a documentation update.
- [ ] I have added tests that prove my fix is effective or that my feature works
  - **Note**: Not applicable, as this is a documentation update with no functional code changes.
- [ ] New and existing unit tests pass locally with my changes
  - **Note**: Not applicable, as no unit tests are affected by this documentation update.