### PR TITLE
Prevent app crashing when calling systray.Run() before app.Run()

### DIFF
--- a/v3/UNRELEASED_CHANGELOG.md
+++ b/v3/UNRELEASED_CHANGELOG.md
@@ -23,6 +23,7 @@ After processing, the content will be moved to the main changelog and this file 
 
 ## Fixed
 <!-- Bug fixes -->
+- Prevent app crashing when calling systray.Run() before app.Run() by @leaanthony
 
 ## Deprecated
 <!-- Soon-to-be removed features -->

--- a/v3/pkg/application/systemtray.go
+++ b/v3/pkg/application/systemtray.go
@@ -96,6 +96,13 @@ func (s *SystemTray) Label() string {
 }
 
 func (s *SystemTray) Run() {
+
+	// exit early if application isn't running.
+	// app.Run() will call this
+	if globalApplication == nil || globalApplication.running == false {
+		return
+	}
+
 	s.impl = newSystemTrayImpl(s)
 
 	if s.attachedWindow.Window != nil {


### PR DESCRIPTION

Prevent app crashing when calling systray.Run() before app.Run()

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved a crash that occurred when system tray was initialized before the application fully started.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->