### PR TITLE
fix(v2): generate nested TS types for embedded structs with named JSON tags

### DIFF
--- a/v2/internal/binding/binding.go
+++ b/v2/internal/binding/binding.go
@@ -271,8 +271,18 @@ func (b *Bindings) AddStructToGenerateTS(packageName string, structName string, 
 
 	for i := 0; i < structType.NumField(); i++ {
 		field := structType.Field(i)
-		if field.Anonymous || !field.IsExported() {
+		if !field.IsExported() {
 			continue
+		}
+		if field.Anonymous {
+			jsonTag, hasTag := field.Tag.Lookup("json")
+			if !hasTag {
+				continue
+			}
+			parts := strings.Split(jsonTag, ",")
+			if len(parts) == 0 || parts[0] == "" || parts[0] == "-" {
+				continue
+			}
 		}
 		kind := field.Type.Kind()
 		if kind == reflect.Struct {

--- a/v2/internal/binding/binding_test/binding_named_embedded_struct_test.go
+++ b/v2/internal/binding/binding_test/binding_named_embedded_struct_test.go
@@ -1,0 +1,106 @@
+package binding_test
+
+type InnerStruct struct {
+	IsInfinite bool  `json:"isInfinite"`
+	StartTime  int64 `json:"startTime"`
+	EndTime    int64 `json:"endTime"`
+}
+
+type AppInfo struct {
+	AppName    string `json:"appName"`
+	AppVersion string `json:"appVersion"`
+}
+
+type StructWithNamedEmbeddedStruct struct {
+	Name        string `json:"name"`
+	Typ         string `json:"typ"`
+	Desc        string `json:"desc"`
+	InnerStruct `json:"timeLimitDef"`
+	AppInfo     `json:"application"`
+}
+
+func (s StructWithNamedEmbeddedStruct) Get() StructWithNamedEmbeddedStruct {
+	return s
+}
+
+var NamedEmbeddedStructTest = BindingTest{
+	name: "StructWithNamedEmbeddedStruct",
+	structs: []interface{}{
+		&StructWithNamedEmbeddedStruct{},
+	},
+	exemptions:  nil,
+	shouldError: false,
+	want: `
+export namespace binding_test {
+	export class AppInfo {
+		appName: string;
+		appVersion: string;
+	
+		static createFrom(source: any = {}) {
+			return new AppInfo(source);
+		}
+	
+		constructor(source: any = {}) {
+			if ('string' === typeof source) source = JSON.parse(source);
+			this.appName = source["appName"];
+			this.appVersion = source["appVersion"];
+		}
+	}
+	export class InnerStruct {
+		isInfinite: boolean;
+		startTime: number;
+		endTime: number;
+	
+		static createFrom(source: any = {}) {
+			return new InnerStruct(source);
+		}
+	
+		constructor(source: any = {}) {
+			if ('string' === typeof source) source = JSON.parse(source);
+			this.isInfinite = source["isInfinite"];
+			this.startTime = source["startTime"];
+			this.endTime = source["endTime"];
+		}
+	}
+	export class StructWithNamedEmbeddedStruct {
+		name: string;
+		typ: string;
+		desc: string;
+		timeLimitDef: InnerStruct;
+		application: AppInfo;
+	
+		static createFrom(source: any = {}) {
+			return new StructWithNamedEmbeddedStruct(source);
+		}
+	
+		constructor(source: any = {}) {
+			if ('string' === typeof source) source = JSON.parse(source);
+			this.name = source["name"];
+			this.typ = source["typ"];
+			this.desc = source["desc"];
+			this.timeLimitDef = this.convertValues(source["timeLimitDef"], InnerStruct);
+			this.application = this.convertValues(source["application"], AppInfo);
+		}
+	
+		convertValues(a: any, classs: any, asMap: boolean = false): any {
+			if (!a) {
+				return a;
+			}
+			if (a.slice && a.map) {
+				return (a as any[]).map(elem => this.convertValues(elem, classs));
+			} else if ("object" === typeof a) {
+				if (asMap) {
+					for (const key of Object.keys(a)) {
+						a[key] = new classs(a[key]);
+					}
+					return a;
+				}
+				return new classs(a);
+			}
+			return a;
+		}
+	}
+
+}
+`,
+}

--- a/v2/internal/binding/binding_test/binding_test.go
+++ b/v2/internal/binding/binding_test/binding_test.go
@@ -46,6 +46,7 @@ func TestBindings_GenerateModels(t *testing.T) {
 		GeneratedJsEntityWithNestedStructInterfacesTest,
 		AnonymousSubStructTest,
 		AnonymousSubStructMultiLevelTest,
+		NamedEmbeddedStructTest,
 		GeneratedJsEntityWithNestedStructTest,
 		EntityWithDiffNamespacesTest,
 		SpecialCharacterFieldTest,

--- a/v2/internal/typescriptify/typescriptify.go
+++ b/v2/internal/typescriptify/typescriptify.go
@@ -155,6 +155,15 @@ func New() *TypeScriptify {
 	return result
 }
 
+func hasNamedJSONTag(f reflect.StructField) bool {
+	jsonTag, hasTag := f.Tag.Lookup("json")
+	if !hasTag {
+		return false
+	}
+	parts := strings.Split(jsonTag, ",")
+	return len(parts) > 0 && parts[0] != "" && parts[0] != "-"
+}
+
 func (t *TypeScriptify) deepFields(typeOf reflect.Type) []reflect.StructField {
 	fields := make([]reflect.StructField, 0)
 
@@ -171,13 +180,24 @@ func (t *TypeScriptify) deepFields(typeOf reflect.Type) []reflect.StructField {
 		kind := f.Type.Kind()
 		isPointer := kind == reflect.Ptr && f.Type.Elem().Kind() == reflect.Struct
 		if f.Anonymous && kind == reflect.Struct {
-			// fmt.Println(v.Interface())
-			fields = append(fields, t.deepFields(f.Type)...)
+			if hasNamedJSONTag(f) {
+				jsonTag := t.getJSONFieldName(f, false)
+				if jsonTag != "" {
+					fields = append(fields, f)
+				}
+			} else {
+				fields = append(fields, t.deepFields(f.Type)...)
+			}
 		} else if f.Anonymous && isPointer {
-			// fmt.Println(v.Interface())
-			fields = append(fields, t.deepFields(f.Type.Elem())...)
+			if hasNamedJSONTag(f) {
+				jsonTag := t.getJSONFieldName(f, true)
+				if jsonTag != "" {
+					fields = append(fields, f)
+				}
+			} else {
+				fields = append(fields, t.deepFields(f.Type.Elem())...)
+			}
 		} else {
-			// Check we have a json tag
 			jsonTag := t.getJSONFieldName(f, isPointer)
 			if jsonTag != "" {
 				fields = append(fields, f)


### PR DESCRIPTION
## Summary
- Fixes TypeScript binding generation for Go structs with embedded (anonymous) struct fields that have named JSON tags
- Previously, `TimeLimitDef \`json:"timeLimitDef"\`` would be flattened into the parent TS class, but Go's JSON encoder produces a nested object — causing deserialization mismatches
- Two fixes:
  1. `deepFields()` in `typescriptify.go`: checks for named JSON tags before flattening embedded structs
  2. `AddStructToGenerateTS()` in `binding.go`: allows anonymous fields with named JSON tags through for struct type registration

## Test plan
- New test `binding_named_embedded_struct_test.go` verifies that `StructWithNamedEmbeddedStruct` generates:
  - Separate `InnerStruct` and `AppInfo` TS classes
  - Properly nested fields (`timeLimitDef: InnerStruct`, `application: AppInfo`) in the parent class
- All 30+ existing binding tests continue to pass (anonymous inline structs still produce `any` as before)

Fixes #4117