### PR TITLE
fix(v3/linux): use normalized binary name in Taskfile for consistent packaging

### DIFF
--- a/v3/internal/commands/taskfile_binaryname_test.go
+++ b/v3/internal/commands/taskfile_binaryname_test.go
@@ -1,0 +1,38 @@
+package commands
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBinaryNameNormalization(t *testing.T) {
+	tests := []struct {
+		projectName string
+		expected    string
+	}{
+		{"Wails", "wails"},
+		{"MyApp", "myapp"},
+		{"Hello World", "hello-world"},
+		{"Test-App", "test-app"},
+		{"lowercase", "lowercase"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.projectName, func(t *testing.T) {
+			result := strings.ToLower(strings.ReplaceAll(tt.projectName, " ", "-"))
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestNfpmTemplateUsesBinaryName(t *testing.T) {
+	data, err := updatableBuildAssets.ReadFile("updatable_build_assets/linux/nfpm/nfpm.yaml.tmpl")
+	if err != nil {
+		t.Skip("nfpm template not found in embedded assets")
+	}
+	content := string(data)
+	assert.True(t, strings.Contains(content, `{{.BinaryName}}`),
+		"nfpm template should use BinaryName variable")
+}

--- a/v3/internal/commands/taskfile_binaryname_test.go
+++ b/v3/internal/commands/taskfile_binaryname_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/wailsapp/wails/v3/internal/templates"
 )
 
 func TestBinaryNameNormalization(t *testing.T) {
@@ -17,11 +19,13 @@ func TestBinaryNameNormalization(t *testing.T) {
 		{"Hello World", "hello-world"},
 		{"Test-App", "test-app"},
 		{"lowercase", "lowercase"},
+		{"My_App!", "my-app"},
+		{"  leading  ", "leading"},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.projectName, func(t *testing.T) {
-			result := strings.ToLower(strings.ReplaceAll(tt.projectName, " ", "-"))
+			result := templates.NormalizeBinaryName(tt.projectName)
 			assert.Equal(t, tt.expected, result)
 		})
 	}
@@ -29,9 +33,7 @@ func TestBinaryNameNormalization(t *testing.T) {
 
 func TestNfpmTemplateUsesBinaryName(t *testing.T) {
 	data, err := updatableBuildAssets.ReadFile("updatable_build_assets/linux/nfpm/nfpm.yaml.tmpl")
-	if err != nil {
-		t.Skip("nfpm template not found in embedded assets")
-	}
+	require.NoError(t, err, "nfpm template should be present in embedded assets")
 	content := string(data)
 	assert.True(t, strings.Contains(content, `{{.BinaryName}}`),
 		"nfpm template should use BinaryName variable")

--- a/v3/internal/templates/_common/Taskfile.tmpl.yml
+++ b/v3/internal/templates/_common/Taskfile.tmpl.yml
@@ -1,7 +1,7 @@
 version: '3'
 
 vars:
-  APP_NAME: "{{.ProjectName}}"
+  APP_NAME: "{{.BinaryName}}"
   BIN_DIR: "bin"
   PACKAGE_MANAGER: '{{.Opn}}.PACKAGE_MANAGER | default "npm"{{.Cls}}'
   VITE_PORT: '{{.Opn}}.WAILS_VITE_PORT | default 9245{{.Cls}}'

--- a/v3/internal/templates/taskfile_template_test.go
+++ b/v3/internal/templates/taskfile_template_test.go
@@ -1,0 +1,19 @@
+package templates
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCommonTaskfileUsesBinaryName(t *testing.T) {
+	data, err := templates.ReadFile("_common/Taskfile.tmpl.yml")
+	require.NoError(t, err, "_common/Taskfile.tmpl.yml should be present in embedded templates")
+	content := string(data)
+	assert.True(t, strings.Contains(content, `{{.BinaryName}}`),
+		"root Taskfile template APP_NAME should use {{.BinaryName}}, not {{.ProjectName}}")
+	assert.False(t, strings.Contains(content, `{{.ProjectName}}`),
+		"root Taskfile template should not fall back to {{.ProjectName}} for APP_NAME")
+}

--- a/v3/internal/templates/templates.go
+++ b/v3/internal/templates/templates.go
@@ -74,10 +74,30 @@ func GetDefaultTemplates() []TemplateData {
 	return defaultTemplates
 }
 
+// NormalizeBinaryName converts a project name into a valid binary/package name:
+// lowercased, with spaces replaced by dashes, and any remaining characters not
+// in [a-z0-9-] replaced by dashes, collapsing runs and trimming edges.
+func NormalizeBinaryName(name string) string {
+	name = strings.ToLower(name)
+	var b strings.Builder
+	prevDash := false
+	for _, r := range name {
+		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') {
+			b.WriteRune(r)
+			prevDash = false
+		} else if !prevDash {
+			b.WriteRune('-')
+			prevDash = true
+		}
+	}
+	return strings.Trim(b.String(), "-")
+}
+
 type TemplateOptions struct {
 	Cls string `description:"A helper for using close template tags safely }}" default:"}}"`
 	Opn string `description:"A helper for using open template tags safely {{" default:"{{"`
 	*flags.Init
+	BinaryName      string
 	LocalModulePath string
 	UseTypescript   bool
 	WailsVersion    string
@@ -308,6 +328,7 @@ func Install(options *flags.Init) error {
 
 	templateData := TemplateOptions{
 		Init:            options,
+		BinaryName:      NormalizeBinaryName(options.ProjectName),
 		LocalModulePath: localModulePath,
 		UseTypescript:   UseTypescript,
 		WailsVersion:    version.String(),
@@ -419,7 +440,7 @@ func Install(options *flags.Init) error {
 		Typescript            bool
 	}{
 		Name:                  options.ProjectName,
-		BinaryName:            strings.ToLower(strings.ReplaceAll(options.ProjectName, " ", "-")),
+		BinaryName:            NormalizeBinaryName(options.ProjectName),
 		Silent:                true,
 		ProductCompany:        options.ProductCompany,
 		ProductName:           options.ProductName,

--- a/v3/internal/templates/templates.go
+++ b/v3/internal/templates/templates.go
@@ -419,6 +419,7 @@ func Install(options *flags.Init) error {
 		Typescript            bool
 	}{
 		Name:                  options.ProjectName,
+		BinaryName:            strings.ToLower(strings.ReplaceAll(options.ProjectName, " ", "-")),
 		Silent:                true,
 		ProductCompany:        options.ProductCompany,
 		ProductName:           options.ProductName,


### PR DESCRIPTION
## Summary
- Set `BinaryName` (lowercased) in the init template data and use it for `APP_NAME` in the root Taskfile template
- Previously `APP_NAME` used the raw project name (e.g., "Wails") while nfpm templates used lowercased `BinaryName`, causing file path mismatches in Linux packages

Fixes #4879

## Test plan
- [x] `TestBinaryNameNormalization` verifies the normalization logic
- [x] `TestNfpmTemplateUsesBinaryName` verifies nfpm template consistency

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for binary name normalization to verify project names transform correctly into lowercase, hyphenated format.
  * Added validation tests for template configuration to verify required placeholders are present.

* **Improvements**
  * Application name assignment in generated Taskfiles now uses normalized binary names for consistent naming conventions across generated files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->