### PR TITLE
fix(v2): prevent focus steal when StartHidden is true on Windows

### DIFF
--- a/v2/internal/frontend/desktop/windows/winc/form.go
+++ b/v2/internal/frontend/desktop/windows/winc/form.go
@@ -168,7 +168,7 @@ func (fm *Form) Center() {
 	winHeight := winRect.Bottom - winRect.Top
 	windowX := screenMiddleW - (winWidth / 2)
 	windowY := screenMiddleH - (winHeight / 2)
-	w32.SetWindowPos(fm.hwnd, w32.HWND_TOP, int(windowX), int(windowY), int(winWidth), int(winHeight), w32.SWP_NOSIZE)
+	w32.SetWindowPos(fm.hwnd, w32.HWND_TOP, int(windowX), int(windowY), int(winWidth), int(winHeight), w32.SWP_NOSIZE|w32.SWP_NOACTIVATE)
 }
 
 func (fm *Form) Fullscreen() {

--- a/v2/test/4882/form_center_noactivate_test.go
+++ b/v2/test/4882/form_center_noactivate_test.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"os"
+	"regexp"
+	"testing"
+)
+
+func TestCenterUsesNoActivateFlag(t *testing.T) {
+	paths := []string{
+		"../../internal/frontend/desktop/windows/winc/form.go",
+		"internal/frontend/desktop/windows/winc/form.go",
+	}
+
+	var data []byte
+	var err error
+	for _, p := range paths {
+		data, err = os.ReadFile(p)
+		if err == nil {
+			break
+		}
+	}
+	if err != nil {
+		t.Skip("form.go not found (only runs in full repo)")
+	}
+
+	content := string(data)
+
+	re := regexp.MustCompile(`SWP_NOSIZE.*SWP_NOACTIVATE`)
+	if !re.MatchString(content) {
+		t.Error("Center() in form.go does not include SWP_NOACTIVATE flag alongside SWP_NOSIZE in SetWindowPos call")
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #4882

When running a Wails app on Windows with `StartHidden: true`, the `Center()` function in `form.go` called `SetWindowPos` with `HWND_TOP` but without the `SWP_NOACTIVATE` flag. This caused Windows to activate and focus the hidden window during centering, stealing focus from the foreground application.

## Changes

- Added `SWP_NOACTIVATE` flag to the `SetWindowPos` call in `Center()` (`v2/internal/frontend/desktop/windows/winc/form.go:171`)
- Added regression test in `v2/test/4882/`

## Test plan

- [ ] Build a Wails v2 app with `StartHidden: true` on Windows
- [ ] Focus another application window
- [ ] Wait for the Wails window to appear in the background
- [ ] Verify the foreground application does NOT lose focus
- [ ] Verify the hidden window still centers correctly when shown