### PR TITLE
Add new template wails-template-svelte-ts-less-prettier-eslint-vite

### DIFF
--- a/website/docs/community/templates.mdx
+++ b/website/docs/community/templates.mdx
@@ -54,6 +54,7 @@ If you are unsure about a template, inspect `package.json` and `wails.json` for 
 - [wails-vite-svelte-tailwind-template](https://github.com/BillBuilt/wails-vite-svelte-tailwind-template) - A template using Svelte and Vite with TailwindCSS v3
 - [wails-svelte-tailwind-vite-template](https://github.com/PylotLight/wails-vite-svelte-tailwind-template/tree/master) - An updated template using Svelte v4.2.0 and Vite with TailwindCSS v3.3.3
 - [wails-sveltekit-template](https://github.com/h8gi/wails-sveltekit-template) - A template using SvelteKit
+- [wails-template-svelte-ts-less-prettier-eslint-vite](https://github.com/Alex6357/wails-template-svelte-ts-less-prettier-eslint-vite) - A template using Svelte5 + TypeScript + less + Prettier + ESlint + Vite
 
 ## Solid
 


### PR DESCRIPTION
Add new template using Svelte 5 + TypeScript + less + Prettier + ESLint + Vite.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new Svelte template, "wails-template-svelte-ts-less-prettier-eslint-vite", to the community templates list with details and repository link.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->