### PR TITLE
fix(v3): use runtime.GOARCH as default ProcessorArchitecture

### DIFF
--- a/v3/UNRELEASED_CHANGELOG.md
+++ b/v3/UNRELEASED_CHANGELOG.md
@@ -23,6 +23,7 @@ After processing, the content will be moved to the main changelog and this file 
 
 ## Fixed
 <!-- Bug fixes -->
+- Fix halved Screen Bounds, WorkArea, and Size values on Retina Macs -  (#5168)
 
 ## Deprecated
 <!-- Soon-to-be removed features -->

--- a/v3/internal/commands/build-assets.go
+++ b/v3/internal/commands/build-assets.go
@@ -44,7 +44,7 @@ type BuildAssetsOptions struct {
 	ProductIdentifier     string `description:"The product identifier, e.g com.mycompany.myproduct"`
 	CFBundleIconName      string `description:"The macOS icon name (for Assets.car icon bundles)"`
 	Publisher             string `description:"Publisher name for MSIX package (e.g., CN=CompanyName)"`
-	ProcessorArchitecture string `description:"Processor architecture for MSIX package" default:"x64"`
+	ProcessorArchitecture string `description:"Processor architecture for MSIX package"`
 	ExecutablePath        string `description:"Path to executable for MSIX package"`
 	ExecutableName        string `description:"Name of executable for MSIX package"`
 	OutputPath            string `description:"Output path for MSIX package"`
@@ -117,7 +117,7 @@ func GenerateBuildAssets(options *BuildAssetsOptions) error {
 	}
 
 	if options.ProcessorArchitecture == "" {
-		options.ProcessorArchitecture = "x64"
+		options.ProcessorArchitecture = runtime.GOARCH
 	}
 
 	if options.ExecutableName == "" {
@@ -341,7 +341,9 @@ type updateCFBundleIconNameSetter struct {
 	config  *UpdateConfig
 }
 
-func (s *updateCFBundleIconNameSetter) GetCFBundleIconName() string { return s.options.CFBundleIconName }
+func (s *updateCFBundleIconNameSetter) GetCFBundleIconName() string {
+	return s.options.CFBundleIconName
+}
 func (s *updateCFBundleIconNameSetter) SetCFBundleIconName(v string) {
 	s.options.CFBundleIconName = v
 	s.config.CFBundleIconName = v

--- a/v3/internal/commands/build-assets_test.go
+++ b/v3/internal/commands/build-assets_test.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"gopkg.in/yaml.v3"
@@ -360,38 +361,38 @@ func TestCFBundleIconNameDetection(t *testing.T) {
 	defer os.RemoveAll(tempDir)
 
 	tests := []struct {
-		name                string
-		createAssetsCar     bool
-		configIconName      string
-		expectedIconName    string
+		name                  string
+		createAssetsCar       bool
+		configIconName        string
+		expectedIconName      string
 		expectIconNameInPlist bool
 	}{
 		{
-			name:                "Assets.car exists, no config - should default to appicon",
-			createAssetsCar:     true,
-			configIconName:      "",
-			expectedIconName:    "appicon",
+			name:                  "Assets.car exists, no config - should default to appicon",
+			createAssetsCar:       true,
+			configIconName:        "",
+			expectedIconName:      "appicon",
 			expectIconNameInPlist: true,
 		},
 		{
-			name:                "Assets.car exists, config set - should use config",
-			createAssetsCar:     true,
-			configIconName:      "custom-icon",
-			expectedIconName:    "custom-icon",
+			name:                  "Assets.car exists, config set - should use config",
+			createAssetsCar:       true,
+			configIconName:        "custom-icon",
+			expectedIconName:      "custom-icon",
 			expectIconNameInPlist: true,
 		},
 		{
-			name:                "No Assets.car, no config - should not set",
-			createAssetsCar:     false,
-			configIconName:      "",
-			expectedIconName:    "",
+			name:                  "No Assets.car, no config - should not set",
+			createAssetsCar:       false,
+			configIconName:        "",
+			expectedIconName:      "",
 			expectIconNameInPlist: false,
 		},
 		{
-			name:                "No Assets.car, config set - should use config",
-			createAssetsCar:     false,
-			configIconName:      "config-icon",
-			expectedIconName:    "config-icon",
+			name:                  "No Assets.car, config set - should use config",
+			createAssetsCar:       false,
+			configIconName:        "config-icon",
+			expectedIconName:      "config-icon",
 			expectIconNameInPlist: true,
 		},
 	}
@@ -456,14 +457,14 @@ func TestCFBundleIconNameDetection(t *testing.T) {
 
 			options := &UpdateBuildAssetsOptions{
 				Dir:               buildDir,
-				Name:               "TestApp",
-				ProductName:        "Test App",
-				ProductVersion:     "1.0.0",
-				ProductCompany:     "Test Company",
-				ProductIdentifier:  "com.test.app",
-				CFBundleIconName:   tt.configIconName,
-				Config:             configFile,
-				Silent:             true,
+				Name:              "TestApp",
+				ProductName:       "Test App",
+				ProductVersion:    "1.0.0",
+				ProductCompany:    "Test Company",
+				ProductIdentifier: "com.test.app",
+				CFBundleIconName:  tt.configIconName,
+				Config:            configFile,
+				Silent:            true,
 			}
 
 			err = UpdateBuildAssets(options)
@@ -669,4 +670,55 @@ func mapsEqual(a, b map[string]any) bool {
 		}
 	}
 	return true
+}
+
+func TestProcessorArchitectureDefault(t *testing.T) {
+	tempDir, err := os.MkdirTemp("", "wails-arch-test-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp directory: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	t.Run("defaults to runtime.GOARCH when not specified", func(t *testing.T) {
+		options := &BuildAssetsOptions{
+			Dir:                filepath.Join(tempDir, "default-arch"),
+			Name:               "ArchTest",
+			ProductName:        "Arch Test",
+			ProductDescription: "Test default arch",
+			ProductVersion:     "1.0.0",
+			ProductCompany:     "Test Co",
+			Silent:             true,
+		}
+
+		err := GenerateBuildAssets(options)
+		if err != nil {
+			t.Fatalf("GenerateBuildAssets() error = %v", err)
+		}
+
+		if options.ProcessorArchitecture != runtime.GOARCH {
+			t.Errorf("Expected ProcessorArchitecture to be %q, got %q", runtime.GOARCH, options.ProcessorArchitecture)
+		}
+	})
+
+	t.Run("respects explicit architecture when specified", func(t *testing.T) {
+		options := &BuildAssetsOptions{
+			Dir:                   filepath.Join(tempDir, "explicit-arch"),
+			Name:                  "ArchTest2",
+			ProductName:           "Arch Test 2",
+			ProductDescription:    "Test explicit arch",
+			ProductVersion:        "1.0.0",
+			ProductCompany:        "Test Co",
+			ProcessorArchitecture: "arm64",
+			Silent:                true,
+		}
+
+		err := GenerateBuildAssets(options)
+		if err != nil {
+			t.Fatalf("GenerateBuildAssets() error = %v", err)
+		}
+
+		if options.ProcessorArchitecture != "arm64" {
+			t.Errorf("Expected ProcessorArchitecture to be %q, got %q", "arm64", options.ProcessorArchitecture)
+		}
+	})
 }

--- a/v3/internal/commands/msix.go
+++ b/v3/internal/commands/msix.go
@@ -202,7 +202,7 @@ func validateMSIXOptions(options *MSIXOptions) error {
 
 	// Set default processor architecture if not provided
 	if options.ProcessorArchitecture == "" {
-		options.ProcessorArchitecture = "x64"
+		options.ProcessorArchitecture = runtime.GOARCH
 	}
 
 	// Set default publisher if not provided


### PR DESCRIPTION
## Summary
- Replace hardcoded invalid `x64` default with `runtime.GOARCH` in both `build-assets.go` and `msix.go`
- `x64` is not a valid Go architecture value; the default now correctly resolves to `amd64`, `arm64`, etc.

Fixes #5155

## Test plan
- [x] `TestProcessorArchitectureDefault` verifies default matches `runtime.GOARCH` and explicit values are preserved