### PR TITLE
When defining ProcessorArchitecture within build-assets, default value is incored

### DIFF
--- a/v3/UNRELEASED_CHANGELOG.md
+++ b/v3/UNRELEASED_CHANGELOG.md
@@ -22,7 +22,7 @@ After processing, the content will be moved to the main changelog and this file 
 <!-- Changes in existing functionality -->
 
 ## Fixed
-<!-- Bug fixes -->
+- Invalid default processor architecture within build-assets
 
 ## Deprecated
 <!-- Soon-to-be removed features -->

--- a/v3/internal/commands/build-assets.go
+++ b/v3/internal/commands/build-assets.go
@@ -117,7 +117,7 @@ func GenerateBuildAssets(options *BuildAssetsOptions) error {
 	}
 
 	if options.ProcessorArchitecture == "" {
-		options.ProcessorArchitecture = "x64"
+		options.ProcessorArchitecture = runtime.GOARCH
 	}
 
 	if options.ExecutableName == "" {
@@ -341,7 +341,9 @@ type updateCFBundleIconNameSetter struct {
 	config  *UpdateConfig
 }
 
-func (s *updateCFBundleIconNameSetter) GetCFBundleIconName() string { return s.options.CFBundleIconName }
+func (s *updateCFBundleIconNameSetter) GetCFBundleIconName() string {
+	return s.options.CFBundleIconName
+}
 func (s *updateCFBundleIconNameSetter) SetCFBundleIconName(v string) {
 	s.options.CFBundleIconName = v
 	s.config.CFBundleIconName = v

--- a/v3/internal/commands/msix.go
+++ b/v3/internal/commands/msix.go
@@ -202,7 +202,7 @@ func validateMSIXOptions(options *MSIXOptions) error {
 
 	// Set default processor architecture if not provided
 	if options.ProcessorArchitecture == "" {
-		options.ProcessorArchitecture = "x64"
+		options.ProcessorArchitecture = runtime.GOARCH
 	}
 
 	// Set default publisher if not provided


### PR DESCRIPTION
`x64` was invalid. Switch to use detected runtime architecture instead which would resolve correctly to `amd64` or other viable targets

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed default processor architecture selection during the build process. The system now correctly uses the native processor architecture instead of defaulting to x64, ensuring proper configuration for build asset generation and MSIX packaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->