### PR TITLE
fix: make options in update build-assets override

### DIFF
--- a/v3/UNRELEASED_CHANGELOG.md
+++ b/v3/UNRELEASED_CHANGELOG.md
@@ -20,6 +20,8 @@ After processing, the content will be moved to the main changelog and this file 
 
 ## Changed
 <!-- Changes in existing functionality -->
+- When running `wails3 update build-assets` with the `-config` parameter, values set via the `-product*` parameters are
+  no longer ignored, and override the config value.
 
 ## Fixed
 <!-- Bug fixes -->

--- a/v3/internal/commands/build-assets.go
+++ b/v3/internal/commands/build-assets.go
@@ -31,15 +31,15 @@ type ProtocolConfig struct {
 
 // BuildAssetsOptions defines the options for generating build assets.
 type BuildAssetsOptions struct {
-	Dir                string `description:"The directory to generate the files into"            default:"."`
-	Name               string `description:"The name of the project"`
-	BinaryName         string `description:"The name of the binary"`
-	ProductName        string `description:"The name of the product" default:"My Product"`
-	ProductDescription string `description:"The description of the product" default:"My Product Description"`
-	ProductVersion     string `description:"The version of the product" default:"0.1.0"`
-	ProductCompany     string `description:"The company of the product" default:"My Company"`
-	ProductCopyright   string `description:"The copyright notice" default:"\u00a9 now, My Company"`
-	ProductComments    string `description:"Comments to add to the generated files" default:"This is a comment"`
+	Dir                   string `description:"The directory to generate the files into"            default:"."`
+	Name                  string `description:"The name of the project"`
+	BinaryName            string `description:"The name of the binary"`
+	ProductName           string `description:"The name of the product" default:"My Product"`
+	ProductDescription    string `description:"The description of the product" default:"My Product Description"`
+	ProductVersion        string `description:"The version of the product" default:"0.1.0"`
+	ProductCompany        string `description:"The company of the product" default:"My Company"`
+	ProductCopyright      string `description:"The copyright notice" default:"\u00a9 now, My Company"`
+	ProductComments       string `description:"Comments to add to the generated files" default:"This is a comment"`
 	ProductIdentifier     string `description:"The product identifier, e.g com.mycompany.myproduct"`
 	Publisher             string `description:"Publisher name for MSIX package (e.g., CN=CompanyName)"`
 	ProcessorArchitecture string `description:"Processor architecture for MSIX package" default:"x64"`
@@ -211,13 +211,27 @@ func UpdateBuildAssets(options *UpdateBuildAssetsOptions) error {
 			return err
 		}
 
-		options.ProductCompany = wailsConfig.Info.CompanyName
-		options.ProductName = wailsConfig.Info.ProductName
-		options.ProductIdentifier = wailsConfig.Info.ProductIdentifier
-		options.ProductDescription = wailsConfig.Info.Description
-		options.ProductCopyright = wailsConfig.Info.Copyright
-		options.ProductComments = wailsConfig.Info.Comments
-		options.ProductVersion = wailsConfig.Info.Version
+		if options.ProductCompany == "My Company" && wailsConfig.Info.CompanyName != "" {
+			options.ProductCompany = wailsConfig.Info.CompanyName
+		}
+		if options.ProductName == "My Product" && wailsConfig.Info.ProductName != "" {
+			options.ProductName = wailsConfig.Info.ProductName
+		}
+		if options.ProductIdentifier == "" {
+			options.ProductIdentifier = wailsConfig.Info.ProductIdentifier
+		}
+		if options.ProductDescription == "My Product Description" && wailsConfig.Info.Description != "" {
+			options.ProductDescription = wailsConfig.Info.Description
+		}
+		if options.ProductCopyright == "© now, My Company" && wailsConfig.Info.Copyright != "" {
+			options.ProductCopyright = wailsConfig.Info.Copyright
+		}
+		if options.ProductComments == "This is a comment" && wailsConfig.Info.Comments != "" {
+			options.ProductComments = wailsConfig.Info.Comments
+		}
+		if options.ProductVersion == "0.1.0" && wailsConfig.Info.Version != "" {
+			options.ProductVersion = wailsConfig.Info.Version
+		}
 		config.FileAssociations = wailsConfig.FileAssociations
 		config.Protocols = wailsConfig.Protocols
 	}


### PR DESCRIPTION
<!--

*********************************************************************
*               PLEASE READ BEFORE SUBMITTING YOUR PR               *
*     YOUR PR MAY BE REJECTED IF IT DOES NOT FOLLOW THESE STEPS     *
*********************************************************************

- *DO NOT* submit PRs for v3 alpha enhancements, unless you have opened a post on the discord channel.
  All enhancements must be discussed first.
  The feedback guide for v3 is here: https://v3alpha.wails.io/getting-started/feedback/

- Before submitting your PR, please ensure you have created and linked the PR to an issue.
- If a relevant issue already exists, please reference it in your PR by including `Fixes #<issue number>` in your PR description.
- Please fill in the checklists.

-->

# Description

Before this fix, if `-config` was passed to `wails3 update build-assets`, the values in the config file, even if they were empty, would be used. Now, we only use the config file value if the value was not passed in on the command line (or is the zero value or default value for the option).

I'll be honest, I feel a little dirty about this implementation since I had to copy string constants out of struct tags. Not very `DRY` of me. That said, there was no obvious way to get the default value of a given option. If I missed something, happy to have this corrected, but I've tested it and it seems to be doing the things it should be doing.


Fixes #4504 

## Type of change
  
Please select the option that is relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
  
Manually. My config:

```
version: '3'

# This information is used to generate the build assets.
info:
  productName: "HavrionTV Now"
  companyName: "Havrion, LLC" # The name of the company
  productIdentifier: "com.havrion.tvnow" # The unique product identifier
  description: "Stream Havrion Perform TV to your computer" # The application description
  copyright: "© 2025, Havrion, LLC" # Copyright text
  comments: "" # Comments
```

My command:

```
wails3 update build-assets binaryname 'tvnow' -productversion '8.9.7' -config build/tvnow/config.yml -dir $TMPDIR
```

      
If you checked Linux, please specify the distro and version.
  
## Test Configuration

Please paste the output of `wails doctor`. If you are unable to run this command, please describe your environment in as much detail as possible.

# Checklist:

- [ ] I have updated `website/src/pages/changelog.mdx` with details of this PR
- [ ] My code follows the general coding style of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserves user-defined app metadata during asset builds; config now fills only detected default values.
  * Command-line product parameters now correctly override configuration values instead of being ignored.
  * Prevents unintended overwrites of custom fields (company, product name, identifier, description, copyright, comments, version, file associations, protocols).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->