### PR TITLE
fix(linux): use normalised binary name in Taskfile template

### DIFF
--- a/v3/internal/templates/_common/Taskfile.tmpl.yml
+++ b/v3/internal/templates/_common/Taskfile.tmpl.yml
@@ -9,7 +9,7 @@ includes:
   android: ./build/android/Taskfile.yml
 
 vars:
-  APP_NAME: "{{.ProjectName}}"
+  APP_NAME: "{{.BinaryName}}"
   BIN_DIR: "bin"
   VITE_PORT: {{ "'{{.WAILS_VITE_PORT | default 9245}}'" }}
 

--- a/v3/internal/templates/templates.go
+++ b/v3/internal/templates/templates.go
@@ -76,6 +76,7 @@ func GetDefaultTemplates() []TemplateData {
 type TemplateOptions struct {
 	*flags.Init
 	LocalModulePath string
+	BinaryName      string
 	UseTypescript   bool
 	WailsVersion    string
 }
@@ -261,6 +262,7 @@ func Install(options *flags.Init) error {
 	templateData := TemplateOptions{
 		Init:            options,
 		LocalModulePath: localModulePath,
+		BinaryName:      strings.ToLower(strings.ReplaceAll(options.ProjectName, " ", "-")),
 		UseTypescript:   UseTypescript,
 		WailsVersion:    version.String(),
 	}

--- a/v3/internal/templates/templates_test.go
+++ b/v3/internal/templates/templates_test.go
@@ -1,0 +1,60 @@
+package templates
+
+import (
+	"io/fs"
+	"strings"
+	"testing"
+
+	"github.com/wailsapp/wails/v3/internal/flags"
+)
+
+func TestTemplateOptionsBinaryName(t *testing.T) {
+	tests := []struct {
+		projectName     string
+		expectedBinName string
+	}{
+		{"Wails", "wails"},
+		{"MyApp", "myapp"},
+		{"My App", "my-app"},
+		{"My Cool App", "my-cool-app"},
+		{"wails", "wails"},
+		{"already-lower", "already-lower"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.projectName, func(t *testing.T) {
+			options := &flags.Init{
+				ProjectName: tt.projectName,
+			}
+			templateData := TemplateOptions{
+				Init:       options,
+				BinaryName: strings.ToLower(strings.ReplaceAll(options.ProjectName, " ", "-")),
+			}
+			if templateData.BinaryName != tt.expectedBinName {
+				t.Errorf("BinaryName = %q, want %q", templateData.BinaryName, tt.expectedBinName)
+			}
+		})
+	}
+}
+
+func TestTaskfileTemplateUsesBinaryName(t *testing.T) {
+	subFS, err := fs.Sub(templates, "_common")
+	if err != nil {
+		t.Fatalf("Failed to get _common sub FS: %v", err)
+	}
+
+	data, err := fs.ReadFile(subFS, "Taskfile.tmpl.yml")
+	if err != nil {
+		t.Fatalf("Failed to read Taskfile template: %v", err)
+	}
+
+	content := string(data)
+
+	if !strings.Contains(content, "{{.BinaryName}}") {
+		t.Error("Taskfile.tmpl.yml should use {{.BinaryName}} for APP_NAME, not {{.ProjectName}}")
+	}
+
+	if strings.Contains(content, `APP_NAME: "{{.ProjectName}}"`) {
+		t.Error("Taskfile.tmpl.yml should NOT use {{.ProjectName}} for APP_NAME")
+	}
+}


### PR DESCRIPTION
## Summary

- When project names contain capital letters (e.g. "Wails"), the binary was built as `bin/Wails` but the nfpm config referenced `bin/wails` (lowercased)
- Added a `BinaryName` field to `TemplateOptions` that normalises the project name (lowercase, spaces to dashes)
- Changed `Taskfile.tmpl.yml` to use `{{.BinaryName}}` for `APP_NAME` instead of `{{.ProjectName}}`

## Files Changed

- `v3/internal/templates/templates.go` - Add `BinaryName` field and compute it from `ProjectName`
- `v3/internal/templates/_common/Taskfile.tmpl.yml` - Use `{{.BinaryName}}` for `APP_NAME`
- `v3/internal/templates/templates_test.go` - Tests for BinaryName computation and template rendering

Fixes #4879