### PR TITLE
feat(v3): add -f flag to force init in non-empty directories

### DIFF
--- a/v3/internal/flags/init.go
+++ b/v3/internal/flags/init.go
@@ -20,4 +20,5 @@ type Init struct {
 	ProductComments    string `description:"Comments to add to the generated files" default:"This is a comment"`
 	ProductIdentifier  string `description:"The product identifier, e.g com.mycompany.myproduct"`
 	SkipWarning        bool   `name:"s" description:"Skips the warning message when using remote templates"`
+	Force              bool   `name:"f" description:"Force initialization in non-empty directories"`
 }

--- a/v3/internal/templates/templates.go
+++ b/v3/internal/templates/templates.go
@@ -293,12 +293,12 @@ func Install(options *flags.Init) error {
 
 	templateData.ProjectDir = projectDir
 
-	// If project directory already exists and is not empty, error
+	// If project directory already exists and is not empty, error (unless --force is used)
 	if _, err := os.Stat(templateData.ProjectDir); !os.IsNotExist(err) {
 		// Check if the directory is empty
 		files := lo.Must(os.ReadDir(templateData.ProjectDir))
-		if len(files) > 0 {
-			return fmt.Errorf("project directory '%s' already exists and is not empty", templateData.ProjectDir)
+		if len(files) > 0 && !options.Force {
+			return fmt.Errorf("project directory '%s' already exists and is not empty. Use -f to force initialization", templateData.ProjectDir)
 		}
 	}
 


### PR DESCRIPTION
## Summary

Add a `--force`/`-f` flag to the `wails init` command to allow initialization in non-empty directories. When the target directory contains files, the command now shows a helpful error message instructing users to use `-f` if they intend to proceed.

This is a minimal, clean implementation targeting v3-alpha (the correct base branch).

## Changes

- Add `Force` flag to `v3/internal/flags/init.go`
- Update safety check in `v3/internal/templates/templates.go` to respect the force flag
- Update error message to guide users to use `-f`

## Test plan

- [ ] Run `wails init -n test` in an empty directory - should succeed
- [ ] Run `wails init -n test` in a non-empty directory - should fail with helpful message
- [ ] Run `wails init -n test -f` in a non-empty directory - should succeed

Fixes #4940

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `-f` flag to force project initialization in non-empty directories, allowing initialization to proceed even when the target directory contains existing files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->