### PR TITLE
Fix copyright year in German website footer

### DIFF
--- a/website/i18n/de/docusaurus-theme-classic/footer.json
+++ b/website/i18n/de/docusaurus-theme-classic/footer.json
@@ -44,7 +44,7 @@
     "description": "The label of footer link with label=Blog linking to /blog"
   },
   "copyright": {
-    "message": "Copyright © 2022 Lea Anthony",
+    "message": "Copyright © 2025 Lea Anthony",
     "description": "The footer copyright"
   },
   "link.item.label.Awesome": {


### PR DESCRIPTION
## Summary
Update copyright year from 2022 to 2025 in German (de) translation footer to match all other language versions.

## Changes
- Updated `website/i18n/de/docusaurus-theme-classic/footer.json` copyright year

## Status of all language versions
- ✅ English, French, Japanese, Korean, Portuguese, Russian, Turkish, Chinese, Vietnamese, Arabic: 2025
- ✅ German: 2025 (fixed by this PR)

Fixes #4239

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated footer copyright year to 2025

<!-- end of auto-generated comment: release notes by coderabbit.ai -->