### PR TITLE
fix: v3-alpha wails3 cli installation path

### DIFF
--- a/.github/workflows/nightly-release-v3.yml
+++ b/.github/workflows/nightly-release-v3.yml
@@ -483,7 +483,7 @@ jobs:
         echo ""
         echo "**Installation:**"
         echo "\`\`\`bash"
-        echo "go install github.com/wailsapp/wails/v3/cmd/wails@${{ steps.release.outputs.tag }}"
+        echo "go install github.com/wailsapp/wails/v3/cmd/wails3@${{ steps.release.outputs.tag }}"
         echo "\`\`\`"
         echo ""
         echo "**⚠️ Alpha Warning:** This is pre-release software and may contain bugs or incomplete features."
@@ -517,7 +517,7 @@ jobs:
         
         **Installation:**
         ```bash
-        go install github.com/wailsapp/wails/v3/cmd/wails@${{ steps.release.outputs.tag }}
+        go install github.com/wailsapp/wails/v3/cmd/wails3@${{ steps.release.outputs.tag }}
         ```
         
         **⚠️ Alpha Warning:** This is pre-release software and may contain bugs or incomplete features.

--- a/v3/UNRELEASED_CHANGELOG.md
+++ b/v3/UNRELEASED_CHANGELOG.md
@@ -27,6 +27,7 @@ After processing, the content will be moved to the main changelog and this file 
 - Fixed redefinition error for liquid glass demo in [#4542](https://github.com/wailsapp/wails/pull/4542) by @Etesam913
 - Fixed issue where AssetServer can crash on MacOS in [#4576](https://github.com/wailsapp/wails/pull/4576) by @jghiloni
 - Fixed compilation issue when building with NextJs. Fixed in [#4585](https://github.com/wailsapp/wails/pull/4585) by @rev42
+- Fixed pipelines for nightly release in [#4597](https://github.com/wailsapp/wails/pull/4597) by @riadafridishibly
 
 ## Deprecated
 <!-- Soon-to-be removed features -->


### PR DESCRIPTION
<!--

*********************************************************************
*               PLEASE READ BEFORE SUBMITTING YOUR PR               *
*     YOUR PR MAY BE REJECTED IF IT DOES NOT FOLLOW THESE STEPS     *
*********************************************************************

- *DO NOT* submit PRs for v3 alpha enhancements, unless you have opened a post on the discord channel.
  All enhancements must be discussed first.
  The feedback guide for v3 is here: https://v3alpha.wails.io/getting-started/feedback/

- Before submitting your PR, please ensure you have created and linked the PR to an issue.
- If a relevant issue already exists, please reference it in your PR by including `Fixes #<issue number>` in your PR description.
- Please fill in the checklists.

-->

# Description

Fixes the wails3 binary installation module path in pre-release note.

Fixes #4596 

## Type of change
  
Please select the option that is relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - Updated nightly release process to reference the correct v3 alpha installation target, ensuring dry-run and live release notifications point to the proper binary.
  - Minor formatting cleanup in release scripts for consistency.
- Bug Fixes
  - Fixed nightly release pipeline issues so nightly releases run and report correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->