### PR TITLE
fix(v3/darwin): update minimum macOS version from 10.15 to 12.0

### DIFF
--- a/v3/internal/commands/build_assets/darwin/Taskfile.yml
+++ b/v3/internal/commands/build_assets/darwin/Taskfile.yml
@@ -48,9 +48,9 @@ tasks:
       GOOS: darwin
       CGO_ENABLED: 1
       GOARCH: '{{.ARCH | default ARCH}}'
-      CGO_CFLAGS: "-mmacosx-version-min=10.15"
-      CGO_LDFLAGS: "-mmacosx-version-min=10.15"
-      MACOSX_DEPLOYMENT_TARGET: "10.15"
+      CGO_CFLAGS: "-mmacosx-version-min=12.0"
+      CGO_LDFLAGS: "-mmacosx-version-min=12.0"
+      MACOSX_DEPLOYMENT_TARGET: "12.0"
 
   build:docker:
     summary: Cross-compiles for macOS using Docker (for Linux/Windows hosts)

--- a/v3/internal/commands/darwin_version_test.go
+++ b/v3/internal/commands/darwin_version_test.go
@@ -1,0 +1,80 @@
+package commands
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestDarwinMinimumVersionInTemplates(t *testing.T) {
+	tempDir, err := os.MkdirTemp("", "wails-darwin-version-test-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp directory: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	options := &BuildAssetsOptions{
+		Dir:                filepath.Join(tempDir, "build"),
+		Name:               "VersionTest",
+		ProductName:        "Version Test App",
+		ProductDescription: "Test",
+		ProductVersion:     "1.0.0",
+		ProductCompany:     "Test Co",
+		ProductIdentifier:  "com.test.version",
+		Silent:             true,
+	}
+
+	err = GenerateBuildAssets(options)
+	if err != nil {
+		t.Fatalf("GenerateBuildAssets() error = %v", err)
+	}
+
+	plistPath := filepath.Join(tempDir, "build", "darwin", "Info.plist")
+	content, err := os.ReadFile(plistPath)
+	if err != nil {
+		t.Fatalf("Failed to read Info.plist: %v", err)
+	}
+
+	if !strings.Contains(string(content), "12.0.0") {
+		t.Errorf("Expected LSMinimumSystemVersion to be 12.0.0, got:\n%s", string(content))
+	}
+
+	if strings.Contains(string(content), "10.15") {
+		t.Errorf("Found outdated version 10.15 in Info.plist, should be 12.0.0")
+	}
+}
+
+func TestDarwinDevPlistMinimumVersion(t *testing.T) {
+	templateDir := "updatable_build_assets/darwin"
+	devPlistPath := filepath.Join(templateDir, "Info.dev.plist.tmpl")
+
+	content, err := os.ReadFile(devPlistPath)
+	if err != nil {
+		t.Skipf("Template file not found: %v", err)
+	}
+
+	if !strings.Contains(string(content), "12.0.0") {
+		t.Errorf("Expected LSMinimumSystemVersion 12.0.0 in Info.dev.plist.tmpl, got:\n%s", string(content))
+	}
+}
+
+func TestDarwinTaskfileMinimumVersion(t *testing.T) {
+	taskfilePath := filepath.Join("build_assets", "darwin", "Taskfile.yml")
+
+	content, err := os.ReadFile(taskfilePath)
+	if err != nil {
+		t.Skipf("Taskfile not found: %v", err)
+	}
+
+	str := string(content)
+	if !strings.Contains(str, "mmacosx-version-min=12.0") {
+		t.Errorf("Expected mmacosx-version-min=12.0 in Taskfile.yml")
+	}
+	if !strings.Contains(str, "MACOSX_DEPLOYMENT_TARGET: \"12.0\"") {
+		t.Errorf("Expected MACOSX_DEPLOYMENT_TARGET: \"12.0\" in Taskfile.yml")
+	}
+	if strings.Contains(str, "10.15") {
+		t.Errorf("Found outdated version 10.15 in Taskfile.yml, should be 12.0")
+	}
+}

--- a/v3/internal/commands/updatable_build_assets/darwin/Info.dev.plist.tmpl
+++ b/v3/internal/commands/updatable_build_assets/darwin/Info.dev.plist.tmpl
@@ -22,7 +22,7 @@
             <string>{{.CFBundleIconName}}</string>
         {{- end}}
         <key>LSMinimumSystemVersion</key>
-            <string>10.15.0</string>
+            <string>12.0.0</string>
         <key>NSHighResolutionCapable</key>
             <string>true</string>
         <key>NSHumanReadableCopyright</key>

--- a/v3/internal/commands/updatable_build_assets/darwin/Info.plist.tmpl
+++ b/v3/internal/commands/updatable_build_assets/darwin/Info.plist.tmpl
@@ -22,7 +22,7 @@
             <string>{{.CFBundleIconName}}</string>
         {{- end}}
         <key>LSMinimumSystemVersion</key>
-            <string>10.15.0</string>
+            <string>12.0.0</string>
         <key>NSHighResolutionCapable</key>
             <string>true</string>
         <key>NSHumanReadableCopyright</key>


### PR DESCRIPTION
## Description

Fixes #5161

Go 1.25+ embeds `LC_BUILD_VERSION` with `minos 12.0` in the Mach-O binary, meaning apps physically cannot run on macOS < 12. The old templates declared `LSMinimumSystemVersion` as 10.15, causing macOS to allow the launch but then reject the binary silently (app flashes and disappears with no error dialog).

Updating to 12.0 ensures macOS shows a clear "requires macOS 12 or later" dialog instead.

### Files changed:
- `v3/internal/commands/updatable_build_assets/darwin/Info.plist.tmpl` - 10.15.0 → 12.0.0
- `v3/internal/commands/updatable_build_assets/darwin/Info.dev.plist.tmpl` - 10.15.0 → 12.0.0
- `v3/internal/commands/build_assets/darwin/Taskfile.yml` - CGO/deployment target 10.15 → 12.0

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- [x] macOS (template validation tests)

Test file `v3/internal/commands/darwin_version_test.go` verifies:
- Generated Info.plist contains 12.0.0
- Dev plist template has 12.0.0
- Taskfile has mmacosx-version-min=12.0 and MACOSX_DEPLOYMENT_TARGET="12.0"

Note: This is a template change. Runtime testing on macOS with Go 1.25+ is recommended.

## Checklist:
- [x] My code follows the general coding style of this project
- [x] I have added tests that prove my fix is effective

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the minimum supported macOS version from 10.15 to 12.0 in native build environment configuration and deployment manifest settings.

* **Tests**
  * Added new tests to validate macOS minimum version configuration, ensuring version consistency is maintained across build templates and deployment manifest files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->