### PR TITLE
fix(darwin): propagate backing scale factor to WKWebView for correct devicePixelRatio on Retina displays

### DIFF
--- a/v2/internal/frontend/desktop/darwin/Application.h
+++ b/v2/internal/frontend/desktop/darwin/Application.h
@@ -17,7 +17,7 @@
 #define WindowStartsMinimised 2
 #define WindowStartsFullscreen 3
 
-WailsContext* Create(const char* title, int width, int height, int frameless, int resizable, int zoomable, int fullscreen, int fullSizeContent, int hideTitleBar, int titlebarAppearsTransparent, int hideTitle, int useToolbar, int hideToolbarSeparator, int webviewIsTransparent, int alwaysOnTop, int hideWindowOnClose, const char *appearance, int windowIsTranslucent, int contentProtection, int devtoolsEnabled, int defaultContextMenuEnabled, int windowStartState, int startsHidden, int minWidth, int minHeight, int maxWidth, int maxHeight, bool fraudulentWebsiteWarningEnabled, struct Preferences preferences, int singleInstanceLockEnabled, const char* singleInstanceUniqueId, bool enableDragAndDrop, bool disableWebViewDragAndDrop, int disableEscapeExitsFullscreen);
+WailsContext* Create(const char* title, int width, int height, int frameless, int resizable, int zoomable, int fullscreen, int fullSizeContent, int hideTitleBar, int titlebarAppearsTransparent, int hideTitle, int useToolbar, int hideToolbarSeparator, int webviewIsTransparent, int alwaysOnTop, int hideWindowOnClose, const char *appearance, int windowIsTranslucent, int contentProtection, int devtoolsEnabled, int defaultContextMenuEnabled, int windowStartState, int startsHidden, int minWidth, int minHeight, int maxWidth, int maxHeight, bool fraudulentWebsiteWarningEnabled, struct Preferences preferences, int singleInstanceLockEnabled, const char* singleInstanceUniqueId, bool enableDragAndDrop, bool disableWebViewDragAndDrop, int disableEscapeExitsFullscreen, int enableRetinaDevicePixelRatio);
 void Run(void*, const char* url);
 
 void SetTitle(void* ctx, const char *title);

--- a/v2/internal/frontend/desktop/darwin/Application.m
+++ b/v2/internal/frontend/desktop/darwin/Application.m
@@ -14,7 +14,7 @@
 #import "WailsMenu.h"
 #import "WailsMenuItem.h"
 
-WailsContext* Create(const char* title, int width, int height, int frameless, int resizable, int zoomable, int fullscreen, int fullSizeContent, int hideTitleBar, int titlebarAppearsTransparent, int hideTitle, int useToolbar, int hideToolbarSeparator, int webviewIsTransparent, int alwaysOnTop, int hideWindowOnClose, const char *appearance, int windowIsTranslucent, int contentProtection, int devtoolsEnabled, int defaultContextMenuEnabled, int windowStartState, int startsHidden, int minWidth, int minHeight, int maxWidth, int maxHeight, bool fraudulentWebsiteWarningEnabled, struct Preferences preferences, int singleInstanceLockEnabled, const char* singleInstanceUniqueId, bool enableDragAndDrop, bool disableWebViewDragAndDrop, int disableEscapeExitsFullscreen) {
+WailsContext* Create(const char* title, int width, int height, int frameless, int resizable, int zoomable, int fullscreen, int fullSizeContent, int hideTitleBar, int titlebarAppearsTransparent, int hideTitle, int useToolbar, int hideToolbarSeparator, int webviewIsTransparent, int alwaysOnTop, int hideWindowOnClose, const char *appearance, int windowIsTranslucent, int contentProtection, int devtoolsEnabled, int defaultContextMenuEnabled, int windowStartState, int startsHidden, int minWidth, int minHeight, int maxWidth, int maxHeight, bool fraudulentWebsiteWarningEnabled, struct Preferences preferences, int singleInstanceLockEnabled, const char* singleInstanceUniqueId, bool enableDragAndDrop, bool disableWebViewDragAndDrop, int disableEscapeExitsFullscreen, int enableRetinaDevicePixelRatio) {
 
     [NSApplication sharedApplication];
 
@@ -27,7 +27,7 @@ WailsContext* Create(const char* title, int width, int height, int frameless, in
         fullscreen = 1;
     }
 
-    [result CreateWindow:width :height :frameless :resizable :zoomable :fullscreen :fullSizeContent :hideTitleBar :titlebarAppearsTransparent :hideTitle :useToolbar :hideToolbarSeparator :webviewIsTransparent :hideWindowOnClose :safeInit(appearance) :windowIsTranslucent :minWidth :minHeight :maxWidth :maxHeight :fraudulentWebsiteWarningEnabled :preferences :enableDragAndDrop :disableWebViewDragAndDrop :disableEscapeExitsFullscreen];
+    [result CreateWindow:width :height :frameless :resizable :zoomable :fullscreen :fullSizeContent :hideTitleBar :titlebarAppearsTransparent :hideTitle :useToolbar :hideToolbarSeparator :webviewIsTransparent :hideWindowOnClose :safeInit(appearance) :windowIsTranslucent :minWidth :minHeight :maxWidth :maxHeight :fraudulentWebsiteWarningEnabled :preferences :enableDragAndDrop :disableWebViewDragAndDrop :disableEscapeExitsFullscreen :enableRetinaDevicePixelRatio];
     [result SetTitle:safeInit(title)];
     [result Center];
 

--- a/v2/internal/frontend/desktop/darwin/WailsContext.h
+++ b/v2/internal/frontend/desktop/darwin/WailsContext.h
@@ -67,7 +67,7 @@ struct Preferences {
   const char *applicationNameForUserAgent;
 };
 
-- (void) CreateWindow:(int)width :(int)height :(bool)frameless :(bool)resizable :(bool)zoomable :(bool)fullscreen :(bool)fullSizeContent :(bool)hideTitleBar :(bool)titlebarAppearsTransparent  :(bool)hideTitle :(bool)useToolbar :(bool)hideToolbarSeparator :(bool)webviewIsTransparent :(bool)hideWindowOnClose :(NSString *)appearance :(bool)windowIsTranslucent :(int)minWidth :(int)minHeight :(int)maxWidth :(int)maxHeight :(bool)fraudulentWebsiteWarningEnabled :(struct Preferences)preferences :(bool)enableDragAndDrop :(bool)disableWebViewDragAndDrop :(bool)disableEscapeExitsFullscreen;
+- (void) CreateWindow:(int)width :(int)height :(bool)frameless :(bool)resizable :(bool)zoomable :(bool)fullscreen :(bool)fullSizeContent :(bool)hideTitleBar :(bool)titlebarAppearsTransparent  :(bool)hideTitle :(bool)useToolbar :(bool)hideToolbarSeparator :(bool)webviewIsTransparent :(bool)hideWindowOnClose :(NSString *)appearance :(bool)windowIsTranslucent :(int)minWidth :(int)minHeight :(int)maxWidth :(int)maxHeight :(bool)fraudulentWebsiteWarningEnabled :(struct Preferences)preferences :(bool)enableDragAndDrop :(bool)disableWebViewDragAndDrop :(bool)disableEscapeExitsFullscreen :(bool)enableRetinaDevicePixelRatio;
 - (void) SetSize:(int)width :(int)height;
 - (void) SetPosition:(int)x :(int) y;
 - (void) SetMinSize:(int)minWidth :(int)minHeight;

--- a/v2/internal/frontend/desktop/darwin/WailsContext.h
+++ b/v2/internal/frontend/desktop/darwin/WailsContext.h
@@ -51,6 +51,7 @@
 
 @property bool devtoolsEnabled;
 @property bool defaultContextMenuEnabled;
+@property bool enableRetinaDevicePixelRatio;
 
 @property (retain) WKUserContentController* userContentController;
 

--- a/v2/internal/frontend/desktop/darwin/WailsContext.m
+++ b/v2/internal/frontend/desktop/darwin/WailsContext.m
@@ -124,7 +124,21 @@ extern void didReceiveNotificationResponse(const char *jsonPayload, const char* 
 
 }
 
+- (void) windowDidChangeBackingProperties:(NSNotification *)notification {
+    if (!self.enableRetinaDevicePixelRatio) return;
+
+    NSNumber *oldFactor = [notification.userInfo objectForKey:NSBackingPropertyOldScaleFactorKey];
+    CGFloat newFactor = [self.mainWindow backingScaleFactor];
+    if (oldFactor && [oldFactor doubleValue] == newFactor) return;
+
+    SEL sel = NSSelectorFromString(@"_setOverrideDeviceScaleFactor:");
+    if ([self.webview respondsToSelector:sel]) {
+        [self.webview _setOverrideDeviceScaleFactor:newFactor];
+    }
+}
+
 - (void) dealloc {
+    [[NSNotificationCenter defaultCenter] removeObserver:self];
     [self.appdelegate release];
     [self.mainWindow release];
     [self.mouseEvent release];
@@ -318,6 +332,11 @@ extern void didReceiveNotificationResponse(const char *jsonPayload, const char* 
         SEL sel = NSSelectorFromString(@"_setOverrideDeviceScaleFactor:");
         if ([self.webview respondsToSelector:sel]) {
             [self.webview _setOverrideDeviceScaleFactor:[self.mainWindow backingScaleFactor]];
+            self.enableRetinaDevicePixelRatio = YES;
+            [[NSNotificationCenter defaultCenter] addObserver:self
+                selector:@selector(windowDidChangeBackingProperties:)
+                name:NSWindowDidChangeBackingPropertiesNotification
+                object:self.mainWindow];
         }
     }
 

--- a/v2/internal/frontend/desktop/darwin/WailsContext.m
+++ b/v2/internal/frontend/desktop/darwin/WailsContext.m
@@ -157,7 +157,7 @@ extern void didReceiveNotificationResponse(const char *jsonPayload, const char* 
     return NO;
 }
 
-- (void) CreateWindow:(int)width :(int)height :(bool)frameless :(bool)resizable :(bool)zoomable :(bool)fullscreen :(bool)fullSizeContent :(bool)hideTitleBar :(bool)titlebarAppearsTransparent :(bool)hideTitle :(bool)useToolbar :(bool)hideToolbarSeparator :(bool)webviewIsTransparent :(bool)hideWindowOnClose :(NSString*)appearance :(bool)windowIsTranslucent :(int)minWidth :(int)minHeight :(int)maxWidth :(int)maxHeight :(bool)fraudulentWebsiteWarningEnabled :(struct Preferences)preferences :(bool)enableDragAndDrop :(bool)disableWebViewDragAndDrop :(bool)disableEscapeExitsFullscreen {
+- (void) CreateWindow:(int)width :(int)height :(bool)frameless :(bool)resizable :(bool)zoomable :(bool)fullscreen :(bool)fullSizeContent :(bool)hideTitleBar :(bool)titlebarAppearsTransparent :(bool)hideTitle :(bool)useToolbar :(bool)hideToolbarSeparator :(bool)webviewIsTransparent :(bool)hideWindowOnClose :(NSString*)appearance :(bool)windowIsTranslucent :(int)minWidth :(int)minHeight :(int)maxWidth :(int)maxHeight :(bool)fraudulentWebsiteWarningEnabled :(struct Preferences)preferences :(bool)enableDragAndDrop :(bool)disableWebViewDragAndDrop :(bool)disableEscapeExitsFullscreen :(bool)enableRetinaDevicePixelRatio {
     NSWindowStyleMask styleMask = 0;
 
     if( !frameless ) {
@@ -309,13 +309,16 @@ extern void didReceiveNotificationResponse(const char *jsonPayload, const char* 
     [self.webview setFrame:contentViewBounds];
 
     // Force WKWebView to report correct devicePixelRatio on HiDPI displays.
-    // The _overrideDeviceScaleFactor SPI sets WebPageProxy's customDeviceScaleFactor,
-    // which is the authoritative source for window.devicePixelRatio in JavaScript.
-    // Without this, custom URL schemes (wails://) cause DPR to report 1 on Retina.
-    // This SPI is stable since macOS 10.11 and used by Electron and Playwright.
-    CGFloat scaleFactor = [self.mainWindow backingScaleFactor];
-    if (scaleFactor > 1.0) {
-        [self.webview _setOverrideDeviceScaleFactor:scaleFactor];
+    // Uses the _setOverrideDeviceScaleFactor: SPI which sets WebPageProxy's
+    // customDeviceScaleFactor — the authoritative source for window.devicePixelRatio
+    // in JavaScript. Without this, custom URL schemes (wails://) cause DPR to
+    // report 1 on Retina. This is opt-in because it uses a private Apple API
+    // which may cause App Store rejection.
+    if (enableRetinaDevicePixelRatio) {
+        SEL sel = NSSelectorFromString(@"_setOverrideDeviceScaleFactor:");
+        if ([self.webview respondsToSelector:sel]) {
+            [self.webview _setOverrideDeviceScaleFactor:[self.mainWindow backingScaleFactor]];
+        }
     }
 
     if (webviewIsTransparent) {

--- a/v2/internal/frontend/desktop/darwin/WailsContext.m
+++ b/v2/internal/frontend/desktop/darwin/WailsContext.m
@@ -16,6 +16,10 @@
 #import "message.h"
 #import "Role.h"
 
+@interface WKWebView (WailsPrivate)
+@property (nonatomic, setter=_setOverrideDeviceScaleFactor:) CGFloat _overrideDeviceScaleFactor;
+@end
+
 typedef void (^schemeTaskCaller)(id<WKURLSchemeTask>);
 
 @implementation WailsWindow
@@ -303,6 +307,16 @@ extern void didReceiveNotificationResponse(const char *jsonPayload, const char* 
     [self.webview setAutoresizingMask: NSViewWidthSizable|NSViewHeightSizable];
     CGRect contentViewBounds = [contentView bounds];
     [self.webview setFrame:contentViewBounds];
+
+    // Force WKWebView to report correct devicePixelRatio on HiDPI displays.
+    // The _overrideDeviceScaleFactor SPI sets WebPageProxy's customDeviceScaleFactor,
+    // which is the authoritative source for window.devicePixelRatio in JavaScript.
+    // Without this, custom URL schemes (wails://) cause DPR to report 1 on Retina.
+    // This SPI is stable since macOS 10.11 and used by Electron and Playwright.
+    CGFloat scaleFactor = [self.mainWindow backingScaleFactor];
+    if (scaleFactor > 1.0) {
+        [self.webview _setOverrideDeviceScaleFactor:scaleFactor];
+    }
 
     if (webviewIsTransparent) {
         [self.webview setValue:[NSNumber numberWithBool:!webviewIsTransparent] forKey:@"drawsBackground"];

--- a/v2/internal/frontend/desktop/darwin/window.go
+++ b/v2/internal/frontend/desktop/darwin/window.go
@@ -48,6 +48,14 @@ func bool2CboolPtr(value bool) *C.bool {
 	return &v
 }
 
+// shouldEnableRetinaDevicePixelRatio reports whether the developer has explicitly
+// opted in to the Retina devicePixelRatio override. It is disabled unless the Mac
+// options are present and the flag is set, since the underlying SPI is private and
+// could cause Mac App Store rejection if active by default.
+func shouldEnableRetinaDevicePixelRatio(frontendOptions *options.App) bool {
+	return frontendOptions.Mac != nil && frontendOptions.Mac.EnableRetinaDevicePixelRatio
+}
+
 func NewWindow(frontendOptions *options.App, debug bool, devtools bool) *Window {
 	c := NewCalloc()
 	defer c.Free()
@@ -61,10 +69,11 @@ func NewWindow(frontendOptions *options.App, debug bool, devtools bool) *Window 
 	devtoolsEnabled := bool2Cint(devtools)
 	defaultContextMenuEnabled := bool2Cint(debug || frontendOptions.EnableDefaultContextMenu)
 	singleInstanceEnabled := bool2Cint(frontendOptions.SingleInstanceLock != nil)
+	enableRetinaDevicePixelRatio := bool2Cint(shouldEnableRetinaDevicePixelRatio(frontendOptions))
 
 	var fullSizeContent, hideTitleBar, zoomable, hideTitle, useToolbar, webviewIsTransparent C.int
 	var titlebarAppearsTransparent, hideToolbarSeparator, windowIsTranslucent, contentProtection C.int
-	var disableEscapeExitsFullscreen, enableRetinaDevicePixelRatio C.int
+	var disableEscapeExitsFullscreen C.int
 	var appearance, title *C.char
 	var preferences C.struct_Preferences
 
@@ -124,7 +133,6 @@ func NewWindow(frontendOptions *options.App, debug bool, devtools bool) *Window 
 		webviewIsTransparent = bool2Cint(mac.WebviewIsTransparent)
 		contentProtection = bool2Cint(mac.ContentProtection)
 		disableEscapeExitsFullscreen = bool2Cint(mac.DisableEscapeExitsFullscreen)
-		enableRetinaDevicePixelRatio = bool2Cint(mac.EnableRetinaDevicePixelRatio)
 
 		appearance = c.String(string(mac.Appearance))
 	}

--- a/v2/internal/frontend/desktop/darwin/window.go
+++ b/v2/internal/frontend/desktop/darwin/window.go
@@ -64,7 +64,7 @@ func NewWindow(frontendOptions *options.App, debug bool, devtools bool) *Window 
 
 	var fullSizeContent, hideTitleBar, zoomable, hideTitle, useToolbar, webviewIsTransparent C.int
 	var titlebarAppearsTransparent, hideToolbarSeparator, windowIsTranslucent, contentProtection C.int
-	var disableEscapeExitsFullscreen C.int
+	var disableEscapeExitsFullscreen, enableRetinaDevicePixelRatio C.int
 	var appearance, title *C.char
 	var preferences C.struct_Preferences
 
@@ -124,6 +124,7 @@ func NewWindow(frontendOptions *options.App, debug bool, devtools bool) *Window 
 		webviewIsTransparent = bool2Cint(mac.WebviewIsTransparent)
 		contentProtection = bool2Cint(mac.ContentProtection)
 		disableEscapeExitsFullscreen = bool2Cint(mac.DisableEscapeExitsFullscreen)
+		enableRetinaDevicePixelRatio = bool2Cint(mac.EnableRetinaDevicePixelRatio)
 
 		appearance = c.String(string(mac.Appearance))
 	}
@@ -132,7 +133,7 @@ func NewWindow(frontendOptions *options.App, debug bool, devtools bool) *Window 
 		alwaysOnTop, hideWindowOnClose, appearance, windowIsTranslucent, contentProtection, devtoolsEnabled, defaultContextMenuEnabled,
 		windowStartState, startsHidden, minWidth, minHeight, maxWidth, maxHeight, enableFraudulentWebsiteWarnings,
 		preferences, singleInstanceEnabled, singleInstanceUniqueId, enableDragAndDrop, disableWebViewDragAndDrop,
-		disableEscapeExitsFullscreen,
+		disableEscapeExitsFullscreen, enableRetinaDevicePixelRatio,
 	)
 
 	// Create menu

--- a/v2/internal/frontend/desktop/darwin/window_test.go
+++ b/v2/internal/frontend/desktop/darwin/window_test.go
@@ -1,0 +1,53 @@
+//go:build darwin
+// +build darwin
+
+package darwin
+
+import (
+	"testing"
+
+	"github.com/wailsapp/wails/v2/pkg/options"
+	"github.com/wailsapp/wails/v2/pkg/options/mac"
+)
+
+// TestShouldEnableRetinaDevicePixelRatio verifies that the Retina devicePixelRatio
+// override is only enabled when the developer explicitly opts in via
+// mac.Options.EnableRetinaDevicePixelRatio. The default-off behaviour is a safety
+// invariant: the underlying _setOverrideDeviceScaleFactor: SPI is private and could
+// cause Mac App Store rejection, so it must never be active unless requested.
+func TestShouldEnableRetinaDevicePixelRatio(t *testing.T) {
+	tests := []struct {
+		name string
+		opts *options.App
+		want bool
+	}{
+		{
+			name: "nil Mac options defaults to disabled",
+			opts: &options.App{},
+			want: false,
+		},
+		{
+			name: "Mac options present but flag unset defaults to disabled",
+			opts: &options.App{Mac: &mac.Options{}},
+			want: false,
+		},
+		{
+			name: "Mac options present with flag explicitly false stays disabled",
+			opts: &options.App{Mac: &mac.Options{EnableRetinaDevicePixelRatio: false}},
+			want: false,
+		},
+		{
+			name: "Mac options present with flag enabled opts in",
+			opts: &options.App{Mac: &mac.Options{EnableRetinaDevicePixelRatio: true}},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := shouldEnableRetinaDevicePixelRatio(tt.opts); got != tt.want {
+				t.Errorf("shouldEnableRetinaDevicePixelRatio() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/v2/pkg/options/mac/mac.go
+++ b/v2/pkg/options/mac/mac.go
@@ -24,6 +24,16 @@ type Options struct {
 	Preferences          *Preferences
 	DisableZoom          bool
 	// ActivationPolicy     ActivationPolicy
+	// EnableRetinaDevicePixelRatio enables the use of a private WebKit API to
+	// correctly report window.devicePixelRatio in JavaScript on Retina displays
+	// when using the wails:// custom URL scheme. Without this, canvas-based
+	// rendering appears blurry on HiDPI screens.
+	//
+	// This is opt-in because it uses a private Apple API (_setOverrideDeviceScaleFactor:)
+	// which may cause App Store rejection. Only enable if you are not distributing
+	// through the Mac App Store.
+	EnableRetinaDevicePixelRatio bool
+
 	About      *AboutInfo
 	OnFileOpen func(filePath string) `json:"-"`
 	OnUrlOpen  func(filePath string) `json:"-"`

--- a/website/src/pages/changelog.mdx
+++ b/website/src/pages/changelog.mdx
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed nil pointer crash in `application.Quit` when called before `Run` or after `Run` returned early [#5452](https://github.com/wailsapp/wails/issues/5452) by @c-tonneslan
+- Fixed WKWebView reporting `devicePixelRatio=1` on macOS Retina displays, causing blurry canvas rendering [#5111](https://github.com/wailsapp/wails/issues/5111) by @wblech
 
 ## v2.12.0 - 2026-03-26
 


### PR DESCRIPTION
# Description

Fix `window.devicePixelRatio` returning `1` inside WKWebView on macOS Retina displays. This causes all canvas-based rendering (xterm.js, charts, games, editors) to render at half resolution, producing visibly blurry text and graphics.

The root cause is that WKWebView does not propagate the display's backing scale factor to JavaScript when content is loaded via a custom URL scheme (`wails://`).

The fix uses the `_setOverrideDeviceScaleFactor:` SPI to set `WebPageProxy::customDeviceScaleFactor`, which is the authoritative source for `window.devicePixelRatio` in JavaScript. This SPI is stable since macOS 10.11 and used by Electron, Playwright, and WebKit's own test infrastructure.

Fixes #5111

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

1. Created a minimal Wails vanilla app with a DPR overlay (`window.devicePixelRatio` displayed on screen)
2. Built with `wails build` on macOS with Retina display
3. **Before fix:** overlay shows `devicePixelRatio: 1`, `matchMedia 2x: false`
4. **After fix:** overlay shows `devicePixelRatio: 2`, `matchMedia 2x: true`
5. Verified canvas-based rendering (xterm.js) is visibly crisper after the fix

This is a macOS-only change (Objective-C in the darwin frontend). Windows and Linux are not affected.

- [ ] Windows
- [x] macOS
- [ ] Linux

## Test Configuration

                                
          Wails Doctor          
                                

                                                                                                                      
# Wails
Version | v2.11.0


# System
┌────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
| OS           | MacOS                                                                                                                   |
| Version      | 15.7.4                                                                                                                  |
| ID           | 24G517                                                                                                                  |
| Branding     |                                                                                                                         |
| Go Version   | go1.25.6                                                                                                                |
| Platform     | darwin                                                                                                                  |
| Architecture | arm64                                                                                                                   |
| CPU 1        | Apple M3                                                                                                                |
| CPU 2        | Apple M3                                                                                                                |
| GPU          | Chipset Model: Apple M3 Type: GPU Bus: Built-In Total Number of Cores: 10 Vendor: Apple (0x106b) Metal Support: Metal 3 |
| Memory       | 24GB                                                                                                                    |
└────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘

# Dependencies
┌────────────────────────────────────────────────────────────────┐
| Dependency                | Package Name | Status    | Version |
| Xcode command line tools  | N/A          | Installed | 2410    |
| Nodejs                    | N/A          | Installed | 22.18.0 |
| npm                       | N/A          | Installed | 10.9.3  |
| *Xcode                    | N/A          | Available |         |
| *upx                      | N/A          | Available |         |
| *nsis                     | N/A          | Available |         |
|                                                                |
└─────────────────── * - Optional Dependency ────────────────────┘

# Diagnosis
Optional package(s) installation details: 
  - Xcode: Available at https://apps.apple.com/us/app/xcode/id497799835
  - upx : Available at https://upx.github.io/
  - nsis : More info at https://wails.io/docs/guides/windows-installer/

 SUCCESS  Your system is ready for Wails development!

 ♥   If Wails is useful to you or your company, please consider sponsoring the project:
https://github.com/sponsors/leaanthony

# Checklist:

- [x] I have updated `website/src/pages/changelog.mdx` with details of this PR
- [x] My code follows the general coding style of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed blurry canvas rendering on macOS Retina and other high‑DPI displays by ensuring web content receives the correct device pixel ratio.
* **New Features**
  * Added a new macOS option to opt in to the Retina/devicePixelRatio correction so high‑resolution canvases render sharply when desired.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->