### PR TITLE
ci: upgrade outdated actions and cache deps in PR Checks (master)

### DIFF
--- a/.github/workflows/pr-master.yml
+++ b/.github/workflows/pr-master.yml
@@ -23,7 +23,7 @@ jobs:
     if: ${{ github.repository == 'wailsapp/wails' && github.base_ref == 'master' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Verify Changed files
         uses: step-security/changed-files@3dbe17c78367e7d60f00d78ae6781a35be47b4a1 # v45.0.1
@@ -59,20 +59,27 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install linux dependencies (22.04)
+        uses: awalsh128/cache-apt-pkgs-action@latest
         if: matrix.os == 'ubuntu-22.04'
-        run: sudo apt-get update -y && sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.0-dev build-essential pkg-config
+        with:
+          packages: libgtk-3-dev libwebkit2gtk-4.0-dev build-essential pkg-config
+          version: 1.0
 
       - name: Install linux dependencies (24.04)
+        uses: awalsh128/cache-apt-pkgs-action@latest
         if: matrix.os == 'ubuntu-24.04'
-        run: sudo apt-get update -y && sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev build-essential pkg-config
+        with:
+          packages: libgtk-3-dev libwebkit2gtk-4.1-dev build-essential pkg-config
+          version: 1.0
 
       - name: Setup Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go-version }}
+          cache-dependency-path: v2/go.sum
 
       - name: Run tests (mac)
         if: matrix.os == 'macos-latest'


### PR DESCRIPTION
## Summary

Companion to #5149 (which targets `v3-alpha`). That PR covers `build-and-test-v3.yml` and the copy of `pr-master.yml` on `v3-alpha`. This PR applies the remaining improvements to `pr-master.yml` on `master`, where the file actually runs (GitHub Actions uses the workflow from the **base branch** of a PR).

**1 file changed, 12 insertions, 5 deletions.**

## Changes

| Change | Detail | Est. Saving |
|--------|--------|-------------|
| `actions/checkout@v3` → `@v4` | Both `check_docs` and `test_go` jobs | Minor — latest checkout speed improvements |
| `actions/setup-go@v3` → `@v5` with `cache-dependency-path: v2/go.sum` | Go module + build cache now active (was completely missing) | ~1–2 min per Linux/macOS/Windows job |
| Raw `apt-get update && apt-get install` → `awalsh128/cache-apt-pkgs-action` | ubuntu-22.04 and ubuntu-24.04 | ~30s per Linux job on cache hit |

## Notes

- The `test_go` condition (runs on all `pull_request` events, not just approvals) was already correct on `master` — not changed here
- All YAML validated before push
- Packages installed are identical to what was there before, just now cached

## Related

- #5149 — v3-alpha equivalent (build-and-test-v3 + pr-master on v3-alpha branch)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD infrastructure to use latest action versions and improved build dependency caching for better reliability and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->