### PR TITLE
fix(v2): ensure correct Content-Type for proxied WASM and other assets

### DIFF
--- a/v2/pkg/assetserver/assethandler_external.go
+++ b/v2/pkg/assetserver/assethandler_external.go
@@ -32,16 +32,22 @@ func NewExternalAssetsHandler(logger Logger, options assetserver.Options, url *u
 	}
 
 	proxy.ModifyResponse = func(res *http.Response) error {
-		if baseHandler == nil {
-			return nil
-		}
-
 		if res.StatusCode == http.StatusSwitchingProtocols {
 			return nil
 		}
 
 		if res.StatusCode == http.StatusNotFound || res.StatusCode == http.StatusMethodNotAllowed {
-			return errSkipProxy
+			if baseHandler != nil {
+				return errSkipProxy
+			}
+			return nil
+		}
+
+		ct := res.Header.Get(HeaderContentType)
+		if ct == "" || ct == "application/octet-stream" {
+			if mimeCt := GetMimetype(res.Request.URL.Path, nil); mimeCt != "" && mimeCt != "application/octet-stream" {
+				res.Header.Set(HeaderContentType, mimeCt)
+			}
 		}
 
 		return nil

--- a/v2/pkg/assetserver/mimecache_test.go
+++ b/v2/pkg/assetserver/mimecache_test.go
@@ -36,6 +36,8 @@ func TestGetMimetype(t *testing.T) {
 		{"svg-w-comment", args{"test_comment.svg", svgWithComment}, "image/svg+xml"},
 		{"svg-w-control-comment", args{"test_control_comment.svg", svgWithCommentAndControlChars}, "image/svg+xml"},
 		{"svg-w-bom-control-comment", args{"test_bom_control_comment.svg", svgWithBomCommentAndControlChars}, "image/svg+xml"},
+		{"wasm nil data", args{"app_bg.wasm", nil}, "application/wasm"},
+		{"wasm binary data", args{"pkg/app_bg.wasm", []byte("\x00asm\x01\x00\x00\x00")}, "application/wasm"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary
When using `wails dev` with a frontend dev server proxy (e.g. Vite), the `ModifyResponse` callback on the reverse proxy was not validating or correcting the `Content-Type` header. For `.wasm` files, this meant the `contentTypeSniffer` would fall back to `http.DetectContentType()`, which returns `application/octet-stream` — preventing `WebAssembly.instantiateStreaming` from working.

The fix adds extension-based MIME type detection in the `ModifyResponse` callback. When the backend response has a missing or generic `application/octet-stream` Content-Type, it uses `GetMimetype()` (which already has the correct `.wasm` → `application/wasm` mapping) to set the proper Content-Type based on the file extension.

This also fixes the unrelated bug where `baseHandler == nil` would short-circuit the 404/405 handling — now the 404/405 skip-proxy logic is only applied when `baseHandler` is non-nil.

**Test case:**
- Dev mode with Vite serving a `.wasm` file
- Before: Response has `Content-Type: application/octet-stream` (or empty) → WASM initialization fails
- After: Response has `Content-Type: application/wasm` → WASM works correctly

Fixes #4274