### PR TITLE
fix(v2): update Masterminds/semver import to v3 for Go 1.25 compatibility

### DIFF
--- a/v2/go.mod
+++ b/v2/go.mod
@@ -3,7 +3,8 @@ module github.com/wailsapp/wails/v2
 go 1.22.0
 
 require (
-	github.com/Masterminds/semver v1.5.0
+	git.sr.ht/~jackmordaunt/go-toast/v2 v2.0.3
+	github.com/Masterminds/semver/v3 v3.3.1
 	github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d
 	github.com/bep/debounce v1.2.1
 	github.com/bitfield/script v0.24.0
@@ -51,7 +52,6 @@ require (
 	atomicgo.dev/keyboard v0.2.9 // indirect
 	atomicgo.dev/schedule v0.1.0 // indirect
 	dario.cat/mergo v1.0.0 // indirect
-	git.sr.ht/~jackmordaunt/go-toast/v2 v2.0.3 // indirect
 	github.com/Microsoft/go-winio v0.6.1 // indirect
 	github.com/ProtonMail/go-crypto v1.1.5 // indirect
 	github.com/alecthomas/chroma/v2 v2.14.0 // indirect

--- a/v2/go.sum
+++ b/v2/go.sum
@@ -19,8 +19,8 @@ github.com/MarvinJWendt/testza v0.3.0/go.mod h1:eFcL4I0idjtIx8P9C6KkAuLgATNKpX4/
 github.com/MarvinJWendt/testza v0.4.2/go.mod h1:mSdhXiKH8sg/gQehJ63bINcCKp7RtYewEjXsvsVUPbE=
 github.com/MarvinJWendt/testza v0.5.2 h1:53KDo64C1z/h/d/stCYCPY69bt/OSwjq5KpFNwi+zB4=
 github.com/MarvinJWendt/testza v0.5.2/go.mod h1:xu53QFE5sCdjtMCKk8YMQ2MnymimEctc4n3EjyIYvEY=
-github.com/Masterminds/semver v1.5.0 h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3QEww=
-github.com/Masterminds/semver v1.5.0/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
+github.com/Masterminds/semver/v3 v3.3.1 h1:QtNSWtVZ3nBfk8mAOu/B6v7FMJ+NHTIgUPi7rj+4nv4=
+github.com/Masterminds/semver/v3 v3.3.1/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
 github.com/Microsoft/go-winio v0.5.2/go.mod h1:WpS1mjBmmwHBEWmogvA2mj8546UReBk4v8QkMxJ6pZY=
 github.com/Microsoft/go-winio v0.6.1 h1:9/kr64B9VUZrLm5YYwbGtUJnMgqWVOdUAXu6Migciow=
 github.com/Microsoft/go-winio v0.6.1/go.mod h1:LRdKpFKfdobln8UmuiYcKPot9D2v6svN5+sAH+4kjUM=

--- a/v2/internal/github/semver.go
+++ b/v2/internal/github/semver.go
@@ -3,7 +3,7 @@ package github
 import (
 	"fmt"
 
-	"github.com/Masterminds/semver"
+	"github.com/Masterminds/semver/v3"
 )
 
 // SemanticVersion is a struct containing a semantic version

--- a/v2/internal/gomod/gomod.go
+++ b/v2/internal/gomod/gomod.go
@@ -3,7 +3,7 @@ package gomod
 import (
 	"fmt"
 
-	"github.com/Masterminds/semver"
+	"github.com/Masterminds/semver/v3"
 	"golang.org/x/mod/modfile"
 )
 

--- a/v2/internal/gomod/gomod_test.go
+++ b/v2/internal/gomod/gomod_test.go
@@ -4,7 +4,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/Masterminds/semver"
+	"github.com/Masterminds/semver/v3"
 	"github.com/matryer/is"
 )
 


### PR DESCRIPTION
## Summary
- Updates `github.com/Masterminds/semver` import to `github.com/Masterminds/semver/v3` across all v2 code
- Updates `go.mod` dependency from `v1.5.0` to `v3.3.1`
- Fixes installation failure on Go 1.25+ where the v1 module path no longer resolves

## Test plan
- Existing `internal/gomod` and `internal/github` tests pass with the updated import
- `go mod tidy` completes successfully
- Installation via `go install github.com/wailsapp/wails/v2/cmd/wails@latest` will now work with Go 1.25+

Fixes #5063