### PR TITLE
Fix ScreenManager data race that causes WebKit DisplayLink deadlock

### DIFF
--- a/v3/UNRELEASED_CHANGELOG.md
+++ b/v3/UNRELEASED_CHANGELOG.md
@@ -23,6 +23,7 @@ After processing, the content will be moved to the main changelog and this file 
 
 ## Fixed
 <!-- Bug fixes -->
+- Fix data race in ScreenManager that causes WebKit DisplayLink deadlock on display configuration change (e.g. external monitor hot-plug during sleep/wake)
 
 ## Deprecated
 <!-- Soon-to-be removed features -->

--- a/v3/pkg/application/screen_darwin.go
+++ b/v3/pkg/application/screen_darwin.go
@@ -177,21 +177,21 @@ func (m *macosApp) processAndCacheScreens() error {
 }
 
 func (m *macosApp) getPrimaryScreen() (*Screen, error) {
-	if m.parent.Screen.primaryScreen == nil {
+	if m.parent.Screen.GetPrimary() == nil {
 		if err := m.processAndCacheScreens(); err != nil {
 			return nil, err
 		}
 	}
-	return m.parent.Screen.primaryScreen, nil
+	return m.parent.Screen.GetPrimary(), nil
 }
 
 func (m *macosApp) getScreens() ([]*Screen, error) {
-	if len(m.parent.Screen.screens) == 0 {
+	if len(m.parent.Screen.GetAll()) == 0 {
 		if err := m.processAndCacheScreens(); err != nil {
 			return nil, err
 		}
 	}
-	return m.parent.Screen.screens, nil
+	return m.parent.Screen.GetAll(), nil
 }
 
 func getScreenForWindow(window *macosWebviewWindow) (*Screen, error) {

--- a/v3/pkg/application/screen_linux.go
+++ b/v3/pkg/application/screen_linux.go
@@ -35,11 +35,11 @@ func (a *linuxApp) processAndCacheScreens() error {
 }
 
 func (a *linuxApp) getPrimaryScreen() (*Screen, error) {
-	return a.parent.Screen.primaryScreen, nil
+	return a.parent.Screen.GetPrimary(), nil
 }
 
 func (a *linuxApp) getScreens() ([]*Screen, error) {
-	return a.parent.Screen.screens, nil
+	return a.parent.Screen.GetAll(), nil
 }
 
 func getScreenForWindow(window *linuxWebviewWindow) (*Screen, error) {

--- a/v3/pkg/application/screen_windows.go
+++ b/v3/pkg/application/screen_windows.go
@@ -60,12 +60,12 @@ func (m *windowsApp) processAndCacheScreens() error {
 
 // NOTE: should be moved to *App after DPI is implemented in all platforms
 func (m *windowsApp) getScreens() ([]*Screen, error) {
-	return m.parent.Screen.screens, nil
+	return m.parent.Screen.GetAll(), nil
 }
 
 // NOTE: should be moved to *App after DPI is implemented in all platforms
 func (m *windowsApp) getPrimaryScreen() (*Screen, error) {
-	return m.parent.Screen.primaryScreen, nil
+	return m.parent.Screen.GetPrimary(), nil
 }
 
 func getScreenForWindow(window *windowsWebviewWindow) (*Screen, error) {
@@ -75,7 +75,7 @@ func getScreenForWindow(window *windowsWebviewWindow) (*Screen, error) {
 func getScreenForWindowHwnd(hwnd w32.HWND) (*Screen, error) {
 	hMonitor := w32.MonitorFromWindow(hwnd, w32.MONITOR_DEFAULTTONEAREST)
 	screenID := hMonitorToScreenID(hMonitor)
-	for _, screen := range globalApplication.Screen.screens {
+	for _, screen := range globalApplication.Screen.GetAll() {
 		if screen.ID == screenID {
 			return screen, nil
 		}

--- a/v3/pkg/application/screenmanager.go
+++ b/v3/pkg/application/screenmanager.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"math"
 	"sort"
+	"sync"
 )
 
 // Heavily inspired by the Chromium project (Copyright 2015 The Chromium Authors)
@@ -11,6 +12,7 @@ import (
 
 type ScreenManager struct {
 	app           *App
+	mu            sync.RWMutex // guards screens and primaryScreen against concurrent display-change events
 	screens       []*Screen
 	primaryScreen *Screen
 }
@@ -374,6 +376,9 @@ func (m *ScreenManager) LayoutScreens(screens []*Screen) error {
 		return errors.New("screens parameter is nil or empty")
 	}
 
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
 	// Store screens before DIP calculation so calculateScreensDipCoordinates
 	// can find the primary and mutate the slice in-place.
 	oldScreens := m.screens
@@ -392,15 +397,21 @@ func (m *ScreenManager) LayoutScreens(screens []*Screen) error {
 }
 
 func (m *ScreenManager) GetAll() []*Screen {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
 	return m.screens
 }
 
 func (m *ScreenManager) GetPrimary() *Screen {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
 	return m.primaryScreen
 }
 
 // GetByID returns the screen with the given display ID, or nil if not found.
 func (m *ScreenManager) GetByID(id string) *Screen {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
 	for _, screen := range m.screens {
 		if screen.ID == id {
 			return screen
@@ -411,6 +422,8 @@ func (m *ScreenManager) GetByID(id string) *Screen {
 
 // GetByIndex returns the screen at the given index in the screen list, or nil if out of range.
 func (m *ScreenManager) GetByIndex(index int) *Screen {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
 	if index < 0 || index >= len(m.screens) {
 		return nil
 	}


### PR DESCRIPTION
# Description

Fix ScreenManager data race that causes WebKit DisplayLink deadlock.

When sleeping on one display (laptop screen), and waking up on an external display, a data race condition occurs.
This does not always happen, and have to repeat this several times. Each time the UI got stuck with a beach ball. Inspecting the process, showed several go routines backed up.  Eventually the `go race` found the cause.

```
go build -race -buildvcs=false -gcflags=all="-l" -o bin/my-app-name
  # my-app-name
  ld: warning: ignoring duplicate libraries: '-lobjc'
  ld: warning:
  '/private/var/folders/40/h2gz12596h37pwhss5_bsqdh0000gn/T/go-link-1873182515/000048.o' has
  malformed LC_DYSYMTAB, expected 98 undefined symbols to start at index 1626, found 95 undefined
  symbols starting at index 1626
  ld: warning: object file
  (/private/var/folders/40/h2gz12596h37pwhss5_bsqdh0000gn/T/go-link-1873182515/go.o) was built for
  newer 'macOS' version (26.0) than being linked (11.0)
  ld: warning: object file
  (/private/var/folders/40/h2gz12596h37pwhss5_bsqdh0000gn/T/go-link-1873182515/000000.o) was built
  for newer 'macOS' version (26.0) than being linked (11.0)
  ld: warning: object file
  (/private/var/folders/40/h2gz12596h37pwhss5_bsqdh0000gn/T/go-link-1873182515/000001.o) was built
  for newer 'macOS' version (26.0) than being linked (11.0)
  ld: warning: object file
  (/private/var/folders/40/h2gz12596h37pwhss5_bsqdh0000gn/T/go-link-1873182515/000002.o) was built
  for newer 'macOS' version (26.0) than being linked (11.0)
  ld: warning: object file
  (/private/var/folders/40/h2gz12596h37pwhss5_bsqdh0000gn/T/go-link-1873182515/000003.o) was built
  for newer 'macOS' version (26.0) than being linked (11.0)
  ld: warning: object file
  (/private/var/folders/40/h2gz12596h37pwhss5_bsqdh0000gn/T/go-link-1873182515/000004.o) was built
  for newer 'macOS' version (26.0) than being linked (11.0)
  ld: warning: object file
  (/private/var/folders/40/h2gz12596h37pwhss5_bsqdh0000gn/T/go-link-1873182515/000005.o) was built
  for newer 'macOS' version (26.0) than being linked (11.0)
  ld: warning: object file
  (/private/var/folders/40/h2gz12596h37pwhss5_bsqdh0000gn/T/go-link-1873182515/000006.o) was built
  for newer 'macOS' version (26.0) than being linked (11.0)
  ld: warning: object file
  (/private/var/folders/40/h2gz12596h37pwhss5_bsqdh0000gn/T/go-link-1873182515/000007.o) was built
  for newer 'macOS' version (26.0) than being linked (11.0)
  ld: warning: object file
  (/private/var/folders/40/h2gz12596h37pwhss5_bsqdh0000gn/T/go-link-1873182515/000008.o) was built
  for newer 'macOS' version (26.0) than being linked (11.0)
  ld: warning: object file
  (/private/var/folders/40/h2gz12596h37pwhss5_bsqdh0000gn/T/go-link-1873182515/000009.o) was built
  for newer 'macOS' version (26.0) than being linked
  … +540 lines …
  8
    github.com/wailsapp/wails/v3/pkg/application.(*ScreenManager).LayoutScreens()
        /Users/wayneforrest/Documents/Projects/wails/v3/pkg/application/screenmanager.go:383 +0xbc
    github.com/wailsapp/wails/v3/pkg/application.(*macosApp).processAndCacheScreens()
        /Users/wayneforrest/Documents/Projects/wails/v3/pkg/application/screen_darwin.go:176 +0x1bc
    github.com/wailsapp/wails/v3/pkg/application.(*macosApp).run.func3()
        /Users/wayneforrest/Documents/Projects/wails/v3/pkg/application/application_darwin.go:312
  +0x2c
    github.com/wailsapp/wails/v3/pkg/application.(*EventManager).handleApplicationEvent.func1()
        /Users/wayneforrest/Documents/Projects/wails/v3/pkg/application/event_manager.go:171 +0x68

  Previous write at 0x00c0002e1d60 by goroutine 4393:
    github.com/wailsapp/wails/v3/pkg/application.(*ScreenManager).calculateScreensDipCoordinates()
        /Users/wayneforrest/Documents/Projects/wails/v3/pkg/application/screenmanager.go:425 +0x48
    github.com/wailsapp/wails/v3/pkg/application.(*ScreenManager).LayoutScreens()
        /Users/wayneforrest/Documents/Projects/wails/v3/pkg/application/screenmanager.go:383 +0xbc
    github.com/wailsapp/wails/v3/pkg/application.(*macosApp).processAndCacheScreens()
        /Users/wayneforrest/Documents/Projects/wails/v3/pkg/application/screen_darwin.go:176 +0x1bc
    github.com/wailsapp/wails/v3/pkg/application.(*macosApp).run.func3()
        /Users/wayneforrest/Documents/Projects/wails/v3/pkg/application/application_darwin.go:312
  +0x2c
    github.com/wailsapp/wails/v3/pkg/application.(*EventManager).handleApplicationEvent.func1()
        /Users/wayneforrest/Documents/Projects/wails/v3/pkg/application/event_manager.go:171 +0x68

  Goroutine 4395 (running) created at:
    github.com/wailsapp/wails/v3/pkg/application.(*EventManager).handleApplicationEvent()
        /Users/wayneforrest/Documents/Projects/wails/v3/pkg/application/event_manager.go:166 +0x1d4
    github.com/wailsapp/wails/v3/pkg/application.(*App).Run.func1.gowrap1()
        /Users/wayneforrest/Documents/Projects/wails/v3/pkg/application/application.go:586 +0x3c

  Goroutine 4393 (finished) created at:
    github.com/wailsapp/wails/v3/pkg/application.(*EventManager).handleApplicationEvent()
        /Users/wayneforrest/Documents/Projects/wails/v3/pkg/application/event_manager.go:166 +0x1d4
    github.com/wailsapp/wails/v3/pkg/application.(*App).Run.func1.gowrap1()
        /Users/wayneforrest/Documents/Projects/wails/v3/pkg/application/application.go:586 +0x3c
  ==================

Fixes #5163

## Type of change
  
Please select the option that is relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
  
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration using `wails doctor`.

- [x] Windows
- [x] macOS
- [x] Linux
      
If you checked Linux, please specify the distro and version.
  
## Test Configuration

Please paste the output of `wails doctor`. If you are unable to run this command, please describe your environment in as much detail as possible.

# Checklist:

- [ ] I have updated `website/src/pages/changelog.mdx` with details of this PR
- [ ] My code follows the general coding style of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved screen management implementation for macOS, Linux, and Windows to be more consistent and robust.
* **Bug Fixes**
  * Fixed a data-race that could cause display-related hangs (e.g., WebKit/display updates) during monitor hot-plug or sleep/wake, by adding synchronization and safer screen access.
* **Chores**
  * Updated changelog entry documenting the fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->