### PR TITLE
fix: prevent white window flash when Hidden option is true

### DIFF
--- a/v3/UNRELEASED_CHANGELOG.md
+++ b/v3/UNRELEASED_CHANGELOG.md
@@ -23,6 +23,7 @@ After processing, the content will be moved to the main changelog and this file 
 
 ## Fixed
 <!-- Bug fixes -->
+- Fix the white window appearing on Windows when creating a hidden window by @leaanthony in [#4612](https://github.com/wailsapp/wails/pull/4612)
 
 ## Deprecated
 <!-- Soon-to-be removed features -->

--- a/v3/pkg/application/webview_window_windows.go
+++ b/v3/pkg/application/webview_window_windows.go
@@ -369,6 +369,11 @@ func (w *windowsWebviewWindow) run() {
 	var parent w32.HWND
 
 	var style uint = w32.WS_OVERLAPPEDWINDOW
+	// If the window should be hidden initially, exclude WS_VISIBLE from the style
+	// This prevents the white window flash reported in issue #4611
+	if options.Hidden {
+		style = style &^ uint(w32.WS_VISIBLE)
+	}
 
 	w.hwnd = w32.CreateWindowEx(
 		uint(exStyle),


### PR DESCRIPTION
Fixes #4611

When creating a window with Hidden: true, the window was briefly visible as a white window before disappearing. This was caused by CreateWindowEx using WS_OVERLAPPEDWINDOW style which includes WS_VISIBLE by default.

The fix excludes WS_VISIBLE from the window style when the Hidden option is set to true, ensuring the window remains invisible until explicitly shown via window.Show().



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * On Windows, windows created with the Hidden option no longer flash white during creation and now start fully hidden for a smoother launch.
  * Reduces flicker and improves consistency of initial window visibility for hidden windows on Windows.
  * No changes in behavior on macOS or Linux.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->