### PR TITLE
fix(v2): preserve nested struct JSON structure for embedded types with json tags

### DIFF
--- a/v2/internal/binding/binding.go
+++ b/v2/internal/binding/binding.go
@@ -271,8 +271,18 @@ func (b *Bindings) AddStructToGenerateTS(packageName string, structName string, 
 
 	for i := 0; i < structType.NumField(); i++ {
 		field := structType.Field(i)
-		if field.Anonymous || !field.IsExported() {
+		if !field.IsExported() {
 			continue
+		}
+		if field.Anonymous {
+			jsonTag, hasTag := field.Tag.Lookup("json")
+			if !hasTag {
+				continue
+			}
+			jsonTagParts := strings.Split(jsonTag, ",")
+			if jsonTagParts[0] == "" || jsonTagParts[0] == "-" {
+				continue
+			}
 		}
 		kind := field.Type.Kind()
 		if kind == reflect.Struct {

--- a/v2/internal/binding/binding_test/binding_embedded_named_struct_jsontag_test.go
+++ b/v2/internal/binding/binding_test/binding_embedded_named_struct_jsontag_test.go
@@ -1,0 +1,104 @@
+package binding_test
+
+type EmbeddedWithJSONTagTimeLimitDef struct {
+	IsInfinite bool  `json:"isInfinite"`
+	StartTime  int64 `json:"startTime"`
+	EndTime    int64 `json:"endTime"`
+}
+
+type EmbeddedWithJSONTagApplication struct {
+	AppName    string `json:"appName"`
+	AppVersion string `json:"appVersion"`
+	AuthUser   string `json:"authUser"`
+	AuthModule string `json:"authModule"`
+}
+
+type StructWithEmbeddedNamedStructJSONTag struct {
+	Name                            string `json:"name"`
+	Typ                             string `json:"typ"`
+	Desc                            string `json:"desc"`
+	EmbeddedWithJSONTagTimeLimitDef `json:"timeLimitDef"`
+	EmbeddedWithJSONTagApplication  `json:"application"`
+}
+
+func (s StructWithEmbeddedNamedStructJSONTag) Get() StructWithEmbeddedNamedStructJSONTag {
+	return s
+}
+
+var EmbeddedNamedStructJSONTagTest = BindingTest{
+	name: "EmbeddedNamedStructJSONTag",
+	structs: []interface{}{
+		&StructWithEmbeddedNamedStructJSONTag{},
+	},
+	exemptions:  nil,
+	shouldError: false,
+	want: `
+export namespace binding_test {
+	export class EmbeddedWithJSONTagApplication {
+		appName: string;
+		appVersion: string;
+		authUser: string;
+		authModule: string;
+		static createFrom(source: any = {}) {
+			return new EmbeddedWithJSONTagApplication(source);
+		}
+		constructor(source: any = {}) {
+			if ('string' === typeof source) source = JSON.parse(source);
+			this.appName = source["appName"];
+			this.appVersion = source["appVersion"];
+			this.authUser = source["authUser"];
+			this.authModule = source["authModule"];
+		}
+	}
+	export class EmbeddedWithJSONTagTimeLimitDef {
+		isInfinite: boolean;
+		startTime: number;
+		endTime: number;
+		static createFrom(source: any = {}) {
+			return new EmbeddedWithJSONTagTimeLimitDef(source);
+		}
+		constructor(source: any = {}) {
+			if ('string' === typeof source) source = JSON.parse(source);
+			this.isInfinite = source["isInfinite"];
+			this.startTime = source["startTime"];
+			this.endTime = source["endTime"];
+		}
+	}
+	export class StructWithEmbeddedNamedStructJSONTag {
+		name: string;
+		typ: string;
+		desc: string;
+		timeLimitDef: EmbeddedWithJSONTagTimeLimitDef;
+		application: EmbeddedWithJSONTagApplication;
+		static createFrom(source: any = {}) {
+			return new StructWithEmbeddedNamedStructJSONTag(source);
+		}
+		constructor(source: any = {}) {
+			if ('string' === typeof source) source = JSON.parse(source);
+			this.name = source["name"];
+			this.typ = source["typ"];
+			this.desc = source["desc"];
+			this.timeLimitDef = this.convertValues(source["timeLimitDef"], EmbeddedWithJSONTagTimeLimitDef);
+			this.application = this.convertValues(source["application"], EmbeddedWithJSONTagApplication);
+		}
+		convertValues(a: any, classs: any, asMap: boolean = false): any {
+			if (!a) {
+				return a;
+			}
+			if (a.slice && a.map) {
+				return (a as any[]).map(elem => this.convertValues(elem, classs));
+			} else if ("object" === typeof a) {
+				if (asMap) {
+					for (const key of Object.keys(a)) {
+						a[key] = new classs(a[key]);
+					}
+					return a;
+				}
+				return new classs(a);
+			}
+			return a;
+		}
+	}
+}
+`,
+}

--- a/v2/internal/binding/binding_test/binding_test.go
+++ b/v2/internal/binding/binding_test/binding_test.go
@@ -46,6 +46,7 @@ func TestBindings_GenerateModels(t *testing.T) {
 		GeneratedJsEntityWithNestedStructInterfacesTest,
 		AnonymousSubStructTest,
 		AnonymousSubStructMultiLevelTest,
+		EmbeddedNamedStructJSONTagTest,
 		GeneratedJsEntityWithNestedStructTest,
 		EntityWithDiffNamespacesTest,
 		SpecialCharacterFieldTest,

--- a/v2/internal/typescriptify/typescriptify.go
+++ b/v2/internal/typescriptify/typescriptify.go
@@ -171,13 +171,24 @@ func (t *TypeScriptify) deepFields(typeOf reflect.Type) []reflect.StructField {
 		kind := f.Type.Kind()
 		isPointer := kind == reflect.Ptr && f.Type.Elem().Kind() == reflect.Struct
 		if f.Anonymous && kind == reflect.Struct {
-			// fmt.Println(v.Interface())
-			fields = append(fields, t.deepFields(f.Type)...)
+			if jsonTag, hasTag := f.Tag.Lookup("json"); hasTag {
+				jsonTagParts := strings.Split(jsonTag, ",")
+				if jsonTagParts[0] != "" && jsonTagParts[0] != "-" {
+					fields = append(fields, f)
+				}
+			} else {
+				fields = append(fields, t.deepFields(f.Type)...)
+			}
 		} else if f.Anonymous && isPointer {
-			// fmt.Println(v.Interface())
-			fields = append(fields, t.deepFields(f.Type.Elem())...)
+			if jsonTag, hasTag := f.Tag.Lookup("json"); hasTag {
+				jsonTagParts := strings.Split(jsonTag, ",")
+				if jsonTagParts[0] != "" && jsonTagParts[0] != "-" {
+					fields = append(fields, f)
+				}
+			} else {
+				fields = append(fields, t.deepFields(f.Type.Elem())...)
+			}
 		} else {
-			// Check we have a json tag
 			jsonTag := t.getJSONFieldName(f, isPointer)
 			if jsonTag != "" {
 				fields = append(fields, f)


### PR DESCRIPTION
## Summary

Fixes #4117

When a Go struct has anonymous embedded struct fields with explicit json tags (e.g., `TimeLimitDef \`json:"timeLimitDef"\``), Go's `encoding/json` marshals them as nested objects. However, the TS binding generator unconditionally flattened these fields, producing incorrect TypeScript that couldn't deserialize the JSON.

## Changes

- **`deepFields()`** in `typescriptify.go`: Check for json tags on anonymous fields before flattening. If an anonymous field has an explicit json tag name, treat it as a regular struct field.
- **`AddStructToGenerateTS()`** in `binding.go`: Register embedded struct types with json tags for separate TS class generation instead of skipping them.
- **New test** `binding_embedded_named_struct_jsontag_test.go` that reproduces the exact scenario from the bug report.

## Before (buggy)

```ts
export class LicenseCreateEntity {
    name: string;
    typ: string;
    desc: string;
    isInfinite: boolean;    // Flattened!
    startTime: number;      // Flattened!
    endTime: number;        // Flattened!
    appName: string;        // Flattened!
    ...
}
```

## After (fixed)

```ts
export class LicenseCreateEntity {
    name: string;
    typ: string;
    desc: string;
    timeLimitDef: TimeLimitDef;   // Nested!
    application: Application;      // Nested!
}
```

## Test plan

- [x] All existing binding tests pass (no regressions)
- [x] New test `EmbeddedNamedStructJSONTagTest` passes with correct nested output
- [ ] Verify generated TS bindings work with actual Go JSON serialization