### PR TITLE
fix(v2): sanitize CFBundleIdentifier for Apple packaging requirements

### DIFF
--- a/v2/pkg/buildassets/build/darwin/Info.dev.plist
+++ b/v2/pkg/buildassets/build/darwin/Info.dev.plist
@@ -8,7 +8,7 @@
         <key>CFBundleExecutable</key>
         <string>{{.OutputFilename}}</string>
         <key>CFBundleIdentifier</key>
-        <string>com.wails.{{.Name}}</string>
+        <string>com.wails.{{.Name | sanitizeIdentifier}}</string>
         <key>CFBundleVersion</key>
         <string>{{.Info.ProductVersion}}</string>
         <key>CFBundleGetInfoString</key>

--- a/v2/pkg/buildassets/build/darwin/Info.plist
+++ b/v2/pkg/buildassets/build/darwin/Info.plist
@@ -8,7 +8,7 @@
         <key>CFBundleExecutable</key>
         <string>{{.OutputFilename}}</string>
         <key>CFBundleIdentifier</key>
-        <string>com.wails.{{.Name}}</string>
+        <string>com.wails.{{.Name | sanitizeIdentifier}}</string>
         <key>CFBundleVersion</key>
         <string>{{.Info.ProductVersion}}</string>
         <key>CFBundleGetInfoString</key>

--- a/v2/pkg/buildassets/buildassets.go
+++ b/v2/pkg/buildassets/buildassets.go
@@ -8,6 +8,7 @@ import (
 	iofs "io/fs"
 	"os"
 	"path/filepath"
+	"regexp"
 	"text/template"
 
 	"github.com/leaanthony/gosod"
@@ -15,6 +16,8 @@ import (
 	"github.com/wailsapp/wails/v2/internal/fs"
 	"github.com/wailsapp/wails/v2/internal/project"
 )
+
+var nonIdentifierChar = regexp.MustCompile(`[^A-Za-z0-9.-]`)
 
 //go:embed build
 var assets embed.FS
@@ -108,7 +111,13 @@ type assetData struct {
 }
 
 func resolveProjectData(content []byte, projectData *project.Project) ([]byte, error) {
-	tmpl, err := template.New("").Parse(string(content))
+	funcMap := template.FuncMap{
+		"sanitizeIdentifier": func(s string) string {
+			return nonIdentifierChar.ReplaceAllString(s, "-")
+		},
+	}
+
+	tmpl, err := template.New("").Funcs(funcMap).Parse(string(content))
 	if err != nil {
 		return nil, err
 	}

--- a/v2/pkg/buildassets/buildassets_test.go
+++ b/v2/pkg/buildassets/buildassets_test.go
@@ -1,0 +1,78 @@
+package buildassets
+
+import (
+	"testing"
+
+	"github.com/wailsapp/wails/v2/internal/project"
+)
+
+func TestResolveProjectData_SanitizeIdentifier(t *testing.T) {
+	tests := []struct {
+		name     string
+		template string
+		project  *project.Project
+		want     string
+	}{
+		{
+			name:     "spaces replaced with hyphens",
+			template: `com.wails.{{.Name | sanitizeIdentifier}}`,
+			project: &project.Project{
+				Name: "My Fab Application",
+			},
+			want: `com.wails.My-Fab-Application`,
+		},
+		{
+			name:     "underscores replaced with hyphens",
+			template: `com.wails.{{.Name | sanitizeIdentifier}}`,
+			project: &project.Project{
+				Name: "my_app_name",
+			},
+			want: `com.wails.my-app-name`,
+		},
+		{
+			name:     "alphanumeric and dots preserved",
+			template: `com.wails.{{.Name | sanitizeIdentifier}}`,
+			project: &project.Project{
+				Name: "My.App.v2",
+			},
+			want: `com.wails.My.App.v2`,
+		},
+		{
+			name:     "already clean identifier",
+			template: `com.wails.{{.Name | sanitizeIdentifier}}`,
+			project: &project.Project{
+				Name: "MyApp",
+			},
+			want: `com.wails.MyApp`,
+		},
+		{
+			name:     "special characters replaced",
+			template: `com.wails.{{.Name | sanitizeIdentifier}}`,
+			project: &project.Project{
+				Name: "App@Beta#3!",
+			},
+			want: `com.wails.App-Beta-3-`,
+		},
+		{
+			name:     "outputfilename used for executable",
+			template: `<string>{{.OutputFilename}}</string>`,
+			project: &project.Project{
+				Name:           "My Fab Application",
+				OutputFilename: "my-fab-application",
+			},
+			want: `<string>my-fab-application</string>`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := resolveProjectData([]byte(tt.template), tt.project)
+			if err != nil {
+				t.Fatalf("resolveProjectData() error = %v", err)
+			}
+			if string(got) != tt.want {
+				t.Errorf("resolveProjectData() = %q, want %q", string(got), tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
The default `Info.plist` template generates `CFBundleIdentifier` as `com.wails.{{.Name}}`, but Apple requires identifiers to contain only `[A-Za-z0-9.-]`. Names like `"My Fab Application"` produce `com.wails.My Fab Application`, which breaks packaging and code signing.

This PR adds a `sanitizeIdentifier` template function that replaces invalid characters with hyphens, so `"My Fab Application"` → `"My-Fab-Application"`.

Note: `CFBundleExecutable` already correctly uses `{{.OutputFilename}}`, which was a previous fix.

**Test case:**
- `wails.json`: `{ "name": "My Fab Application" }`
- Before: `<string>com.wails.My Fab Application</string>` (invalid)
- After: `<string>com.wails.My-Fab-Application</string>` (valid)

Fixes #4866