### PR TITLE
fix(v2): strip debug symbols from wailsbindings binary for Go 1.25 compat

### DIFF
--- a/v2/pkg/commands/bindings/bindings.go
+++ b/v2/pkg/commands/bindings/bindings.go
@@ -60,7 +60,7 @@ func GenerateBindings(options Options) (string, error) {
 	// So, use the default C compiler, not the one set for cross compiling.
 	envBuild = shell.RemoveEnv(envBuild, "CC")
 
-	stdout, stderr, err = shell.RunCommandWithEnv(envBuild, workingDirectory, options.Compiler, "build", "-buildvcs=false", "-tags", tagString, "-o", filename)
+	stdout, stderr, err = shell.RunCommandWithEnv(envBuild, workingDirectory, options.Compiler, "build", "-buildvcs=false", "-tags", tagString, "-ldflags", "-s -w", "-o", filename)
 	if err != nil {
 		return stdout, fmt.Errorf("%s\n%s\n%s", stdout, stderr, err)
 	}

--- a/v2/test/4551/bindings_test.go
+++ b/v2/test/4551/bindings_test.go
@@ -1,0 +1,22 @@
+package test4551
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestGenerateBindingsUsesStrippedSymbols(t *testing.T) {
+	sourceFile := filepath.Join("..", "..", "pkg", "commands", "bindings", "bindings.go")
+	data, err := os.ReadFile(sourceFile)
+	if err != nil {
+		t.Skipf("could not read bindings source: %v", err)
+	}
+
+	source := string(data)
+	if !strings.Contains(source, `"-ldflags", "-s -w"`) {
+		t.Error("expected wailsbindings build command to include -ldflags -s -w for stripped symbols, " +
+			"which is required to avoid the Go 1.25 DWARF5+CGO Windows PE linker bug (golang/go#75077)")
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `-ldflags "-s -w"` to the `wailsbindings` build command in `v2/pkg/commands/bindings/bindings.go`
- Go 1.25 defaults to DWARF5 debug format, which when combined with CGO produces malformed Windows PE binaries ([golang/go#75077](https://github.com/golang/go/issues/75077))
- The `wailsbindings` binary is a temporary throwaway helper used only for TypeScript binding generation, so stripping symbols is safe
- This was already done for production builds (`-w -s` in `base.go`) but was missing from the bindings helper

## Test plan
- Test in `v2/test/4551/bindings_test.go` verifies the ldflags are present in the build command
- Windows users with Go 1.25+ should now be able to run `wails dev` and `wails build` without the "not a valid Win32 application" error

Also fixes #4605, #4831

Fixes #4551

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Applied build optimization to bindings generation.

* **Tests**
  * Added test to verify bindings build configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->