### PR TITLE
fix(v3): default CanChooseFiles to true in SetOptions and fix purego action

### DIFF
--- a/v3/pkg/application/dialogs.go
+++ b/v3/pkg/application/dialogs.go
@@ -330,6 +330,9 @@ func (d *OpenFileDialogStruct) SetOptions(options *OpenFileDialogOptions) {
 	d.directory = options.Directory
 	d.canChooseDirectories = options.CanChooseDirectories
 	d.canChooseFiles = options.CanChooseFiles
+	if !options.CanChooseFiles && !options.CanChooseDirectories {
+		d.canChooseFiles = true
+	}
 	d.canCreateDirectories = options.CanCreateDirectories
 	d.showHiddenFiles = options.ShowHiddenFiles
 	d.resolvesAliases = options.ResolvesAliases

--- a/v3/pkg/application/dialogs_test.go
+++ b/v3/pkg/application/dialogs_test.go
@@ -221,3 +221,44 @@ func TestSaveFileDialogOptions_Fields(t *testing.T) {
 		t.Error("Filename not set correctly")
 	}
 }
+
+func TestOpenFileDialogSetOptions_CanChooseFilesDefault(t *testing.T) {
+	t.Run("zero-value options defaults canChooseFiles to true", func(t *testing.T) {
+		dialog := newOpenFileDialog()
+		dialog.SetOptions(&OpenFileDialogOptions{})
+
+		if !dialog.canChooseFiles {
+			t.Error("canChooseFiles should default to true when neither CanChooseFiles nor CanChooseDirectories is set")
+		}
+	})
+
+	t.Run("explicit CanChooseFiles true is preserved", func(t *testing.T) {
+		dialog := newOpenFileDialog()
+		dialog.SetOptions(&OpenFileDialogOptions{CanChooseFiles: true})
+
+		if !dialog.canChooseFiles {
+			t.Error("canChooseFiles should be true when explicitly set")
+		}
+	})
+
+	t.Run("CanChooseDirectories=true CanChooseFiles=false works", func(t *testing.T) {
+		dialog := newOpenFileDialog()
+		dialog.SetOptions(&OpenFileDialogOptions{CanChooseDirectories: true, CanChooseFiles: false})
+
+		if dialog.canChooseFiles {
+			t.Error("canChooseFiles should be false when CanChooseDirectories is explicitly true and CanChooseFiles is false")
+		}
+		if !dialog.canChooseDirectories {
+			t.Error("canChooseDirectories should be true")
+		}
+	})
+
+	t.Run("explicit CanChooseFiles false without directories still defaults to true", func(t *testing.T) {
+		dialog := newOpenFileDialog()
+		dialog.SetOptions(&OpenFileDialogOptions{CanChooseFiles: false})
+
+		if !dialog.canChooseFiles {
+			t.Error("canChooseFiles should default to true when neither option is explicitly enabled")
+		}
+	})
+}

--- a/v3/pkg/application/linux_purego.go
+++ b/v3/pkg/application/linux_purego.go
@@ -1189,7 +1189,7 @@ func runOpenFileDialog(dialog *OpenFileDialogStruct) ([]string, error) {
 		dialog.showHiddenFiles,
 		dialog.directory,
 		dialog.title,
-		GtkFileChooserActionOpen,
+		action,
 		buttonText,
 		dialog.filters,
 		"")

--- a/v3/pkg/application/linux_purego_action_test.go
+++ b/v3/pkg/application/linux_purego_action_test.go
@@ -1,0 +1,30 @@
+package application
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestLinuxPuregoOpenFileDialogUsesComputedAction(t *testing.T) {
+	data, err := os.ReadFile("linux_purego.go")
+	if err != nil {
+		t.Skip("linux_purego.go not available")
+	}
+	content := string(data)
+
+	lines := strings.Split(content, "\n")
+	inRunOpenFileDialog := false
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if strings.Contains(trimmed, "func runOpenFileDialog") {
+			inRunOpenFileDialog = true
+		}
+		if inRunOpenFileDialog && strings.HasPrefix(trimmed, "func ") && !strings.Contains(trimmed, "runOpenFileDialog") {
+			break
+		}
+		if inRunOpenFileDialog && strings.Contains(trimmed, "GtkFileChooserActionOpen") && strings.Contains(trimmed, "runChooserDialog") {
+			t.Errorf("runOpenFileDialog should pass computed 'action' variable to runChooserDialog, not hardcoded GtkFileChooserActionOpen")
+		}
+	}
+}


### PR DESCRIPTION
## Description

Fixes #4421

Two fixes for the file dialog:

1. **CanChooseFiles default**: When `OpenFileWithOptions` is called from JavaScript with zero-value options (`CanChooseFiles=false`, `CanChooseDirectories=false`), Go's JSON deserialization overwrites the `canChooseFiles=true` default from `newOpenFileDialog()`. On macOS, this causes `NSOpenPanel` to show all files as grey/unselectable. Now `SetOptions` defaults `canChooseFiles` to `true` when neither option is explicitly enabled.

2. **Linux purego action bug**: In `linux_purego.go`, `runOpenFileDialog` computed the `action` variable based on `canChooseDirectories` but then hardcoded `GtkFileChooserActionOpen` in the `runChooserDialog` call, ignoring the computed value. This meant the directory picker never worked via the purego backend.

### Files changed:
- `v3/pkg/application/dialogs.go` - Default `canChooseFiles=true` when both options are zero-value
- `v3/pkg/application/linux_purego.go` - Pass computed `action` instead of hardcoded `GtkFileChooserActionOpen`

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- [x] Linux
- [x] macOS (cross-platform Go logic, tested on Linux)

Tests:
- `v3/pkg/application/dialogs_test.go` - 4 sub-tests for CanChooseFiles defaulting behavior
- `v3/pkg/application/linux_purego_action_test.go` - Source-level check that computed action is used

## Checklist:
- [x] My code follows the general coding style of this project
- [x] I have added tests that prove my fix is effective

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed file dialog option handling to properly enable file selection when no valid options are provided.
  * Corrected directory selection mode to use the appropriate dialog action on Linux systems.

* **Tests**
  * Added test coverage for file dialog option configuration behavior.
  * Added validation test for Linux file dialog action handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->