### PR TITLE
fix(linux): account for window decorator offset on Wayland for max size constraints

### DIFF
--- a/v3/UNRELEASED_CHANGELOG.md
+++ b/v3/UNRELEASED_CHANGELOG.md
@@ -26,6 +26,7 @@ After processing, the content will be moved to the main changelog and this file 
 - Fix window menu crash on Wayland caused by appmenu-gtk-module accessing unrealized window (#4769) by @leaanthony
 - Fix GTK application crash when app name contains invalid characters (spaces, parentheses, etc.) by @leaanthony
 - Fix "not enough memory" error when initializing drag and drop on Windows (#4701) by @overlordtm
+- Fix window maximum width and height constraints not working on Wayland by accounting for window decorator offsets (#4429) by @leaanthony
 <!-- Bug fixes -->
 
 ## Deprecated

--- a/v3/UNRELEASED_CHANGELOG.md
+++ b/v3/UNRELEASED_CHANGELOG.md
@@ -26,7 +26,6 @@ After processing, the content will be moved to the main changelog and this file 
 - Fix window menu crash on Wayland caused by appmenu-gtk-module accessing unrealized window (#4769) by @leaanthony
 - Fix GTK application crash when app name contains invalid characters (spaces, parentheses, etc.) by @leaanthony
 - Fix "not enough memory" error when initializing drag and drop on Windows (#4701) by @overlordtm
-- Fix window maximum width and height constraints not working on Wayland by accounting for window decorator offsets (#4429) by @leaanthony
 - Fix file explorer opening wrong directory on Linux due to incorrect URI escaping (#4397) by @leaanthony
 - Fix AppImage build failure on modern Linux distributions (Arch, Fedora 39+, Ubuntu 24.04+) by auto-detecting `.relr.dyn` ELF sections and disabling stripping (#4642) by @leaanthony
 <!-- Bug fixes -->


### PR DESCRIPTION
## Summary
- Ports the v2 fix from PR #4047 to v3 for Wayland window max size constraints
- On Wayland, GTK reports window allocation size including decorations but `gtk_window_get_size()` returns size without decorations
- This caused max size constraints to prevent fullscreen/maximize from filling the screen properly
- The fix calculates and caches the decorator offset and adds it to max size constraints on Wayland

## Technical Details
- Added `isWayland()` helper that caches Wayland detection via `XDG_SESSION_TYPE` environment variable
- Added `setDecoratorOffset()` and `getDecoratorOffset()` functions to calculate and cache the decorator dimensions
- Modified `windowSetGeometryHints` in both CGO and PureGo implementations to add decorator offset to max width/height

## Test plan
- [x] Build passes
- [ ] Test on Wayland: verify window can be maximized and goes fullscreen properly with max size constraints set
- [ ] Test on X11: verify behavior is unchanged (decorator offset will be 0)

Fixes #4429

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved window sizing on Wayland so maximum window dimensions account for window decorations more accurately.
  * Reduced issues where GTK windows could be clipped or sized incorrectly when resizing or applying geometry constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->