### PR TITLE
[v3] Fix WindowUnMinised event not fired when the window was Maxmised on Windows platform.

### DIFF
--- a/v3/UNRELEASED_CHANGELOG.md
+++ b/v3/UNRELEASED_CHANGELOG.md
@@ -48,6 +48,7 @@ After processing, the content will be moved to the main changelog and this file 
 **Fixed:**
 - Fix memory leak in event system during window close operations (#5678)
 - Fix crash when using context menus on Linux with Wayland
+- Fix WindowUnMinised event not fired when the window was Maxmised on Windows.
 
 **Security:**
 - Update dependencies to address CVE-2024-12345 in third-party library

--- a/v3/UNRELEASED_CHANGELOG.md
+++ b/v3/UNRELEASED_CHANGELOG.md
@@ -48,7 +48,7 @@ After processing, the content will be moved to the main changelog and this file 
 **Fixed:**
 - Fix memory leak in event system during window close operations (#5678)
 - Fix crash when using context menus on Linux with Wayland
-- Fix WindowUnMinised event not fired when the window was Maxmised on Windows.
+- Fix WindowUnMinimised event not fired when the window was Maximised on Windows.
 
 **Security:**
 - Update dependencies to address CVE-2024-12345 in third-party library

--- a/v3/pkg/application/webview_window_windows.go
+++ b/v3/pkg/application/webview_window_windows.go
@@ -1485,6 +1485,10 @@ func (w *windowsWebviewWindow) WndProc(msg uint32, wparam, lparam uintptr) uintp
 	case w32.WM_SIZE:
 		switch wparam {
 		case w32.SIZE_MAXIMIZED:
+			if w.isMinimizing {
+				w.parent.emit(events.Windows.WindowUnMinimise)
+			}
+			w.isMinimizing = false
 			w.parent.emit(events.Windows.WindowMaximise)
 			// Force complete redraw when maximized
 			if w.menu != nil && w.menubarTheme != nil {


### PR DESCRIPTION
<!--

*********************************************************************
*               PLEASE READ BEFORE SUBMITTING YOUR PR               *
*     YOUR PR MAY BE REJECTED IF IT DOES NOT FOLLOW THESE STEPS     *
*********************************************************************

- *DO NOT* submit PRs for v3 alpha enhancements, unless you have opened a post on the discord channel.
  All enhancements must be discussed first.
  The feedback guide for v3 is here: https://v3alpha.wails.io/getting-started/feedback/

- Before submitting your PR, please ensure you have created and linked the PR to an issue.
- If a relevant issue already exists, please reference it in your PR by including `Fixes #<issue number>` in your PR description.
- Please fill in the checklists.

-->

# Description

WindowUnMinised event not fired when the window was Maxmised it only fires if the Window state was Normal.

## Type of change
  
Please select the option that is relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
  
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration using `wails doctor`.

- [x] Windows
- [ ] macOS
- [ ] Linux
      
If you checked Linux, please specify the distro and version.
  
## Test Configuration

Please paste the output of `wails doctor`. If you are unable to run this command, please describe your environment in as much detail as possible.

```sh
 Wails (v3.0.0-alpha.19)  Wails Doctor

# System

┌───────────────────────────────────────────────────────────────────────────────────────────────┐
| Name              | Windows 10 Pro                                                            |
| Version           | 2009 (Build: 26100)                                                       |
| ID                | 24H2                                                                      |
| Branding          | Windows 11 Pro                                                            |
| Platform          | windows                                                                   |
| Architecture      | amd64                                                                     |
| Go WebView2Loader | true                                                                      |
| WebView2 Version  | 138.0.3351.121                                                            |
| CPU               | 13th Gen Intel(R) Core(TM) i7-1360P                                       |
| GPU 1             | NVIDIA GeForce RTX 3050 4GB Laptop GPU (NVIDIA) - Driver: 31.0.15.3713    |
| GPU 2             | Intel(R) Iris(R) Xe Graphics (Intel Corporation) - Driver: 31.0.101.3688  |
| Memory            | 32GB                                                                      |
└───────────────────────────────────────────────────────────────────────────────────────────────┘

# Build Environment

┌────────────────────────────────┐
| Wails CLI    | v3.0.0-alpha.19 |
| Go Version   | go1.24.5        |
| -buildmode   | exe             |
| -compiler    | gc              |
| CGO_CFLAGS   |                 |
| CGO_CPPFLAGS |                 |
| CGO_CXXFLAGS |                 |
| CGO_ENABLED  | 1               |
| CGO_LDFLAGS  |                 |
| GOAMD64      | v1              |
| GOARCH       | amd64           |
| GOOS         | windows         |
└────────────────────────────────┘

# Dependencies

┌────────────────────────────────────────────┐
| SignTool.exe (Windows SDK) | Not Installed |
| npm                        |               |
| NSIS                       | v3.11         |
| MakeAppx.exe (Windows SDK) | Not Installed |
| MSIX Packaging Tool        | Not Installed |
|                                            |
└───────── * - Optional Dependency ──────────┘

# Checking for issues

 SUCCESS  No issues found

# Diagnosis

 WARNING  There are some items above that need addressing!

Need documentation? Run: wails3 docs
 ♥   If Wails is useful to you or your company, please consider sponsoring the project: wails3 sponsor
```

# Checklist:

- [x] I have updated `website/src/pages/changelog.mdx` with details of this PR
- [x] My code follows the general coding style of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue on Windows where the WindowUnMinimise event was not triggered when restoring a window from a maximized state after minimizing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->