### PR TITLE
fix(v3): set WKWebView layer scale for correct devicePixelRatio on Retina displays

### DIFF
--- a/v3/pkg/application/webview_window_darwin.go
+++ b/v3/pkg/application/webview_window_darwin.go
@@ -102,6 +102,16 @@ void* windowNew(unsigned int id, int width, int height, bool fraudulentWebsiteWa
 	WKWebView* webView = [[WKWebView alloc] initWithFrame:frame configuration:config];
 	[webView autorelease];
 
+	// Ensure WKWebView reports correct devicePixelRatio on Retina displays
+	// when using custom URL scheme (wails://). Without this, the web process
+	// does not inherit the native backing scale factor.
+	[webView setWantsLayer:YES];
+	if (webView.layer) {
+		webView.layer.contentsScale = [[NSScreen mainScreen] backingScaleFactor];
+		webView.layer.rasterizationScale = [[NSScreen mainScreen] backingScaleFactor];
+		webView.layer.shouldRasterize = YES;
+	}
+
     // Set allowsBackForwardNavigationGestures if specified
     if (preferences.AllowsBackForwardNavigationGestures != NULL) {
         webView.allowsBackForwardNavigationGestures = *preferences.AllowsBackForwardNavigationGestures;

--- a/v3/pkg/application/webview_window_darwin.m
+++ b/v3/pkg/application/webview_window_darwin.m
@@ -419,6 +419,12 @@ typedef NS_ENUM(NSInteger, MacLiquidGlassStyle) {
     }
 }
 - (void)windowDidChangeBackingProperties:(NSNotification *)notification {
+    WebviewWindow* window = (WebviewWindow*)[self delegate];
+    if (window && window.webView && window.webView.layer) {
+        CGFloat scale = [window screen].backingScaleFactor;
+        window.webView.layer.contentsScale = scale;
+        window.webView.layer.rasterizationScale = scale;
+    }
     if( hasListeners(EventWindowDidChangeBackingProperties) ) {
         processWindowEvent(self.windowId, EventWindowDidChangeBackingProperties);
     }

--- a/v3/test/5111-retina-dpr/README.md
+++ b/v3/test/5111-retina-dpr/README.md
@@ -1,0 +1,33 @@
+# Test: WKWebView devicePixelRatio on Retina (#5111)
+
+## Issue
+WKWebView reports `devicePixelRatio=1` on macOS Retina displays when content is loaded via custom URL scheme (`wails://`).
+
+## Fix
+Added `contentsScale` and `rasterizationScale` configuration to the WKWebView layer during initialization in `windowNew()` (`v3/pkg/application/webview_window_darwin.go`), and updated `windowDidChangeBackingProperties:` in `webview_window_darwin.m` to update the scale when the window moves between displays.
+
+## Manual Test Steps
+
+1. Build a Wails v3 app on a Mac with a Retina display
+2. Run the app and open the web inspector console
+3. Check `window.devicePixelRatio` — should be `2` (not `1`)
+4. Check `window.matchMedia('(-webkit-min-device-pixel-ratio: 2)').matches` — should be `true`
+5. Test canvas rendering — text and graphics should be sharp, not blurry
+6. Move the window to an external non-Retina display — `devicePixelRatio` should update to `1`
+7. Move back to Retina — `devicePixelRatio` should return to `2`
+
+## Expected Code Changes
+
+### webview_window_darwin.go (windowNew)
+After WKWebView creation, the layer scale is set:
+```objc
+[webView setWantsLayer:YES];
+if (webView.layer) {
+    webView.layer.contentsScale = [[NSScreen mainScreen] backingScaleFactor];
+    webView.layer.rasterizationScale = [[NSScreen mainScreen] backingScaleFactor];
+    webView.layer.shouldRasterize = YES;
+}
+```
+
+### webview_window_darwin.m (windowDidChangeBackingProperties)
+The delegate method now updates the webview layer scale when the backing properties change (e.g., window moved between Retina and non-Retina displays).


### PR DESCRIPTION
## Summary

Fixes `window.devicePixelRatio` reporting `1` instead of `2` on macOS Retina displays when content is loaded via the custom `wails://` URL scheme. This caused all canvas-based rendering (xterm.js, chart libraries, drawing tools) to appear blurry because the content was rendered at 1x and upscaled by macOS.

### Root Cause
WKWebView does not automatically inherit the native backing scale factor when content is loaded through a `WKURLSchemeHandler` (custom URL scheme). The web process relies on the URL scheme to determine rendering context, and custom schemes default to 1x.

### Fix
1. **`windowNew()` in `webview_window_darwin.go`** — After creating the WKWebView, set `contentsScale` and `rasterizationScale` on the layer to the screen's `backingScaleFactor`.
2. **`windowDidChangeBackingProperties:` in `webview_window_darwin.m`** — Updated to refresh the webview layer scale when the window moves between Retina and non-Retina displays.

### Test
- Manual test instructions in `v3/test/5111-retina-dpr/README.md`
- **Requires testing on macOS with a Retina display** (cannot verify from Linux)
- Verify: `window.devicePixelRatio === 2` on Retina, `=== 1` on non-Retina
- Verify: canvas text is sharp, not blurry
- Verify: scale updates correctly when moving window between displays

Fixes #5111

## Notes for reviewer
- This is a macOS-only fix. No changes to other platforms.
- The `setWantsLayer:YES` call ensures the view has a backing layer. This is safe for WKWebView which already uses layers internally.
- `shouldRasterize = YES` with the correct `rasterizationScale` ensures consistent rendering during animations and moves.