### PR TITLE
fix(security): restrict GITHUB_TOKEN permissions in workflows

### DIFF
--- a/.github/workflows/automated-releases.yml
+++ b/.github/workflows/automated-releases.yml
@@ -20,6 +20,10 @@ on:
 env:
   GO_VERSION: '1.24'
 
+# Restrict default GITHUB_TOKEN permissions
+permissions:
+  contents: read
+
 jobs:
   check-permissions:
     name: Check Release Permissions
@@ -45,6 +49,8 @@ jobs:
   detect-v2-changes:
     name: Detect v2 Changes
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     needs: check-permissions
     if: needs.check-permissions.outputs.authorized == 'true'
     outputs:
@@ -90,8 +96,10 @@ jobs:
           fi
 
   detect-v3-changes:
-    name: Detect v3-alpha Changes  
+    name: Detect v3-alpha Changes
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     needs: check-permissions
     if: needs.check-permissions.outputs.authorized == 'true'
     outputs:
@@ -140,6 +148,8 @@ jobs:
   release-v2:
     name: Create v2 Release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     needs: [check-permissions, detect-v2-changes]
     if: |
       needs.check-permissions.outputs.authorized == 'true' &&
@@ -232,6 +242,8 @@ jobs:
   release-v3:
     name: Create v3-alpha Release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     needs: [check-permissions, detect-v3-changes]
     if: |
       needs.check-permissions.outputs.authorized == 'true' &&
@@ -326,6 +338,7 @@ jobs:
   summary:
     name: Release Summary
     runs-on: ubuntu-latest
+    permissions: {}
     needs: [check-permissions, detect-v2-changes, detect-v3-changes, release-v2, release-v3]
     if: always() && needs.check-permissions.outputs.authorized == 'true'
     steps:

--- a/.github/workflows/build-and-test-v3.yml
+++ b/.github/workflows/build-and-test-v3.yml
@@ -10,10 +10,15 @@ on:
     branches:
       - v3-alpha
 
+# Restrict default GITHUB_TOKEN permissions
+permissions:
+  contents: read
+
 jobs:
   check_approval:
     name: Check PR Approval
     runs-on: ubuntu-latest
+    permissions: {}
     if: github.base_ref == 'v3-alpha'
     outputs:
       approved: ${{ steps.check.outputs.approved }}
@@ -31,6 +36,8 @@ jobs:
     name: Run JS Tests
     needs: check_approval
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     if: github.base_ref == 'v3-alpha'
     strategy:
       matrix:
@@ -100,6 +107,8 @@ jobs:
     name: Run Go Tests v3
     needs: [check_approval, test_js]
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
     if: github.base_ref == 'v3-alpha'
     strategy:
       fail-fast: false
@@ -175,6 +184,7 @@ jobs:
     if: always()
     needs: [test_js, test_go, test_templates]
     runs-on: ubuntu-latest
+    permissions: {}
     steps:
       - uses: geekyeggo/delete-artifact@v5
         with:
@@ -187,6 +197,8 @@ jobs:
     name: Test Templates
     needs: [test_js, test_go]
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
     if: github.base_ref == 'v3-alpha'
     strategy:
       fail-fast: false
@@ -263,6 +275,7 @@ jobs:
   build_results:
     if: ${{ always() }}
     runs-on: ubuntu-latest
+    permissions: {}
     name: v3 Build Results
     needs: [test_go, test_js, test_templates]
     steps:

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -3,6 +3,10 @@ on:
     branches: ['v3-alpha']
   workflow_dispatch:
 
+# Restrict default GITHUB_TOKEN permissions
+permissions:
+  contents: read
+
 concurrency:
   group: publish-npm-v3
   cancel-in-progress: true
@@ -11,6 +15,8 @@ jobs:
   detect:
     name: Detect committed changes
     if: github.event_name != 'workflow_dispatch'
+    permissions:
+      contents: read
     outputs:
       changed: ${{ steps.package-json-changes.outputs.any_modified == 'true' || steps.source-changes.outputs.any_modified == 'true' }}
     runs-on: ubuntu-latest

--- a/.github/workflows/test-simple.yml
+++ b/.github/workflows/test-simple.yml
@@ -3,9 +3,13 @@ name: Test Simple
 on:
   workflow_dispatch:
 
+# Restrict default GITHUB_TOKEN permissions
+permissions: {}
+
 jobs:
   test:
     runs-on: ubuntu-latest
+    permissions: {}
     steps:
     - name: Test
       run: echo "Hello World"


### PR DESCRIPTION
## Summary
- Add explicit permissions blocks to GitHub Actions workflow files to follow the principle of least privilege
- Addresses CodeQL security warnings about workflows not limiting GITHUB_TOKEN permissions

## Changes
- `automated-releases.yml`: Add workflow-level `contents: read` default, job-level permissions for release jobs that need write access
- `build-and-test-v3.yml`: Add workflow-level `contents: read` default, job-level permissions for each job
- `publish-npm.yml`: Add workflow-level `contents: read` default, job-level permissions for detect job (rebuild_and_publish already had explicit permissions)
- `test-simple.yml`: Add empty permissions block since it only echoes text

## Test plan
- [ ] Verify workflows run successfully after permissions changes
- [ ] Confirm release workflow can still create releases (has write permissions)
- [ ] Confirm publish workflow can still push commits (has write permissions)

Generated with [Claude Code](https://claude.ai/claude-code)