### PR TITLE
feat(linux): add WebKitGTK spellcheck options

### DIFF
--- a/v2/internal/frontend/desktop/linux/window.c
+++ b/v2/internal/frontend/desktop/linux/window.c
@@ -555,7 +555,7 @@ static gboolean onDragDrop(GtkWidget* self, GdkDragContext* context, gint x, gin
 }
 
 // WebView
-GtkWidget *SetupWebview(void *contentManager, GtkWindow *window, int hideWindowOnClose, int gpuPolicy, int disableWebViewDragAndDrop, int enableDragAndDrop)
+GtkWidget *SetupWebview(void *contentManager, GtkWindow *window, int hideWindowOnClose, int gpuPolicy, int disableWebViewDragAndDrop, int enableDragAndDrop, int spellCheckEnabled, char *spellCheckLanguagesCSV)
 {
     GtkWidget *webview = webkit_web_view_new_with_user_content_manager((WebKitUserContentManager *)contentManager);
 
@@ -564,6 +564,13 @@ GtkWidget *SetupWebview(void *contentManager, GtkWindow *window, int hideWindowO
     // gtk_container_add(GTK_CONTAINER(window), webview);
     WebKitWebContext *context = webkit_web_context_get_default();
     webkit_web_context_register_uri_scheme(context, "wails", (WebKitURISchemeRequestCallback)processURLRequest, NULL, NULL);
+    webkit_web_context_set_spell_checking_enabled(context, spellCheckEnabled == 1);
+    if (spellCheckEnabled == 1 && spellCheckLanguagesCSV != NULL && spellCheckLanguagesCSV[0] != '\0')
+    {
+        gchar **languages = g_strsplit(spellCheckLanguagesCSV, ",", -1);
+        webkit_web_context_set_spell_checking_languages(context, (const gchar * const *)languages);
+        g_strfreev(languages);
+    }
     g_signal_connect(G_OBJECT(webview), "load-changed", G_CALLBACK(webviewLoadChanged), NULL);
 
     if(disableWebViewDragAndDrop)

--- a/v2/internal/frontend/desktop/linux/window.go
+++ b/v2/internal/frontend/desktop/linux/window.go
@@ -91,12 +91,28 @@ func NewWindow(appoptions *options.App, debug bool, devtoolsEnabled bool) *Windo
 	C.SetupInvokeSignal(result.contentManager)
 
 	var webviewGpuPolicy int
+	spellCheckEnabled := false
+	spellCheckLanguagesCSV := ""
 	if appoptions.Linux != nil {
 		webviewGpuPolicy = int(appoptions.Linux.WebviewGpuPolicy)
+		spellCheckEnabled = appoptions.Linux.SpellCheckEnabled
+		if len(appoptions.Linux.SpellCheckLanguages) > 0 {
+			languages := make([]string, 0, len(appoptions.Linux.SpellCheckLanguages))
+			for _, language := range appoptions.Linux.SpellCheckLanguages {
+				language = strings.TrimSpace(language)
+				if language == "" {
+					continue
+				}
+				languages = append(languages, language)
+			}
+			spellCheckLanguagesCSV = strings.Join(languages, ",")
+		}
 	} else {
 		// workaround for https://github.com/wailsapp/wails/issues/2977
 		webviewGpuPolicy = int(linux.WebviewGpuPolicyNever)
 	}
+	spellCheckLanguages := C.CString(spellCheckLanguagesCSV)
+	defer C.free(unsafe.Pointer(spellCheckLanguages))
 
 	webview := C.SetupWebview(
 		result.contentManager,
@@ -105,6 +121,8 @@ func NewWindow(appoptions *options.App, debug bool, devtoolsEnabled bool) *Windo
 		C.int(webviewGpuPolicy),
 		bool2Cint(appoptions.DragAndDrop != nil && appoptions.DragAndDrop.DisableWebViewDrop),
 		bool2Cint(appoptions.DragAndDrop != nil && appoptions.DragAndDrop.EnableFileDrop),
+		bool2Cint(spellCheckEnabled),
+		spellCheckLanguages,
 	)
 	result.webview = unsafe.Pointer(webview)
 	buttonPressedName := C.CString("button-press-event")

--- a/v2/internal/frontend/desktop/linux/window.h
+++ b/v2/internal/frontend/desktop/linux/window.h
@@ -106,7 +106,7 @@ gboolean Fullscreen(gpointer data);
 gboolean UnFullscreen(gpointer data);
 
 // WebView
-GtkWidget *SetupWebview(void *contentManager, GtkWindow *window, int hideWindowOnClose, int gpuPolicy, int disableWebViewDragAndDrop, int enableDragAndDrop);
+GtkWidget *SetupWebview(void *contentManager, GtkWindow *window, int hideWindowOnClose, int gpuPolicy, int disableWebViewDragAndDrop, int enableDragAndDrop, int spellCheckEnabled, char *spellCheckLanguagesCSV);
 void LoadIndex(void *webview, char *url);
 void DevtoolsEnabled(void *webview, int enabled, bool showInspector);
 void ExecuteJS(void *data);

--- a/v2/pkg/options/linux/linux.go
+++ b/v2/pkg/options/linux/linux.go
@@ -43,6 +43,13 @@ type Options struct {
 	//
 	//[see the docs]: https://docs.gtk.org/glib/func.set_prgname.html
 	ProgramName string
+
+	// SpellCheckEnabled controls WebKitGTK spell checking for editable web content.
+	SpellCheckEnabled bool
+
+	// SpellCheckLanguages sets the preferred spellcheck languages in BCP 47 style,
+	// for example "en-AU" or "en-US". Empty values are ignored.
+	SpellCheckLanguages []string
 }
 
 type Messages struct {


### PR DESCRIPTION
## Summary
Add Linux WebKitGTK spellcheck support to Wails v2 by exposing spellcheck settings through `options.Linux` and wiring them into the WebKit web context.

## Problem
Wails currently exposes the browser default context menu, but on Linux there is no way for an app to explicitly enable WebKitGTK spellchecking or set spellcheck languages. For editors built on `contenteditable` or `<textarea spellcheck>`, this prevents native misspelling underlines and spelling suggestions from working reliably.

This addresses #3534.

## Changes
- add `SpellCheckEnabled bool` to `options.Linux`
- add `SpellCheckLanguages []string` to `options.Linux`
- pass those options through the Linux desktop frontend
- call `webkit_web_context_set_spell_checking_enabled()`
- call `webkit_web_context_set_spell_checking_languages()` when languages are provided

## Scope
This PR only changes the Linux WebKitGTK implementation. It does not add Windows or macOS spellcheck support.

## Validation
Used this patch from a downstream Wails app and confirmed:
- native misspelling squiggles appear in the editor
- right-click spelling suggestions appear in the native context menu
- downstream app still passes `go test ./...`
- downstream app still builds successfully on Linux with `wails build`

## Notes
Language handling is intentionally minimal here: Wails accepts a list of language tags and passes them straight to WebKitGTK after filtering empty values.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added spell-check configuration options for Linux desktop users. Users can now enable or disable spell checking on editable web content and specify preferred spell-check languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->