### PR TITLE
Add UNRELEASED_CHANGELOG entry for PR #5168

### DIFF
--- a/v3/UNRELEASED_CHANGELOG.md
+++ b/v3/UNRELEASED_CHANGELOG.md
@@ -23,6 +23,7 @@ After processing, the content will be moved to the main changelog and this file 
 
 ## Fixed
 <!-- Bug fixes -->
+- Fix halved Screen Bounds, WorkArea, and Size values on Retina Macs -  (#5168)
 
 ## Deprecated
 <!-- Soon-to-be removed features -->


### PR DESCRIPTION
## Summary
- Add missing changelog entry for PR #5168 (Fix halved Screen Bounds, WorkArea, and Size on Retina Macs) to `v3/UNRELEASED_CHANGELOG.md`

This was missed when the original PR was merged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Screen Bounds, WorkArea, and Size values no longer being incorrectly halved on Retina Macs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->