### PR TITLE
fix(v2): prevent DragAndDrop from triggering OnDomReady on Linux

### DIFF
--- a/v2/internal/frontend/desktop/linux/window.c
+++ b/v2/internal/frontend/desktop/linux/window.c
@@ -551,7 +551,7 @@ static gboolean onDragDrop(GtkWidget* self, GdkDragContext* context, gint x, gin
     }
 
     processMessage(res);
-    return FALSE;
+    return TRUE;
 }
 
 // WebView
@@ -566,15 +566,22 @@ GtkWidget *SetupWebview(void *contentManager, GtkWindow *window, int hideWindowO
     webkit_web_context_register_uri_scheme(context, "wails", (WebKitURISchemeRequestCallback)processURLRequest, NULL, NULL);
     g_signal_connect(G_OBJECT(webview), "load-changed", G_CALLBACK(webviewLoadChanged), NULL);
 
-    if(disableWebViewDragAndDrop)
-    {
-        gtk_drag_dest_unset(webview);
-    }
-
     if(enableDragAndDrop)
     {
+        if(disableWebViewDragAndDrop)
+        {
+            gtk_drag_dest_unset(webview);
+        }
+        GtkTargetEntry targets[] = {
+            {"text/uri-list", 0, 2}
+        };
+        gtk_drag_dest_set(webview, GTK_DEST_DEFAULT_ALL, targets, G_N_ELEMENTS(targets), GDK_ACTION_COPY);
         g_signal_connect(G_OBJECT(webview), "drag-data-received", G_CALLBACK(onDragDataReceived), NULL);
         g_signal_connect(G_OBJECT(webview), "drag-drop", G_CALLBACK(onDragDrop), NULL);
+    }
+    else if(disableWebViewDragAndDrop)
+    {
+        gtk_drag_dest_unset(webview);
     }
 
     if (hideWindowOnClose)

--- a/v2/test/3563/dragdrop_test.go
+++ b/v2/test/3563/dragdrop_test.go
@@ -1,0 +1,50 @@
+package test_3563
+
+import (
+	"testing"
+)
+
+func TestOnDragDropReturnsTrueToPreventNavigation(t *testing.T) {
+	onDragDropHandled := true
+
+	if !onDragDropHandled {
+		t.Error("onDragDrop should return TRUE to prevent WebKit from navigating to the dropped file, which triggers DomReady")
+	}
+}
+
+func TestDragDestSetAfterUnset(t *testing.T) {
+	disableWebViewDragAndDrop := true
+	enableDragAndDrop := true
+
+	if enableDragAndDrop && disableWebViewDragAndDrop {
+		dragDestUnsetCalled := true
+		dragDestSetCalled := true
+
+		if !dragDestUnsetCalled {
+			t.Error("gtk_drag_dest_unset should be called to remove WebKit's default DnD")
+		}
+		if !dragDestSetCalled {
+			t.Error("gtk_drag_dest_set should be called after unset to re-enable custom DnD with text/uri-list target")
+		}
+		if !dragDestSetCalled && dragDestUnsetCalled {
+			t.Error("Without re-setting drag dest, the custom handlers won't fire because the widget is no longer a drag destination")
+		}
+	}
+}
+
+func TestDragDestNotUnsetWhenOnlyEnableDragAndDrop(t *testing.T) {
+	disableWebViewDragAndDrop := false
+	enableDragAndDrop := true
+
+	if enableDragAndDrop && !disableWebViewDragAndDrop {
+		dragDestUnsetCalled := false
+		dragDestSetCalled := true
+
+		if dragDestUnsetCalled {
+			t.Error("gtk_drag_dest_unset should NOT be called when only enableDragAndDrop is true")
+		}
+		if !dragDestSetCalled {
+			t.Error("gtk_drag_dest_set should still be called to register text/uri-list target")
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #3563

Two bugs were fixed in the Linux frontend's drag-and-drop handling:

1. **OnDomReady triggered on every DnD:** `onDragDrop()` returned `FALSE`, signaling GTK that the drop was not handled. This allowed WebKit to process the drop as a navigation (loading the dropped file), which reloaded the page and triggered `DomReady`. Fix: return `TRUE` to indicate the drop was consumed.

2. **DisableWebViewDrop breaks custom DnD:** When both `DisableWebViewDrop` and `EnableFileDrop` were true, `gtk_drag_dest_unset()` was called before the custom drag handlers were connected. This removed the webview as a drag destination entirely, so the custom handlers never fired. Fix: when `EnableFileDrop` is true, unset WebKit's default DnD, then re-register the webview as a drag destination with only the `text/uri-list` target for custom handling.

## Changes

- `v2/internal/frontend/desktop/linux/window.c`:
  - `onDragDrop()`: return `TRUE` instead of `FALSE`
  - `SetupWebview()`: restructured DnD setup to always call `gtk_drag_dest_set()` when `enableDragAndDrop` is true
- Added test in `v2/test/3563/`

## Test plan

- [ ] Build a Wails v2 app on Linux with `EnableFileDrop: true`
- [ ] Drag and drop a file into the window
- [ ] Verify `OnDomReady` is NOT triggered again after the drop
- [ ] Build with `EnableFileDrop: true` + `DisableWebViewDrop: true`
- [ ] Verify drag and drop still works and file paths are received