### PR TITLE
fix(darwin): escape special XML characters in Info.plist template values

### DIFF
--- a/v2/pkg/buildassets/build/darwin/Info.dev.plist
+++ b/v2/pkg/buildassets/build/darwin/Info.dev.plist
@@ -4,17 +4,17 @@
         <key>CFBundlePackageType</key>
         <string>APPL</string>
         <key>CFBundleName</key>
-        <string>{{.Info.ProductName}}</string>
+        <string>{{xml .Info.ProductName}}</string>
         <key>CFBundleExecutable</key>
-        <string>{{.OutputFilename}}</string>
+        <string>{{xml .OutputFilename}}</string>
         <key>CFBundleIdentifier</key>
-        <string>com.wails.{{.Name}}</string>
+        <string>com.wails.{{xml .Name}}</string>
         <key>CFBundleVersion</key>
-        <string>{{.Info.ProductVersion}}</string>
+        <string>{{xml .Info.ProductVersion}}</string>
         <key>CFBundleGetInfoString</key>
-        <string>{{.Info.Comments}}</string>
+        <string>{{xml .Info.Comments}}</string>
         <key>CFBundleShortVersionString</key>
-        <string>{{.Info.ProductVersion}}</string>
+        <string>{{xml .Info.ProductVersion}}</string>
         <key>CFBundleIconFile</key>
         <string>iconfile</string>
         <key>LSMinimumSystemVersion</key>
@@ -22,7 +22,7 @@
         <key>NSHighResolutionCapable</key>
         <string>true</string>
         <key>NSHumanReadableCopyright</key>
-        <string>{{.Info.Copyright}}</string>
+        <string>{{xml .Info.Copyright}}</string>
         {{if .Info.FileAssociations}}
         <key>CFBundleDocumentTypes</key>
         <array>

--- a/v2/pkg/buildassets/build/darwin/Info.plist
+++ b/v2/pkg/buildassets/build/darwin/Info.plist
@@ -4,17 +4,17 @@
         <key>CFBundlePackageType</key>
         <string>APPL</string>
         <key>CFBundleName</key>
-        <string>{{.Info.ProductName}}</string>
+        <string>{{xml .Info.ProductName}}</string>
         <key>CFBundleExecutable</key>
-        <string>{{.OutputFilename}}</string>
+        <string>{{xml .OutputFilename}}</string>
         <key>CFBundleIdentifier</key>
-        <string>com.wails.{{.Name}}</string>
+        <string>com.wails.{{xml .Name}}</string>
         <key>CFBundleVersion</key>
-        <string>{{.Info.ProductVersion}}</string>
+        <string>{{xml .Info.ProductVersion}}</string>
         <key>CFBundleGetInfoString</key>
-        <string>{{.Info.Comments}}</string>
+        <string>{{xml .Info.Comments}}</string>
         <key>CFBundleShortVersionString</key>
-        <string>{{.Info.ProductVersion}}</string>
+        <string>{{xml .Info.ProductVersion}}</string>
         <key>CFBundleIconFile</key>
         <string>iconfile</string>
         <key>LSMinimumSystemVersion</key>
@@ -22,7 +22,7 @@
         <key>NSHighResolutionCapable</key>
         <string>true</string>
         <key>NSHumanReadableCopyright</key>
-        <string>{{.Info.Copyright}}</string>
+        <string>{{xml .Info.Copyright}}</string>
         {{if .Info.FileAssociations}}
         <key>CFBundleDocumentTypes</key>
         <array>

--- a/v2/pkg/buildassets/buildassets.go
+++ b/v2/pkg/buildassets/buildassets.go
@@ -16,6 +16,12 @@ import (
 	"github.com/wailsapp/wails/v2/internal/project"
 )
 
+func xmlEscape(s string) string {
+	var buf bytes.Buffer
+	template.HTMLEscape(&buf, []byte(s))
+	return buf.String()
+}
+
 //go:embed build
 var assets embed.FS
 
@@ -108,7 +114,10 @@ type assetData struct {
 }
 
 func resolveProjectData(content []byte, projectData *project.Project) ([]byte, error) {
-	tmpl, err := template.New("").Parse(string(content))
+	funcMap := template.FuncMap{
+		"xml": xmlEscape,
+	}
+	tmpl, err := template.New("").Funcs(funcMap).Parse(string(content))
 	if err != nil {
 		return nil, err
 	}

--- a/v2/pkg/buildassets/xml_escape_test.go
+++ b/v2/pkg/buildassets/xml_escape_test.go
@@ -1,0 +1,68 @@
+package buildassets
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/wailsapp/wails/v2/internal/project"
+)
+
+func TestXmlEscapeAmpersand(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"Joe & Bill", "Joe &amp; Bill"},
+		{"<tag>", "&lt;tag&gt;"},
+		{`"quoted"`, "&#34;quoted&#34;"},
+		{"normal", "normal"},
+	}
+	for _, tt := range tests {
+		got := xmlEscape(tt.input)
+		if got != tt.expected {
+			t.Errorf("xmlEscape(%q) = %q, want %q", tt.input, got, tt.expected)
+		}
+	}
+}
+
+func TestResolveProjectDataEscapesAmpersand(t *testing.T) {
+	copyright := "Joe & Bill, Inc."
+	comments := "A <test> & more"
+	pd := &project.Project{
+		Name:           "My App & Co",
+		OutputFilename: "my-app",
+		Info: project.Info{
+			CompanyName:    "Test & Co",
+			ProductName:    "Test\"Product",
+			ProductVersion: "1.0.0",
+			Copyright:      &copyright,
+			Comments:       &comments,
+		},
+	}
+
+	tmpl := `<key>Copyright</key>
+<string>{{xml .Info.Copyright}}</string>
+<key>Comments</key>
+<string>{{xml .Info.Comments}}</string>
+<key>Name</key>
+<string>{{xml .Name}}</string>`
+
+	content, err := resolveProjectData([]byte(tmpl), pd)
+	if err != nil {
+		t.Fatalf("resolveProjectData() error = %v", err)
+	}
+
+	result := string(content)
+	if strings.Contains(result, "Joe & Bill") && !strings.Contains(result, "Joe &amp; Bill") {
+		t.Error("Ampersand in copyright was not escaped")
+	}
+	if !strings.Contains(result, "Joe &amp; Bill, Inc.") {
+		t.Errorf("Expected escaped copyright, got: %s", result)
+	}
+	if !strings.Contains(result, "A &lt;test&gt; &amp; more") {
+		t.Errorf("Expected escaped comments, got: %s", result)
+	}
+	if !strings.Contains(result, "My App &amp; Co") {
+		t.Errorf("Expected escaped name, got: %s", result)
+	}
+}


### PR DESCRIPTION
## Summary
- Adds an `xmlEscape` template function that uses Go's `html/template` escaping
- Applies `{{xml .Value}}` to all user-facing values in `Info.plist` and `Info.dev.plist` templates
- Characters like `&`, `<`, `>` in `wails.json` fields (e.g. copyright) now produce valid XML

## Test
- `v2/pkg/buildassets/xml_escape_test.go` — verifies ampersand, angle bracket, and quote escaping
- `TestResolveProjectDataEscapesAmpersand` — end-to-end test with a plist-like template

Fixes #4865