### PR TITLE
Add new template wails-template-sveltekit-less-prettier-eslint

### DIFF
--- a/website/docs/community/templates.mdx
+++ b/website/docs/community/templates.mdx
@@ -54,6 +54,7 @@ If you are unsure about a template, inspect `package.json` and `wails.json` for 
 - [wails-vite-svelte-tailwind-template](https://github.com/BillBuilt/wails-vite-svelte-tailwind-template) - A template using Svelte and Vite with TailwindCSS v3
 - [wails-svelte-tailwind-vite-template](https://github.com/PylotLight/wails-vite-svelte-tailwind-template/tree/master) - An updated template using Svelte v4.2.0 and Vite with TailwindCSS v3.3.3
 - [wails-sveltekit-template](https://github.com/h8gi/wails-sveltekit-template) - A template using SvelteKit
+- [wails-template-sveltekit-less-prettier-eslint](https://github.com/Alex6357/wails-template-sveltekit-less-prettier-eslint) - A template using SvelteKit with less, Prettier and ESlint
 
 ## Solid
 


### PR DESCRIPTION
Add new template using SvelteKit with less, Prettier and ESlint.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new SvelteKit-based template to the community templates list, featuring Less, Prettier, and ESLint integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->