### PR TITLE
feat: add FullscreenButtonState to WebviewWindowOptions for API consistency

### DIFF
--- a/v3/pkg/application/webview_window_android.go
+++ b/v3/pkg/application/webview_window_android.go
@@ -136,6 +136,8 @@ func (w *androidWebviewWindow) setFrameless(_ bool) {}
 
 func (w *androidWebviewWindow) setFullscreenButtonEnabled(_ bool) {}
 
+func (w *androidWebviewWindow) setFullscreenButtonState(_ ButtonState) {}
+
 func (w *androidWebviewWindow) setMaxSize(_ int, _ int) {}
 
 func (w *androidWebviewWindow) setMinSize(_ int, _ int) {}

--- a/v3/pkg/application/webview_window_darwin.go
+++ b/v3/pkg/application/webview_window_darwin.go
@@ -461,10 +461,11 @@ void windowRestore(void* nsWindow) {
 	}
 }
 
-// disable window fullscreen button
-void setFullscreenButtonEnabled(void* nsWindow, bool enabled) {
-	NSButton *fullscreenButton = [(WebviewWindow*)nsWindow standardWindowButton:NSWindowZoomButton];
-	fullscreenButton.enabled = enabled;
+// setFullscreenButtonState sets the fullscreen button state
+static void setFullscreenButtonState(void *window, int state) {
+	WebviewWindow* nsWindow = (WebviewWindow*)window;
+	NSButton *fullscreenButton = [nsWindow standardWindowButton:NSWindowZoomButton];
+	setButtonState(fullscreenButton, state);
 }
 
 // Set the titlebar style
@@ -1041,7 +1042,15 @@ func (w *macosWebviewWindow) hide() {
 }
 
 func (w *macosWebviewWindow) setFullscreenButtonEnabled(enabled bool) {
-	C.setFullscreenButtonEnabled(w.nsWindow, C.bool(enabled))
+	state := ButtonDisabled
+	if enabled {
+		state = ButtonEnabled
+	}
+	w.setFullscreenButtonState(state)
+}
+
+func (w *macosWebviewWindow) setFullscreenButtonState(state ButtonState) {
+	C.setFullscreenButtonState(w.nsWindow, C.int(state))
 }
 
 func (w *macosWebviewWindow) disableSizeConstraints() {
@@ -1390,6 +1399,7 @@ func (w *macosWebviewWindow) run() {
 		w.setMinimiseButtonState(options.MinimiseButtonState)
 		w.setMaximiseButtonState(options.MaximiseButtonState)
 		w.setCloseButtonState(options.CloseButtonState)
+		w.setFullscreenButtonState(options.FullscreenButtonState)
 
 		// Ignore mouse events if requested
 		w.setIgnoreMouseEvents(options.IgnoreMouseEvents)

--- a/v3/pkg/application/webview_window_ios.go
+++ b/v3/pkg/application/webview_window_ios.go
@@ -142,13 +142,13 @@ func (w *iosWebviewWindow) setAbsolutePosition(_ int, _ int) {}
 func (w *iosWebviewWindow) setAlwaysOnTop(_ bool) {}
 
 func (w *iosWebviewWindow) setBackgroundColour(col RGBA) {
-    if w.nativeHandle == nil {
-        return
-    }
-    C.ios_window_set_background_color(
-        w.nativeHandle,
-        C.uchar(col.Red), C.uchar(col.Green), C.uchar(col.Blue), C.uchar(col.Alpha),
-    )
+	if w.nativeHandle == nil {
+		return
+	}
+	C.ios_window_set_background_color(
+		w.nativeHandle,
+		C.uchar(col.Red), C.uchar(col.Green), C.uchar(col.Blue), C.uchar(col.Alpha),
+	)
 }
 
 func (w *iosWebviewWindow) setEnabled(_ bool) {}
@@ -156,6 +156,8 @@ func (w *iosWebviewWindow) setEnabled(_ bool) {}
 func (w *iosWebviewWindow) setFrameless(_ bool) {}
 
 func (w *iosWebviewWindow) setFullscreenButtonEnabled(_ bool) {}
+
+func (w *iosWebviewWindow) setFullscreenButtonState(_ ButtonState) {}
 
 func (w *iosWebviewWindow) setMaxSize(_ int, _ int) {}
 

--- a/v3/pkg/application/webview_window_linux.go
+++ b/v3/pkg/application/webview_window_linux.go
@@ -97,6 +97,10 @@ func (w *linuxWebviewWindow) setFullscreenButtonEnabled(enabled bool) {
 	// Not implemented
 }
 
+func (w *linuxWebviewWindow) setFullscreenButtonState(state ButtonState) {
+	// Not implemented
+}
+
 func (w *linuxWebviewWindow) setMinimiseButtonEnabled(enabled bool) {
 	//C.enableMinimiseButton(w.nsWindow, C.bool(enabled))
 }

--- a/v3/pkg/application/webview_window_options.go
+++ b/v3/pkg/application/webview_window_options.go
@@ -128,9 +128,10 @@ type WebviewWindowOptions struct {
 	Linux LinuxWindow
 
 	// Toolbar button states
-	MinimiseButtonState ButtonState
-	MaximiseButtonState ButtonState
-	CloseButtonState    ButtonState
+	MinimiseButtonState   ButtonState
+	MaximiseButtonState   ButtonState
+	CloseButtonState      ButtonState
+	FullscreenButtonState ButtonState
 
 	// If true, the window's devtools will be available (default true in builds without the `production` build tag)
 	DevToolsEnabled bool

--- a/v3/pkg/application/webview_window_windows.go
+++ b/v3/pkg/application/webview_window_windows.go
@@ -463,6 +463,7 @@ func (w *windowsWebviewWindow) run() {
 	w.setMinimiseButtonState(options.MinimiseButtonState)
 	w.setMaximiseButtonState(options.MaximiseButtonState)
 	w.setCloseButtonState(options.CloseButtonState)
+	w.setFullscreenButtonState(options.FullscreenButtonState)
 
 	// Register the window with the application
 	getNativeApplication().registerWindow(w)
@@ -2447,6 +2448,14 @@ func (w *windowsWebviewWindow) setCloseButtonState(state ButtonState) {
 	case ButtonHidden:
 		w.setStyle(false, w32.WS_SYSMENU)
 	}
+}
+
+func (w *windowsWebviewWindow) setFullscreenButtonEnabled(_ bool) {
+	// Not implemented on Windows
+}
+
+func (w *windowsWebviewWindow) setFullscreenButtonState(_ ButtonState) {
+	// Not implemented on Windows
 }
 
 func (w *windowsWebviewWindow) setGWLStyle(style int) {


### PR DESCRIPTION
## Description

Adds `FullscreenButtonState ButtonState` to `WebviewWindowOptions` for consistency with the existing `MinimiseButtonState`, `MaximiseButtonState`, and `CloseButtonState` fields.

Previously, the fullscreen button used `setFullscreenButtonEnabled(bool)` with a simple bool, while all other titlebar buttons used the `ButtonState` type (Enabled/Disabled/Hidden).

**Changes:**
- Add `FullscreenButtonState ButtonState` to `WebviewWindowOptions`
- Update macOS C code from `setFullscreenButtonEnabled(bool)` to `setFullscreenButtonState(int)` using the same `setButtonState` pattern as other buttons — now supports Hidden state too
- Add `setFullscreenButtonState(ButtonState)` to all platform implementations (Linux, Windows, iOS, Android)
- Apply `FullscreenButtonState` during window initialization on macOS and Windows
- Keep `setFullscreenButtonEnabled(bool)` for backward compatibility

**Files changed:**
- `webview_window_options.go` — new option field
- `webview_window_darwin.go` — C code + Go wrapper updated
- `webview_window_linux.go` — new stub
- `webview_window_windows.go` — new stub + init
- `webview_window_ios.go` — new stub
- `webview_window_android.go` — new stub

Fixes #4967

## Type of change

- [x] Enhancement (non-breaking change — new option field, default zero-value is ButtonEnabled which matches current behavior)

## How Has This Been Tested?

- `go build ./pkg/application/` compiles cleanly on Linux
- Cross-platform stubs verified for all platforms
- **macOS testing needed** — I don't have access to a macOS environment to verify the CGo changes

## Checklist:

- [x] My code follows the general coding style of this project
- [x] My changes generate no new warnings
- [ ] Platform testing needed on macOS