### PR TITLE
Simplify checking if Bundle icon is set within build-assets and set…

### DIFF
--- a/v3/internal/commands/build-assets.go
+++ b/v3/internal/commands/build-assets.go
@@ -150,7 +150,13 @@ func GenerateBuildAssets(options *BuildAssetsOptions) error {
 	}
 	// Check if Assets.car exists - if so, set CFBundleIconName if not already set
 	// This must happen BEFORE the updatable_build_assets extraction so CFBundleIconName is available in Info.plist templates
-	checkAndSetCFBundleIconNameCommon(options.Dir, &buildCFBundleIconNameSetter{options, &config})
+	assetsCarPath := filepath.Join(config.Dir, "darwin", "Assets.car")
+	if _, err := os.Stat(assetsCarPath); err == nil {
+		if config.CFBundleIconName == "" {
+			config.CFBundleIconName = "appicon"
+			options.CFBundleIconName = "appicon"
+		}
+	}
 	// Update config with the potentially modified options
 	config.BuildAssetsOptions = *options
 
@@ -261,7 +267,14 @@ func UpdateBuildAssets(options *UpdateBuildAssetsOptions) error {
 	}
 
 	// Check if Assets.car exists - if so, set CFBundleIconName if not already set
-	checkAndSetCFBundleIconNameCommon(options.Dir, &updateCFBundleIconNameSetter{options, &config})
+	assetsCarPath := filepath.Join(config.Dir, "darwin", "Assets.car")
+	if _, err := os.Stat(assetsCarPath); err == nil {
+		if config.CFBundleIconName == "" {
+			config.CFBundleIconName = "appicon"
+			options.CFBundleIconName = "appicon"
+		}
+	}
+
 	// Update config with the potentially modified options
 	config.UpdateBuildAssetsOptions = *options
 
@@ -300,51 +313,6 @@ func UpdateBuildAssets(options *UpdateBuildAssetsOptions) error {
 
 func normaliseName(name string) string {
 	return strings.ToLower(strings.ReplaceAll(name, " ", "-"))
-}
-
-// CFBundleIconNameSetter is implemented by types that can get and set CFBundleIconName
-// (used to keep options and config in sync when defaulting the macOS icon name).
-type CFBundleIconNameSetter interface {
-	GetCFBundleIconName() string
-	SetCFBundleIconName(string)
-}
-
-// checkAndSetCFBundleIconNameCommon checks if Assets.car exists in the darwin folder
-// and sets CFBundleIconName via setter if not already set. The icon name should be configured
-// in config.yml under info.cfBundleIconName and should match the name of the .icon file without the extension
-// with which Assets.car was generated. If not set, defaults to "appicon".
-func checkAndSetCFBundleIconNameCommon(dir string, setter CFBundleIconNameSetter) {
-	darwinDir := filepath.Join(dir, "darwin")
-	assetsCarPath := filepath.Join(darwinDir, "Assets.car")
-	if _, err := os.Stat(assetsCarPath); err == nil {
-		if setter.GetCFBundleIconName() == "" {
-			setter.SetCFBundleIconName("appicon")
-		}
-	}
-}
-
-// buildCFBundleIconNameSetter sets CFBundleIconName on both options and config for GenerateBuildAssets.
-type buildCFBundleIconNameSetter struct {
-	options *BuildAssetsOptions
-	config  *BuildConfig
-}
-
-func (s *buildCFBundleIconNameSetter) GetCFBundleIconName() string { return s.options.CFBundleIconName }
-func (s *buildCFBundleIconNameSetter) SetCFBundleIconName(v string) {
-	s.options.CFBundleIconName = v
-	s.config.CFBundleIconName = v
-}
-
-// updateCFBundleIconNameSetter sets CFBundleIconName on both options and config for UpdateBuildAssets.
-type updateCFBundleIconNameSetter struct {
-	options *UpdateBuildAssetsOptions
-	config  *UpdateConfig
-}
-
-func (s *updateCFBundleIconNameSetter) GetCFBundleIconName() string { return s.options.CFBundleIconName }
-func (s *updateCFBundleIconNameSetter) SetCFBundleIconName(v string) {
-	s.options.CFBundleIconName = v
-	s.config.CFBundleIconName = v
 }
 
 // mergeMaps recursively merges src into dst.


### PR DESCRIPTION
A minor refactor of build-asset code that keeps the same behaviour to clean up the code a bit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified internal icon name handling logic in the build process by removing unused abstraction layers and helper functions.
  * Streamlined control flow for icon name configuration during asset generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->