### PR TITLE
Fix background color alpha on linux

### DIFF
--- a/v3/UNRELEASED_CHANGELOG.md
+++ b/v3/UNRELEASED_CHANGELOG.md
@@ -24,7 +24,7 @@ After processing, the content will be moved to the main changelog and this file 
 ## Fixed
 <!-- Bug fixes -->
 
-- Fixed an issue where the alpha value in `application.WebviewWindowOptions.BackgroundColour` is not respected. Fixed in [#4722](https://github.com/wailsapp/wails/pull/4722) by @BradHacker.
+- Resolve alpha value being ignored in `application.WebviewWindowOptions.BackgroundColour` on Linux ([#4722](https://github.com/wailsapp/wails/pull/4722), @BradHacker)
 
 ## Deprecated
 <!-- Soon-to-be removed features -->

--- a/v3/UNRELEASED_CHANGELOG.md
+++ b/v3/UNRELEASED_CHANGELOG.md
@@ -24,6 +24,8 @@ After processing, the content will be moved to the main changelog and this file 
 ## Fixed
 <!-- Bug fixes -->
 
+- Fixed an issue where the alpha value in `application.WebviewWindowOptions.BackgroundColour` is not respected. Fixed in [#4722](https://github.com/wailsapp/wails/pull/4722) by @BradHacker.
+
 ## Deprecated
 <!-- Soon-to-be removed features -->
 

--- a/v3/pkg/application/linux_cgo.go
+++ b/v3/pkg/application/linux_cgo.go
@@ -1190,7 +1190,6 @@ func (w *linuxWebviewWindow) setBackgroundColour(colour RGBA) {
 	rgba := C.GdkRGBA{C.double(colour.Red) / 255.0, C.double(colour.Green) / 255.0, C.double(colour.Blue) / 255.0, C.double(colour.Alpha) / 255.0}
 	C.webkit_web_view_set_background_color((*C.WebKitWebView)(w.webview), &rgba)
 
-	colour.Alpha = 255
 	cssStr := C.CString(fmt.Sprintf("#webview-box {background-color: rgba(%d, %d, %d, %1.1f);}", colour.Red, colour.Green, colour.Blue, float32(colour.Alpha)/255.0))
 	provider := C.gtk_css_provider_new()
 	C.gtk_style_context_add_provider(


### PR DESCRIPTION
<!--

*********************************************************************
*               PLEASE READ BEFORE SUBMITTING YOUR PR               *
*     YOUR PR MAY BE REJECTED IF IT DOES NOT FOLLOW THESE STEPS     *
*********************************************************************

- *DO NOT* submit PRs for v3 alpha enhancements, unless you have opened a post on the discord channel.
  All enhancements must be discussed first.
  The feedback guide for v3 is here: https://v3alpha.wails.io/getting-started/feedback/

- Before submitting your PR, please ensure you have created and linked the PR to an issue.
- If a relevant issue already exists, please reference it in your PR by including `Fixes #<issue number>` in your PR description.
- Please fill in the checklists.

-->

# Description

This PR patches what seems to be a mistakenly hardcoded value for the background color alpha. This causes all background colors to always be fully opaque instead of respecting the user-set background color.

Fixes #4721 

## Type of change
  
Please select the option that is relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
  
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration using `wails doctor`.

- [ ] Windows
- [ ] macOS
- [x] Linux (Fedora 42)

Tested against configurations described in #4721 and fixes the behavior:

<img width="175" height="120" alt="2025-11-20_23-59" src="https://github.com/user-attachments/assets/11b77e02-1bfd-40e6-9ab4-425042333195" />
  
## Test Configuration

Please paste the output of `wails doctor`. If you are unable to run this command, please describe your environment in as much detail as possible.

```shell
Wails (v3.0.0-alpha.40)  Wails Doctor

# System

┌────────────────────────────────────────────────────────────────────────────────────┐
| Name         | Fedora Linux                                                        |
| Version      | 42                                                                  |
| ID           | fedora                                                              |
| Branding     | 42 (Workstation Edition)                                            |
| Platform     | linux                                                               |
| Architecture | amd64                                                               |
| CPU          | AMD Ryzen 7 7840U w/ Radeon  780M Graphics                          |
| GPU 1        | Phoenix1 (Advanced Micro Devices, Inc. [AMD/ATI]) - Driver: amdgpu  |
| Memory       | 64GB                                                                |
└────────────────────────────────────────────────────────────────────────────────────┘

# Build Environment

┌────────────────────────────────┐
| Wails CLI    | v3.0.0-alpha.40 |
| Go Version   | go1.25.4        |
| -buildmode   | exe             |
| -compiler    | gc              |
| CGO_CFLAGS   |                 |
| CGO_CPPFLAGS |                 |
| CGO_CXXFLAGS |                 |
| CGO_ENABLED  | 1               |
| CGO_LDFLAGS  |                 |
| GOAMD64      | v1              |
| GOARCH       | amd64           |
| GOOS         | linux           |
└────────────────────────────────┘

# Dependencies

┌───────────────────────────┐
| pkg-config | 2.3.0        |
| webkit2gtk | 2.50.1       |
| gcc        | 15.0.1       |
| gtk3       | 3.24.49      |
| npm        | 11.6.2       |
|                           |
└─ * - Optional Dependency ─┘

# Checking for issues

 SUCCESS  No issues found

# Diagnosis

 SUCCESS  Your system is ready for Wails development!

Need documentation? Run: wails3 docs
 ♥   If Wails is useful to you or your company, please consider sponsoring the project: wails3 sponsor
```

# Checklist:

- [ ] I have updated `website/src/pages/changelog.mdx` with details of this PR
- [x] My code follows the general coding style of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Webview background transparency on Linux now respects the provided alpha value so backgrounds render correctly instead of being forced fully opaque.

* **Documentation**
  * Added changelog entry documenting the fix for background color alpha handling on Linux.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->