### PR TITLE
fix(v3/bindings): map time.Time to JavaScript Date type

### DIFF
--- a/v3/internal/generator/collect/imports.go
+++ b/v3/internal/generator/collect/imports.go
@@ -152,6 +152,11 @@ func (imports *ImportMap) addTypeImpl(typ types.Type, visited *typeutil.Map) {
 				return
 			}
 
+			// Special case: time.Time will render as JS Date hence no dependencies and no model
+			if obj.Pkg().Path() == "time" && obj.Name() == "Time" {
+				return
+			}
+
 			if obj.Pkg().Path() == imports.Self {
 				imports.ImportModels = true
 			}

--- a/v3/internal/generator/collect/predicates.go
+++ b/v3/internal/generator/collect/predicates.go
@@ -426,6 +426,13 @@ func IsAny(typ types.Type) bool {
 	// Follow alias chain.
 	typ = types.Unalias(typ)
 
+	// Special case: time.Time renders as JS Date, not any
+	if named, ok := typ.(*types.Named); ok {
+		if obj := named.Obj(); obj.Pkg() != nil && obj.Pkg().Path() == "time" && obj.Name() == "Time" {
+			return false
+		}
+	}
+
 	if MaybeJSONMarshaler(typ) != NonMarshaler {
 		// If typ is either a named type, an interface, a pointer or a struct,
 		// it will be rendered as (possibly an alias for) the TS any type.

--- a/v3/internal/generator/render/create.go
+++ b/v3/internal/generator/render/create.go
@@ -54,6 +54,11 @@ func (m *module) needsCreateImpl(typ types.Type, visited *typeutil.Map) bool {
 			return false
 		}
 
+		// Special case: time.Time renders as JS Date, needs creation to parse string to Date
+		if t.Obj().Pkg().Path() == "time" && t.Obj().Name() == "Time" {
+			return true
+		}
+
 		if collect.IsAny(typ) || collect.IsStringAlias(typ) {
 			break
 		} else if collect.IsClass(typ) {
@@ -149,6 +154,12 @@ func (m *module) JSCreateWithParams(typ types.Type, params string) string {
 
 		if m.collector.IsVoidAlias(t.Obj()) {
 			return "$Create.Any"
+		}
+
+		// Special case: time.Time renders as JS Date
+		// JSON marshals time.Time as RFC3339 string, which Date constructor can parse
+		if t.Obj().Pkg().Path() == "time" && t.Obj().Name() == "Time" {
+			return "$Create.Date"
 		}
 
 		if !m.NeedsCreate(typ) {

--- a/v3/internal/generator/render/default.go
+++ b/v3/internal/generator/render/default.go
@@ -102,6 +102,12 @@ func (m *module) renderNamedDefault(typ aliasOrNamed, quoted bool) (result strin
 		return m.JSDefault(typ.Underlying(), quoted), true
 	}
 
+	// Special case: time.Time renders as JS Date, default to null
+	// (Go's zero time doesn't map cleanly to JS Date)
+	if typ.Obj().Pkg().Path() == "time" && typ.Obj().Name() == "Time" {
+		return "null", true
+	}
+
 	if quoted {
 		// WARN: Do not test with IsAny/IsStringAlias here!! We only want to catch marshalers.
 		if collect.MaybeJSONMarshaler(typ) == collect.NonMarshaler && collect.MaybeTextMarshaler(typ) == collect.NonMarshaler {

--- a/v3/internal/generator/render/type.go
+++ b/v3/internal/generator/render/type.go
@@ -181,6 +181,13 @@ func (m *module) renderNamedType(typ aliasOrNamed, quoted bool) (result string, 
 		return "void", false
 	}
 
+	// Special case: time.Time renders as JS Date
+	// time.Time implements json.Marshaler and normally renders as 'any',
+	// but it actually marshals to an RFC3339 string that JS Date can parse.
+	if typ.Obj().Pkg().Path() == "time" && typ.Obj().Name() == "Time" {
+		return "Date", false
+	}
+
 	if quoted {
 		switch a := types.Unalias(typ).(type) {
 		case *types.Basic:

--- a/v3/internal/runtime/desktop/@wailsio/runtime/src/create.ts
+++ b/v3/internal/runtime/desktop/@wailsio/runtime/src/create.ts
@@ -24,6 +24,14 @@ export function ByteSlice(source: any): string {
 }
 
 /**
+ * Date is a creation function that converts RFC3339 strings
+ * (from Go's time.Time JSON marshaling) to JavaScript Date objects.
+ */
+export function Date(source: any): globalThis.Date | null {
+    return ((source == null) ? null : new globalThis.Date(source));
+}
+
+/**
  * Array takes a creation function for an arbitrary type
  * and returns an in-place creation function for an array
  * whose elements are of that type.


### PR DESCRIPTION
## Summary

- Maps Go's `time.Time` type to JavaScript's native `Date` type in TypeScript bindings
- Adds `$Create.Date` runtime function to convert RFC3339 strings to Date objects
- Removes generation of unnecessary `time/models.ts` file with `export type Time = any;`

## Problem

When a Go service method returns `time.Time`, the TypeScript binding generator was creating:
```typescript
// time/models.ts
export type Time = any;

// greetservice.ts
import * as time$0 from "../time/models.js";
export function GetTime(): $CancellablePromise<time$0.Time> { ... }
```

This happened because `time.Time` implements `json.Marshaler`, and the generator treats all JSON marshalers as `any` since their output type is unknown.

## Solution

Added special-case handling for `time.Time` since it marshals to RFC3339 format which JavaScript's `Date` constructor can parse:

1. **type.go**: Return `"Date"` directly for `time.Time` types
2. **imports.go**: Don't import `time` package or create models for `time.Time`
3. **predicates.go**: `IsAny()` returns `false` for `time.Time`
4. **default.go**: Default value for `time.Time` is `null`
5. **create.go**: Use `$Create.Date` to convert RFC3339 strings to Date objects
6. **create.ts**: Added `Date()` creation function to runtime

## Test plan

- [x] Generator tests pass
- [ ] Manually test with a service that returns `time.Time`
- [ ] Verify generated TypeScript uses `Date` type
- [ ] Verify dates are properly parsed from RFC3339 strings

Fixes #4753

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Improved date/time handling in code generation: Go's time.Time type now maps directly to JavaScript Date objects in generated TypeScript. Added RFC3339 string-to-Date conversion support and proper null value handling for zero timestamps, providing better type safety and developer experience.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->