### PR TITLE
fix(v2/dnf): use 'dnf -q list --installed' for accurate detection

### DIFF
--- a/v2/internal/system/packagemanager/dnf.go
+++ b/v2/internal/system/packagemanager/dnf.go
@@ -73,7 +73,7 @@ func (y *Dnf) PackageInstalled(pkg *Package) (bool, error) {
 	if pkg.SystemPackage == false {
 		return false, nil
 	}
-	stdout, _, err := shell.RunCommand(".", "dnf", "info", "installed", pkg.Name)
+	stdout, _, err := shell.RunCommand(".", "dnf", "-q", "list", "--installed", pkg.Name)
 	if err != nil {
 		_, ok := err.(*exec.ExitError)
 		if ok {
@@ -84,13 +84,18 @@ func (y *Dnf) PackageInstalled(pkg *Package) (bool, error) {
 
 	splitoutput := strings.Split(stdout, "\n")
 	for _, line := range splitoutput {
-		if strings.HasPrefix(line, "Version") {
-			splitline := strings.Split(line, ":")
-			pkg.Version = strings.TrimSpace(splitline[1])
+		fields := strings.Fields(line)
+		if len(fields) >= 2 {
+			version := fields[1]
+			if idx := strings.Index(version, "-"); idx != -1 {
+				pkg.Version = version[:idx]
+			} else {
+				pkg.Version = version
+			}
 		}
 	}
 
-	return true, err
+	return true, nil
 }
 
 // PackageAvailable tests if the given package is available for installation

--- a/v2/internal/system/packagemanager/dnf_test.go
+++ b/v2/internal/system/packagemanager/dnf_test.go
@@ -1,0 +1,54 @@
+//go:build linux
+// +build linux
+
+package packagemanager
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestDnfListInstalledVersionParsing(t *testing.T) {
+	tests := []struct {
+		name     string
+		output   string
+		expected string
+	}{
+		{
+			name:     "package with release suffix",
+			output:   "webkit2gtk4.0-devel.x86_64 2.46.5-1.fc41 @updates",
+			expected: "2.46.5",
+		},
+		{
+			name:     "package simple release",
+			output:   "gcc-c++.x86_64 14.3.1-1.fc41 @updates",
+			expected: "14.3.1",
+		},
+		{
+			name:     "package no dash in version",
+			output:   "somepkg.x86_64 1.0 @repo",
+			expected: "1.0",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var got string
+			splitoutput := strings.Split(tt.output, "\n")
+			for _, line := range splitoutput {
+				fields := strings.Fields(line)
+				if len(fields) >= 2 {
+					version := fields[1]
+					if idx := strings.Index(version, "-"); idx != -1 {
+						got = version[:idx]
+					} else {
+						got = version
+					}
+				}
+			}
+			if got != tt.expected {
+				t.Errorf("expected version %q, got %q", tt.expected, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
Fixes #4457

On Fedora/DNF systems, `wails doctor` incorrectly reported packages like `webkit2gtk4.0-devel` as installed even when they weren't.

## Problem
`dnf info installed <pkg>` returns available package info even when the package is not locally installed, so the exit code was 0 and the code found a "Version" line in the output.

## Fix
Switch to `dnf -q list --installed <pkg>` which returns exit code 1 when a package is not installed. Version parsing updated to match the new output format (`pkg.arch version-release repo`).

Backport of v3 fix (PR #4781).

## Testing
- `v2/internal/system/packagemanager/dnf_test.go` — 3 version parsing tests, all passing