### PR TITLE
[v2] Fix Windows HTML drag and drop (#3782)

### DIFF
--- a/v2/internal/frontend/desktop/windows/frontend.go
+++ b/v2/internal/frontend/desktop/windows/frontend.go
@@ -488,12 +488,6 @@ func (f *Frontend) setupChromium() {
 		chromium.AdditionalBrowserArgs = append(chromium.AdditionalBrowserArgs, arg)
 	}
 
-	if f.frontendOptions.DragAndDrop != nil && f.frontendOptions.DragAndDrop.DisableWebViewDrop {
-		if err := chromium.AllowExternalDrag(false); err != nil {
-			f.logger.Warning("WebView failed to set AllowExternalDrag to false!")
-		}
-	}
-
 	chromium.MessageCallback = f.processMessage
 	chromium.MessageWithAdditionalObjectsCallback = f.processMessageWithAdditionalObjects
 	chromium.WebResourceRequestedCallback = f.processRequest
@@ -547,6 +541,15 @@ func (f *Frontend) setupChromium() {
 	}
 
 	chromium.Embed(f.mainWindow.Handle())
+
+	if f.frontendOptions.DragAndDrop != nil && f.frontendOptions.DragAndDrop.EnableFileDrop {
+		if chromium.HasCapability(edge.AllowExternalDrop) {
+			err := chromium.AllowExternalDrag(false)
+			if err != nil {
+				f.logger.Warning("WebView failed to set AllowExternalDrag to false!")
+			}
+		}
+	}
 
 	if chromium.HasCapability(edge.SwipeNavigation) {
 		swipeGesturesEnabled := f.frontendOptions.Windows != nil && f.frontendOptions.Windows.EnableSwipeGestures

--- a/website/src/pages/changelog.mdx
+++ b/website/src/pages/changelog.mdx
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed C compilation error in onWayland on Linux due to declaration after label [#4446](https://github.com/wailsapp/wails/pull/4446) by [@jaesung9507](https://github.com/jaesung9507)
 - Use computed style when adding 'wails-drop-target-active' [PR](https://github.com/wailsapp/wails/pull/4420) by [@riannucci](https://github.com/riannucci)
 - Fixed panic when adding menuroles on Linux [#4558](https://github.com/wailsapp/wails/pull/4558) by [@jaesung9507](https://github.com/jaesung9507)
+- Fixed Windows HTML drag and drop by moving AllowExternalDrag call after Embed and adding capability check [#3782](https://github.com/wailsapp/wails/issues/3782)
 
 ## v2.10.2 - 2025-07-06
 


### PR DESCRIPTION
## Summary
Fixes Windows HTML drag and drop functionality by properly configuring `AllowExternalDrag` after WebView2 initialization.

This is a backport of the v3 fix from PR #4259 to v2.

## Changes
- Move `AllowExternalDrag(false)` call to after `chromium.Embed()` (was called before)
- Add `chromium.HasCapability(edge.AllowExternalDrop)` check before calling
- Change condition from `DisableWebViewDrop` to `EnableFileDrop` (consistent with v3)
- Update changelog

## Technical Details
The issue occurred because:
1. `AllowExternalDrag` was called before the WebView2 was embedded, causing it to fail silently
2. Missing capability check meant it could fail on older WebView2 versions
3. Wrong condition logic - should disable external drag when Wails handles file drops

When `EnableFileDrop` is true, Wails needs to handle dropped files, so we disable the webview's native external drag to prevent it from opening files automatically.

## Testing
- Code compiles successfully on Windows
- Logic matches proven v3 implementation from #4259

## Related
- Fixes #3782
- Based on v3 fix: #4259

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows HTML drag-and-drop reliability by enabling external file drop only when explicitly configured and supported, preventing unintended blocking and ensuring smoother interactions.
  * Adjusted initialization order to better align with platform capabilities, enhancing compatibility and stability for drag-and-drop on Windows.

* **Documentation**
  * Updated changelog with details on the Windows drag-and-drop fix and guidance on enabling external file drop when supported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->