### PR TITLE
fix(v3/linux): preserve application name in .desktop file generation

### DIFF
--- a/v3/internal/commands/dot_desktop.go
+++ b/v3/internal/commands/dot_desktop.go
@@ -63,14 +63,12 @@ func GenerateDotDesktop(options *DotDesktopOptions) error {
 		return fmt.Errorf("name is required")
 	}
 
-	options.Name = normaliseName(options.Name)
-
 	if options.Exec == "" {
 		return fmt.Errorf("exec is required")
 	}
 
 	if options.OutputFile == "" {
-		options.OutputFile = options.Name + ".desktop"
+		options.OutputFile = normaliseName(options.Name) + ".desktop"
 	}
 
 	// Write to file

--- a/v3/internal/commands/dot_desktop_test.go
+++ b/v3/internal/commands/dot_desktop_test.go
@@ -1,0 +1,144 @@
+package commands
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestGenerateDotDesktopPreservesAppName(t *testing.T) {
+	tempDir, err := os.MkdirTemp("", "wails-dotdesktop-test-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp directory: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	tests := []struct {
+		name         string
+		inputName    string
+		exec         string
+		expectedName string
+		expectedFile string
+	}{
+		{
+			name:         "name with spaces preserved",
+			inputName:    "My App",
+			exec:         "my-app",
+			expectedName: "My App",
+			expectedFile: "my-app.desktop",
+		},
+		{
+			name:         "name with mixed case preserved",
+			inputName:    "MyAwesome App",
+			exec:         "myawesome-app",
+			expectedName: "MyAwesome App",
+			expectedFile: "myawesome-app.desktop",
+		},
+		{
+			name:         "simple name unchanged",
+			inputName:    "MyApp",
+			exec:         "myapp",
+			expectedName: "MyApp",
+			expectedFile: "myapp.desktop",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			outputFile := filepath.Join(tempDir, tt.expectedFile)
+			options := &DotDesktopOptions{
+				Name:       tt.inputName,
+				Exec:       tt.exec,
+				OutputFile: outputFile,
+			}
+
+			err := GenerateDotDesktop(options)
+			if err != nil {
+				t.Fatalf("GenerateDotDesktop() error = %v", err)
+			}
+
+			content, err := os.ReadFile(outputFile)
+			if err != nil {
+				t.Fatalf("Failed to read output file: %v", err)
+			}
+
+			if !strings.Contains(string(content), "Name="+tt.expectedName) {
+				t.Errorf("Expected Name=%s in .desktop file, got:\n%s", tt.expectedName, string(content))
+			}
+
+			if !strings.Contains(string(content), "Exec="+tt.exec) {
+				t.Errorf("Expected Exec=%s in .desktop file, got:\n%s", tt.exec, string(content))
+			}
+		})
+	}
+}
+
+func TestGenerateDotDesktopDefaultOutputFile(t *testing.T) {
+	tempDir, err := os.MkdirTemp("", "wails-dotdesktop-test-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp directory: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	options := &DotDesktopOptions{
+		Name: "My App",
+		Exec: "my-app",
+	}
+	DisableFooter = true
+
+	oldDir, _ := os.Getwd()
+	os.Chdir(tempDir)
+	defer os.Chdir(oldDir)
+
+	err = GenerateDotDesktop(options)
+	if err != nil {
+		t.Fatalf("GenerateDotDesktop() error = %v", err)
+	}
+
+	expectedFile := "my-app.desktop"
+	if _, err := os.Stat(expectedFile); os.IsNotExist(err) {
+		t.Errorf("Expected output file %s to be created", expectedFile)
+	}
+
+	content, err := os.ReadFile(expectedFile)
+	if err != nil {
+		t.Fatalf("Failed to read output file: %v", err)
+	}
+
+	if !strings.Contains(string(content), "Name=My App") {
+		t.Errorf("Expected 'Name=My App' in .desktop file (name should NOT be normalised), got:\n%s", string(content))
+	}
+}
+
+func TestGenerateDotDesktopErrors(t *testing.T) {
+	tests := []struct {
+		name    string
+		options *DotDesktopOptions
+		wantErr bool
+	}{
+		{
+			name: "missing name",
+			options: &DotDesktopOptions{
+				Exec: "my-app",
+			},
+			wantErr: true,
+		},
+		{
+			name: "missing exec",
+			options: &DotDesktopOptions{
+				Name: "My App",
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := GenerateDotDesktop(tt.options)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GenerateDotDesktop() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description

Fixes #5072

The `wails3 generate .desktop` command was lowercasing and replacing spaces with dashes in the application `Name` field. The `Name=` field in a `.desktop` file is the user-visible display name and should not be normalised per the [FreeDesktop specs](https://specifications.freedesktop.org/desktop-entry/latest/value-types.html).

The `normaliseName()` call was removed from the `Name` field and is now only used for the output filename.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- [x] Linux

New test file `v3/internal/commands/dot_desktop_test.go` verifies:
- Name with spaces is preserved in the generated file
- Mixed case names are preserved
- Default output filename is still normalised
- Missing name/exec returns errors

## Checklist:
- [x] My code follows the general coding style of this project
- [x] I have added tests that prove my fix is effective

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed .desktop file generation to preserve the original Name field casing and whitespace instead of normalizing it.
  * Improved default output filename derivation for .desktop files when no output path is specified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->