### PR TITLE
Fix linux appimage task

### DIFF
--- a/v3/UNRELEASED_CHANGELOG.md
+++ b/v3/UNRELEASED_CHANGELOG.md
@@ -23,6 +23,7 @@ After processing, the content will be moved to the main changelog and this file 
 
 ## Fixed
 <!-- Bug fixes -->
+- Fix Linux appimage appicon variable in Linux taskfile [PR #4644](https://github.com/wailsapp/wails/pull/4644)
 
 ## Deprecated
 <!-- Soon-to-be removed features -->

--- a/v3/internal/commands/build_assets/linux/Taskfile.yml
+++ b/v3/internal/commands/build_assets/linux/Taskfile.yml
@@ -47,12 +47,12 @@ tasks:
       - task: generate:dotdesktop
     cmds:
       - cp {{.APP_BINARY}} {{.APP_NAME}}
-      - cp ../../appicon.png appicon.png
+      - cp ../../appicon.png {{.APP_NAME}}.png
       - wails3 generate appimage -binary {{.APP_NAME}} -icon {{.ICON}} -desktopfile {{.DESKTOP_FILE}} -outputdir {{.OUTPUT_DIR}} -builddir {{.ROOT_DIR}}/build/linux/appimage/build
     vars:
       APP_NAME: '{{.APP_NAME}}'
       APP_BINARY: '../../../bin/{{.APP_NAME}}'
-      ICON: '../../appicon.png'
+      ICON: '{{.APP_NAME}}.png'
       DESKTOP_FILE: '../{{.APP_NAME}}.desktop'
       OUTPUT_DIR: '../../../bin'
 


### PR DESCRIPTION
Currently appimage builds are broken as per https://github.com/wailsapp/wails/pull/4641

This fixes appimage builds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - AppImage now uses the correct app-specific icon, improving how the app appears in desktop environments, launchers, and file managers and avoiding icon conflicts across builds.

- Chores
  - Build process updated to dynamically name the app icon from the application name, ensuring consistent branding for generated AppImages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->