### PR TITLE
chore(workflows): pre-merge changelog-trigger permission from master

### DIFF
--- a/.github/workflows/auto-label-issues.yml
+++ b/.github/workflows/auto-label-issues.yml
@@ -3,7 +3,7 @@ name: Auto Label Issues
 on:
   issues:
     types: [opened, edited, reopened]
-  pull_request:
+  pull_request_target:
     types: [opened, edited, reopened, synchronize]
 
 jobs:

--- a/.github/workflows/auto-label-issues.yml
+++ b/.github/workflows/auto-label-issues.yml
@@ -3,7 +3,7 @@ name: Auto Label Issues
 on:
   issues:
     types: [opened, edited, reopened]
-  pull_request_target:
+  pull_request:
     types: [opened, edited, reopened, synchronize]
 
 jobs:

--- a/.github/workflows/unreleased-changelog-trigger.yml
+++ b/.github/workflows/unreleased-changelog-trigger.yml
@@ -39,6 +39,7 @@ jobs:
     name: Trigger v3-alpha Release
     permissions:
       contents: read
+      actions: write
     runs-on: ubuntu-latest
     needs: check-permissions
     if: needs.check-permissions.outputs.authorized == 'true'


### PR DESCRIPTION
## Summary
Adopts a workflow change that already exists on `master` so the eventual `v3-alpha → master` merge has one fewer conflict to hand-resolve.

- `.github/workflows/unreleased-changelog-trigger.yml` — add the `actions: write` permission needed by the trigger step (already in place on master).

## Erratum
An earlier commit on this branch also touched `auto-label-issues.yml` in the wrong direction (master's older `pull_request` accidentally copied over v3-alpha's `pull_request_target`); that has been reverted in commit `bebdcf77`. The correct fix for that file goes onto master, not v3-alpha — see the companion PR for master-side workflow pre-merges.

## Test plan
- [ ] CI green
- [ ] Net diff vs `v3-alpha` is the single `actions: write` line in `unreleased-changelog-trigger.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow permissions to support workflow dispatch functionality during release processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->