### PR TITLE
fix(build): use runtime.GOARCH for default processor architecture

### DIFF
--- a/v3/internal/commands/build-assets.go
+++ b/v3/internal/commands/build-assets.go
@@ -117,7 +117,7 @@ func GenerateBuildAssets(options *BuildAssetsOptions) error {
 	}
 
 	if options.ProcessorArchitecture == "" {
-		options.ProcessorArchitecture = "x64"
+		options.ProcessorArchitecture = archToMSIX(runtime.GOARCH)
 	}
 
 	if options.ExecutableName == "" {
@@ -313,6 +313,17 @@ func UpdateBuildAssets(options *UpdateBuildAssetsOptions) error {
 
 func normaliseName(name string) string {
 	return strings.ToLower(strings.ReplaceAll(name, " ", "-"))
+}
+
+func archToMSIX(goarch string) string {
+	switch goarch {
+	case "amd64":
+		return "x64"
+	case "386":
+		return "x86"
+	default:
+		return goarch
+	}
 }
 
 // mergeMaps recursively merges src into dst.

--- a/v3/internal/commands/build_assets_arch_test.go
+++ b/v3/internal/commands/build_assets_arch_test.go
@@ -1,0 +1,50 @@
+package commands
+
+import (
+	"runtime"
+	"testing"
+)
+
+func TestArchToMSIX(t *testing.T) {
+	tests := []struct {
+		goarch string
+		msix   string
+	}{
+		{"amd64", "x64"},
+		{"386", "x86"},
+		{"arm64", "arm64"},
+		{"arm", "arm"},
+		{"unknown", "unknown"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.goarch, func(t *testing.T) {
+			got := archToMSIX(tt.goarch)
+			if got != tt.msix {
+				t.Errorf("archToMSIX(%q) = %q, want %q", tt.goarch, got, tt.msix)
+			}
+		})
+	}
+}
+
+func TestBuildAssetsDefaultArchNotX64(t *testing.T) {
+	if runtime.GOARCH == "amd64" {
+		t.Skip("skipping on amd64 where x64 happens to be correct")
+	}
+
+	options := &BuildAssetsOptions{
+		Name:               "TestApp",
+		ProductName:        "Test App",
+		ProductDescription: "Test",
+		ProductVersion:     "1.0.0",
+		ProductCompany:     "Test",
+		Silent:             true,
+	}
+
+	GenerateBuildAssets(options)
+
+	expected := archToMSIX(runtime.GOARCH)
+	if options.ProcessorArchitecture != expected {
+		t.Errorf("ProcessorArchitecture = %q, want %q (from runtime.GOARCH=%q)", options.ProcessorArchitecture, expected, runtime.GOARCH)
+	}
+}

--- a/v3/internal/commands/msix.go
+++ b/v3/internal/commands/msix.go
@@ -202,7 +202,7 @@ func validateMSIXOptions(options *MSIXOptions) error {
 
 	// Set default processor architecture if not provided
 	if options.ProcessorArchitecture == "" {
-		options.ProcessorArchitecture = "x64"
+		options.ProcessorArchitecture = archToMSIX(runtime.GOARCH)
 	}
 
 	// Set default publisher if not provided


### PR DESCRIPTION
## Summary

- The hardcoded `x64` default for `ProcessorArchitecture` was incorrect on non-amd64 systems (e.g. Apple Silicon arm64)
- Added `archToMSIX()` helper that maps Go arch names to MSIX format: `amd64→x64`, `386→x86`, others pass through
- Default is now `runtime.GOARCH` mapped via this helper

## Files Changed

- `v3/internal/commands/build-assets.go` - Use `archToMSIX(runtime.GOARCH)` instead of hardcoded `"x64"`
- `v3/internal/commands/msix.go` - Same fix for MSIX tool command
- `v3/internal/commands/build_assets_arch_test.go` - Tests for arch mapping

Fixes #5155

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * MSIX package builds now automatically detect the correct processor architecture based on the compilation target platform instead of defaulting to a fixed value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->