### PR TITLE
docs(readme): clarify install for v2 vs v3 alpha

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Wails has two active versions:
 | v2 | Stable | `go install github.com/wailsapp/wails/v2/cmd/wails@latest` | [wails.io](https://wails.io/) |
 | v3 | Alpha | `go install github.com/wailsapp/wails/v3/cmd/wails3@latest` | [v3.wails.io](https://v3.wails.io/) |
 
-Full installation instructions are on the [official website](https://wails.io/docs/gettingstarted/installation).
+Full installation instructions are available for [v2](https://wails.io/docs/gettingstarted/installation) and [v3](https://v3.wails.io).
 
 ## Sponsors
 

--- a/README.md
+++ b/README.md
@@ -91,7 +91,14 @@ it before creating an enhancement request.
 
 ## Getting Started
 
-The installation instructions are on the [official website](https://wails.io/docs/gettingstarted/installation).
+Wails has two active versions:
+
+| Version | Status | Install | Docs |
+|---|---|---|---|
+| v2 | Stable | `go install github.com/wailsapp/wails/v2/cmd/wails@latest` | [wails.io](https://wails.io/) |
+| v3 | Alpha | `go install github.com/wailsapp/wails/v3/cmd/wails3@latest` | [v3.wails.io](https://v3.wails.io/) |
+
+Full installation instructions are on the [official website](https://wails.io/docs/gettingstarted/installation).
 
 ## Sponsors
 


### PR DESCRIPTION
## Summary
Adds a small two-row table under "Getting Started" so readers can see at a glance which version of Wails they want — v2 stable, or v3 alpha — and copy the appropriate `go install` line.

Everything else (badges, sponsors image, JetBrains, FAQ, contributors, license, inspiration) is unchanged.

## Test plan
- [ ] Render the README on github.com/wailsapp/wails and confirm the table looks right.
- [ ] Confirm the sponsors image still renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated "Getting Started" section with version information, installation commands, and documentation links for Wails v2 and v3 in a clear table format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->