### PR TITLE
Fix Windows systray icon regression

### DIFF
--- a/v3/UNRELEASED_CHANGELOG.md
+++ b/v3/UNRELEASED_CHANGELOG.md
@@ -23,6 +23,7 @@ After processing, the content will be moved to the main changelog and this file 
 
 ## Fixed
 <!-- Bug fixes -->
+- Fix Windows systray icon not defaulting to application icon when no custom icon is provided (#4704)
 
 ## Deprecated
 <!-- Soon-to-be removed features -->

--- a/v3/pkg/application/systemtray_windows.go
+++ b/v3/pkg/application/systemtray_windows.go
@@ -225,7 +225,7 @@ func (s *windowsSystemTray) run() {
 	s.uid = uint32(s.parent.id)
 
 	// Resolve the base icons once so we can reuse them for light/dark modes
-	defaultIcon := getNativeApplication().windowClass.Icon
+	defaultIcon := w32.LoadIconWithResourceID(w32.GetModuleHandle(""), w32.RT_ICON)
 
 	// Priority: custom icon > default app icon > built-in icon
 	if s.parent.icon != nil {


### PR DESCRIPTION
## Summary

Fixes a regression where the Windows systray icon no longer defaults to the application icon when no custom systray icon is provided.

Fixes #4704

## Problem

After commit d58d4ba (#4653), the systray icon on Windows would display the default Wails icon instead of the application's custom icon when no explicit systray icon was set. This broke the expected behavior where the systray should automatically use the app's icon as a fallback.

## Root Cause

The regression was introduced on line 228 of `systemtray_windows.go` where the default icon loading was changed from:
```go
defaultIcon := w32.LoadIconWithResourceID(w32.GetModuleHandle(""), w32.RT_ICON)
```
To:
```go
defaultIcon := getNativeApplication().windowClass.Icon
```

The getNativeApplication().windowClass.Icon approach doesn't correctly load the application's icon resource, while w32.LoadIconWithResourceID with w32.RT_ICON properly loads the app icon from the resource with the correct resource type identifier.

## Solution

Revert the default icon loading back to using w32.LoadIconWithResourceID(w32.GetModuleHandle(""), w32.RT_ICON), which correctly loads the application's icon resource.

## Testing

Verified the change addresses the specific line identified in the issue report
The fix restores the original behavior from before commit d58d4ba

## Changes
Modified v3/pkg/application/systemtray_windows.go:228 to restore proper icon loading

Note: This is a minimal, surgical fix that only changes the single line that caused the regression, maintaining all other improvements from the refactor PR #4653.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed an issue on Windows where the systray icon would fail to default to the application icon when no custom icon was configured. The system now properly retrieves and displays the application icon in the system tray with correct light and dark mode handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->