### PR TITLE
fix: correct feedback URL in PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,7 +9,7 @@
 - *DO NOT* submit bugs for a source install of v3, ONLY tagged versions, e.g. v3.0.0-alpha.11
 - *DO NOT* submit PRs for v3 alpha enhancements, unless you have opened a post on the discord channel.
   All enhancements must be discussed first.
-  The feedback guide for v3 is here: https://v3alpha.wails.io/getting-started/feedback/
+  The feedback guide for v3 is here: https://v3alpha.wails.io/feedback/
 
 - Before submitting your PR, please ensure you have created and linked the PR to an issue.
 - If a relevant issue already exists, please reference it in your PR by including `Fixes #<issue number>` in your PR description.

--- a/v3/test/5108-pr-template-url/go.mod
+++ b/v3/test/5108-pr-template-url/go.mod
@@ -1,0 +1,3 @@
+module test-5108
+
+go 1.26.2

--- a/v3/test/5108-pr-template-url/main_test.go
+++ b/v3/test/5108-pr-template-url/main_test.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestPRTemplateFeedbackURL(t *testing.T) {
+	repoRoot := filepath.Join("..", "..", "..")
+	templatePath := filepath.Join(repoRoot, ".github", "pull_request_template.md")
+
+	data, err := os.ReadFile(templatePath)
+	if err != nil {
+		t.Fatalf("Failed to read PR template at %s: %v", templatePath, err)
+	}
+	content := string(data)
+
+	if strings.Contains(content, "v3alpha.wails.io/getting-started/feedback") {
+		t.Error("PR template contains incorrect feedback URL with '/getting-started/' path; should be https://v3alpha.wails.io/feedback/")
+	}
+	if !strings.Contains(content, "https://v3alpha.wails.io/feedback/") {
+		t.Error("PR template should contain correct feedback URL: https://v3alpha.wails.io/feedback/")
+	}
+}


### PR DESCRIPTION
## Description

Fixes #5108

The feedback guide URL in the PR template pointed to `https://v3alpha.wails.io/getting-started/feedback/` which returns 404. The correct URL is `https://v3alpha.wails.io/feedback/`.

### Files changed:
- `.github/pull_request_template.md` - Fixed feedback URL

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Test at `v3/test/5108-pr-template-url/main_test.go` verifies:
- Template does not contain the old incorrect URL
- Template contains the correct URL

## Checklist:
- [x] My code follows the general coding style of this project
- [x] I have added tests that prove my fix is effective