### PR TITLE
Docs: Add project structure page

### DIFF
--- a/docs/src/content/docs/guides/dev/project-structure.mdx
+++ b/docs/src/content/docs/guides/dev/project-structure.mdx
@@ -1,0 +1,42 @@
+---
+title: Project Structure
+description: Understand the file layout for a typical Wails project
+sidebar:
+  order: 1
+---
+
+This page is a simple reference to the files created when you initiate a new project using the Vanilla template
+
+```
+/
+├── main.go                 # Application entry point
+├── greetservice.go         # Example backend service exposed to frontend
+├── go.mod                  # Go module definition
+├── config.yml              # Wails/project configuration
+├── Taskfile.yml            # Task runner for dev/build commands
+├── build/                  # Packaging and platform-specific assets
+│   ├── appicon.png         # Default app icon
+│   ├── appicon.icon/       # Icon source files
+│   ├── darwin/             # macOS build config
+│   ├── windows/            # Windows build config
+│   ├── linux/              # Linux build config
+│   ├── android/            # Android build config
+│   ├── ios/                # iOS build config
+│   └── docker/             # Containerized build environment
+├── frontend/               # Frontend (Vite + React + TS)
+│   ├── index.html          # HTML entry point
+│   ├── src/
+│   │   └── main.js         # Frontend bootstrap
+│   ├── public/             # Static assets
+│   ├── dist/               # Built frontend output
+│   ├── bindings/           # Auto-generated Go bindings
+│   ├── package.json        # Frontend dependencies
+│   ├── vite.config.ts      # Vite configuration
+│   └── tsconfig.json       # TypeScript configuration
+├── bin/                    # Compiled binaries
+└── .task/                  # Task runner cache
+  ```
+
+:::note[Frontend project files]
+If you choose to use a different starter template, contents of `frontend/src` will differ depending on your chosen framework
+:::

--- a/v3/UNRELEASED_CHANGELOG.md
+++ b/v3/UNRELEASED_CHANGELOG.md
@@ -16,7 +16,7 @@ After processing, the content will be moved to the main changelog and this file 
 -->
 
 ## Added
-<!-- New features, capabilities, or enhancements -->
+- Added missing project structure page
 
 ## Changed
 <!-- Changes in existing functionality -->


### PR DESCRIPTION
Add missing Project Structure docs page

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a "Project Structure" guide describing the typical directory and file layout for a Wails project, covering frontend stack (Vite + React + TypeScript), backend configuration, dev tooling, and build/packaging assets; notes on variation with other starter templates.
* **Chores**
  * Updated unreleased changelog to list the new project structure page.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->