### PR TITLE
fix(linux): fix race conditions and potential deadlocks in event handling (#4424)

### DIFF
--- a/v3/UNRELEASED_CHANGELOG.md
+++ b/v3/UNRELEASED_CHANGELOG.md
@@ -26,6 +26,8 @@ After processing, the content will be moved to the main changelog and this file 
 - Fix window menu crash on Wayland caused by appmenu-gtk-module accessing unrealized window (#4769) by @leaanthony
 - Fix GTK application crash when app name contains invalid characters (spaces, parentheses, etc.) by @leaanthony
 - Fix "not enough memory" error when initializing drag and drop on Windows (#4701) by @overlordtm
+- Fix race condition in mainthread callback store using incorrect RLock for map deletion (Linux, macOS, iOS) (#4424) by @leaanthony
+- Fix potential deadlock in event dispatch by not holding windowsLock during blocking ExecJS calls (#4424) by @leaanthony
 <!-- Bug fixes -->
 
 ## Deprecated

--- a/v3/pkg/application/mainthread_darwin.go
+++ b/v3/pkg/application/mainthread_darwin.go
@@ -33,13 +33,15 @@ func (m *macosApp) dispatchOnMainThread(id uint) {
 
 //export dispatchOnMainThreadCallback
 func dispatchOnMainThreadCallback(callbackID C.uint) {
-	mainThreadFunctionStoreLock.RLock()
+	mainThreadFunctionStoreLock.Lock()
 	id := uint(callbackID)
 	fn := mainThreadFunctionStore[id]
 	if fn == nil {
+		mainThreadFunctionStoreLock.Unlock()
 		Fatal("dispatchCallback called with invalid id: %v", id)
+		return
 	}
 	delete(mainThreadFunctionStore, id)
-	mainThreadFunctionStoreLock.RUnlock()
+	mainThreadFunctionStoreLock.Unlock()
 	fn()
 }

--- a/v3/pkg/application/mainthread_ios.go
+++ b/v3/pkg/application/mainthread_ios.go
@@ -32,13 +32,15 @@ func (a *iosApp) dispatchOnMainThread(id uint) {
 
 //export dispatchOnMainThreadCallback
 func dispatchOnMainThreadCallback(callbackID C.uint) {
-	mainThreadFunctionStoreLock.RLock()
+	mainThreadFunctionStoreLock.Lock()
 	id := uint(callbackID)
 	fn := mainThreadFunctionStore[id]
 	if fn == nil {
+		mainThreadFunctionStoreLock.Unlock()
 		Fatal("dispatchCallback called with invalid id: %v", id)
+		return
 	}
 	delete(mainThreadFunctionStore, id)
-	mainThreadFunctionStoreLock.RUnlock()
+	mainThreadFunctionStoreLock.Unlock()
 	fn()
 }

--- a/v3/pkg/application/mainthread_linux.go
+++ b/v3/pkg/application/mainthread_linux.go
@@ -7,12 +7,14 @@ func (a *linuxApp) dispatchOnMainThread(id uint) {
 }
 
 func executeOnMainThread(callbackID uint) {
-	mainThreadFunctionStoreLock.RLock()
+	mainThreadFunctionStoreLock.Lock()
 	fn := mainThreadFunctionStore[callbackID]
 	if fn == nil {
+		mainThreadFunctionStoreLock.Unlock()
 		Fatal("dispatchCallback called with invalid id: %v", callbackID)
+		return
 	}
 	delete(mainThreadFunctionStore, callbackID)
-	mainThreadFunctionStoreLock.RUnlock()
+	mainThreadFunctionStoreLock.Unlock()
 	fn()
 }

--- a/v3/pkg/application/transport_event_ipc.go
+++ b/v3/pkg/application/transport_event_ipc.go
@@ -5,10 +5,17 @@ type EventIPCTransport struct {
 }
 
 func (t *EventIPCTransport) DispatchWailsEvent(event *CustomEvent) {
-	// Snapshot windows under RLock
+	// Snapshot windows under RLock - release lock before dispatching
+	// to avoid holding the lock during potentially blocking operations.
+	// This prevents deadlocks when ExecJS blocks waiting for the main thread.
 	t.app.windowsLock.RLock()
-	defer t.app.windowsLock.RUnlock()
+	windows := make([]Window, 0, len(t.app.windows))
 	for _, window := range t.app.windows {
+		windows = append(windows, window)
+	}
+	t.app.windowsLock.RUnlock()
+
+	for _, window := range windows {
 		if event.IsCancelled() {
 			return
 		}

--- a/v3/test/4424-event-block/Taskfile.yml
+++ b/v3/test/4424-event-block/Taskfile.yml
@@ -1,0 +1,6 @@
+version: "3"
+
+tasks:
+  run:
+    cmds:
+      - go run .

--- a/v3/test/4424-event-block/main.go
+++ b/v3/test/4424-event-block/main.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	_ "embed"
+	"log"
+	"time"
+
+	"github.com/wailsapp/wails/v3/pkg/application"
+	"github.com/wailsapp/wails/v3/pkg/events"
+	"github.com/wailsapp/wails/v3/pkg/icons"
+)
+
+func main() {
+	app := application.New(application.Options{
+		Name:        "Event Block Test",
+		Description: "Test for issue #4424 - Event emitter blocks menu button press",
+		Assets:      application.AlphaAssets,
+		Mac: application.MacOptions{
+			ActivationPolicy: application.ActivationPolicyAccessory,
+		},
+	})
+
+	// Create a system tray with a menu
+	systemTray := app.SystemTray.New()
+	systemTray.SetIcon(icons.WailsLogoBlack)
+
+	menu := app.NewMenu()
+	menu.Add("About").OnClick(func(ctx *application.Context) {
+		log.Println("About clicked!")
+		application.InfoDialog().
+			SetTitle("About").
+			SetMessage("This is a test for issue #4424").
+			Show()
+	})
+	menu.Add("Show Time").OnClick(func(ctx *application.Context) {
+		log.Printf("Time clicked! Current time: %s\n", time.Now().Format(time.RFC3339))
+	})
+	menu.AddSeparator()
+	menu.Add("Quit").OnClick(func(ctx *application.Context) {
+		log.Println("Quit clicked!")
+		app.Quit()
+	})
+
+	systemTray.SetMenu(menu)
+
+	// Start emitting events after application starts
+	app.Event.OnApplicationEvent(events.Common.ApplicationStarted, func(event *application.ApplicationEvent) {
+		go func() {
+			log.Println("Starting event emitter...")
+			log.Println("TEST: Right-click the systray icon and click menu items.")
+			log.Println("They should continue to work even with events being emitted.")
+			log.Println("BUG: On Linux, menu clicks stop working after events start.")
+
+			counter := 0
+			for {
+				counter++
+				log.Printf("Emitting event #%d...\n", counter)
+				app.Event.Emit("backendmessage", map[string]interface{}{
+					"counter": counter,
+					"time":    time.Now().Format(time.RFC3339),
+				})
+				time.Sleep(3 * time.Second)
+			}
+		}()
+	})
+
+	// Run the application
+	if err := app.Run(); err != nil {
+		log.Fatal(err)
+	}
+}


### PR DESCRIPTION
## Summary

This PR addresses issues that could cause menu buttons to stop responding when events are being emitted frequently on Linux (and potentially macOS/iOS).

### Changes:

1. **Fixed race condition in mainthread callback store** (Linux, macOS, iOS):
   - Changed `RLock()` to `Lock()` when deleting from `mainThreadFunctionStore`
   - The previous code used `RLock` for what should be a read-only operation, but then called `delete()` which modifies the map - this violates the RWMutex contract

2. **Fixed potential deadlock in `EventIPCTransport.DispatchWailsEvent`**:
   - Changed to snapshot the windows list and release the lock before dispatching
   - Previously held `windowsLock.RLock()` during `ExecJS` which blocks waiting for the main thread
   - If any main thread operation needed `windowsLock.Lock()`, this could cause a deadlock

3. **Added test case** (`v3/test/4424-event-block/`) to reproduce the issue

## Test plan

- [ ] Run the test case in `v3/test/4424-event-block/` 
- [ ] Verify that systray menu items remain responsive while events are being emitted every 3 seconds
- [ ] Test on Linux with both X11 and Wayland

Fixes #4424

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved thread safety in callback handling across Linux, macOS, and iOS platforms
  * Enhanced event dispatch to prevent potential deadlock scenarios during blocking operations

* **Tests**
  * Added test case for event blocking scenarios

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->