### PR TITLE
docs: add Linux runtime dependencies and nfpm packaging guide

### DIFF
--- a/v3/UNRELEASED_CHANGELOG.md
+++ b/v3/UNRELEASED_CHANGELOG.md
@@ -17,6 +17,7 @@ After processing, the content will be moved to the main changelog and this file 
 
 ## Added
 - Add `XDG_SESSION_TYPE` to `wails3 doctor` output on Linux by @leaanthony
+- Add Linux runtime dependencies documentation with distro-specific package names and nfpm packaging examples (#4339) by @leaanthony
 <!-- New features, capabilities, or enhancements -->
 
 ## Changed

--- a/website/docs/guides/linux-distro-support.mdx
+++ b/website/docs/guides/linux-distro-support.mdx
@@ -108,3 +108,86 @@ Take a look at the other package managers code to get an idea how this works.
 If you add support for a new package manager, don't forget to also update this page!
 
 :::
+
+## Runtime Dependencies
+
+When distributing your Wails application, end users need the GTK3 and WebKit2GTK runtime libraries installed.
+The package names vary by distribution:
+
+| Distribution | GTK3 | WebKit2GTK | ABI | Installation Command |
+|--------------|------|------------|-----|---------------------|
+| Debian 12 / Ubuntu 22.04+ | libgtk-3-0 | libwebkit2gtk-4.1-0 | 4.1 | `apt install libgtk-3-0 libwebkit2gtk-4.1-0` |
+| Debian 11 / Ubuntu 20.04 | libgtk-3-0 | libwebkit2gtk-4.0-37 | 4.0 | `apt install libgtk-3-0 libwebkit2gtk-4.0-37` |
+| Fedora 40+ | gtk3 | webkit2gtk4.1 | 4.1 | `dnf install gtk3 webkit2gtk4.1` |
+| RHEL / CentOS / AlmaLinux / Rocky 8-9 | gtk3 | webkit2gtk3 | 4.0 | `dnf install gtk3 webkit2gtk3` |
+| openSUSE Leap / Tumbleweed | libgtk-3-0 | libwebkit2gtk-4_1-0 | 4.1 | `zypper install libgtk-3-0 libwebkit2gtk-4_1-0` |
+| Arch Linux / Manjaro | gtk3 | webkit2gtk-4.1 | 4.1 | `pacman -S gtk3 webkit2gtk-4.1` |
+
+### WebKit2GTK ABI Versions
+
+WebKit2GTK has two ABI versions:
+- **ABI 4.1** - Modern version, used by most current distributions
+- **ABI 4.0** - Legacy version, required for older distributions (Debian 11, Ubuntu 20.04, RHEL/CentOS 8-9)
+
+When building your application, use the appropriate build tag:
+- `-tags webkit2_41` for distributions with ABI 4.1 (default for most modern distros)
+- `-tags webkit2_40` for RHEL-based systems and older Debian/Ubuntu
+
+### Notes
+
+- openSUSE provides both WebKitGTK 4.0 and 4.1; use `libwebkit2gtk-4_1-0` for the modern ABI
+- Fedora only has `webkit2gtk4.1` starting from version 40; earlier versions use 4.0
+- On RHEL/AlmaLinux/Rocky/CentOS 8-9, `webkit2gtk3` corresponds to ABI 4.0; 4.1 is not available
+- Arch Linux offers both `webkit2gtk` (4.0) and `webkit2gtk-4.1`; use the latter for modern ABI
+
+## Packaging with nfpm
+
+When creating Linux packages with [nfpm](https://nfpm.goreleaser.com/), you need to specify the correct dependencies for each distribution.
+
+### For Debian 12 / Ubuntu 22.04+ / openSUSE / Arch Linux (ABI 4.1)
+
+```yaml
+depends:
+  - libgtk-3-0
+  - libwebkit2gtk-4.1-0
+overrides:
+  rpm:
+    depends:
+      - libgtk-3-0
+      - libwebkit2gtk-4_1-0
+  archlinux:
+    depends:
+      - gtk3
+      - webkit2gtk-4.1
+```
+
+### For RHEL / CentOS / AlmaLinux / Rocky and older Debian/Ubuntu (ABI 4.0)
+
+```yaml
+depends:
+  - gtk3
+  - webkit2gtk3
+overrides:
+  deb:
+    depends:
+      - libgtk-3-0
+      - libwebkit2gtk-4.0-37
+  archlinux:
+    depends:
+      - gtk3
+      - webkit2gtk
+```
+
+### For Fedora 40+
+
+```yaml
+depends:
+  - gtk3
+  - webkit2gtk4.1
+```
+
+:::tip
+
+To support multiple distributions, you may need separate nfpm configuration files for different ABI versions.
+
+:::


### PR DESCRIPTION
## Summary
- Add runtime dependencies table for different Linux distributions
- Document WebKit2GTK ABI version differences (4.0 vs 4.1)
- Add build tag documentation for targeting different ABI versions
- Include nfpm configuration examples for packaging

## Details

This documents the runtime dependencies that end users need when running Wails applications on Linux. The table covers:

| Distribution | ABI Version |
|--------------|-------------|
| Debian 12 / Ubuntu 22.04+ | 4.1 |
| Debian 11 / Ubuntu 20.04 | 4.0 |
| Fedora 40+ | 4.1 |
| RHEL / CentOS / AlmaLinux / Rocky 8-9 | 4.0 |
| openSUSE | 4.1 |
| Arch Linux | 4.1 |

Also includes nfpm configuration examples for creating Linux packages with the correct dependencies.

Based on community contribution by @jidckii in the discussion linked to #4339.

Fixes #4339

🤖 Generated with [Claude Code](https://claude.com/claude-code)