### PR TITLE
docs: phase-d sweep — replace stale v3-alpha branch references

### DIFF
--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,1 +1,1 @@
-v3alpha.wails.io
+v3.wails.io

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -35,7 +35,7 @@ export default defineConfig({
       lastUpdated: true,
       pagination: true,
       editLink: {
-        baseUrl: "https://github.com/wailsapp/wails/edit/v3-alpha/docs",
+        baseUrl: "https://github.com/wailsapp/wails/edit/master/docs",
       },
       social: [
         { icon: 'github', label: 'GitHub', href: 'https://github.com/wailsapp/wails' },

--- a/docs/src/content/docs/concepts/bridge.mdx
+++ b/docs/src/content/docs/concepts/bridge.mdx
@@ -697,4 +697,4 @@ The bridge is secure by default:
 
 ---
 
-**Questions about the bridge?** Ask in [Discord](https://discord.gg/JDdSxwjhGf) or check the [binding examples](https://github.com/wailsapp/wails/tree/v3-alpha/v3/examples/binding).
+**Questions about the bridge?** Ask in [Discord](https://discord.gg/JDdSxwjhGf) or check the [binding examples](https://github.com/wailsapp/wails/tree/master/v3/examples/binding).

--- a/docs/src/content/docs/concepts/build-system.mdx
+++ b/docs/src/content/docs/concepts/build-system.mdx
@@ -697,4 +697,4 @@ wait
 
 ---
 
-**Questions about building?** Ask in [Discord](https://discord.gg/JDdSxwjhGf) or check the [build examples](https://github.com/wailsapp/wails/tree/v3-alpha/v3/examples/build).
+**Questions about building?** Ask in [Discord](https://discord.gg/JDdSxwjhGf) or check the [build examples](https://github.com/wailsapp/wails/tree/master/v3/examples/build).

--- a/docs/src/content/docs/concepts/lifecycle.mdx
+++ b/docs/src/content/docs/concepts/lifecycle.mdx
@@ -804,4 +804,4 @@ The error will be logged and the application will not start.
 
 ---
 
-**Questions about lifecycle?** Ask in [Discord](https://discord.gg/JDdSxwjhGf) or check the [examples](https://github.com/wailsapp/wails/tree/v3-alpha/v3/examples).
+**Questions about lifecycle?** Ask in [Discord](https://discord.gg/JDdSxwjhGf) or check the [examples](https://github.com/wailsapp/wails/tree/master/v3/examples).

--- a/docs/src/content/docs/faq.mdx
+++ b/docs/src/content/docs/faq.mdx
@@ -252,7 +252,7 @@ See the [Contributing Guide](/contributing).
 
 ### Where can I find examples?
 
-- [Official Examples](https://github.com/wailsapp/wails/tree/v3-alpha/v3/examples)
+- [Official Examples](https://github.com/wailsapp/wails/tree/master/v3/examples)
 - [Community Examples](https://github.com/topics/wails)
 
 ## Still Have Questions?

--- a/docs/src/content/docs/features/bindings/best-practices.mdx
+++ b/docs/src/content/docs/features/bindings/best-practices.mdx
@@ -685,4 +685,4 @@ func TestUserService_WithMock(t *testing.T) {
 
 ---
 
-**Questions?** Ask in [Discord](https://discord.gg/JDdSxwjhGf) or check the [binding examples](https://github.com/wailsapp/wails/tree/v3-alpha/v3/examples/binding).
+**Questions?** Ask in [Discord](https://discord.gg/JDdSxwjhGf) or check the [binding examples](https://github.com/wailsapp/wails/tree/master/v3/examples/binding).

--- a/docs/src/content/docs/features/bindings/enums.mdx
+++ b/docs/src/content/docs/features/bindings/enums.mdx
@@ -526,4 +526,4 @@ switch (bg.type) {
 
 ---
 
-**Questions?** Ask in [Discord](https://discord.gg/JDdSxwjhGf) or check the [binding examples](https://github.com/wailsapp/wails/tree/v3-alpha/v3/examples/binding).
+**Questions?** Ask in [Discord](https://discord.gg/JDdSxwjhGf) or check the [binding examples](https://github.com/wailsapp/wails/tree/master/v3/examples/binding).

--- a/docs/src/content/docs/features/bindings/methods.mdx
+++ b/docs/src/content/docs/features/bindings/methods.mdx
@@ -640,4 +640,4 @@ app.loadTodos()
 
 ---
 
-**Questions?** Ask in [Discord](https://discord.gg/JDdSxwjhGf) or check the [binding examples](https://github.com/wailsapp/wails/tree/v3-alpha/v3/examples/binding).
+**Questions?** Ask in [Discord](https://discord.gg/JDdSxwjhGf) or check the [binding examples](https://github.com/wailsapp/wails/tree/master/v3/examples/binding).

--- a/docs/src/content/docs/features/bindings/models.mdx
+++ b/docs/src/content/docs/features/bindings/models.mdx
@@ -732,4 +732,4 @@ manager.loadUsers()
 
 ---
 
-**Questions?** Ask in [Discord](https://discord.gg/JDdSxwjhGf) or check the [binding examples](https://github.com/wailsapp/wails/tree/v3-alpha/v3/examples/binding).
+**Questions?** Ask in [Discord](https://discord.gg/JDdSxwjhGf) or check the [binding examples](https://github.com/wailsapp/wails/tree/master/v3/examples/binding).

--- a/docs/src/content/docs/features/bindings/services.mdx
+++ b/docs/src/content/docs/features/bindings/services.mdx
@@ -794,4 +794,4 @@ func main() {
 
 ---
 
-**Questions?** Ask in [Discord](https://discord.gg/JDdSxwjhGf) or check the [service examples](https://github.com/wailsapp/wails/tree/v3-alpha/v3/examples).
+**Questions?** Ask in [Discord](https://discord.gg/JDdSxwjhGf) or check the [service examples](https://github.com/wailsapp/wails/tree/master/v3/examples).

--- a/docs/src/content/docs/features/clipboard/basics.mdx
+++ b/docs/src/content/docs/features/clipboard/basics.mdx
@@ -490,4 +490,4 @@ async function paste() {
 
 ---
 
-**Questions?** Ask in [Discord](https://discord.gg/JDdSxwjhGf) or check the [clipboard examples](https://github.com/wailsapp/wails/tree/v3-alpha/v3/examples).
+**Questions?** Ask in [Discord](https://discord.gg/JDdSxwjhGf) or check the [clipboard examples](https://github.com/wailsapp/wails/tree/master/v3/examples).

--- a/docs/src/content/docs/features/dialogs/custom.mdx
+++ b/docs/src/content/docs/features/dialogs/custom.mdx
@@ -624,4 +624,4 @@ button.secondary {
 
 ---
 
-**Questions?** Ask in [Discord](https://discord.gg/JDdSxwjhGf) or check the [custom dialog examples](https://github.com/wailsapp/wails/tree/v3-alpha/v3/examples/dialogs).
+**Questions?** Ask in [Discord](https://discord.gg/JDdSxwjhGf) or check the [custom dialog examples](https://github.com/wailsapp/wails/tree/master/v3/examples/dialogs).

--- a/docs/src/content/docs/features/dialogs/file.mdx
+++ b/docs/src/content/docs/features/dialogs/file.mdx
@@ -565,4 +565,4 @@ func importConfiguration(app *application.App) {
 
 ---
 
-**Questions?** Ask in [Discord](https://discord.gg/JDdSxwjhGf) or check the [file dialog examples](https://github.com/wailsapp/wails/tree/v3-alpha/v3/examples/dialogs).
+**Questions?** Ask in [Discord](https://discord.gg/JDdSxwjhGf) or check the [file dialog examples](https://github.com/wailsapp/wails/tree/master/v3/examples/dialogs).

--- a/docs/src/content/docs/features/dialogs/message.mdx
+++ b/docs/src/content/docs/features/dialogs/message.mdx
@@ -513,4 +513,4 @@ func showCustomIconQuestion(app *application.App, iconBytes []byte) {
 
 ---
 
-**Questions?** Ask in [Discord](https://discord.gg/JDdSxwjhGf) or check the [dialog examples](https://github.com/wailsapp/wails/tree/v3-alpha/v3/examples/dialogs).
+**Questions?** Ask in [Discord](https://discord.gg/JDdSxwjhGf) or check the [dialog examples](https://github.com/wailsapp/wails/tree/master/v3/examples/dialogs).

--- a/docs/src/content/docs/features/dialogs/overview.mdx
+++ b/docs/src/content/docs/features/dialogs/overview.mdx
@@ -515,4 +515,4 @@ func exportData(app *application.App) {
 
 ---
 
-**Questions?** Ask in [Discord](https://discord.gg/JDdSxwjhGf) or check the [dialog examples](https://github.com/wailsapp/wails/tree/v3-alpha/v3/examples/dialogs).
+**Questions?** Ask in [Discord](https://discord.gg/JDdSxwjhGf) or check the [dialog examples](https://github.com/wailsapp/wails/tree/master/v3/examples/dialogs).

--- a/docs/src/content/docs/features/events/system.mdx
+++ b/docs/src/content/docs/features/events/system.mdx
@@ -588,4 +588,4 @@ document.getElementById('button').addEventListener('click', () => {
 
 ---
 
-**Questions?** Ask in [Discord](https://discord.gg/JDdSxwjhGf) or check the [event examples](https://github.com/wailsapp/wails/tree/v3-alpha/v3/examples/events).
+**Questions?** Ask in [Discord](https://discord.gg/JDdSxwjhGf) or check the [event examples](https://github.com/wailsapp/wails/tree/master/v3/examples/events).

--- a/docs/src/content/docs/features/menus/application.mdx
+++ b/docs/src/content/docs/features/menus/application.mdx
@@ -680,4 +680,4 @@ func showAbout(ctx *application.Context) {
 
 ---
 
-**Questions?** Ask in [Discord](https://discord.gg/JDdSxwjhGf) or check the [menu example](https://github.com/wailsapp/wails/tree/v3-alpha/v3/examples/menu).
+**Questions?** Ask in [Discord](https://discord.gg/JDdSxwjhGf) or check the [menu example](https://github.com/wailsapp/wails/tree/master/v3/examples/menu).

--- a/docs/src/content/docs/features/menus/context.mdx
+++ b/docs/src/content/docs/features/menus/context.mdx
@@ -725,4 +725,4 @@ contextMenu.Update()  // Add this!
 
 ---
 
-**Questions?** Ask in [Discord](https://discord.gg/JDdSxwjhGf) or check the [context menu example](https://github.com/wailsapp/wails/tree/v3-alpha/v3/examples/contextmenus).
+**Questions?** Ask in [Discord](https://discord.gg/JDdSxwjhGf) or check the [context menu example](https://github.com/wailsapp/wails/tree/master/v3/examples/contextmenus).

--- a/docs/src/content/docs/features/menus/reference.mdx
+++ b/docs/src/content/docs/features/menus/reference.mdx
@@ -559,4 +559,4 @@ menuItem.SetAccelerator("Ctrl+S")       // ❌ Wrong (macOS uses Cmd)
 
 ---
 
-**Questions?** Ask in [Discord](https://discord.gg/JDdSxwjhGf) or check the [menu examples](https://github.com/wailsapp/wails/tree/v3-alpha/v3/examples/menu).
+**Questions?** Ask in [Discord](https://discord.gg/JDdSxwjhGf) or check the [menu examples](https://github.com/wailsapp/wails/tree/master/v3/examples/menu).

--- a/docs/src/content/docs/features/menus/systray.mdx
+++ b/docs/src/content/docs/features/menus/systray.mdx
@@ -710,4 +710,4 @@ menu.Update()  // Add this!
 
 ---
 
-**Questions?** Ask in [Discord](https://discord.gg/JDdSxwjhGf) or check the [system tray examples](https://github.com/wailsapp/wails/tree/v3-alpha/v3/examples/systray-basic).
+**Questions?** Ask in [Discord](https://discord.gg/JDdSxwjhGf) or check the [system tray examples](https://github.com/wailsapp/wails/tree/master/v3/examples/systray-basic).

--- a/docs/src/content/docs/features/platform/dock.mdx
+++ b/docs/src/content/docs/features/platform/dock.mdx
@@ -184,7 +184,7 @@ dockService.GetBadge()
 ## Best Practices
 
 1. **When hiding the dock icon (macOS):**
-   - Ensure users can still access your app (e.g., via [system tray](https://v3alpha.wails.io/learn/systray/))
+   - Ensure users can still access your app (e.g., via [system tray](https://v3.wails.io/learn/systray/))
    - Include a "Quit" option in your alternative UI
    - The app won't appear in Command+Tab switcher
    - Open windows remain visible and functional

--- a/docs/src/content/docs/features/screens/info.mdx
+++ b/docs/src/content/docs/features/screens/info.mdx
@@ -463,4 +463,4 @@ func visualiseScreenLayout() string {
 
 ---
 
-**Questions?** Ask in [Discord](https://discord.gg/JDdSxwjhGf) or check the [screen examples](https://github.com/wailsapp/wails/tree/v3-alpha/v3/examples).
+**Questions?** Ask in [Discord](https://discord.gg/JDdSxwjhGf) or check the [screen examples](https://github.com/wailsapp/wails/tree/master/v3/examples).

--- a/docs/src/content/docs/features/windows/basics.mdx
+++ b/docs/src/content/docs/features/windows/basics.mdx
@@ -613,4 +613,4 @@ app := application.New(application.Options{
 
 ---
 
-**Questions?** Ask in [Discord](https://discord.gg/JDdSxwjhGf) or check the [window examples](https://github.com/wailsapp/wails/tree/v3-alpha/v3/examples).
+**Questions?** Ask in [Discord](https://discord.gg/JDdSxwjhGf) or check the [window examples](https://github.com/wailsapp/wails/tree/master/v3/examples).

--- a/docs/src/content/docs/features/windows/events.mdx
+++ b/docs/src/content/docs/features/windows/events.mdx
@@ -690,4 +690,4 @@ window.OnDestroy(func() {
 
 ---
 
-**Questions?** Ask in [Discord](https://discord.gg/JDdSxwjhGf) or check the [examples](https://github.com/wailsapp/wails/tree/v3-alpha/v3/examples).
+**Questions?** Ask in [Discord](https://discord.gg/JDdSxwjhGf) or check the [examples](https://github.com/wailsapp/wails/tree/master/v3/examples).

--- a/docs/src/content/docs/features/windows/frameless.mdx
+++ b/docs/src/content/docs/features/windows/frameless.mdx
@@ -857,4 +857,4 @@ body {
 
 ---
 
-**Questions?** Ask in [Discord](https://discord.gg/JDdSxwjhGf) or check the [frameless example](https://github.com/wailsapp/wails/tree/v3-alpha/v3/examples/frameless).
+**Questions?** Ask in [Discord](https://discord.gg/JDdSxwjhGf) or check the [frameless example](https://github.com/wailsapp/wails/tree/master/v3/examples/frameless).

--- a/docs/src/content/docs/features/windows/multiple.mdx
+++ b/docs/src/content/docs/features/windows/multiple.mdx
@@ -791,4 +791,4 @@ type WindowState struct {
 
 ---
 
-**Questions?** Ask in [Discord](https://discord.gg/JDdSxwjhGf) or check the [multi-window example](https://github.com/wailsapp/wails/tree/v3-alpha/v3/examples/multi-window).
+**Questions?** Ask in [Discord](https://discord.gg/JDdSxwjhGf) or check the [multi-window example](https://github.com/wailsapp/wails/tree/master/v3/examples/multi-window).

--- a/docs/src/content/docs/features/windows/options.mdx
+++ b/docs/src/content/docs/features/windows/options.mdx
@@ -1092,4 +1092,4 @@ func main() {
 
 ---
 
-**Questions?** Ask in [Discord](https://discord.gg/JDdSxwjhGf) or check the [examples](https://github.com/wailsapp/wails/tree/v3-alpha/v3/examples).
+**Questions?** Ask in [Discord](https://discord.gg/JDdSxwjhGf) or check the [examples](https://github.com/wailsapp/wails/tree/master/v3/examples).

--- a/docs/src/content/docs/getting-started/installation.mdx
+++ b/docs/src/content/docs/getting-started/installation.mdx
@@ -90,7 +90,6 @@ commands:
 ```shell
 git clone https://github.com/wailsapp/wails.git
 cd wails
-git checkout v3-alpha
 cd v3/cmd/wails3
 go install
 ```

--- a/docs/src/content/docs/guides/distribution/custom-protocols.mdx
+++ b/docs/src/content/docs/guides/distribution/custom-protocols.mdx
@@ -661,4 +661,4 @@ app := application.New(application.Options{
 
 ---
 
-**Questions?** Ask in [Discord](https://discord.gg/JDdSxwjhGf) or check the [examples](https://github.com/wailsapp/wails/tree/v3-alpha/v3/examples).
+**Questions?** Ask in [Discord](https://discord.gg/JDdSxwjhGf) or check the [examples](https://github.com/wailsapp/wails/tree/master/v3/examples).

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -277,7 +277,7 @@ cd myapp && wails3 dev
 
 ## Next Steps
 
-Next: [Build a complete application](/tutorials/03-notes-vanilla), browse [examples](https://github.com/wailsapp/wails/tree/v3-alpha/v3/examples), or check the [API reference](/reference/application). Migrating from v2? See the [upgrade guide](/migration/v2-to-v3).
+Next: [Build a complete application](/tutorials/03-notes-vanilla), browse [examples](https://github.com/wailsapp/wails/tree/master/v3/examples), or check the [API reference](/reference/application). Migrating from v2? See the [upgrade guide](/migration/v2-to-v3).
 
 
 :::note[Production Ready]

--- a/docs/src/content/docs/migration/v2-to-v3.mdx
+++ b/docs/src/content/docs/migration/v2-to-v3.mdx
@@ -678,7 +678,7 @@ wails3 generate bindings
 - [Documentation](/quick-start/why-wails)
 - [Discord Community](https://discord.gg/JDdSxwjhGf)
 - [GitHub Issues](https://github.com/wailsapp/wails/issues)
-- [Examples](https://github.com/wailsapp/wails/tree/v3-alpha/v3/examples)
+- [Examples](https://github.com/wailsapp/wails/tree/master/v3/examples)
 
 ### Common Questions
 
@@ -718,7 +718,7 @@ A: 1-4 hours for typical applications.
   <Card title="Examples" icon="open-book">
     See complete v3 examples.
     
-    [View Examples →](https://github.com/wailsapp/wails/tree/v3-alpha/v3/examples)
+    [View Examples →](https://github.com/wailsapp/wails/tree/master/v3/examples)
   </Card>
 </CardGrid>
 

--- a/docs/src/content/docs/quick-start/next-steps.mdx
+++ b/docs/src/content/docs/quick-start/next-steps.mdx
@@ -30,5 +30,5 @@ Wails provides native desktop capabilities:
 ## Get Help
 
 - [Discord](https://discord.gg/JDdSxwjhGf) - Ask questions, share projects
-- [Examples](https://github.com/wailsapp/wails/tree/v3-alpha/v3/examples) - 50+ working examples
+- [Examples](https://github.com/wailsapp/wails/tree/master/v3/examples) - 50+ working examples
 - [API Reference](/reference/overview) - Complete documentation

--- a/docs/src/content/docs/reference/cli.mdx
+++ b/docs/src/content/docs/reference/cli.mdx
@@ -25,4 +25,4 @@ wails3 doctor        # Check development environment
 
 ---
 
-**Questions?** Ask in [Discord](https://discord.gg/JDdSxwjhGf) or check the [examples](https://github.com/wailsapp/wails/tree/v3-alpha/v3/examples).
+**Questions?** Ask in [Discord](https://discord.gg/JDdSxwjhGf) or check the [examples](https://github.com/wailsapp/wails/tree/master/v3/examples).

--- a/docs/src/content/docs/reference/overview.mdx
+++ b/docs/src/content/docs/reference/overview.mdx
@@ -258,7 +258,7 @@ Unstable APIs are marked in documentation.
 ### API Questions
 
 1. **Check this reference** - Complete API documentation
-2. **Check examples** - [GitHub examples](https://github.com/wailsapp/wails/tree/v3-alpha/v3/examples)
+2. **Check examples** - [GitHub examples](https://github.com/wailsapp/wails/tree/master/v3/examples)
 3. **Search Discord** - [Discord server](https://discord.gg/JDdSxwjhGf)
 4. **Ask the community** - Discord #help channel
 
@@ -275,7 +275,7 @@ Found a bug or inconsistency?
 - [Tutorials](/tutorials/overview) - Learn by building real applications
 - [Guides](/guides/dev/project-structure) - Task-oriented guides for common scenarios
 - [Features](/features/windows/basics) - Feature-by-feature documentation
-- [Examples](https://github.com/wailsapp/wails/tree/v3-alpha/v3/examples) - Working code examples on GitHub
+- [Examples](https://github.com/wailsapp/wails/tree/master/v3/examples) - Working code examples on GitHub
 
 ---
 

--- a/docs/src/content/docs/whats-new.md
+++ b/docs/src/content/docs/whats-new.md
@@ -404,5 +404,5 @@ An experimental feature to call runtime methods using plain html, similar to
 ## Examples
 
 There are more examples available in the
-[examples](https://github.com/wailsapp/wails/tree/v3-alpha/v3/examples)
+[examples](https://github.com/wailsapp/wails/tree/master/v3/examples)
 directory. Check them out!

--- a/website/docs/guides/mobile.mdx
+++ b/website/docs/guides/mobile.mdx
@@ -253,8 +253,8 @@ The following features are not yet fully implemented on mobile platforms:
 
 For detailed technical information about the mobile implementations:
 
-- **Android Architecture**: See [`ANDROID_ARCHITECTURE.md`](https://github.com/wailsapp/wails/blob/v3-alpha/v3/ANDROID_ARCHITECTURE.md) in the repository
-- **iOS Architecture**: See [`IOS_ARCHITECTURE.md`](https://github.com/wailsapp/wails/blob/v3-alpha/v3/IOS_ARCHITECTURE.md) in the repository
+- **Android Architecture**: See [`ANDROID_ARCHITECTURE.md`](https://github.com/wailsapp/wails/blob/master/v3/ANDROID_ARCHITECTURE.md) in the repository
+- **iOS Architecture**: See [`IOS_ARCHITECTURE.md`](https://github.com/wailsapp/wails/blob/master/v3/IOS_ARCHITECTURE.md) in the repository
 
 These documents provide comprehensive information about:
 - Architecture and design patterns


### PR DESCRIPTION
## Summary
Post-merge cleanup of customer-facing references that still pointed at the now-archived `v3-alpha` branch. The v3 source lives in `v3/` on `master` after PR #5272.

- `docs/CNAME`, `docs/src/content/docs/features/platform/dock.mdx`: `v3alpha.wails.io` → `v3.wails.io`.
- `docs/astro.config.mjs`: Starlight `editLink.baseUrl` now points at `/edit/master/docs`.
- ~30 MDX files in `docs/src/content/docs/`: `github.com/wailsapp/wails/tree/v3-alpha/v3/...` → `/tree/master/v3/...` so example links resolve to the live source.
- `website/docs/guides/mobile.mdx`: same for `blob/v3-alpha/v3/` links.
- `docs/src/content/docs/getting-started/installation.mdx`: remove the obsolete `git checkout v3-alpha` step from the build-from-source guide.

The CF zone redirect rule still routes any old `v3alpha.wails.io` traffic to `v3.wails.io`, so external inbound links keep working.

## Out of scope
Cosmetic `v3-alpha` mentions inside `.github/workflows/` (job names, log strings) are intentionally left untouched — they don't affect functionality, and changing them en masse would be churn.

## Test plan
- [ ] Render the docs site (CF Pages preview build); confirm internal example links work.
- [ ] Confirm the Starlight "Edit this page" link goes to `master`, not `v3-alpha`.
- [ ] No remaining `v3-alpha` in `docs/` or `website/`: `grep -rn v3-alpha docs/ website/` is empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation domain to v3.wails.io
  * Updated all documentation links to reference the master branch instead of alpha branch
  * Simplified installation instructions for development setup

<!-- end of auto-generated comment: release notes by coderabbit.ai -->