### PR TITLE
chore: remove unnecessary embed imports

### DIFF
--- a/v3/examples/android/main.go
+++ b/v3/examples/android/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"embed"
-	_ "embed"
 	"log"
 	"time"
 

--- a/v3/examples/badge-custom/main.go
+++ b/v3/examples/badge-custom/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"embed"
-	_ "embed"
 	"image/color"
 	"log"
 	"time"

--- a/v3/examples/badge/main.go
+++ b/v3/examples/badge/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"embed"
-	_ "embed"
 	"log"
 	"time"
 

--- a/v3/examples/build/main.go
+++ b/v3/examples/build/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	_ "embed"
 	"fmt"
 	"log"
 	"math/rand"

--- a/v3/examples/clipboard/main.go
+++ b/v3/examples/clipboard/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	_ "embed"
 	"log"
 	"runtime"
 	"time"

--- a/v3/examples/contextmenus/main.go
+++ b/v3/examples/contextmenus/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"embed"
-	_ "embed"
 	"log"
 
 	"github.com/wailsapp/wails/v3/pkg/application"

--- a/v3/examples/custom-protocol-example/main.go
+++ b/v3/examples/custom-protocol-example/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"embed"
-	_ "embed"
 	"log"
 	"time"
 

--- a/v3/examples/dev/main.go
+++ b/v3/examples/dev/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"embed"
-	_ "embed"
 	"log"
 
 	"github.com/wailsapp/wails/v3/pkg/application"

--- a/v3/examples/dialogs/main.go
+++ b/v3/examples/dialogs/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	_ "embed"
 	"log"
 	"log/slog"
 	"os"

--- a/v3/examples/dock/main.go
+++ b/v3/examples/dock/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"embed"
-	_ "embed"
 	"log"
 
 	"github.com/wailsapp/wails/v3/pkg/application"

--- a/v3/examples/environment/main.go
+++ b/v3/examples/environment/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"embed"
-	_ "embed"
 	"log"
 
 	"github.com/wailsapp/wails/v3/pkg/application"

--- a/v3/examples/events-bug/main.go
+++ b/v3/examples/events-bug/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	_ "embed"
 	"github.com/wailsapp/wails/v3/pkg/application"
 	"log"
 )

--- a/v3/examples/events/main.go
+++ b/v3/examples/events/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"embed"
-	_ "embed"
 	"log"
 	"time"
 

--- a/v3/examples/file-association/main.go
+++ b/v3/examples/file-association/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"embed"
-	_ "embed"
 	"github.com/wailsapp/wails/v3/pkg/events"
 	"log"
 	"time"

--- a/v3/examples/frameless/main.go
+++ b/v3/examples/frameless/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"embed"
-	_ "embed"
 	"log"
 
 	"github.com/wailsapp/wails/v3/pkg/application"

--- a/v3/examples/hide-window/main.go
+++ b/v3/examples/hide-window/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	_ "embed"
 	"github.com/wailsapp/wails/v3/pkg/application"
 	"github.com/wailsapp/wails/v3/pkg/events"
 	"github.com/wailsapp/wails/v3/pkg/icons"

--- a/v3/examples/ios/main.go
+++ b/v3/examples/ios/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"embed"
-	_ "embed"
 	"log"
 	"time"
 

--- a/v3/examples/keybindings/main.go
+++ b/v3/examples/keybindings/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	_ "embed"
 	"github.com/wailsapp/wails/v3/pkg/application"
 	"log"
 )

--- a/v3/examples/notifications/main.go
+++ b/v3/examples/notifications/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"embed"
-	_ "embed"
 	"fmt"
 	"log"
 

--- a/v3/examples/plain/main.go
+++ b/v3/examples/plain/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	_ "embed"
 	"log"
 	"net/http"
 	"time"

--- a/v3/examples/raw-message/main.go
+++ b/v3/examples/raw-message/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"embed"
-	_ "embed"
 	"fmt"
 	"log"
 

--- a/v3/examples/show-macos-toolbar/main.go
+++ b/v3/examples/show-macos-toolbar/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	_ "embed"
 	"log"
 
 	"github.com/wailsapp/wails/v3/pkg/application"

--- a/v3/examples/systray-basic/main.go
+++ b/v3/examples/systray-basic/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	_ "embed"
 	"log"
 	"runtime"
 

--- a/v3/examples/systray-custom/main.go
+++ b/v3/examples/systray-custom/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	_ "embed"
 	"github.com/wailsapp/wails/v3/pkg/application"
 	"github.com/wailsapp/wails/v3/pkg/events"
 	"github.com/wailsapp/wails/v3/pkg/icons"

--- a/v3/examples/video/main.go
+++ b/v3/examples/video/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	_ "embed"
 	"github.com/wailsapp/wails/v3/pkg/events"
 	"log"
 

--- a/v3/examples/window-menu/main.go
+++ b/v3/examples/window-menu/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"embed"
-	_ "embed"
 	"github.com/wailsapp/wails/v3/pkg/application"
 	"log"
 )

--- a/v3/examples/wml/main.go
+++ b/v3/examples/wml/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"embed"
-	_ "embed"
 	"log"
 
 	"github.com/wailsapp/wails/v3/pkg/application"

--- a/v3/internal/assetserver/build_dev.go
+++ b/v3/internal/assetserver/build_dev.go
@@ -3,7 +3,6 @@
 package assetserver
 
 import (
-	_ "embed"
 	"io/fs"
 	"net/http"
 	"net/http/httputil"

--- a/v3/internal/commands/appimage_testfiles/main.go
+++ b/v3/internal/commands/appimage_testfiles/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	_ "embed"
 	"fmt"
 	"log"
 	"math/rand"

--- a/v3/internal/commands/build-assets.go
+++ b/v3/internal/commands/build-assets.go
@@ -2,7 +2,6 @@ package commands
 
 import (
 	"embed"
-	_ "embed"
 	"fmt"
 	"io/fs"
 	"os"

--- a/v3/internal/commands/version.go
+++ b/v3/internal/commands/version.go
@@ -1,7 +1,6 @@
 package commands
 
 import (
-	_ "embed"
 	"github.com/wailsapp/wails/v3/internal/version"
 )
 

--- a/v3/internal/generator/collect/events.go
+++ b/v3/internal/generator/collect/events.go
@@ -1,7 +1,6 @@
 package collect
 
 import (
-	_ "embed"
 	"go/ast"
 	"go/constant"
 	"go/token"

--- a/v3/internal/generator/testcases/aliases/main.go
+++ b/v3/internal/generator/testcases/aliases/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	_ "embed"
 	"encoding"
 	"log"
 

--- a/v3/internal/generator/testcases/complex_expressions/main.go
+++ b/v3/internal/generator/testcases/complex_expressions/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	_ "embed"
 	"log"
 	"slices"
 

--- a/v3/internal/generator/testcases/complex_instantiations/main.go
+++ b/v3/internal/generator/testcases/complex_instantiations/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	_ "embed"
 	"log"
 
 	"github.com/wailsapp/wails/v3/internal/generator/testcases/complex_instantiations/other"

--- a/v3/internal/generator/testcases/complex_json/main.go
+++ b/v3/internal/generator/testcases/complex_json/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	_ "embed"
 	"log"
 
 	"github.com/wailsapp/wails/v3/pkg/application"

--- a/v3/internal/generator/testcases/complex_method/main.go
+++ b/v3/internal/generator/testcases/complex_method/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	_ "embed"
 	"log"
 
 	"github.com/wailsapp/wails/v3/pkg/application"

--- a/v3/internal/generator/testcases/cyclic_imports/main.go
+++ b/v3/internal/generator/testcases/cyclic_imports/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	_ "embed"
 	"log"
 
 	"github.com/wailsapp/wails/v3/pkg/application"

--- a/v3/internal/generator/testcases/cyclic_types/main.go
+++ b/v3/internal/generator/testcases/cyclic_types/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	_ "embed"
 	"log"
 
 	"github.com/wailsapp/wails/v3/pkg/application"

--- a/v3/internal/generator/testcases/directives/main.go
+++ b/v3/internal/generator/testcases/directives/main.go
@@ -11,7 +11,6 @@
 package main
 
 import (
-	_ "embed"
 	"log"
 
 	"github.com/wailsapp/wails/v3/internal/generator/testcases/directives/otherpackage"

--- a/v3/internal/generator/testcases/enum/main.go
+++ b/v3/internal/generator/testcases/enum/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	_ "embed"
 	"log"
 
 	"github.com/wailsapp/wails/v3/pkg/application"

--- a/v3/internal/generator/testcases/enum_from_imported_package/main.go
+++ b/v3/internal/generator/testcases/enum_from_imported_package/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	_ "embed"
 	"log"
 
 	"github.com/wailsapp/wails/v3/internal/generator/testcases/enum_from_imported_package/services"

--- a/v3/internal/generator/testcases/enum_map_keys/main.go
+++ b/v3/internal/generator/testcases/enum_map_keys/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	_ "embed"
 	"log"
 
 	"github.com/wailsapp/wails/v3/pkg/application"

--- a/v3/internal/generator/testcases/function_from_imported_package/main.go
+++ b/v3/internal/generator/testcases/function_from_imported_package/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	_ "embed"
 	"log"
 
 	"github.com/wailsapp/wails/v3/internal/generator/testcases/function_from_imported_package/services"

--- a/v3/internal/generator/testcases/function_from_nested_imported_package/main.go
+++ b/v3/internal/generator/testcases/function_from_nested_imported_package/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	_ "embed"
 	"log"
 
 	"github.com/wailsapp/wails/v3/internal/generator/testcases/function_from_nested_imported_package/services/other"

--- a/v3/internal/generator/testcases/function_multiple_files/greet.go
+++ b/v3/internal/generator/testcases/function_multiple_files/greet.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	_ "embed"
 
 	"github.com/wailsapp/wails/v3/pkg/application"
 )

--- a/v3/internal/generator/testcases/function_multiple_files/main.go
+++ b/v3/internal/generator/testcases/function_multiple_files/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	_ "embed"
 	"log"
 
 	"github.com/wailsapp/wails/v3/pkg/application"

--- a/v3/internal/generator/testcases/function_single/main.go
+++ b/v3/internal/generator/testcases/function_single/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	_ "embed"
 	"log"
 
 	"github.com/wailsapp/wails/v3/pkg/application"

--- a/v3/internal/generator/testcases/function_single_context/main.go
+++ b/v3/internal/generator/testcases/function_single_context/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	_ "embed"
 	"log"
 
 	"github.com/wailsapp/wails/v3/pkg/application"

--- a/v3/internal/generator/testcases/function_single_internal/main.go
+++ b/v3/internal/generator/testcases/function_single_internal/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	_ "embed"
 	"log"
 	"net/http"
 

--- a/v3/internal/generator/testcases/map_keys/main.go
+++ b/v3/internal/generator/testcases/map_keys/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	_ "embed"
 	"encoding"
 	"encoding/json"
 	"log"

--- a/v3/internal/generator/testcases/marshalers/main.go
+++ b/v3/internal/generator/testcases/marshalers/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	_ "embed"
 	"encoding"
 	"encoding/json"
 	"log"

--- a/v3/internal/generator/testcases/out_of_tree/main.go
+++ b/v3/internal/generator/testcases/out_of_tree/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	_ "embed"
 	"log"
 
 	nobindingshere "github.com/wailsapp/wails/v3/internal/generator/testcases/no_bindings_here"

--- a/v3/internal/generator/testcases/struct_literal_multiple/main.go
+++ b/v3/internal/generator/testcases/struct_literal_multiple/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	_ "embed"
 	"log"
 
 	"github.com/wailsapp/wails/v3/pkg/application"

--- a/v3/internal/generator/testcases/struct_literal_multiple_files/greet.go
+++ b/v3/internal/generator/testcases/struct_literal_multiple_files/greet.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	_ "embed"
 )
 
 type GreetService struct {

--- a/v3/internal/generator/testcases/struct_literal_multiple_files/main.go
+++ b/v3/internal/generator/testcases/struct_literal_multiple_files/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	_ "embed"
 	"log"
 
 	"github.com/wailsapp/wails/v3/pkg/application"

--- a/v3/internal/generator/testcases/struct_literal_multiple_other/main.go
+++ b/v3/internal/generator/testcases/struct_literal_multiple_other/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	_ "embed"
 	"log"
 
 	"github.com/wailsapp/wails/v3/internal/generator/testcases/struct_literal_multiple_other/services"

--- a/v3/internal/generator/testcases/struct_literal_non_pointer_single/main.go
+++ b/v3/internal/generator/testcases/struct_literal_non_pointer_single/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	_ "embed"
 	"log"
 	"strings"
 

--- a/v3/internal/generator/testcases/struct_literal_single/main.go
+++ b/v3/internal/generator/testcases/struct_literal_single/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	_ "embed"
 	"log"
 	"strings"
 

--- a/v3/internal/generator/testcases/variable_single/main.go
+++ b/v3/internal/generator/testcases/variable_single/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	_ "embed"
 	"log"
 
 	"github.com/wailsapp/wails/v3/pkg/application"

--- a/v3/internal/generator/testcases/variable_single_from_function/main.go
+++ b/v3/internal/generator/testcases/variable_single_from_function/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	_ "embed"
 	"log"
 
 	"github.com/wailsapp/wails/v3/pkg/application"

--- a/v3/internal/generator/testcases/variable_single_from_other_function/main.go
+++ b/v3/internal/generator/testcases/variable_single_from_other_function/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	_ "embed"
 	"log"
 
 	"github.com/wailsapp/wails/v3/internal/generator/testcases/variable_single_from_other_function/services"

--- a/v3/pkg/services/log/log.go
+++ b/v3/pkg/services/log/log.go
@@ -2,7 +2,6 @@ package log
 
 import (
 	"context"
-	_ "embed"
 	"log/slog"
 	"sync/atomic"
 

--- a/v3/test/4769-menu/main.go
+++ b/v3/test/4769-menu/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"embed"
-	_ "embed"
 	"log"
 
 	"github.com/wailsapp/wails/v3/pkg/application"

--- a/v3/test/manual/systray/custom-handlers/main.go
+++ b/v3/test/manual/systray/custom-handlers/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	_ "embed"
 	"log"
 	"runtime"
 

--- a/v3/test/manual/systray/hide-options/main.go
+++ b/v3/test/manual/systray/hide-options/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	_ "embed"
 	"log"
 	"runtime"
 

--- a/v3/test/manual/systray/menu-only/main.go
+++ b/v3/test/manual/systray/menu-only/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	_ "embed"
 	"log"
 	"runtime"
 

--- a/v3/test/manual/systray/window-menu/main.go
+++ b/v3/test/manual/systray/window-menu/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	_ "embed"
 	"log"
 	"runtime"
 

--- a/v3/test/manual/systray/window-only/main.go
+++ b/v3/test/manual/systray/window-only/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	_ "embed"
 	"log"
 	"runtime"
 


### PR DESCRIPTION
## Description

Removes 69 unused `_ "embed"` imports across the v3 codebase:

- **53 files** where `_ "embed"` was entirely unused (no `//go:embed` directive and no `embed.FS` usage)
- **16 files** where `_ "embed"` was redundant because a named `"embed"` import already exists in the same file

The `_ "embed"` blank import is a side-effect import that enables `//go:embed` directives. When no such directive exists in the file, the import serves no purpose and can be safely removed.

Fixes #5140

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Chore/cleanup

## How Has This Been Tested?

- Verified no empty import blocks remain after removal
- Spot-checked files in both categories to confirm correctness

## Checklist:

- [x] My code follows the general coding style of this project
- [x] My changes generate no new warnings