### PR TITLE
fix(assetserver): use extension-based MIME type detection for WASM and other file types

### DIFF
--- a/v2/pkg/assetserver/assetserver_webview.go
+++ b/v2/pkg/assetserver/assetserver_webview.go
@@ -73,15 +73,16 @@ func (d *AssetServer) processWebViewRequestInternal(r webview.Request) {
 		}
 	}()
 
-	var rw http.ResponseWriter = &contentTypeSniffer{rw: wrw} // Make sure we have a Content-Type sniffer
-	defer rw.WriteHeader(http.StatusNotImplemented)           // This is a NOP when a handler has already written and set the status
-
 	uri, err = r.URL()
 	if err != nil {
 		d.logError("Error processing request, unable to get URL: %s (HttpResponse=500)", err)
+		rw := &contentTypeSniffer{rw: wrw}
 		http.Error(rw, err.Error(), http.StatusInternalServerError)
 		return
 	}
+
+	var rw http.ResponseWriter = &contentTypeSniffer{rw: wrw, reqPath: uri}
+	defer rw.WriteHeader(http.StatusNotImplemented)
 
 	method, err := r.Method()
 	if err != nil {

--- a/v2/pkg/assetserver/content_type_sniffer.go
+++ b/v2/pkg/assetserver/content_type_sniffer.go
@@ -2,10 +2,12 @@ package assetserver
 
 import (
 	"net/http"
+	"path/filepath"
 )
 
 type contentTypeSniffer struct {
-	rw http.ResponseWriter
+	rw      http.ResponseWriter
+	reqPath string
 
 	wroteHeader bool
 }
@@ -35,8 +37,23 @@ func (rw *contentTypeSniffer) writeHeader(b []byte) {
 
 	m := rw.rw.Header()
 	if _, hasType := m[HeaderContentType]; !hasType {
-		m.Set(HeaderContentType, http.DetectContentType(b))
+		ct := http.DetectContentType(b)
+		if rw.reqPath != "" {
+			if ext := filepath.Ext(rw.reqPath); ext != "" {
+				if custom := getMimeTypeByExt(ext); custom != "" {
+					ct = custom
+				}
+			}
+		}
+		m.Set(HeaderContentType, ct)
 	}
 
 	rw.WriteHeader(http.StatusOK)
+}
+
+func getMimeTypeByExt(ext string) string {
+	if ct, ok := mimeTypesByExt[ext]; ok {
+		return ct
+	}
+	return ""
 }

--- a/v2/pkg/assetserver/content_type_sniffer_test.go
+++ b/v2/pkg/assetserver/content_type_sniffer_test.go
@@ -1,0 +1,133 @@
+package assetserver
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestContentTypeSnifferWasmFile(t *testing.T) {
+	rec := httptest.NewRecorder()
+	sniffer := &contentTypeSniffer{rw: rec, reqPath: "/app_bg.wasm"}
+
+	wasmData := []byte{0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00}
+	_, err := sniffer.Write(wasmData)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ct := rec.Header().Get(HeaderContentType)
+	if ct != "application/wasm" {
+		t.Errorf("expected Content-Type 'application/wasm', got '%s'", ct)
+	}
+}
+
+func TestContentTypeSnifferJSFile(t *testing.T) {
+	rec := httptest.NewRecorder()
+	sniffer := &contentTypeSniffer{rw: rec, reqPath: "/app.js"}
+
+	_, err := sniffer.Write([]byte("console.log(1)"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ct := rec.Header().Get(HeaderContentType)
+	if ct != "text/javascript; charset=utf-8" {
+		t.Errorf("expected Content-Type 'text/javascript; charset=utf-8', got '%s'", ct)
+	}
+}
+
+func TestContentTypeSnifferHTMLFile(t *testing.T) {
+	rec := httptest.NewRecorder()
+	sniffer := &contentTypeSniffer{rw: rec, reqPath: "/index.html"}
+
+	_, err := sniffer.Write([]byte("<html></html>"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ct := rec.Header().Get(HeaderContentType)
+	if ct != "text/html; charset=utf-8" {
+		t.Errorf("expected Content-Type 'text/html; charset=utf-8', got '%s'", ct)
+	}
+}
+
+func TestContentTypeSnifferPreservesExplicitContentType(t *testing.T) {
+	rec := httptest.NewRecorder()
+	sniffer := &contentTypeSniffer{rw: rec, reqPath: "/app.wasm"}
+
+	sniffer.Header().Set(HeaderContentType, "custom/type")
+	_, err := sniffer.Write([]byte("data"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ct := rec.Header().Get(HeaderContentType)
+	if ct != "custom/type" {
+		t.Errorf("expected Content-Type 'custom/type' to be preserved, got '%s'", ct)
+	}
+}
+
+func TestContentTypeSnifferUnknownFileFallsBack(t *testing.T) {
+	rec := httptest.NewRecorder()
+	sniffer := &contentTypeSniffer{rw: rec, reqPath: "/unknown.dat"}
+
+	_, err := sniffer.Write([]byte("some binary data"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ct := rec.Header().Get(HeaderContentType)
+	if ct == "" {
+		t.Error("expected a Content-Type to be set")
+	}
+}
+
+func TestContentTypeSnifferNoReqPath(t *testing.T) {
+	rec := httptest.NewRecorder()
+	sniffer := &contentTypeSniffer{rw: rec}
+
+	wasmData := []byte{0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00}
+	_, err := sniffer.Write(wasmData)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ct := rec.Header().Get(HeaderContentType)
+	if ct == "" {
+		t.Error("expected a Content-Type to be set")
+	}
+}
+
+func TestGetMimeTypeByExt(t *testing.T) {
+	tests := []struct {
+		ext      string
+		expected string
+	}{
+		{".wasm", "application/wasm"},
+		{".js", "text/javascript; charset=utf-8"},
+		{".css", "text/css; charset=utf-8"},
+		{".html", "text/html; charset=utf-8"},
+		{".json", "application/json"},
+		{".svg", "image/svg+xml"},
+		{".xyz", ""},
+	}
+	for _, tt := range tests {
+		got := getMimeTypeByExt(tt.ext)
+		if got != tt.expected {
+			t.Errorf("getMimeTypeByExt(%q) = %q, want %q", tt.ext, got, tt.expected)
+		}
+	}
+}
+
+func TestContentTypeSnifferWriteHeaderOnce(t *testing.T) {
+	rec := httptest.NewRecorder()
+	sniffer := &contentTypeSniffer{rw: rec, reqPath: "/test.txt"}
+
+	sniffer.WriteHeader(http.StatusOK)
+	sniffer.WriteHeader(http.StatusBadRequest)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected status %d, got %d", http.StatusOK, rec.Code)
+	}
+}


### PR DESCRIPTION
## Summary

- The `contentTypeSniffer` in the asset server used `http.DetectContentType()` as its fallback, which doesn't recognize WASM binary format (returns `application/octet-stream` instead of `application/wasm`)
- This caused `WebAssembly.instantiateStreaming` to fail when loading WASM files through the `wails://` protocol in dev mode
- Fix: pass the request URI path to the sniffer and use extension-based MIME type lookup (`.wasm` → `application/wasm`, `.js` → `text/javascript`, etc.) when the file extension is known
- When the extension is not in the known map, falls back to `http.DetectContentType()` as before

## Test Plan

- `v2/pkg/assetserver/content_type_sniffer_test.go` contains 8 tests:
  - `TestContentTypeSnifferWasmFile` — verifies `.wasm` files get `application/wasm`
  - `TestContentTypeSnifferJSFile` — verifies `.js` files get `text/javascript`
  - `TestContentTypeSnifferHTMLFile` — verifies `.html` files get `text/html`
  - `TestContentTypeSnifferPreservesExplicitContentType` — verifies explicitly set Content-Type is not overwritten
  - `TestContentTypeSnifferUnknownFileFallsBack` — verifies fallback for unknown extensions
  - `TestContentTypeSnifferNoReqPath` — verifies fallback when no request path is available
  - `TestGetMimeTypeByExt` — unit test for the extension lookup
  - `TestContentTypeSnifferWriteHeaderOnce` — verifies header is written only once

## Related Issue

Fixes #4274

## Notes

- This fix benefits all file types in the `mimeTypesByExt` map, not just WASM
- For the proxy path (`ExternalAssetHandler`), `httputil.ReverseProxy` should already copy upstream headers correctly in most cases. This fix addresses the fallback sniffer path when headers are not set by any handler.