### PR TITLE
fix(build): sync frontend assets to embed dir when frontend:dir is custom

### DIFF
--- a/v2/pkg/commands/build/build.go
+++ b/v2/pkg/commands/build/build.go
@@ -141,6 +141,10 @@ func Build(options *Options) (string, error) {
 		if err != nil {
 			return "", err
 		}
+
+		if err := syncFrontendAssetsToEmbedDir(options); err != nil {
+			return "", err
+		}
 	}
 
 	compileBinary := ""
@@ -189,6 +193,89 @@ func CreateEmbedDirectories(cwd string, buildOptions *Options) error {
 		}
 	}
 
+	return nil
+}
+
+func syncFrontendAssetsToEmbedDir(options *Options) error {
+	frontendDir := options.ProjectData.GetFrontendDir()
+	defaultEmbedDir := filepath.Join(options.ProjectData.Path, "frontend")
+	absFrontendDir, err := filepath.Abs(frontendDir)
+	if err != nil {
+		return err
+	}
+	absDefaultDir, err := filepath.Abs(defaultEmbedDir)
+	if err != nil {
+		return err
+	}
+
+	if absFrontendDir == absDefaultDir {
+		return nil
+	}
+
+	embedDetails, err := staticanalysis.GetEmbedDetails(options.ProjectData.Path)
+	if err != nil {
+		return nil
+	}
+
+	for _, ed := range embedDetails {
+		if filepath.Ext(ed.GetFullPath()) != "" {
+			continue
+		}
+		relPath, err := filepath.Rel(options.ProjectData.Path, ed.GetFullPath())
+		if err != nil {
+			continue
+		}
+		if !strings.HasPrefix(relPath, "frontend"+string(filepath.Separator)) {
+			continue
+		}
+		frontendSubPath := strings.TrimPrefix(relPath, "frontend"+string(filepath.Separator))
+		srcDir := filepath.Join(absFrontendDir, frontendSubPath)
+
+		if !fs.DirExists(srcDir) {
+			continue
+		}
+
+		destDir := ed.GetFullPath()
+		if fs.DirExists(destDir) {
+			if err := os.RemoveAll(destDir); err != nil {
+				return fmt.Errorf("failed to clear embed directory %s: %w", destDir, err)
+			}
+		}
+		if err := fs.MkDirs(destDir, 0o755); err != nil {
+			return fmt.Errorf("failed to create embed directory %s: %w", destDir, err)
+		}
+		if err := copyDirContents(srcDir, destDir); err != nil {
+			return fmt.Errorf("failed to copy frontend assets from %s to %s: %w", srcDir, destDir, err)
+		}
+	}
+	return nil
+}
+
+func copyDirContents(src, dst string) error {
+	entries, err := os.ReadDir(src)
+	if err != nil {
+		return err
+	}
+	for _, entry := range entries {
+		srcPath := filepath.Join(src, entry.Name())
+		dstPath := filepath.Join(dst, entry.Name())
+		if entry.IsDir() {
+			if err := fs.MkDirs(dstPath, 0o755); err != nil {
+				return err
+			}
+			if err := copyDirContents(srcPath, dstPath); err != nil {
+				return err
+			}
+		} else {
+			data, err := os.ReadFile(srcPath)
+			if err != nil {
+				return err
+			}
+			if err := os.WriteFile(dstPath, data, 0o644); err != nil {
+				return err
+			}
+		}
+	}
 	return nil
 }
 

--- a/v2/pkg/commands/build/build.go
+++ b/v2/pkg/commands/build/build.go
@@ -141,6 +141,10 @@ func Build(options *Options) (string, error) {
 		if err != nil {
 			return "", err
 		}
+
+		if err := syncFrontendAssetsToEmbedDir(options); err != nil {
+			return "", err
+		}
 	}
 
 	compileBinary := ""
@@ -190,6 +194,89 @@ func CreateEmbedDirectories(cwd string, buildOptions *Options) error {
 	}
 
 	return nil
+}
+
+func syncFrontendAssetsToEmbedDir(buildOptions *Options) error {
+	if buildOptions.ProjectData == nil {
+		return nil
+	}
+	projectPath := buildOptions.ProjectData.Path
+	frontendDir := buildOptions.ProjectData.GetFrontendDir()
+
+	defaultFrontendDir := filepath.Join(projectPath, "frontend")
+	if frontendDir == defaultFrontendDir {
+		return nil
+	}
+
+	embedDetails, err := staticanalysis.GetEmbedDetails(projectPath)
+	if err != nil {
+		return err
+	}
+
+	return syncAssetsToEmbedPaths(frontendDir, projectPath, embedDetails)
+}
+
+func syncAssetsToEmbedPaths(frontendDir string, projectPath string, embedDetails []*staticanalysis.EmbedDetails) error {
+	defaultFrontendDir := filepath.Join(projectPath, "frontend")
+	for _, embedDetail := range embedDetails {
+		fullPath := embedDetail.GetFullPath()
+		if filepath.Ext(fullPath) != "" {
+			continue
+		}
+		embedRelPath, err := filepath.Rel(projectPath, fullPath)
+		if err != nil {
+			continue
+		}
+		subPath, err := filepath.Rel(defaultFrontendDir, fullPath)
+		if err != nil {
+			continue
+		}
+		if strings.HasPrefix(subPath, "..") {
+			continue
+		}
+		sourceDir := filepath.Join(frontendDir, subPath)
+		if !fs.DirExists(sourceDir) {
+			continue
+		}
+		entries, err := os.ReadDir(sourceDir)
+		if err != nil || len(entries) == 0 {
+			continue
+		}
+		embedTargetPath := filepath.Join(defaultFrontendDir, subPath)
+		if embedTargetPath == sourceDir {
+			continue
+		}
+		if err := os.MkdirAll(embedTargetPath, 0o755); err != nil {
+			return fmt.Errorf("failed to create embed directory %s: %w", embedTargetPath, err)
+		}
+		if err := copyDir(sourceDir, embedTargetPath); err != nil {
+			return fmt.Errorf("failed to sync frontend assets from %s to %s: %w", sourceDir, embedTargetPath, err)
+		}
+		_ = embedRelPath
+	}
+
+	return nil
+}
+
+func copyDir(src, dst string) error {
+	return filepath.Walk(src, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		relPath, err := filepath.Rel(src, path)
+		if err != nil {
+			return err
+		}
+		targetPath := filepath.Join(dst, relPath)
+		if info.IsDir() {
+			return os.MkdirAll(targetPath, info.Mode())
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		return os.WriteFile(targetPath, data, info.Mode())
+	})
 }
 
 func fatal(message string) {

--- a/v2/pkg/commands/build/sync_test.go
+++ b/v2/pkg/commands/build/sync_test.go
@@ -1,0 +1,47 @@
+package build
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestCopyDirContents(t *testing.T) {
+	srcDir := t.TempDir()
+	dstDir := t.TempDir()
+
+	files := []struct {
+		path    string
+		content string
+	}{
+		{"index.html", "<html></html>"},
+		{"assets/main.js", "console.log('hi')"},
+		{"assets/style.css", "body {}"},
+		{"assets/sub/deep.txt", "deep"},
+	}
+
+	for _, f := range files {
+		fullPath := filepath.Join(srcDir, f.path)
+		if err := os.MkdirAll(filepath.Dir(fullPath), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(fullPath, []byte(f.content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if err := copyDirContents(srcDir, dstDir); err != nil {
+		t.Fatalf("copyDirContents() error = %v", err)
+	}
+
+	for _, f := range files {
+		data, err := os.ReadFile(filepath.Join(dstDir, f.path))
+		if err != nil {
+			t.Errorf("file %s not found in destination: %v", f.path, err)
+			continue
+		}
+		if string(data) != f.content {
+			t.Errorf("file %s: got %q, want %q", f.path, string(data), f.content)
+		}
+	}
+}

--- a/v2/pkg/commands/build/sync_test.go
+++ b/v2/pkg/commands/build/sync_test.go
@@ -1,0 +1,119 @@
+package build
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/wailsapp/wails/v2/internal/project"
+	"github.com/wailsapp/wails/v2/internal/staticanalysis"
+)
+
+func TestSyncAssetsToEmbedPathsCopiesFromCustomDir(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	customFrontend := filepath.Join(tmpDir, "web")
+	customDist := filepath.Join(customFrontend, "dist")
+	if err := os.MkdirAll(customDist, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(customDist, "index.html"), []byte("<h1>test</h1>"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	defaultDist := filepath.Join(tmpDir, "frontend", "dist")
+	if err := os.MkdirAll(defaultDist, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	embedDetails := []*staticanalysis.EmbedDetails{
+		{BaseDir: tmpDir, EmbedPath: "frontend/dist", All: true},
+	}
+
+	if err := syncAssetsToEmbedPaths(customFrontend, tmpDir, embedDetails); err != nil {
+		t.Fatalf("syncAssetsToEmbedPaths failed: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(defaultDist, "index.html"))
+	if err != nil {
+		t.Fatalf("expected index.html in default embed dir: %v", err)
+	}
+	if string(data) != "<h1>test</h1>" {
+		t.Errorf("unexpected content: %s", data)
+	}
+}
+
+func TestSyncFrontendAssetsNoOpForDefaultDir(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	frontendDist := filepath.Join(tmpDir, "frontend", "dist")
+	if err := os.MkdirAll(frontendDist, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(frontendDist, "index.html"), []byte("<h1>original</h1>"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	opts := &Options{
+		ProjectData: &project.Project{
+			Path:        tmpDir,
+			FrontendDir: "frontend",
+		},
+	}
+
+	if err := syncFrontendAssetsToEmbedDir(opts); err != nil {
+		t.Fatalf("syncFrontendAssetsToEmbedDir failed: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(frontendDist, "index.html"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != "<h1>original</h1>" {
+		t.Errorf("content should be unchanged for default frontend dir")
+	}
+}
+
+func TestSyncFrontendAssetsNoOpForNilProject(t *testing.T) {
+	opts := &Options{}
+	if err := syncFrontendAssetsToEmbedDir(opts); err != nil {
+		t.Errorf("should be no-op for nil project data: %v", err)
+	}
+}
+
+func TestCopyDir(t *testing.T) {
+	srcDir := t.TempDir()
+	dstDir := t.TempDir()
+
+	subDir := filepath.Join(srcDir, "assets")
+	if err := os.MkdirAll(subDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(subDir, "app.js"), []byte("console.log(1)"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(srcDir, "index.html"), []byte("<html></html>"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	targetDir := filepath.Join(dstDir, "output")
+	if err := copyDir(srcDir, targetDir); err != nil {
+		t.Fatal(err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(targetDir, "index.html"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != "<html></html>" {
+		t.Errorf("unexpected index.html content: %s", data)
+	}
+
+	data, err = os.ReadFile(filepath.Join(targetDir, "assets", "app.js"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != "console.log(1)" {
+		t.Errorf("unexpected app.js content: %s", data)
+	}
+}


### PR DESCRIPTION
## Summary

- When `frontend:dir` in `wails.json` is set to a non-default directory, `wails build` now correctly syncs the built frontend assets to the `//go:embed` directory
- The `go:embed` directive in `main.go` is hardcoded (e.g., `//go:embed all:frontend/dist`), so when the frontend is in a custom directory, the assets end up in the wrong place at compile time
- After `BuildFrontend`, a new `syncFrontendAssetsToEmbedDir` step copies assets from `<custom-frontend>/dist` to `frontend/dist`
- No-op when `frontend:dir` is the default `"frontend"`

## Test Plan

- `v2/pkg/commands/build/sync_test.go` contains 4 tests:
  - `TestSyncAssetsToEmbedPathsCopiesFromCustomDir` — verifies assets are copied from custom dir to embed dir
  - `TestSyncFrontendAssetsNoOpForDefaultDir` — verifies no copying when frontend:dir is default
  - `TestSyncFrontendAssetsNoOpForNilProject` — verifies nil safety
  - `TestCopyDir` — verifies the recursive directory copy utility

## Related Issue

Fixes #5034

## Notes

- Does not modify `//go:embed` directives (that would require rewriting user source code)
- For frontends *outside* the project directory, this fix works for relative paths. Absolute paths outside the project remain unsupported due to `go:embed` limitations.
- This is a v2-only fix.