### PR TITLE
feat: Add runtime devtools API with -runtimedevtools flag

### DIFF
--- a/v2/cmd/wails/build.go
+++ b/v2/cmd/wails/build.go
@@ -67,6 +67,7 @@ func buildApplication(f *flags.Build) error {
 		CleanBinDirectory: f.Clean,
 		Mode:              f.GetBuildMode(),
 		Devtools:          f.Debug || f.Devtools,
+		RuntimeDevtools:   f.RuntimeDevtools,
 		Pack:              !f.NoPackage,
 		LDFlags:           f.LdFlags,
 		Compiler:          f.Compiler,

--- a/v2/cmd/wails/flags/build.go
+++ b/v2/cmd/wails/flags/build.go
@@ -35,6 +35,7 @@ type Build struct {
 	UpdateWailsVersionGoMod bool   `name:"u" description:"Updates go.mod to use the same Wails version as the CLI"`
 	Debug                   bool   `description:"Builds the application in debug mode"`
 	Devtools                bool   `description:"Enable Devtools in productions, Already enabled in debug mode (-debug)"`
+	RuntimeDevtools         bool   `description:"Enable runtime devtools API support (allows programmatic opening of devtools)"`
 	NSIS                    bool   `description:"Generate NSIS installer for Windows"`
 	TrimPath                bool   `description:"Remove all file system paths from the resulting executable"`
 	WindowsConsole          bool   `description:"Keep the console when building for Windows"`

--- a/v2/internal/frontend/desktop/darwin/devtools_not_runtimedevtools.go
+++ b/v2/internal/frontend/desktop/darwin/devtools_not_runtimedevtools.go
@@ -1,0 +1,7 @@
+//go:build darwin && !runtimedevtools
+
+package darwin
+
+func (f *Frontend) OpenDevTools() {
+	// Runtime devtools not enabled - this method does nothing
+}

--- a/v2/internal/frontend/desktop/darwin/devtools_runtimedevtools.go
+++ b/v2/internal/frontend/desktop/darwin/devtools_runtimedevtools.go
@@ -1,0 +1,7 @@
+//go:build darwin && runtimedevtools
+
+package darwin
+
+func (f *Frontend) OpenDevTools() {
+	showInspector(f.mainWindow.context)
+}

--- a/v2/internal/frontend/desktop/linux/devtools_not_runtimedevtools.go
+++ b/v2/internal/frontend/desktop/linux/devtools_not_runtimedevtools.go
@@ -1,0 +1,7 @@
+//go:build !runtimedevtools
+
+package linux
+
+func (f *Frontend) OpenDevTools() {
+	// Runtime devtools not enabled - this method does nothing
+}

--- a/v2/internal/frontend/desktop/linux/devtools_runtimedevtools.go
+++ b/v2/internal/frontend/desktop/linux/devtools_runtimedevtools.go
@@ -1,0 +1,15 @@
+//go:build runtimedevtools
+
+package linux
+
+/*
+#include "gtk/gtk.h"
+#include <webkit2/webkit2.h>
+
+void ShowInspector(void *webview);
+*/
+import "C"
+
+func (f *Frontend) OpenDevTools() {
+	C.ShowInspector(f.mainWindow.webView)
+}

--- a/v2/internal/frontend/desktop/windows/devtools_not_runtimedevtools.go
+++ b/v2/internal/frontend/desktop/windows/devtools_not_runtimedevtools.go
@@ -1,0 +1,7 @@
+//go:build !runtimedevtools
+
+package windows
+
+func (f *Frontend) OpenDevTools() {
+	// Runtime devtools not enabled - this method does nothing
+}

--- a/v2/internal/frontend/desktop/windows/devtools_runtimedevtools.go
+++ b/v2/internal/frontend/desktop/windows/devtools_runtimedevtools.go
@@ -1,0 +1,7 @@
+//go:build runtimedevtools
+
+package windows
+
+func (f *Frontend) OpenDevTools() {
+	f.chromium.OpenDevToolsWindow()
+}

--- a/v2/internal/frontend/frontend.go
+++ b/v2/internal/frontend/frontend.go
@@ -139,4 +139,7 @@ type Frontend interface {
 	// Clipboard
 	ClipboardGetText() (string, error)
 	ClipboardSetText(text string) error
+
+	// DevTools
+	OpenDevTools()
 }

--- a/v2/pkg/commands/build/base.go
+++ b/v2/pkg/commands/build/base.go
@@ -235,6 +235,11 @@ func (b *BaseBuilder) CompileProject(options *Options) error {
 		tags.Add("devtools")
 	}
 
+	// This option allows you to enable runtime devtools API support
+	if options.RuntimeDevtools {
+		tags.Add("runtimedevtools")
+	}
+
 	if options.Obfuscated {
 		tags.Add("obfuscated")
 	}

--- a/v2/pkg/commands/build/build.go
+++ b/v2/pkg/commands/build/build.go
@@ -42,6 +42,7 @@ type Options struct {
 	OutputType        string               // EG: desktop, server....
 	Mode              Mode                 // release or dev
 	Devtools          bool                 // Enable devtools in production
+	RuntimeDevtools   bool                 // Enable runtime devtools API support
 	ProjectData       *project.Project     // The project data
 	Pack              bool                 // Create a package for the app after building
 	Platform          string               // The platform to build for

--- a/v2/pkg/runtime/devtools.go
+++ b/v2/pkg/runtime/devtools.go
@@ -1,0 +1,16 @@
+package runtime
+
+import (
+	"context"
+)
+
+// OpenDevTools opens the developer tools window if runtime devtools support is enabled.
+// This function only works when the application is built with the -runtimedevtools flag.
+// On platforms where devtools cannot be opened programmatically (e.g., macOS in production),
+// this function will do nothing.
+func OpenDevTools(ctx context.Context) {
+	appFrontend := getFrontend(ctx)
+	if appFrontend != nil {
+		appFrontend.OpenDevTools()
+	}
+}

--- a/website/src/pages/changelog.mdx
+++ b/website/src/pages/changelog.mdx
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added "Branding" section to `wails doctor` to correctly identify Windows 11 [#3891](https://github.com/wailsapp/wails/pull/3891) by [@ronen25](https://github.com/ronen25)
 - Added `-skipembedcreate` flag to build and dev command to improve compile and recompile speed [#4143](https://github.com/wailsapp/wails/pull/4143) by @josStorer
 - Added `DisablePanicRecovery` option to allow handle panics manually [#4136](https://github.com/wailsapp/wails/pull/4136) by [@APshenkin](https://github.com/APshenkin)
+- Added `-runtimedevtools` flag and `runtime.OpenDevTools()` API for programmatic devtools access [#2740](https://github.com/wailsapp/wails/issues/2740)
 
 ### Fixed
 - Fixed build fails when cross compiling on Linux for Windows [#4262](https://github.com/wailsapp/wails/issues/4262) by [@rynsf](https://github.com/rynsf)


### PR DESCRIPTION
## Summary

Adds programmatic devtools access via new `-runtimedevtools` build flag and `runtime.OpenDevTools()` API.

## Resolves

Closes #2740

## Key Features

- **New CLI flag**: `wails build -runtimedevtools` enables runtime devtools support
- **Runtime API**: `runtime.OpenDevTools(ctx)` for programmatic devtools access  
- **Cross-platform**: Works on Windows, Linux, and macOS
- **Zero overhead**: Code excluded by default unless flag is used

## Usage

```bash
wails build -runtimedevtools    # Enable support
```

```go
import "github.com/wailsapp/wails/v2/pkg/runtime"

func openDevtools(ctx context.Context) {
    runtime.OpenDevTools(ctx)   // Open devtools programmatically
}
```

## Implementation

Uses build tags for conditional compilation - runtime devtools code is only included when explicitly enabled via the `-runtimedevtools` flag.

🤖 Generated with [Claude Code](https://claude.ai/code)