### PR TITLE
Fix/webview2 initialization order

### DIFF
--- a/v2/go.mod
+++ b/v2/go.mod
@@ -37,7 +37,7 @@ require (
 	github.com/tc-hib/winres v0.3.1
 	github.com/tidwall/sjson v1.2.5
 	github.com/tkrajina/go-reflector v0.5.8
-	github.com/wailsapp/go-webview2 v1.0.22
+	github.com/wailsapp/go-webview2 v1.0.23
 	github.com/wailsapp/mimetype v1.4.1
 	github.com/wzshiming/ctc v1.2.3
 	golang.org/x/mod v0.23.0

--- a/v2/go.sum
+++ b/v2/go.sum
@@ -246,6 +246,8 @@ github.com/valyala/fasttemplate v1.2.2 h1:lxLXG0uE3Qnshl9QyaK6XJxMXlQZELvChBOCmQ
 github.com/valyala/fasttemplate v1.2.2/go.mod h1:KHLXt3tVN2HBp8eijSv/kGJopbvo7S+qRAEEKiv+SiQ=
 github.com/wailsapp/go-webview2 v1.0.22 h1:YT61F5lj+GGaat5OB96Aa3b4QA+mybD0Ggq6NZijQ58=
 github.com/wailsapp/go-webview2 v1.0.22/go.mod h1:qJmWAmAmaniuKGZPWwne+uor3AHMB5PFhqiK0Bbj8kc=
+github.com/wailsapp/go-webview2 v1.0.23 h1:jmv8qhz1lHibCc79bMM/a/FqOnnzOGEisLav+a0b9P0=
+github.com/wailsapp/go-webview2 v1.0.23/go.mod h1:qJmWAmAmaniuKGZPWwne+uor3AHMB5PFhqiK0Bbj8kc=
 github.com/wailsapp/mimetype v1.4.1 h1:pQN9ycO7uo4vsUUuPeHEYoUkLVkaRntMnHJxVwYhwHs=
 github.com/wailsapp/mimetype v1.4.1/go.mod h1:9aV5k31bBOv5z6u+QP8TltzvNGJPmNJD4XlAL3U+j3o=
 github.com/wzshiming/ctc v1.2.3 h1:q+hW3IQNsjIlOFBTGZZZeIXTElFM4grF4spW/errh/c=

--- a/v2/internal/frontend/desktop/windows/frontend.go
+++ b/v2/internal/frontend/desktop/windows/frontend.go
@@ -539,16 +539,20 @@ func (f *Frontend) setupChromium() {
 			}
 		}
 	}
-
+	f.logger.Debug("About to call chromium.Embed()")
 	chromium.Embed(f.mainWindow.Handle())
+	f.logger.Debug("chromium.Embed() completed successfully")
 
 	// Handle drag and drop configuration after WebView2 is embedded
 	// This must be done after Embed() to avoid "Not enough memory" errors
 	if f.frontendOptions.DragAndDrop != nil && f.frontendOptions.DragAndDrop.EnableFileDrop {
 		if chromium.HasCapability(edge.AllowExternalDrop) {
-			err := chromium.AllowExternalDrop(false)
+			f.logger.Debug("Calling AllowExternalDrag(false) after Embed")
+			err := chromium.AllowExternalDrag(false)
 			if err != nil {
 				f.logger.Warning("WebView failed to set AllowExternalDrop to false: %s", err)
+			} else {
+				f.logger.Debug("AllowExternalDrag(false) succeeded")
 			}
 		}
 	}
@@ -648,6 +652,7 @@ func (f *Frontend) processRequest(req *edge.ICoreWebView2WebResourceRequest, arg
 
 	//Get the request
 	uri, _ := req.GetUri()
+	f.logger.Debug("processRequest called for URI: %s", uri)
 	reqUri, err := url.ParseRequestURI(uri)
 	if err != nil {
 		f.logger.Error("Unable to parse equest uri %s: %s", uri, err)

--- a/v2/internal/frontend/desktop/windows/frontend.go
+++ b/v2/internal/frontend/desktop/windows/frontend.go
@@ -546,9 +546,9 @@ func (f *Frontend) setupChromium() {
 	// This must be done after Embed() to avoid "Not enough memory" errors
 	if f.frontendOptions.DragAndDrop != nil && f.frontendOptions.DragAndDrop.EnableFileDrop {
 		if chromium.HasCapability(edge.AllowExternalDrop) {
-			err := chromium.AllowExternalDrag(false)
+			err := chromium.AllowExternalDrop(false)
 			if err != nil {
-				f.logger.Warning("WebView failed to set AllowExternalDrag to false: %s", err)
+				f.logger.Warning("WebView failed to set AllowExternalDrop to false: %s", err)
 			}
 		}
 	}

--- a/v2/internal/frontend/desktop/windows/frontend.go
+++ b/v2/internal/frontend/desktop/windows/frontend.go
@@ -488,12 +488,6 @@ func (f *Frontend) setupChromium() {
 		chromium.AdditionalBrowserArgs = append(chromium.AdditionalBrowserArgs, arg)
 	}
 
-	if f.frontendOptions.DragAndDrop != nil && f.frontendOptions.DragAndDrop.DisableWebViewDrop {
-		if err := chromium.AllowExternalDrag(false); err != nil {
-			f.logger.Warning("WebView failed to set AllowExternalDrag to false!")
-		}
-	}
-
 	chromium.MessageCallback = f.processMessage
 	chromium.MessageWithAdditionalObjectsCallback = f.processMessageWithAdditionalObjects
 	chromium.WebResourceRequestedCallback = f.processRequest
@@ -547,6 +541,17 @@ func (f *Frontend) setupChromium() {
 	}
 
 	chromium.Embed(f.mainWindow.Handle())
+
+	// Handle drag and drop configuration after WebView2 is embedded
+	// This must be done after Embed() to avoid "Not enough memory" errors
+	if f.frontendOptions.DragAndDrop != nil && f.frontendOptions.DragAndDrop.EnableFileDrop {
+		if chromium.HasCapability(edge.AllowExternalDrop) {
+			err := chromium.AllowExternalDrag(false)
+			if err != nil {
+				f.logger.Warning("WebView failed to set AllowExternalDrag to false: %s", err)
+			}
+		}
+	}
 
 	if chromium.HasCapability(edge.SwipeNavigation) {
 		swipeGesturesEnabled := f.frontendOptions.Windows != nil && f.frontendOptions.Windows.EnableSwipeGestures

--- a/website/src/pages/changelog.mdx
+++ b/website/src/pages/changelog.mdx
@@ -31,6 +31,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed panic when adding menuroles on Linux [#4558](https://github.com/wailsapp/wails/pull/4558) by [@jaesung9507](https://github.com/jaesung9507)
 - Fixed Discord badge in README by @sharkmu in [PR](https://github.com/wailsapp/wails/pull/4626)
 - Fixed HTML DnD by @leaanthony
+- Fixed Windows WebView2 initialization order issue causing "Not enough memory" errors [#4701](https://github.com/wailsapp/wails/issues/4701) [#4700](https://github.com/wailsapp/wails/issues/4700) [#4694](https://github.com/wailsapp/wails/issues/4694)
+
+### Changed
+- Updated go-webview2 to v1.0.23
 
 ## v2.10.2 - 2025-07-06
 

--- a/website/src/pages/changelog.mdx
+++ b/website/src/pages/changelog.mdx
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Windows WebView2 initialization order issue causing "Not enough memory" errors [#4701](https://github.com/wailsapp/wails/issues/4701) [#4700](https://github.com/wailsapp/wails/issues/4700) [#4694](https://github.com/wailsapp/wails/issues/4694)
+
 ## v2.11.0 - 2025-11-08
 
 ### Added
@@ -31,7 +35,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed panic when adding menuroles on Linux [#4558](https://github.com/wailsapp/wails/pull/4558) by [@jaesung9507](https://github.com/jaesung9507)
 - Fixed Discord badge in README by @sharkmu in [PR](https://github.com/wailsapp/wails/pull/4626)
 - Fixed HTML DnD by @leaanthony
-- Fixed Windows WebView2 initialization order issue causing "Not enough memory" errors [#4701](https://github.com/wailsapp/wails/issues/4701) [#4700](https://github.com/wailsapp/wails/issues/4700) [#4694](https://github.com/wailsapp/wails/issues/4694)
 
 ### Changed
 - Updated go-webview2 to v1.0.23


### PR DESCRIPTION
Reorder initialisation of webview2

Potentially Fixes #4694 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved Windows "Not enough memory" errors during WebView2 startup by changing when drag-and-drop is configured, improving startup reliability on Windows.
  * Added additional startup diagnostics to aid troubleshooting.

* **Chores**
  * Bumped go-webview2 dependency to v1.0.23.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->