### PR TITLE
[V2] add url validation for BrowserOpenURL

### DIFF
--- a/v2/internal/frontend/desktop/darwin/browser.go
+++ b/v2/internal/frontend/desktop/darwin/browser.go
@@ -14,6 +14,7 @@ import (
 func (f *Frontend) BrowserOpenURL(url string) {
 	if err := utils.ValidateURL(url); err != nil {
 		f.logger.Error(fmt.Sprintf("Invalid URL %s", err.Error()))
+		return
 	}
 	// Specific method implementation
 	if err := browser.OpenURL(url); err != nil {

--- a/v2/internal/frontend/desktop/darwin/browser.go
+++ b/v2/internal/frontend/desktop/darwin/browser.go
@@ -4,11 +4,17 @@
 package darwin
 
 import (
+	"fmt"
+
 	"github.com/pkg/browser"
+	"github.com/wailsapp/wails/v2/internal/frontend/utils"
 )
 
 // BrowserOpenURL Use the default browser to open the url
 func (f *Frontend) BrowserOpenURL(url string) {
+	if err := utils.ValidateURL(url); err != nil {
+		f.logger.Error(fmt.Sprintf("Invalid URL %s", err.Error()))
+	}
 	// Specific method implementation
 	if err := browser.OpenURL(url); err != nil {
 		f.logger.Error("Unable to open default system browser")

--- a/v2/internal/frontend/desktop/darwin/browser.go
+++ b/v2/internal/frontend/desktop/darwin/browser.go
@@ -5,17 +5,18 @@ package darwin
 
 import (
 	"fmt"
-
 	"github.com/pkg/browser"
 	"github.com/wailsapp/wails/v2/internal/frontend/utils"
 )
 
 // BrowserOpenURL Use the default browser to open the url
-func (f *Frontend) BrowserOpenURL(url string) {
-	if err := utils.ValidateURL(url); err != nil {
+func (f *Frontend) BrowserOpenURL(rawURL string) {
+	url, err := utils.ValidateAndSanitizeURL(rawURL)
+	if err != nil {
 		f.logger.Error(fmt.Sprintf("Invalid URL %s", err.Error()))
 		return
 	}
+
 	// Specific method implementation
 	if err := browser.OpenURL(url); err != nil {
 		f.logger.Error("Unable to open default system browser")

--- a/v2/internal/frontend/desktop/linux/browser.go
+++ b/v2/internal/frontend/desktop/linux/browser.go
@@ -14,6 +14,7 @@ import (
 func (f *Frontend) BrowserOpenURL(url string) {
 	if err := utils.ValidateURL(url); err != nil {
 		f.logger.Error(fmt.Sprintf("Invalid URL %s", err.Error()))
+		return
 	}
 	// Specific method implementation
 	if err := browser.OpenURL(url); err != nil {

--- a/v2/internal/frontend/desktop/linux/browser.go
+++ b/v2/internal/frontend/desktop/linux/browser.go
@@ -5,14 +5,14 @@ package linux
 
 import (
 	"fmt"
-
 	"github.com/pkg/browser"
 	"github.com/wailsapp/wails/v2/internal/frontend/utils"
 )
 
 // BrowserOpenURL Use the default browser to open the url
-func (f *Frontend) BrowserOpenURL(url string) {
-	if err := utils.ValidateURL(url); err != nil {
+func (f *Frontend) BrowserOpenURL(rawURL string) {
+	url, err := utils.ValidateAndSanitizeURL(rawURL)
+	if err != nil {
 		f.logger.Error(fmt.Sprintf("Invalid URL %s", err.Error()))
 		return
 	}

--- a/v2/internal/frontend/desktop/linux/browser.go
+++ b/v2/internal/frontend/desktop/linux/browser.go
@@ -3,10 +3,18 @@
 
 package linux
 
-import "github.com/pkg/browser"
+import (
+	"fmt"
+
+	"github.com/pkg/browser"
+	"github.com/wailsapp/wails/v2/internal/frontend/utils"
+)
 
 // BrowserOpenURL Use the default browser to open the url
 func (f *Frontend) BrowserOpenURL(url string) {
+	if err := utils.ValidateURL(url); err != nil {
+		f.logger.Error(fmt.Sprintf("Invalid URL %s", err.Error()))
+	}
 	// Specific method implementation
 	if err := browser.OpenURL(url); err != nil {
 		f.logger.Error("Unable to open default system browser")

--- a/v2/internal/frontend/desktop/windows/browser.go
+++ b/v2/internal/frontend/desktop/windows/browser.go
@@ -4,7 +4,10 @@
 package windows
 
 import (
+	"fmt"
+
 	"github.com/pkg/browser"
+	"github.com/wailsapp/wails/v2/internal/frontend/utils"
 	"golang.org/x/sys/windows"
 )
 
@@ -17,6 +20,10 @@ var fallbackBrowserPaths = []string{
 
 // BrowserOpenURL Use the default browser to open the url
 func (f *Frontend) BrowserOpenURL(url string) {
+	if err := utils.ValidateURL(url); err != nil {
+		f.logger.Error(fmt.Sprintf("Invalid URL %s", err.Error()))
+	}
+
 	// Specific method implementation
 	err := browser.OpenURL(url)
 	if err == nil {

--- a/v2/internal/frontend/desktop/windows/browser.go
+++ b/v2/internal/frontend/desktop/windows/browser.go
@@ -5,7 +5,6 @@ package windows
 
 import (
 	"fmt"
-
 	"github.com/pkg/browser"
 	"github.com/wailsapp/wails/v2/internal/frontend/utils"
 	"golang.org/x/sys/windows"
@@ -19,14 +18,15 @@ var fallbackBrowserPaths = []string{
 }
 
 // BrowserOpenURL Use the default browser to open the url
-func (f *Frontend) BrowserOpenURL(url string) {
-	if err := utils.ValidateURL(url); err != nil {
+func (f *Frontend) BrowserOpenURL(rawURL string) {
+	url, err := utils.ValidateAndSanitizeURL(rawURL)
+	if err != nil {
 		f.logger.Error(fmt.Sprintf("Invalid URL %s", err.Error()))
 		return
 	}
 
 	// Specific method implementation
-	err := browser.OpenURL(url)
+	err = browser.OpenURL(url)
 	if err == nil {
 		return
 	}

--- a/v2/internal/frontend/desktop/windows/browser.go
+++ b/v2/internal/frontend/desktop/windows/browser.go
@@ -22,6 +22,7 @@ var fallbackBrowserPaths = []string{
 func (f *Frontend) BrowserOpenURL(url string) {
 	if err := utils.ValidateURL(url); err != nil {
 		f.logger.Error(fmt.Sprintf("Invalid URL %s", err.Error()))
+		return
 	}
 
 	// Specific method implementation

--- a/v2/internal/frontend/utils/urlValidator.go
+++ b/v2/internal/frontend/utils/urlValidator.go
@@ -1,0 +1,44 @@
+package utils
+
+import (
+	"errors"
+	"fmt"
+	"net/url"
+	"strings"
+)
+
+// Alternative simpler validation function if you don't need the struct approach
+func ValidateURL(rawURL string) error {
+	// Check for null bytes (can cause truncation issues in some systems)
+	if strings.Contains(rawURL, "\x00") {
+		return errors.New("null bytes not allowed in URL")
+	}
+
+	// Parse URL first - this handles most malformed URLs
+	parsedURL, err := url.Parse(rawURL)
+	if err != nil {
+		return fmt.Errorf("invalid URL format: %v", err)
+	}
+
+	scheme := parsedURL.Scheme
+
+	if scheme == "javascript" || scheme == "data" || scheme == "file" || scheme == "ftp" || scheme == "" {
+		return errors.New("scheme not allowed")
+	}
+
+	// Ensure there's actually a host for http/https URLs
+	if (scheme == "http" || scheme == "https") && parsedURL.Host == "" {
+		return fmt.Errorf("missing host for %s URL", scheme)
+	}
+
+	// Optional: Check for control characters that might cause issues
+	// (but allow legitimate URL characters like &, ;, etc.)
+	for i, r := range rawURL {
+		// Block control characters except tab, but allow other printable chars
+		if r < 32 && r != 9 { // 9 is tab, which might be legitimate
+			return fmt.Errorf("control character at position %d not allowed", i)
+		}
+	}
+
+	return nil
+}

--- a/v2/internal/frontend/utils/urlValidator.go
+++ b/v2/internal/frontend/utils/urlValidator.go
@@ -20,7 +20,7 @@ func ValidateURL(rawURL string) error {
 		return fmt.Errorf("invalid URL format: %v", err)
 	}
 
-	scheme := parsedURL.Scheme
+	scheme := strings.ToLower(parsedURL.Scheme)
 
 	if scheme == "javascript" || scheme == "data" || scheme == "file" || scheme == "ftp" || scheme == "" {
 		return errors.New("scheme not allowed")

--- a/v2/internal/frontend/utils/urlValidator.go
+++ b/v2/internal/frontend/utils/urlValidator.go
@@ -4,41 +4,55 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"regexp"
 	"strings"
 )
 
-// Alternative simpler validation function if you don't need the struct approach
-func ValidateURL(rawURL string) error {
+func ValidateAndSanitizeURL(rawURL string) (string, error) {
 	// Check for null bytes (can cause truncation issues in some systems)
 	if strings.Contains(rawURL, "\x00") {
-		return errors.New("null bytes not allowed in URL")
+		return "", errors.New("null bytes not allowed in URL")
 	}
 
 	// Parse URL first - this handles most malformed URLs
 	parsedURL, err := url.Parse(rawURL)
 	if err != nil {
-		return fmt.Errorf("invalid URL format: %v", err)
+		return "", fmt.Errorf("invalid URL format: %v", err)
 	}
 
 	scheme := strings.ToLower(parsedURL.Scheme)
 
 	if scheme == "javascript" || scheme == "data" || scheme == "file" || scheme == "ftp" || scheme == "" {
-		return errors.New("scheme not allowed")
+		return "", errors.New("scheme not allowed")
 	}
 
 	// Ensure there's actually a host for http/https URLs
 	if (scheme == "http" || scheme == "https") && parsedURL.Host == "" {
-		return fmt.Errorf("missing host for %s URL", scheme)
+		return "", fmt.Errorf("missing host for %s URL", scheme)
 	}
 
-	// Optional: Check for control characters that might cause issues
+	sanitizedURL := parsedURL.String()
+
+	// Check for control characters that might cause issues
 	// (but allow legitimate URL characters like &, ;, etc.)
-	for i, r := range rawURL {
+	for i, r := range sanitizedURL {
 		// Block control characters except tab, but allow other printable chars
 		if r < 32 && r != 9 { // 9 is tab, which might be legitimate
-			return fmt.Errorf("control character at position %d not allowed", i)
+			return "", fmt.Errorf("control character at position %d not allowed", i)
 		}
 	}
 
-	return nil
+	// Shell metacharacter check
+	shellDangerous := `[;\|` + "`" + `$\\<>*{}\[\]()~! \t\n\r]`
+	if matched, _ := regexp.MatchString(shellDangerous, sanitizedURL); matched {
+		return "", errors.New("shell metacharacters not allowed")
+	}
+
+	// Unicode danger check
+	unicodeDangerous := "[\u0000-\u001F\u007F\u00A0\u1680\u2000-\u200F\u2028-\u202F\u205F\u2060\u3000\uFEFF]"
+	if matched, _ := regexp.MatchString(unicodeDangerous, sanitizedURL); matched {
+		return "", errors.New("unicode dangerous characters not allowed")
+	}
+
+	return sanitizedURL, nil
 }

--- a/v2/internal/frontend/utils/urlValidator_test.go
+++ b/v2/internal/frontend/utils/urlValidator_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 // Test cases for ValidateAndOpenURL
-func TestValidateAndOpenURL(t *testing.T) {
+func TestValidateURL(t *testing.T) {
 	testCases := []struct {
 		name      string
 		url       string
@@ -124,7 +124,7 @@ func TestValidateAndOpenURL(t *testing.T) {
 			errMsg:    "control character",
 		},
 		{
-			name:      "URL with tab character (allowed)",
+			name:      "URL with tab character",
 			url:       "https://example.com/path?q=hello\tworld",
 			shouldErr: true,
 			errMsg:    "control character",

--- a/v2/internal/frontend/utils/urlValidator_test.go
+++ b/v2/internal/frontend/utils/urlValidator_test.go
@@ -14,42 +14,44 @@ func TestValidateURL(t *testing.T) {
 		url       string
 		shouldErr bool
 		errMsg    string
+		expected  string
 	}{
 		// Valid URLs
 		{
 			name:      "valid https URL",
 			url:       "https://www.example.com",
 			shouldErr: false,
+			expected:  "https://www.example.com",
 		},
 		{
 			name:      "valid http URL",
 			url:       "http://example.com",
 			shouldErr: false,
+			expected:  "http://example.com",
 		},
 		{
 			name:      "URL with query parameters",
 			url:       "https://example.com/search?q=cats&dogs",
 			shouldErr: false,
-		},
-		{
-			name:      "URL with path parameters",
-			url:       "https://example.com/path;param=value",
-			shouldErr: false,
-		},
-		{
-			name:      "URL with special characters in query",
-			url:       "https://example.com/search?q=hello world&filter=price>100",
-			shouldErr: false,
+			expected:  "https://example.com/search?q=cats&dogs",
 		},
 		{
 			name:      "URL with port",
 			url:       "https://example.com:8080/path",
 			shouldErr: false,
+			expected:  "https://example.com:8080/path",
 		},
 		{
 			name:      "URL with fragment",
 			url:       "https://example.com/page#section",
 			shouldErr: false,
+			expected:  "https://example.com/page#section",
+		},
+		{
+			name:      "urlencode params",
+			url:       "http://google.com/ ----browser-subprocess-path=C:\\\\Users\\\\Public\\\\test.bat",
+			shouldErr: false,
+			expected:  "http://google.com/%20----browser-subprocess-path=C:%5C%5CUsers%5C%5CPublic%5C%5Ctest.bat",
 		},
 
 		// Invalid schemes
@@ -129,36 +131,62 @@ func TestValidateURL(t *testing.T) {
 			shouldErr: true,
 			errMsg:    "control character",
 		},
+		{
+			name:      "URL with path parameters",
+			url:       "https://example.com/path;param=value",
+			shouldErr: true,
+			errMsg:    "shell metacharacters not allowed",
+		},
+		{
+			name:      "URL with special characters in query",
+			url:       "https://example.com/search?q=hello world&filter=price>100",
+			shouldErr: true,
+			errMsg:    "shell metacharacters not allowed",
+		},
+		{
+			name:      "URL with special characters in query and params",
+			url:       "https://example.com/search?q=hello ----browser-subprocess-path=C:\\\\Users\\\\Public\\\\test.bat",
+			shouldErr: true,
+			errMsg:    "shell metacharacters not allowed",
+		},
+		{
+			name:      "URL with dollar sign in query",
+			url:       "https://example.com/search?price=$100",
+			shouldErr: true,
+			errMsg:    "shell metacharacters not allowed",
+		},
+		{
+			name:      "URL with parentheses",
+			url:       "https://example.com/file(1).html",
+			shouldErr: true,
+			errMsg:    "shell metacharacters not allowed",
+		},
+		{
+			name:      "URL with unicode",
+			url:       "https://example.com/search?q=hello\u2001foo",
+			shouldErr: true,
+			errMsg:    "unicode dangerous characters not allowed",
+		},
 
 		// Edge cases
 		{
 			name:      "international domain",
 			url:       "https://例え.テスト/path",
 			shouldErr: false,
-		},
-
-		// URLs that might look suspicious but are valid
-		{
-			name:      "URL with dollar sign in query",
-			url:       "https://example.com/search?price=$100",
-			shouldErr: false,
-		},
-		{
-			name:      "URL with parentheses",
-			url:       "https://example.com/file(1).html",
-			shouldErr: false,
+			expected:  "https://%E4%BE%8B%E3%81%88.%E3%83%86%E3%82%B9%E3%83%88/path",
 		},
 		{
 			name:      "URL with pipe character",
 			url:       "https://example.com/user/123|admin",
 			shouldErr: false,
+			expected:  "https://example.com/user/123%7Cadmin",
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			// We'll test only the validation part to avoid actually opening URLs
-			err := utils.ValidateURL(tc.url)
+			sanitized, err := utils.ValidateAndSanitizeURL(tc.url)
 
 			if tc.shouldErr {
 				if err == nil {
@@ -169,6 +197,9 @@ func TestValidateURL(t *testing.T) {
 			} else {
 				if err != nil {
 					t.Errorf("expected no error for URL %q, but got: %v", tc.url, err)
+				}
+				if sanitized != tc.expected {
+					t.Errorf("unexpected sanitized URL for %q: expected %q, got %q", tc.url, tc.expected, sanitized)
 				}
 			}
 		})

--- a/v2/internal/frontend/utils/urlValidator_test.go
+++ b/v2/internal/frontend/utils/urlValidator_test.go
@@ -1,0 +1,176 @@
+package utils_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/wailsapp/wails/v2/internal/frontend/utils"
+)
+
+// Test cases for ValidateAndOpenURL
+func TestValidateAndOpenURL(t *testing.T) {
+	testCases := []struct {
+		name      string
+		url       string
+		shouldErr bool
+		errMsg    string
+	}{
+		// Valid URLs
+		{
+			name:      "valid https URL",
+			url:       "https://www.example.com",
+			shouldErr: false,
+		},
+		{
+			name:      "valid http URL",
+			url:       "http://example.com",
+			shouldErr: false,
+		},
+		{
+			name:      "URL with query parameters",
+			url:       "https://example.com/search?q=cats&dogs",
+			shouldErr: false,
+		},
+		{
+			name:      "URL with path parameters",
+			url:       "https://example.com/path;param=value",
+			shouldErr: false,
+		},
+		{
+			name:      "URL with special characters in query",
+			url:       "https://example.com/search?q=hello world&filter=price>100",
+			shouldErr: false,
+		},
+		{
+			name:      "URL with port",
+			url:       "https://example.com:8080/path",
+			shouldErr: false,
+		},
+		{
+			name:      "URL with fragment",
+			url:       "https://example.com/page#section",
+			shouldErr: false,
+		},
+
+		// Invalid schemes
+		{
+			name:      "javascript scheme",
+			url:       "javascript:alert('xss')",
+			shouldErr: true,
+			errMsg:    "scheme not allowed",
+		},
+		{
+			name:      "data scheme",
+			url:       "data:text/html,<script>alert(1)</script>",
+			shouldErr: true,
+			errMsg:    "scheme not allowed",
+		},
+		{
+			name:      "file scheme",
+			url:       "file:///etc/passwd",
+			shouldErr: true,
+			errMsg:    "scheme not allowed",
+		},
+		{
+			name:      "ftp scheme",
+			url:       "ftp://files.example.com/file.txt",
+			shouldErr: true,
+			errMsg:    "scheme not allowed",
+		},
+
+		// Malformed URLs
+		{
+			name:      "not a URL",
+			url:       "not-a-url",
+			shouldErr: true,
+			errMsg:    "scheme not allowed", // will have empty scheme
+		},
+		{
+			name:      "missing scheme",
+			url:       "example.com",
+			shouldErr: true,
+			errMsg:    "scheme not allowed",
+		},
+		{
+			name:      "malformed URL",
+			url:       "https://",
+			shouldErr: true,
+			errMsg:    "missing host",
+		},
+		{
+			name:      "empty host",
+			url:       "http:///path",
+			shouldErr: true,
+			errMsg:    "missing host",
+		},
+
+		// Security issues
+		{
+			name:      "null byte in URL",
+			url:       "https://example.com\x00/hidden",
+			shouldErr: true,
+			errMsg:    "null bytes not allowed",
+		},
+		{
+			name:      "control characters",
+			url:       "https://example.com\n/path",
+			shouldErr: true,
+			errMsg:    "control character",
+		},
+		{
+			name:      "carriage return",
+			url:       "https://example.com\r/path",
+			shouldErr: true,
+			errMsg:    "control character",
+		},
+		{
+			name:      "URL with tab character (allowed)",
+			url:       "https://example.com/path?q=hello\tworld",
+			shouldErr: true,
+			errMsg:    "control character",
+		},
+
+		// Edge cases
+		{
+			name:      "international domain",
+			url:       "https://例え.テスト/path",
+			shouldErr: false,
+		},
+
+		// URLs that might look suspicious but are valid
+		{
+			name:      "URL with dollar sign in query",
+			url:       "https://example.com/search?price=$100",
+			shouldErr: false,
+		},
+		{
+			name:      "URL with parentheses",
+			url:       "https://example.com/file(1).html",
+			shouldErr: false,
+		},
+		{
+			name:      "URL with pipe character",
+			url:       "https://example.com/user/123|admin",
+			shouldErr: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// We'll test only the validation part to avoid actually opening URLs
+			err := utils.ValidateURL(tc.url)
+
+			if tc.shouldErr {
+				if err == nil {
+					t.Errorf("expected error for URL %q, but got none", tc.url)
+				} else if tc.errMsg != "" && !strings.Contains(err.Error(), tc.errMsg) {
+					t.Errorf("expected error containing %q, got %q", tc.errMsg, err.Error())
+				}
+			} else {
+				if err != nil {
+					t.Errorf("expected no error for URL %q, but got: %v", tc.url, err)
+				}
+			}
+		})
+	}
+}

--- a/website/src/pages/changelog.mdx
+++ b/website/src/pages/changelog.mdx
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `build:tags` to project specification for automatically adding compilation tags by @symball in [PR](https://github.com/wailsapp/wails/pull/4439)
 
 ### Fixed
+- Added url validation for BrowserOpenURL by @APshenkin in [PR](https://github.com/wailsapp/wails/pull/4484)
 - Fixed C compilation error in onWayland on Linux due to declaration after label [#4446](https://github.com/wailsapp/wails/pull/4446) by [@jaesung9507](https://github.com/jaesung9507)
 - Use computed style when adding 'wails-drop-target-active' [PR](https://github.com/wailsapp/wails/pull/4420) by [@riannucci](https://github.com/riannucci)
 


### PR DESCRIPTION
# Description

This PR adds validation for url parameter that is used in BrowserOpenURL to verify that it's valid and safe url. As this parameter is used then in shell command, it should be properly formed.

Fixes # (issue)

## Type of change
  
Please select the option that is relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
  
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration using `wails doctor`.

- [x] Windows
- [x] macOS
- [x] Linux – Fedora 42
      
If you checked Linux, please specify the distro and version.
  
## Test Configuration

```

# Wails
Version | v2.10.2


# System
┌────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
| OS           | MacOS                                                                                                                       |
| Version      | 15.6                                                                                                                        |
| ID           | 24G84                                                                                                                       |
| Branding     |                                                                                                                             |
| Go Version   | go1.24.0                                                                                                                    |
| Platform     | darwin                                                                                                                      |
| Architecture | arm64                                                                                                                       |
| CPU 1        | Apple M4 Max                                                                                                                |
| CPU 2        | Apple M4 Max                                                                                                                |
| GPU          | Chipset Model: Apple M4 Max Type: GPU Bus: Built-In Total Number of Cores: 40 Vendor: Apple (0x106b) Metal Support: Metal 3 |
| Memory       | 128GB                                                                                                                       |
└────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘

```

```

# Wails
Version | v2.10.2


# System
┌───────────────────────────────────────────────────────────────────────────────────────┐
| OS           | Windows 10 Pro                                                         |
| Version      | 2009 (Build: 26120)                                                    |
| ID           | 24H2                                                                   |
| Go Version   | go1.24.1                                                               |
| Platform     | windows                                                                |
| Architecture | arm64                                                                  |
| CPU          | virt-9.1                                                               |
| GPU          | Red Hat VirtIO GPU DOD controller (Red Hat, Inc.) - Driver: 22.7.38.43 |
| Memory       | 32GB                                                                   |
└───────────────────────────────────────────────────────────────────────────────────────┘

```

```

# Wails
Version         | v2.10.2
Package Manager | dnf    


# System
┌────────────────────────────────────────────────────────────────────┐
| OS           | Fedora Linux                                        |
| Version      | 42                                                  |
| ID           | fedora                                              |
| Branding     |                                                     |
| Go Version   | go1.24.5                                            |
| Platform     | linux                                               |
| Architecture | arm64                                               |
| CPU          |                                                     |
| GPU 1        | Unknown                                             |
| GPU 2        | Virtio 1.0 GPU (Red Hat, Inc.) - Driver: virtio-pci |
| Memory       | 16GB                                                |
└────────────────────────────────────────────────────────────────────┘

```

# Checklist:

- [x] I have updated `website/src/pages/changelog.mdx` with details of this PR
- [x] My code follows the general coding style of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added URL validation when opening links from the desktop app to enhance security and prevent opening potentially unsafe URLs.

* **Bug Fixes**
  * Improved handling of invalid or malformed URLs across all supported desktop platforms.

* **Tests**
  * Introduced comprehensive tests to ensure robust URL validation.

* **Documentation**
  * Updated the changelog to reflect the addition of URL validation for opening browser links.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->