### PR TITLE
fix(linux): preserve application name in .desktop file generation

### DIFF
--- a/v3/internal/commands/dot_desktop.go
+++ b/v3/internal/commands/dot_desktop.go
@@ -63,14 +63,12 @@ func GenerateDotDesktop(options *DotDesktopOptions) error {
 		return fmt.Errorf("name is required")
 	}
 
-	options.Name = normaliseName(options.Name)
-
 	if options.Exec == "" {
 		return fmt.Errorf("exec is required")
 	}
 
 	if options.OutputFile == "" {
-		options.OutputFile = options.Name + ".desktop"
+		options.OutputFile = normaliseName(options.Name) + ".desktop"
 	}
 
 	// Write to file

--- a/v3/internal/commands/dot_desktop_test.go
+++ b/v3/internal/commands/dot_desktop_test.go
@@ -1,0 +1,112 @@
+package commands
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestGenerateDotDesktopPreservesName(t *testing.T) {
+	tempDir, err := os.MkdirTemp("", "wails-desktop-test-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp directory: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	tests := []struct {
+		name         string
+		inputName    string
+		expectedName string
+		expectedFile string
+	}{
+		{
+			name:         "simple name",
+			inputName:    "MyApp",
+			expectedName: "MyApp",
+			expectedFile: "myapp.desktop",
+		},
+		{
+			name:         "name with spaces",
+			inputName:    "My App",
+			expectedName: "My App",
+			expectedFile: "my-app.desktop",
+		},
+		{
+			name:         "name with mixed case",
+			inputName:    "Wails",
+			expectedName: "Wails",
+			expectedFile: "wails.desktop",
+		},
+		{
+			name:         "name with spaces and capitals",
+			inputName:    "My Cool App",
+			expectedName: "My Cool App",
+			expectedFile: "my-cool-app.desktop",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			outputFile := filepath.Join(tempDir, tt.expectedFile)
+
+			options := &DotDesktopOptions{
+				Name:       tt.inputName,
+				Exec:       "my-app",
+				OutputFile: outputFile,
+			}
+
+			err := GenerateDotDesktop(options)
+			if err != nil {
+				t.Fatalf("GenerateDotDesktop() error = %v", err)
+			}
+
+			data, err := os.ReadFile(outputFile)
+			if err != nil {
+				t.Fatalf("Failed to read output file: %v", err)
+			}
+
+			content := string(data)
+
+			if !strings.Contains(content, "Name="+tt.expectedName) {
+				t.Errorf("Expected Name=%s in desktop entry, got:\n%s", tt.expectedName, content)
+			}
+		})
+	}
+}
+
+func TestGenerateDotDesktopFilenameNormalized(t *testing.T) {
+	tempDir, err := os.MkdirTemp("", "wails-desktop-filename-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp directory: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	options := &DotDesktopOptions{
+		Name: "My App",
+		Exec: "my-app",
+	}
+
+	oldDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Failed to get working directory: %v", err)
+	}
+	defer os.Chdir(oldDir)
+
+	os.Chdir(tempDir)
+
+	err = GenerateDotDesktop(options)
+	if err != nil {
+		t.Fatalf("GenerateDotDesktop() error = %v", err)
+	}
+
+	expectedFile := "my-app.desktop"
+	if _, err := os.Stat(expectedFile); os.IsNotExist(err) {
+		files, _ := os.ReadDir(".")
+		var names []string
+		for _, f := range files {
+			names = append(names, f.Name())
+		}
+		t.Errorf("Expected file %s to exist, got files: %v", expectedFile, names)
+	}
+}


### PR DESCRIPTION
## Summary

- The `Name=` field in `.desktop` files should preserve the original casing and spaces per [FreeDesktop spec](https://specifications.freedesktop.org/desktop-entry-spec/latest/ar01s06.html)
- Previously `normaliseName()` was applied to the Name field, converting "My App" to "my-app"
- Now only the output filename is normalized; the `Name=` field preserves the user's input

## Files Changed

- `v3/internal/commands/dot_desktop.go` - Remove `normaliseName()` from Name field, apply only to filename
- `v3/internal/commands/dot_desktop_test.go` - Tests for name preservation and filename normalization

## Test

```
TestGenerateDotDesktopPreservesName - verifies Name= field preserves original casing/spaces
TestGenerateDotDesktopFilenameNormalized - verifies output filename is normalized
```

Fixes #5072