### PR TITLE
docs(v2): add `wails-template` organization to templates

### DIFF
--- a/website/docs/community/templates.mdx
+++ b/website/docs/community/templates.mdx
@@ -80,3 +80,7 @@ If you are unsure about a template, inspect `package.json` and `wails.json` for 
 ## Lit (web components)
 
 - [wails-lit-shoelace-esbuild-template](https://github.com/Braincompiler/wails-lit-shoelace-esbuild-template) - Wails template providing frontend with lit, Shoelace component library + pre-configured prettier and typescript.
+
+## Framework templates
+
+- [wails-template organization](https://github.com/wails-template) - An organization that provides up-to-date templates synced with other frameworks, such as Vite.


### PR DESCRIPTION
I've added a cron job to automatically sync templates from other frameworks (starting with Vite). You can now find these in the https://github.com/wails-template which currently includes 16 newly synced templates from Vite.

I want to add it to the doc, but I don't know how to add the content correctly. 

# Description

add a templates organization.

## Type of change
  
Please select the option that is relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Updated community templates documentation with a new "Framework templates" section
* Added information about the wails-template organization as a centralized resource for framework-specific templates

<!-- end of auto-generated comment: release notes by coderabbit.ai -->