### PR TITLE
fix(darwin): update minimum macOS version from 10.15 to 12.0

### DIFF
--- a/v3/examples/android/build/darwin/Info.dev.plist
+++ b/v3/examples/android/build/darwin/Info.dev.plist
@@ -18,7 +18,7 @@
         <key>CFBundleIconFile</key>
             <string>icons</string>
         <key>LSMinimumSystemVersion</key>
-            <string>10.15.0</string>
+            <string>12.0.0</string>
         <key>NSHighResolutionCapable</key>
             <string>true</string>
         <key>NSHumanReadableCopyright</key>

--- a/v3/examples/android/build/darwin/Info.plist
+++ b/v3/examples/android/build/darwin/Info.plist
@@ -18,7 +18,7 @@
         <key>CFBundleIconFile</key>
             <string>icons</string>
         <key>LSMinimumSystemVersion</key>
-            <string>10.15.0</string>
+            <string>12.0.0</string>
         <key>NSHighResolutionCapable</key>
             <string>true</string>
         <key>NSHumanReadableCopyright</key>

--- a/v3/examples/android/build/darwin/Taskfile.yml
+++ b/v3/examples/android/build/darwin/Taskfile.yml
@@ -25,9 +25,9 @@ tasks:
       GOOS: darwin
       CGO_ENABLED: 1
       GOARCH: '{{.ARCH | default ARCH}}'
-      CGO_CFLAGS: "-mmacosx-version-min=10.15"
-      CGO_LDFLAGS: "-mmacosx-version-min=10.15"
-      MACOSX_DEPLOYMENT_TARGET: "10.15"
+      CGO_CFLAGS: "-mmacosx-version-min=12.0"
+      CGO_LDFLAGS: "-mmacosx-version-min=12.0"
+      MACOSX_DEPLOYMENT_TARGET: "12.0"
       PRODUCTION: '{{.PRODUCTION | default "false"}}'
 
   build:universal:

--- a/v3/examples/badge-custom/build/darwin/Info.dev.plist
+++ b/v3/examples/badge-custom/build/darwin/Info.dev.plist
@@ -18,7 +18,7 @@
         <key>CFBundleIconFile</key>
             <string>icons</string>
         <key>LSMinimumSystemVersion</key>
-            <string>10.15.0</string>
+            <string>12.0.0</string>
         <key>NSHighResolutionCapable</key>
             <string>true</string>
         <key>NSHumanReadableCopyright</key>

--- a/v3/examples/badge-custom/build/darwin/Info.plist
+++ b/v3/examples/badge-custom/build/darwin/Info.plist
@@ -18,7 +18,7 @@
         <key>CFBundleIconFile</key>
             <string>icons</string>
         <key>LSMinimumSystemVersion</key>
-            <string>10.15.0</string>
+            <string>12.0.0</string>
         <key>NSHighResolutionCapable</key>
             <string>true</string>
         <key>NSHumanReadableCopyright</key>

--- a/v3/examples/badge-custom/build/darwin/Taskfile.yml
+++ b/v3/examples/badge-custom/build/darwin/Taskfile.yml
@@ -25,9 +25,9 @@ tasks:
       GOOS: darwin
       CGO_ENABLED: 1
       GOARCH: '{{.ARCH | default ARCH}}'
-      CGO_CFLAGS: "-mmacosx-version-min=10.15"
-      CGO_LDFLAGS: "-mmacosx-version-min=10.15"
-      MACOSX_DEPLOYMENT_TARGET: "10.15"
+      CGO_CFLAGS: "-mmacosx-version-min=12.0"
+      CGO_LDFLAGS: "-mmacosx-version-min=12.0"
+      MACOSX_DEPLOYMENT_TARGET: "12.0"
       PRODUCTION: '{{.PRODUCTION | default "false"}}'
 
   build:universal:

--- a/v3/examples/badge/build/darwin/Info.dev.plist
+++ b/v3/examples/badge/build/darwin/Info.dev.plist
@@ -18,7 +18,7 @@
         <key>CFBundleIconFile</key>
             <string>icons</string>
         <key>LSMinimumSystemVersion</key>
-            <string>10.15.0</string>
+            <string>12.0.0</string>
         <key>NSHighResolutionCapable</key>
             <string>true</string>
         <key>NSHumanReadableCopyright</key>

--- a/v3/examples/badge/build/darwin/Info.plist
+++ b/v3/examples/badge/build/darwin/Info.plist
@@ -18,7 +18,7 @@
         <key>CFBundleIconFile</key>
             <string>icons</string>
         <key>LSMinimumSystemVersion</key>
-            <string>10.15.0</string>
+            <string>12.0.0</string>
         <key>NSHighResolutionCapable</key>
             <string>true</string>
         <key>NSHumanReadableCopyright</key>

--- a/v3/examples/badge/build/darwin/Taskfile.yml
+++ b/v3/examples/badge/build/darwin/Taskfile.yml
@@ -25,9 +25,9 @@ tasks:
       GOOS: darwin
       CGO_ENABLED: 1
       GOARCH: '{{.ARCH | default ARCH}}'
-      CGO_CFLAGS: "-mmacosx-version-min=10.15"
-      CGO_LDFLAGS: "-mmacosx-version-min=10.15"
-      MACOSX_DEPLOYMENT_TARGET: "10.15"
+      CGO_CFLAGS: "-mmacosx-version-min=12.0"
+      CGO_LDFLAGS: "-mmacosx-version-min=12.0"
+      MACOSX_DEPLOYMENT_TARGET: "12.0"
       PRODUCTION: '{{.PRODUCTION | default "false"}}'
 
   build:universal:

--- a/v3/examples/custom-protocol-example/build/darwin/Info.dev.plist
+++ b/v3/examples/custom-protocol-example/build/darwin/Info.dev.plist
@@ -18,7 +18,7 @@
         <key>CFBundleIconFile</key>
             <string>icons</string>
         <key>LSMinimumSystemVersion</key>
-            <string>10.15.0</string>
+            <string>12.0.0</string>
         <key>NSHighResolutionCapable</key>
             <string>true</string>
         <key>NSHumanReadableCopyright</key>

--- a/v3/examples/custom-protocol-example/build/darwin/Info.plist
+++ b/v3/examples/custom-protocol-example/build/darwin/Info.plist
@@ -18,7 +18,7 @@
         <key>CFBundleIconFile</key>
             <string>icons</string>
         <key>LSMinimumSystemVersion</key>
-            <string>10.15.0</string>
+            <string>12.0.0</string>
         <key>NSHighResolutionCapable</key>
             <string>true</string>
         <key>NSHumanReadableCopyright</key>

--- a/v3/examples/custom-protocol-example/build/darwin/Taskfile.yml
+++ b/v3/examples/custom-protocol-example/build/darwin/Taskfile.yml
@@ -20,9 +20,9 @@ tasks:
       GOOS: darwin
       CGO_ENABLED: 1
       GOARCH: '{{.ARCH | default ARCH}}'
-      CGO_CFLAGS: "-mmacosx-version-min=10.15"
-      CGO_LDFLAGS: "-mmacosx-version-min=10.15"
-      MACOSX_DEPLOYMENT_TARGET: "10.15"
+      CGO_CFLAGS: "-mmacosx-version-min=12.0"
+      CGO_LDFLAGS: "-mmacosx-version-min=12.0"
+      MACOSX_DEPLOYMENT_TARGET: "12.0"
       PRODUCTION: '{{.PRODUCTION | default "false"}}'
 
   build:universal:

--- a/v3/examples/dock/build/darwin/Info.dev.plist
+++ b/v3/examples/dock/build/darwin/Info.dev.plist
@@ -18,7 +18,7 @@
         <key>CFBundleIconFile</key>
             <string>icons</string>
         <key>LSMinimumSystemVersion</key>
-            <string>10.15.0</string>
+            <string>12.0.0</string>
         <key>NSHighResolutionCapable</key>
             <string>true</string>
         <key>NSHumanReadableCopyright</key>

--- a/v3/examples/dock/build/darwin/Info.plist
+++ b/v3/examples/dock/build/darwin/Info.plist
@@ -18,7 +18,7 @@
         <key>CFBundleIconFile</key>
             <string>icons</string>
         <key>LSMinimumSystemVersion</key>
-            <string>10.15.0</string>
+            <string>12.0.0</string>
         <key>NSHighResolutionCapable</key>
             <string>true</string>
         <key>NSHumanReadableCopyright</key>

--- a/v3/examples/dock/build/darwin/Taskfile.yml
+++ b/v3/examples/dock/build/darwin/Taskfile.yml
@@ -25,9 +25,9 @@ tasks:
       GOOS: darwin
       CGO_ENABLED: 1
       GOARCH: '{{.ARCH | default ARCH}}'
-      CGO_CFLAGS: "-mmacosx-version-min=10.15"
-      CGO_LDFLAGS: "-mmacosx-version-min=10.15"
-      MACOSX_DEPLOYMENT_TARGET: "10.15"
+      CGO_CFLAGS: "-mmacosx-version-min=12.0"
+      CGO_LDFLAGS: "-mmacosx-version-min=12.0"
+      MACOSX_DEPLOYMENT_TARGET: "12.0"
       PRODUCTION: '{{.PRODUCTION | default "false"}}'
 
   build:universal:

--- a/v3/examples/file-association/build/Taskfile.darwin.yml
+++ b/v3/examples/file-association/build/Taskfile.darwin.yml
@@ -18,9 +18,9 @@ tasks:
       GOOS: darwin
       CGO_ENABLED: 1
       GOARCH: '{{.ARCH | default ARCH}}'
-      CGO_CFLAGS: "-mmacosx-version-min=10.15"
-      CGO_LDFLAGS: "-mmacosx-version-min=10.15"
-      MACOSX_DEPLOYMENT_TARGET: "10.15"
+      CGO_CFLAGS: "-mmacosx-version-min=12.0"
+      CGO_LDFLAGS: "-mmacosx-version-min=12.0"
+      MACOSX_DEPLOYMENT_TARGET: "12.0"
       PRODUCTION: '{{.PRODUCTION | default "false"}}'
 
   package:

--- a/v3/examples/ios/build/darwin/Info.dev.plist
+++ b/v3/examples/ios/build/darwin/Info.dev.plist
@@ -18,7 +18,7 @@
         <key>CFBundleIconFile</key>
             <string>icons</string>
         <key>LSMinimumSystemVersion</key>
-            <string>10.15.0</string>
+            <string>12.0.0</string>
         <key>NSHighResolutionCapable</key>
             <string>true</string>
         <key>NSHumanReadableCopyright</key>

--- a/v3/examples/ios/build/darwin/Info.plist
+++ b/v3/examples/ios/build/darwin/Info.plist
@@ -18,7 +18,7 @@
         <key>CFBundleIconFile</key>
             <string>icons</string>
         <key>LSMinimumSystemVersion</key>
-            <string>10.15.0</string>
+            <string>12.0.0</string>
         <key>NSHighResolutionCapable</key>
             <string>true</string>
         <key>NSHumanReadableCopyright</key>

--- a/v3/examples/ios/build/darwin/Taskfile.yml
+++ b/v3/examples/ios/build/darwin/Taskfile.yml
@@ -25,9 +25,9 @@ tasks:
       GOOS: darwin
       CGO_ENABLED: 1
       GOARCH: '{{.ARCH | default ARCH}}'
-      CGO_CFLAGS: "-mmacosx-version-min=10.15"
-      CGO_LDFLAGS: "-mmacosx-version-min=10.15"
-      MACOSX_DEPLOYMENT_TARGET: "10.15"
+      CGO_CFLAGS: "-mmacosx-version-min=12.0"
+      CGO_LDFLAGS: "-mmacosx-version-min=12.0"
+      MACOSX_DEPLOYMENT_TARGET: "12.0"
       PRODUCTION: '{{.PRODUCTION | default "false"}}'
 
   build:universal:

--- a/v3/examples/notifications/build/darwin/Info.dev.plist
+++ b/v3/examples/notifications/build/darwin/Info.dev.plist
@@ -18,7 +18,7 @@
         <key>CFBundleIconFile</key>
         <string>icons</string>
         <key>LSMinimumSystemVersion</key>
-        <string>10.15.0</string>
+        <string>12.0.0</string>
         <key>NSHighResolutionCapable</key>
         <string>true</string>
         <key>NSHumanReadableCopyright</key>

--- a/v3/examples/notifications/build/darwin/Info.plist
+++ b/v3/examples/notifications/build/darwin/Info.plist
@@ -18,7 +18,7 @@
         <key>CFBundleIconFile</key>
         <string>icons</string>
         <key>LSMinimumSystemVersion</key>
-        <string>10.15.0</string>
+        <string>12.0.0</string>
         <key>NSHighResolutionCapable</key>
         <string>true</string>
         <key>NSHumanReadableCopyright</key>

--- a/v3/examples/notifications/build/darwin/Taskfile.yml
+++ b/v3/examples/notifications/build/darwin/Taskfile.yml
@@ -25,9 +25,9 @@ tasks:
       GOOS: darwin
       CGO_ENABLED: 1
       GOARCH: '{{.ARCH | default ARCH}}'
-      CGO_CFLAGS: "-mmacosx-version-min=10.15"
-      CGO_LDFLAGS: "-mmacosx-version-min=10.15"
-      MACOSX_DEPLOYMENT_TARGET: "10.15"
+      CGO_CFLAGS: "-mmacosx-version-min=12.0"
+      CGO_LDFLAGS: "-mmacosx-version-min=12.0"
+      MACOSX_DEPLOYMENT_TARGET: "12.0"
       PRODUCTION: '{{.PRODUCTION | default "false"}}'
 
   build:universal:

--- a/v3/internal/commands/build_assets/darwin/Taskfile.yml
+++ b/v3/internal/commands/build_assets/darwin/Taskfile.yml
@@ -48,9 +48,9 @@ tasks:
       GOOS: darwin
       CGO_ENABLED: 1
       GOARCH: '{{.ARCH | default ARCH}}'
-      CGO_CFLAGS: "-mmacosx-version-min=10.15"
-      CGO_LDFLAGS: "-mmacosx-version-min=10.15"
-      MACOSX_DEPLOYMENT_TARGET: "10.15"
+      CGO_CFLAGS: "-mmacosx-version-min=12.0"
+      CGO_LDFLAGS: "-mmacosx-version-min=12.0"
+      MACOSX_DEPLOYMENT_TARGET: "12.0"
 
   build:docker:
     summary: Cross-compiles for macOS using Docker (for Linux/Windows hosts)

--- a/v3/internal/commands/updatable_build_assets/darwin/Info.dev.plist.tmpl
+++ b/v3/internal/commands/updatable_build_assets/darwin/Info.dev.plist.tmpl
@@ -22,7 +22,7 @@
             <string>{{.CFBundleIconName}}</string>
         {{- end}}
         <key>LSMinimumSystemVersion</key>
-            <string>10.15.0</string>
+            <string>12.0.0</string>
         <key>NSHighResolutionCapable</key>
             <string>true</string>
         <key>NSHumanReadableCopyright</key>

--- a/v3/internal/commands/updatable_build_assets/darwin/Info.plist.tmpl
+++ b/v3/internal/commands/updatable_build_assets/darwin/Info.plist.tmpl
@@ -22,7 +22,7 @@
             <string>{{.CFBundleIconName}}</string>
         {{- end}}
         <key>LSMinimumSystemVersion</key>
-            <string>10.15.0</string>
+            <string>12.0.0</string>
         <key>NSHighResolutionCapable</key>
             <string>true</string>
         <key>NSHumanReadableCopyright</key>


### PR DESCRIPTION
## Description

Updates the minimum macOS deployment target from 10.15 (Catalina) to 12.0 (Monterey) in build templates and example projects.

Since Go 1.25, the linker embeds `LC_BUILD_VERSION` with `minos 12.0` into Mach-O binaries. This means apps built with Go 1.25+ physically cannot run on macOS < 12. The mismatch between `LSMinimumSystemVersion` (10.15) and the actual binary minimum (12.0) caused apps to silently crash on older macOS with no error dialog.

Setting `LSMinimumSystemVersion` to 12.0 ensures macOS shows a clear dialog: _"MyApp" requires macOS 12 or later._

**Files updated:**
- `updatable_build_assets/darwin/Info.plist.tmpl` + `Info.dev.plist.tmpl` (`LSMinimumSystemVersion`)
- `build_assets/darwin/Taskfile.yml` (`CGO_CFLAGS`, `CGO_LDFLAGS`, `MACOSX_DEPLOYMENT_TARGET`)
- All example project build files for consistency

**Not changed:** Runtime `@available(macOS 10.15, *)` guards and the version name map in `os_darwin.go` — these are feature detection checks, not minimum version declarations.

Fixes #5161

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Verified only template/build files were modified, not runtime feature checks
- Confirmed no remaining 10.15 references in plist/yml files

## Checklist:

- [x] My code follows the general coding style of this project
- [x] My changes generate no new warnings