### PR TITLE
fix(v2): copy frontend build output to embed target when frontend:dir is custom

### DIFF
--- a/v2/pkg/commands/build/build.go
+++ b/v2/pkg/commands/build/build.go
@@ -141,6 +141,11 @@ func Build(options *Options) (string, error) {
 		if err != nil {
 			return "", err
 		}
+
+		err = syncFrontendToEmbedTarget(options)
+		if err != nil {
+			return "", err
+		}
 	}
 
 	compileBinary := ""
@@ -159,6 +164,88 @@ func Build(options *Options) (string, error) {
 
 	}
 	return compileBinary, nil
+}
+
+func syncFrontendToEmbedTarget(options *Options) error {
+	projectData := options.ProjectData
+	frontendDir := projectData.GetFrontendDir()
+	projectPath := projectData.Path
+
+	defaultFrontendDir := filepath.Join(projectPath, "frontend")
+	if frontendDir == defaultFrontendDir {
+		return nil
+	}
+
+	frontendDistDir := filepath.Join(frontendDir, "dist")
+	if !fs.DirExists(frontendDistDir) {
+		return nil
+	}
+
+	embedDetails, err := staticanalysis.GetEmbedDetails(projectPath)
+	if err != nil {
+		return nil
+	}
+
+	for _, detail := range embedDetails {
+		embedFullPath := detail.GetFullPath()
+		if !strings.HasSuffix(embedFullPath, "dist") {
+			continue
+		}
+		if embedFullPath == frontendDistDir {
+			continue
+		}
+
+		if err := os.RemoveAll(embedFullPath); err != nil {
+			return fmt.Errorf("failed to clear embed target directory %s: %w", embedFullPath, err)
+		}
+		if err := fs.MkDirs(embedFullPath, 0o755); err != nil {
+			return fmt.Errorf("failed to create embed target directory %s: %w", embedFullPath, err)
+		}
+
+		entries, err := os.ReadDir(frontendDistDir)
+		if err != nil {
+			return fmt.Errorf("failed to read frontend dist directory %s: %w", frontendDistDir, err)
+		}
+		for _, entry := range entries {
+			src := filepath.Join(frontendDistDir, entry.Name())
+			dst := filepath.Join(embedFullPath, entry.Name())
+			if entry.IsDir() {
+				if err := copyDir(src, dst); err != nil {
+					return fmt.Errorf("failed to copy %s to %s: %w", src, dst, err)
+				}
+			} else {
+				if err := fs.CopyFile(src, dst); err != nil {
+					return fmt.Errorf("failed to copy %s to %s: %w", src, dst, err)
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+func copyDir(src string, dst string) error {
+	if err := fs.MkDirs(dst, 0o755); err != nil {
+		return err
+	}
+	entries, err := os.ReadDir(src)
+	if err != nil {
+		return err
+	}
+	for _, entry := range entries {
+		s := filepath.Join(src, entry.Name())
+		d := filepath.Join(dst, entry.Name())
+		if entry.IsDir() {
+			if err := copyDir(s, d); err != nil {
+				return err
+			}
+		} else {
+			if err := fs.CopyFile(s, d); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
 }
 
 func CreateEmbedDirectories(cwd string, buildOptions *Options) error {

--- a/v2/pkg/commands/build/sync_test.go
+++ b/v2/pkg/commands/build/sync_test.go
@@ -1,0 +1,55 @@
+package build
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/wailsapp/wails/v2/internal/fs"
+)
+
+func TestCopyDir(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	srcDir := filepath.Join(tmpDir, "src")
+	dstDir := filepath.Join(tmpDir, "dst")
+
+	if err := fs.MkDirs(filepath.Join(srcDir, "subdir"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(srcDir, "file1.txt"), []byte("hello"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(srcDir, "subdir", "file2.txt"), []byte("world"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := copyDir(srcDir, dstDir); err != nil {
+		t.Fatalf("copyDir() error = %v", err)
+	}
+
+	got, err := os.ReadFile(filepath.Join(dstDir, "file1.txt"))
+	if err != nil {
+		t.Fatalf("failed to read copied file: %v", err)
+	}
+	if string(got) != "hello" {
+		t.Errorf("file1.txt = %q, want %q", string(got), "hello")
+	}
+
+	got2, err := os.ReadFile(filepath.Join(dstDir, "subdir", "file2.txt"))
+	if err != nil {
+		t.Fatalf("failed to read copied nested file: %v", err)
+	}
+	if string(got2) != "world" {
+		t.Errorf("file2.txt = %q, want %q", string(got2), "world")
+	}
+}
+
+func TestCopyDir_SourceNotExist(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	err := copyDir(filepath.Join(tmpDir, "nonexistent"), filepath.Join(tmpDir, "dst"))
+	if err == nil {
+		t.Error("copyDir() expected error for non-existent source, got nil")
+	}
+}


### PR DESCRIPTION
## Summary
When `frontend:dir` in `wails.json` is set to a non-default directory (e.g. `"jsfrontend"` instead of `"frontend"`), the `//go:embed all:frontend/dist` directive in `main.go` still looks at `frontend/dist`. The built assets end up in `jsfrontend/dist`, so the compiled binary has no frontend assets — just the gitkeep placeholder.

This PR adds a `syncFrontendToEmbedTarget()` function that runs after `BuildFrontend`. When the frontend dir differs from the default, it copies the built dist contents to the embed target directory (determined via static analysis of `//go:embed` directives).

**Limitations:**
- Only works when the custom frontend directory is within the project tree
- External frontend directories (e.g. `../frontend`) cannot be supported due to Go's embed path restrictions (no `..` allowed)
- Users with external frontends must still manually update their `//go:embed` directive to match their `frontend:dir`

**Test case:**
1. `wails init -n client`
2. Rename `frontend` to `jsfrontend`
3. Add `"frontend:dir": "./jsfrontend"` to `wails.json`
4. `wails build` → app now works correctly

Fixes #5034