### PR TITLE
fix(v2): Allow HTML5 drag-and-drop on Linux

### DIFF
--- a/v2/internal/frontend/desktop/linux/window.c
+++ b/v2/internal/frontend/desktop/linux/window.c
@@ -557,6 +557,7 @@ static gboolean onDragDrop(GtkWidget* self, GdkDragContext* context, gint x, gin
 // WebView
 GtkWidget *SetupWebview(void *contentManager, GtkWindow *window, int hideWindowOnClose, int gpuPolicy, int disableWebViewDragAndDrop, int enableDragAndDrop)
 {
+    (void)disableWebViewDragAndDrop;
     GtkWidget *webview = webkit_web_view_new_with_user_content_manager((WebKitUserContentManager *)contentManager);
 
     // Store webview reference in the content manager
@@ -566,13 +567,18 @@ GtkWidget *SetupWebview(void *contentManager, GtkWindow *window, int hideWindowO
     webkit_web_context_register_uri_scheme(context, "wails", (WebKitURISchemeRequestCallback)processURLRequest, NULL, NULL);
     g_signal_connect(G_OBJECT(webview), "load-changed", G_CALLBACK(webviewLoadChanged), NULL);
 
-    if(disableWebViewDragAndDrop)
-    {
-        gtk_drag_dest_unset(webview);
-    }
+    // Always unset the default GTK drag destination to allow WebKit
+    // to handle HTML5 drag-and-drop events (dragover, dragleave, drop).
+    // Without this, GTK intercepts drag events before WebKit processes them,
+    // preventing standard HTML5 drag-and-drop from working (issue #4673).
+    gtk_drag_dest_unset(webview);
 
     if(enableDragAndDrop)
     {
+        // Re-enable GTK drag destination specifically for file URI drops
+        // when the Wails file drop feature is enabled.
+        GtkTargetEntry targets[] = { { "text/uri-list", 0, 2 } };
+        gtk_drag_dest_set(webview, GTK_DEST_DEFAULT_ALL, targets, 1, GDK_ACTION_COPY);
         g_signal_connect(G_OBJECT(webview), "drag-data-received", G_CALLBACK(onDragDataReceived), NULL);
         g_signal_connect(G_OBJECT(webview), "drag-drop", G_CALLBACK(onDragDrop), NULL);
     }

--- a/v2/test/4673/test_html_drag_drop.go
+++ b/v2/test/4673/test_html_drag_drop.go
@@ -1,0 +1,41 @@
+//go:build linux
+// +build linux
+
+package main
+
+import (
+	"fmt"
+	"os"
+)
+
+// This is a manual test program for issue #4673.
+// Run on Linux: go run v2/test/4673/test_html_drag_drop.go
+//
+// Expected behavior:
+// 1. Window opens with two HTML elements: a draggable div and a drop zone
+// 2. Drag the "DRAG ME" box over the drop zone
+// 3. The cursor should show the "copy" indicator (not "not allowed")
+// 4. The drop zone should highlight and log "dragover" events
+// 5. Dropping on the zone should log "drop" event
+//
+// The fix ensures that GTK's default drag destination is unset on the webview,
+// allowing WebKit to handle HTML5 drag-and-drop events natively.
+// When Wails file drops are enabled, the drag destination is re-enabled
+// specifically for text/uri-list targets (file drops).
+
+func main() {
+	fmt.Println("Test for issue #4673: HTML5 drag-and-drop should work on Linux")
+	fmt.Println("")
+	fmt.Println("This test must be run on Linux with WebKitGTK.")
+	fmt.Println("")
+	fmt.Println("Manual verification steps:")
+	fmt.Println("1. Create a new wails project: wails init -n dndtest -t vanilla")
+	fmt.Println("2. Add a draggable element and a drop zone in index.html:")
+	fmt.Println("   <div draggable=\"true\">DRAG ME</div>")
+	fmt.Println("   <div id=\"dz\" style=\"border:2px dotted gray;width:300px;height:300px;\">Drop here</div>")
+	fmt.Println("3. Add dragover listener: document.getElementById('dz').addEventListener('dragover', (e) => { console.log('dragover'); e.preventDefault(); })")
+	fmt.Println("4. Run: wails dev")
+	fmt.Println("5. Drag the element over the drop zone - dragover events should fire")
+	fmt.Println("6. Without this fix, dragover events would NOT fire on Linux")
+	os.Exit(0)
+}


### PR DESCRIPTION
## Summary

Fixes #4673

HTML5 drag-and-drop (dragover, dragleave, drop events) was completely broken on Linux/WebKitGTK. The cursor showed "not allowed" and no drag events reached web content.

## Root Cause

WebKitGTK's WebView widget is registered as a GTK drag destination by default. This means GTK intercepts drag events at the platform level before WebKit can process them and forward them to the web content as JavaScript drag events.

The previous code only called `gtk_drag_dest_unset()` when `DisableWebViewDrop` was explicitly set to true. Since this option defaults to false, GTK was always intercepting drag events.

## Fix

Changed `SetupWebview` in `window.c` to:

1. **Always** call `gtk_drag_dest_unset(webview)` - This removes GTK's default drag destination, allowing WebKit to handle drag events natively and forward them to web content.
2. When Wails file drop is enabled (`EnableFileDrop`), explicitly re-enable the GTK drag destination with `text/uri-list` targets so file drops continue to work.

## Behavior Change

| Scenario | Before | After |
|---|---|---|
| Default (no DragAndDrop config) | HTML5 DnD broken | HTML5 DnD works |
| EnableFileDrop=true | File drops work, HTML5 DnD broken | File drops work, HTML5 DnD may conflict |
| DisableWebViewDrop=true | HTML5 DnD works | HTML5 DnD works (same behavior) |

**Note:** When `EnableFileDrop` is true, file drops should continue to work via the explicit `text/uri-list` target. HTML5 drag-and-drop for file-type drags may still conflict, but internal HTML element drags should work fine.

## Test Plan

Manual testing on Linux:
1. `wails init -n dndtest -t vanilla`
2. Add draggable element and drop zone with dragover listener
3. `wails dev` - dragover events should now fire

Test file: `v2/test/4673/test_html_drag_drop.go`

---
[:bulb:](mention://agent/d5c5204d-1cc6-4b76-a654-71c642c38fec) *This PR was created by the Wails Engineer agent.*