### PR TITLE
fix: Add Windows UAC execution level support to manifest template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,4 +38,7 @@ v2/cmd/wails/internal/commands/initialise/templates/testtemplates/
 /v3/examples/plugins/bin/testapp
 
 # Temporary called mkdocs, should be renamed to more standard -website or similar
+/docs/site
+.aider*
+/.claude/
 /mkdocs-website/site

--- a/v2/internal/project/project.go
+++ b/v2/internal/project/project.go
@@ -221,6 +221,11 @@ type Info struct {
 	Comments         *string           `json:"comments"`
 	FileAssociations []FileAssociation `json:"fileAssociations"`
 	Protocols        []Protocol        `json:"protocols"`
+	Windows          *WindowsInfo      `json:"windows,omitempty"`
+}
+
+type WindowsInfo struct {
+	ExecutionLevel string `json:"executionLevel,omitempty"`
 }
 
 type FileAssociation struct {

--- a/v2/pkg/buildassets/build/windows/wails.exe.manifest
+++ b/v2/pkg/buildassets/build/windows/wails.exe.manifest
@@ -12,4 +12,13 @@
             <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">permonitorv2,permonitor</dpiAwareness> <!-- falls back to per-monitor if per-monitor v2 is not supported -->
         </asmv3:windowsSettings>
     </asmv3:application>
+    {{- if .ExecutionLevel}}
+    <trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
+        <security>
+            <requestedPrivileges>
+                <requestedExecutionLevel level="{{.ExecutionLevel}}" uiAccess="false" />
+            </requestedPrivileges>
+        </security>
+    </trustInfo>
+    {{- end}}
 </assembly>

--- a/v2/pkg/buildassets/buildassets.go
+++ b/v2/pkg/buildassets/buildassets.go
@@ -105,6 +105,7 @@ type assetData struct {
 	Name           string
 	Info           project.Info
 	OutputFilename string
+	ExecutionLevel string
 }
 
 func resolveProjectData(content []byte, projectData *project.Project) ([]byte, error) {
@@ -113,10 +114,17 @@ func resolveProjectData(content []byte, projectData *project.Project) ([]byte, e
 		return nil, err
 	}
 
+	// Extract Windows execution level if specified
+	executionLevel := ""
+	if projectData.Info.Windows != nil && projectData.Info.Windows.ExecutionLevel != "" {
+		executionLevel = projectData.Info.Windows.ExecutionLevel
+	}
+
 	data := &assetData{
 		Name:           projectData.Name,
 		Info:           projectData.Info,
 		OutputFilename: projectData.OutputFilename,
+		ExecutionLevel: executionLevel,
 	}
 
 	var out bytes.Buffer

--- a/website/docs/guides/windows.mdx
+++ b/website/docs/guides/windows.mdx
@@ -75,3 +75,59 @@ cmd.Start()
 
 Solution provided by [sithembiso](https://github.com/sithembiso) on the
 [discussions board](https://github.com/wailsapp/wails/discussions/1734#discussioncomment-3386172).
+
+## UAC Execution Level
+
+Windows applications can request specific User Account Control (UAC) execution levels through the application manifest. Wails supports configuring UAC execution levels that will persist when your application is distributed to other machines.
+
+### Configuring Execution Level
+
+You can configure the UAC execution level in your `wails.json` project configuration:
+
+```json
+{
+  "info": {
+    "companyName": "My Company",
+    "productName": "My App",
+    "productVersion": "1.0.0",
+    "windows": {
+      "executionLevel": "requireAdministrator"
+    }
+  }
+}
+```
+
+### Supported Execution Levels
+
+| Level | Description |
+|-------|-------------|
+| `requireAdministrator` | The application requires administrator privileges and will prompt for elevation |
+| `highestAvailable` | The application runs with the highest privileges available to the user |
+| `asInvoker` | The application runs with the same privileges as the calling process (default behavior) |
+
+### Example: Admin-Required Application
+
+For applications that need administrator privileges (e.g., system utilities, installers):
+
+```json
+{
+  "name": "SystemTool",
+  "info": {
+    "companyName": "My Company",
+    "productName": "System Administration Tool",
+    "productVersion": "1.0.0",
+    "windows": {
+      "executionLevel": "requireAdministrator"
+    }
+  }
+}
+```
+
+When built, this application will:
+- Display a UAC prompt when launched on Windows
+- Request administrator privileges before starting
+- Persist this behavior when copied to other machines
+
+### Backward Compatibility
+
+If no `executionLevel` is specified, no UAC requirements are added to the manifest, maintaining the default Windows behavior where applications run with the same privileges as the launching process.

--- a/website/docs/reference/project-config.mdx
+++ b/website/docs/reference/project-config.mdx
@@ -99,7 +99,12 @@ The project config resides in the `wails.json` file in the project directory. Th
         // macOS-only. The app’s role with respect to the type. Corresponds to CFBundleTypeRole.
         "role": "Editor"
       }
-    ]
+    ],
+    // Windows-specific configuration
+    "windows": {
+      // UAC execution level for Windows applications. Valid values: "requireAdministrator", "highestAvailable", "asInvoker"
+      "executionLevel": ""
+    }
   },
   // 'multiple': One installer per architecture. 'single': Single universal installer for all architectures being built. Default: 'multiple'
   "nsisType": "",


### PR DESCRIPTION
## Summary

Fixes #4349: Windows admin permissions not persisting between machines

This PR adds configurable UAC (User Account Control) execution level support to the Windows manifest template, allowing developers to specify admin requirements that persist when executables are distributed to other machines.

## Problem Solved

Users building Wails applications with admin privileges using custom manifest files reported that:
- Admin requirements worked on the build machine
- Admin requirements were lost when copying executables to other machines  
- Using rsrc tool directly resulted in "too many .rsrc sections" errors

## Root Cause

The default Wails manifest template didn't include UAC configuration options, and users trying to add their own resource files conflicted with Wails' resource embedding process.

## Solution

### ✅ Enhanced Windows Manifest Template
- Added conditional UAC `trustInfo` section using `{{.ExecutionLevel}}` template variable
- Backward compatible: no UAC section when execution level not specified
- Proper XML structure following Microsoft UAC manifest specifications

### ✅ Project Configuration Support  
- Added `WindowsInfo` struct to project configuration (`v2/internal/project/project.go`)
- Added `executionLevel` field for specifying UAC requirements
- Integrated into existing template data processing pipeline

### ✅ Template Data Enhancement
- Extended `assetData` struct to include execution level field
- Updated template resolution to extract Windows-specific configuration
- Maintained full backward compatibility with existing projects

### ✅ Comprehensive Documentation
- Added Windows UAC guide with practical examples (`website/docs/guides/windows.mdx`)
- Updated project configuration reference (`website/docs/reference/project-config.mdx`) 
- Included usage examples for all supported execution levels

## Usage

Developers can now configure UAC execution level in `wails.json`:

```json
{
  "info": {
    "companyName": "My Company", 
    "productName": "My App",
    "productVersion": "1.0.0",
    "windows": {
      "executionLevel": "requireAdministrator"
    }
  }
}
```

### Supported Execution Levels

| Level | Description |
|-------|-------------|
| `requireAdministrator` | Requires admin privileges, shows UAC prompt |
| `highestAvailable` | Runs with highest available user privileges |
| `asInvoker` | Runs with same privileges as calling process |

## Testing

### ✅ Verification Completed
- Built Windows executable with `requireAdministrator` setting
- Extracted resources using `go-winres extract` tool
- **Confirmed UAC `trustInfo` section properly embedded in executable**
- **Verified `requestedExecutionLevel level="requireAdministrator"` present in manifest**
- Tested backward compatibility with projects without execution level specified

### Resource Extraction Results
```xml
<trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
  <security>
    <requestedPrivileges>
      <requestedExecutionLevel level="requireAdministrator" uiAccess="false"/>
    </requestedPrivileges>
  </security>
</trustInfo>
```

## Files Changed

- `v2/internal/project/project.go` - Added Windows configuration struct
- `v2/pkg/buildassets/build/windows/wails.exe.manifest` - Enhanced template with UAC support
- `v2/pkg/buildassets/buildassets.go` - Updated template data processing
- `website/docs/guides/windows.mdx` - Added comprehensive UAC guide
- `website/docs/reference/project-config.mdx` - Updated configuration reference

## Backward Compatibility

✅ **Fully backward compatible** - existing projects continue to work unchanged
✅ **No breaking changes** - UAC section only added when explicitly configured
✅ **Default behavior preserved** - applications run with invoker privileges when not specified

## Impact

- **Resolves persistent admin permissions issue** affecting Windows developers
- **Eliminates "too many .rsrc sections" errors** from manual rsrc tool usage
- **Provides clean, documented approach** for Windows privilege configuration
- **Maintains Wails' ease-of-use philosophy** with simple JSON configuration

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>