### PR TITLE
Add Frontend Routing to v3 sidebar

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -312,6 +312,7 @@ export default defineConfig({
               label: "Integration Patterns",
               collapsed: true,
               items: [
+                { label: "Frontend Routing", link: "/guides/routing" },
                 { label: "Using Gin Router", link: "/guides/patterns/gin-routing" },
                 { label: "Gin Services", link: "/guides/patterns/gin-services" },
                 { label: "Database Integration", link: "/guides/patterns/database" },


### PR DESCRIPTION
## Summary

- Adds "Frontend Routing" entry to the Guides > Integration Patterns sidebar section in `docs/astro.config.mjs`
- Links to the routing guide added in #5185

The routing guide was merged without the sidebar entry, making it only discoverable via search.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new "Frontend Routing" guide in the Integration Patterns section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->