### PR TITLE
fix(v3/windows): pass ARCH to generate:syso for correct cross-compilation

### DIFF
--- a/v3/UNRELEASED_CHANGELOG.md
+++ b/v3/UNRELEASED_CHANGELOG.md
@@ -23,6 +23,7 @@ After processing, the content will be moved to the main changelog and this file 
 
 ## Fixed
 <!-- Bug fixes -->
+- Fix halved Screen Bounds, WorkArea, and Size values on Retina Macs -  (#5168)
 
 ## Deprecated
 <!-- Soon-to-be removed features -->

--- a/v3/internal/commands/build_assets/windows/Taskfile.yml
+++ b/v3/internal/commands/build_assets/windows/Taskfile.yml
@@ -42,6 +42,8 @@ tasks:
       - task: common:generate:icons
     cmds:
       - task: generate:syso
+        vars:
+          ARCH: '{{.ARCH}}'
       - go build {{.BUILD_FLAGS}} -o "{{.BIN_DIR}}/{{.APP_NAME}}.exe"
       - cmd: powershell Remove-item *.syso
         platforms: [windows]
@@ -69,6 +71,8 @@ tasks:
           Build it first: wails3 task setup:docker
     cmds:
       - task: generate:syso
+        vars:
+          ARCH: '{{.ARCH}}'
       - docker run --rm -v "{{.ROOT_DIR}}:/app" {{.GO_CACHE_MOUNT}} {{.REPLACE_MOUNTS}} -e APP_NAME="{{.APP_NAME}}" {{if .EXTRA_TAGS}}-e EXTRA_TAGS="{{.EXTRA_TAGS}}"{{end}} {{.CROSS_IMAGE}} windows {{.DOCKER_ARCH}}
       - docker run --rm -v "{{.ROOT_DIR}}:/app" alpine chown -R $(id -u):$(id -g) /app/bin
       - rm -f *.syso

--- a/v3/internal/commands/taskfile_syso_arch_test.go
+++ b/v3/internal/commands/taskfile_syso_arch_test.go
@@ -1,0 +1,70 @@
+package commands
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWindowsTaskfilePassesArchToSyso(t *testing.T) {
+	data, err := buildAssets.ReadFile("build_assets/windows/Taskfile.yml")
+	require.NoError(t, err)
+
+	content := string(data)
+
+	t.Run("build:native passes ARCH to generate:syso", func(t *testing.T) {
+		inBuildNative := false
+		found := false
+		lines := strings.Split(content, "\n")
+
+		for i := 0; i < len(lines); i++ {
+			line := lines[i]
+			if strings.Contains(line, "build:native:") {
+				inBuildNative = true
+				continue
+			}
+			if !inBuildNative {
+				continue
+			}
+			if strings.Contains(line, "- task: generate:syso") {
+				for j := i + 1; j < len(lines) && j <= i+3; j++ {
+					if strings.Contains(lines[j], "ARCH:") {
+						found = true
+						break
+					}
+				}
+				break
+			}
+		}
+		assert.True(t, found, "build:native should pass ARCH to generate:syso")
+	})
+
+	t.Run("build:docker passes ARCH to generate:syso", func(t *testing.T) {
+		inBuildDocker := false
+		found := false
+		lines := strings.Split(content, "\n")
+
+		for i := 0; i < len(lines); i++ {
+			line := lines[i]
+			if strings.Contains(line, "build:docker:") {
+				inBuildDocker = true
+				continue
+			}
+			if !inBuildDocker {
+				continue
+			}
+			if strings.Contains(line, "- task: generate:syso") {
+				for j := i + 1; j < len(lines) && j <= i+3; j++ {
+					if strings.Contains(lines[j], "ARCH:") {
+						found = true
+						break
+					}
+				}
+				break
+			}
+		}
+		assert.True(t, found, "build:docker should pass ARCH to generate:syso")
+	})
+}


### PR DESCRIPTION
## Summary
- Pass `ARCH` explicitly when calling `generate:syso` from `build:native` and `build:docker` tasks
- Previously `generate:syso` fell back to the host machine's architecture, producing wrong `.syso` files when cross-compiling

Fixes #5051

## Test plan
- [x] `TestWindowsTaskfilePassesArchToSyso` verifies the embedded Taskfile passes ARCH to generate:syso

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue on Retina Mac displays where Screen Bounds, WorkArea, and Size values were incorrectly halved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->