### PR TITLE
fix(v3/windows): downgrade fatal to error in popup menu build

### DIFF
--- a/v3/pkg/application/popupmenu_nofatal_test.go
+++ b/v3/pkg/application/popupmenu_nofatal_test.go
@@ -1,0 +1,26 @@
+package application
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestPopupmenuBuildMenuUsesErrorNotFatal(t *testing.T) {
+	data, err := os.ReadFile("popupmenu_windows.go")
+	if err != nil {
+		t.Skip("popupmenu_windows.go not available")
+	}
+	content := string(data)
+
+	if strings.Contains(content, `globalApplication.fatal("error adding menu item`) {
+		t.Error("buildMenu should not call fatal() for menu item errors - use error() instead")
+	}
+	if strings.Contains(content, `globalApplication.fatal("error setting menu icons`) {
+		t.Error("buildMenu should not call fatal() for menu icon errors - use error() instead")
+	}
+
+	if !strings.Contains(content, `globalApplication.error("error adding menu item`) {
+		t.Error("buildMenu should use error() for menu item failures")
+	}
+}

--- a/v3/pkg/application/popupmenu_windows.go
+++ b/v3/pkg/application/popupmenu_windows.go
@@ -143,11 +143,12 @@ func (p *Win32Menu) buildMenu(parentMenu w32.HMENU, inputMenu *Menu) {
 
 		ok := w32.AppendMenu(parentMenu, flags, uintptr(itemID), w32.MustStringToUTF16Ptr(menuText))
 		if !ok {
-			globalApplication.fatal("error adding menu item '%s'", menuText)
+			globalApplication.error("error adding menu item '%s'", menuText)
+			continue
 		}
 		if item.bitmap != nil {
 			if err := w32.SetMenuIcons(parentMenu, itemID, item.bitmap, nil); err != nil {
-				globalApplication.fatal("error setting menu icons: %w", err)
+				globalApplication.error("error setting menu icons: %v", err)
 			}
 		}
 	}


### PR DESCRIPTION
## Description

Fixes #5227

When `SystemTray.SetMenu()` is called to update the tray menu, `AppendMenu` or `SetMenuIcons` can fail (e.g. after rapid repeated updates causing resource handle corruption). Previously this called `fatal()` which terminated the entire process.

Now it logs an error and continues, matching the existing non-fatal handling of `TrackPopupMenuEx` failures at line 227.

### Files changed:
- `v3/pkg/application/popupmenu_windows.go` - Changed `fatal()` to `error()` for menu item and icon errors, added `continue` on AppendMenu failure

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- [ ] Windows (needs runtime testing on Windows)

Test file `v3/pkg/application/popupmenu_nofatal_test.go` verifies the source code does not contain `fatal()` calls for the relevant error paths.

**Note:** This is a Windows-only code change. Runtime testing on Windows with a systray app that rapidly updates its menu is recommended to verify the fix.

## Checklist:
- [x] My code follows the general coding style of this project
- [x] I have added tests that prove my fix is effective

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Menu item construction failures now log non-fatal errors and allow the application to continue operating instead of terminating the process.

* **Tests**
  * Added test suite to validate that menu building failures utilize non-fatal error handling rather than fatal termination.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->