### PR TITLE
fix: correct feedback URL in PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,7 +9,7 @@
 - *DO NOT* submit bugs for a source install of v3, ONLY tagged versions, e.g. v3.0.0-alpha.11
 - *DO NOT* submit PRs for v3 alpha enhancements, unless you have opened a post on the discord channel.
   All enhancements must be discussed first.
-  The feedback guide for v3 is here: https://v3alpha.wails.io/getting-started/feedback/
+  The feedback guide for v3 is here: https://v3alpha.wails.io/feedback/
 
 - Before submitting your PR, please ensure you have created and linked the PR to an issue.
 - If a relevant issue already exists, please reference it in your PR by including `Fixes #<issue number>` in your PR description.


### PR DESCRIPTION
## Summary

Fixes the incorrect feedback URL in the PR template:
- **Before:** `https://v3alpha.wails.io/getting-started/feedback/`
- **After:** `https://v3alpha.wails.io/feedback/`

Fixes #5108

## Test plan
- [x] Verify the URL in `.github/pull_request_template.md` now reads `https://v3alpha.wails.io/feedback/`