### PR TITLE
fix(workflows): rewrite unreleased-changelog-trigger.yml

### DIFF
--- a/.github/workflows/unreleased-changelog-trigger.yml
+++ b/.github/workflows/unreleased-changelog-trigger.yml
@@ -5,7 +5,6 @@ on:
     branches: [master]
     paths:
       - 'v3/UNRELEASED_CHANGELOG.md'
-      - '.github/workflows/unreleased-changelog-trigger.yml'
   workflow_dispatch:
     inputs:
       dry_run:
@@ -28,7 +27,7 @@ jobs:
       - name: Check UNRELEASED_CHANGELOG.md has content
         id: check
         run: |
-          curl -fsSL \
+          curl -fsSL --retry 3 --retry-delay 2 --retry-connrefused \
             -H "Accept: application/vnd.github.raw" \
             -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
             "https://api.github.com/repos/${{ github.repository }}/contents/v3/UNRELEASED_CHANGELOG.md?ref=master" \

--- a/.github/workflows/unreleased-changelog-trigger.yml
+++ b/.github/workflows/unreleased-changelog-trigger.yml
@@ -23,7 +23,7 @@ jobs:
     name: Trigger v3 nightly release
     runs-on: ubuntu-latest
     # Only run for trusted actors. auto-changelog-v3 commits as github-actions[bot].
-    if: contains(fromJSON('["leaanthony", "github-actions[bot]"]'), github.actor)
+    if: github.actor == 'leaanthony' || github.actor == 'github-actions[bot]'
     steps:
       - name: Check UNRELEASED_CHANGELOG.md has content
         id: check

--- a/.github/workflows/unreleased-changelog-trigger.yml
+++ b/.github/workflows/unreleased-changelog-trigger.yml
@@ -2,10 +2,10 @@ name: Auto Release on Changelog Update
 
 on:
   push:
-    branches:
-      - master
+    branches: [master]
     paths:
       - 'v3/UNRELEASED_CHANGELOG.md'
+      - '.github/workflows/unreleased-changelog-trigger.yml'
   workflow_dispatch:
     inputs:
       dry_run:
@@ -14,116 +14,42 @@ on:
         default: false
         type: boolean
 
+permissions:
+  contents: read
+  actions: write
+
 jobs:
-  check-permissions:
-    name: Check Release Permissions
+  trigger-release:
+    name: Trigger v3 nightly release
     runs-on: ubuntu-latest
-    outputs:
-      authorized: ${{ steps.check.outputs.authorized }}
+    # Only run for trusted actors. auto-changelog-v3 commits as github-actions[bot].
+    if: contains(fromJSON('["leaanthony", "github-actions[bot]"]'), github.actor)
     steps:
-      - name: Check if user is authorized for releases
+      - name: Check UNRELEASED_CHANGELOG.md has content
         id: check
         run: |
-          # Only allow specific users to trigger releases
-          AUTHORIZED_USERS="leaanthony"
-          
-          if [[ "$AUTHORIZED_USERS" == *"${{ github.actor }}"* ]]; then
-            echo "✅ User ${{ github.actor }} is authorized for releases"
-            echo "authorized=true" >> $GITHUB_OUTPUT
+          curl -fsSL \
+            -H "Accept: application/vnd.github.raw" \
+            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+            "https://api.github.com/repos/${{ github.repository }}/contents/v3/UNRELEASED_CHANGELOG.md?ref=master" \
+            > /tmp/UNRELEASED_CHANGELOG.md
+          if grep -E '^\s*-\s+\S' /tmp/UNRELEASED_CHANGELOG.md >/dev/null; then
+            echo "has_content=true" >> "$GITHUB_OUTPUT"
+            echo "✅ Changelog has content; will trigger release."
           else
-            echo "❌ User ${{ github.actor }} is not authorized for releases"
-            echo "authorized=false" >> $GITHUB_OUTPUT
+            echo "has_content=false" >> "$GITHUB_OUTPUT"
+            echo "ℹ️ No bullet content in UNRELEASED_CHANGELOG.md; skipping."
           fi
 
-  trigger-release:
-    name: Trigger v3-alpha Release
-    permissions:
-      contents: read
-      actions: write
-    runs-on: ubuntu-latest
-    needs: check-permissions
-    if: needs.check-permissions.outputs.authorized == 'true'
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          ref: master
-          fetch-depth: 0
-          token: ${{ secrets.WAILS_REPO_TOKEN || github.token }}
-
-      - name: Check for unreleased changelog content
-        id: changelog_check
+      - name: Dispatch nightly-release-v3
+        if: steps.check.outputs.has_content == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.WAILS_REPO_TOKEN || secrets.GITHUB_TOKEN }}
+          DRY_RUN: ${{ inputs.dry_run && 'true' || 'false' }}
         run: |
-          echo "🔍 Checking UNRELEASED_CHANGELOG.md for content..."
-          
-          cd v3
-          # Check if UNRELEASED_CHANGELOG.md has actual content beyond the template
-          if [ -f "UNRELEASED_CHANGELOG.md" ]; then
-            # Use a simple check for actual content (bullet points starting with -)
-            CONTENT_LINES=$(grep -E "^\s*-\s+[^[:space:]]" UNRELEASED_CHANGELOG.md | wc -l)
-            if [ "$CONTENT_LINES" -gt 0 ]; then
-              echo "✅ Found $CONTENT_LINES content lines in UNRELEASED_CHANGELOG.md"
-              echo "has_content=true" >> $GITHUB_OUTPUT
-            else
-              echo "ℹ️  No actual content found in UNRELEASED_CHANGELOG.md"
-              echo "has_content=false" >> $GITHUB_OUTPUT
-            fi
-          else
-            echo "❌ UNRELEASED_CHANGELOG.md not found"
-            echo "has_content=false" >> $GITHUB_OUTPUT
-          fi
-
-      - name: Trigger nightly release workflow
-        if: steps.changelog_check.outputs.has_content == 'true'
-        uses: actions/github-script@v7
-        with:
-          github-token: ${{ secrets.WAILS_REPO_TOKEN || github.token }}
-          script: |
-            const response = await github.rest.actions.createWorkflowDispatch({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              workflow_id: 'nightly-release-v3.yml',
-              ref: 'master',
-              inputs: {
-                force_release: 'true',
-                dry_run: '${{ github.event.inputs.dry_run || "false" }}'
-              }
-            });
-            
-            console.log('🚀 Successfully triggered nightly release workflow');
-            console.log(`Workflow dispatch response status: ${response.status}`);
-            
-            // Create a summary
-            core.summary
-              .addHeading('🚀 Auto Release Triggered')
-              .addRaw('The v3-alpha release workflow has been automatically triggered due to changes in UNRELEASED_CHANGELOG.md')
-              .addTable([
-                [{data: 'Trigger', header: true}, {data: 'Value', header: true}],
-                ['Repository', context.repo.repo],
-                ['Branch', 'v3-alpha'],
-                ['Actor', context.actor],
-                ['Dry Run', '${{ github.event.inputs.dry_run || "false" }}'],
-                ['Force Release', 'true']
-              ])
-              .addRaw('\n---\n*This release was automatically triggered by the unreleased-changelog-trigger workflow*')
-              .write();
-
-      - name: No content found
-        if: steps.changelog_check.outputs.has_content == 'false'
-        run: |
-          echo "ℹ️  No content found in UNRELEASED_CHANGELOG.md, skipping release trigger"
-          echo "## ℹ️  No Release Triggered" >> $GITHUB_STEP_SUMMARY
-          echo "**Reason:** UNRELEASED_CHANGELOG.md does not contain actual changelog content" >> $GITHUB_STEP_SUMMARY
-          echo "**Action:** No release workflow was triggered" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "To trigger a release, add actual changelog entries to the UNRELEASED_CHANGELOG.md file." >> $GITHUB_STEP_SUMMARY
-
-      - name: Unauthorized user
-        if: needs.check-permissions.outputs.authorized == 'false'
-        run: |
-          echo "❌ User ${{ github.actor }} is not authorized to trigger releases"
-          echo "## ❌ Unauthorized Release Attempt" >> $GITHUB_STEP_SUMMARY
-          echo "**User:** ${{ github.actor }}" >> $GITHUB_STEP_SUMMARY
-          echo "**Action:** Release trigger was blocked due to insufficient permissions" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "Only authorized users can trigger automatic releases via changelog updates." >> $GITHUB_STEP_SUMMARY
+          gh workflow run nightly-release-v3.yml \
+            -R "${{ github.repository }}" \
+            --ref master \
+            -f force_release=true \
+            -f dry_run="$DRY_RUN"
+          echo "🚀 Dispatched nightly-release-v3.yml"


### PR DESCRIPTION
## Summary
The previous version was failing on every push with **zero job output** — GitHub's API reported the workflow's `name` as the file path rather than the configured `name:` field, indicating a startup-level parse/validation failure (likely from the `actions/github-script` step with a nested `${{ ... || "false" }}` expression containing double-quoted strings).

Rather than chase the YAML/expression mess, rewrite from scratch with a smaller, simpler structure.

## Changes
- Single job (drop the redundant `check-permissions` job; gate via job-level `if:` against `github.actor`).
- **Allow `github-actions[bot]` as an actor** (the committer that `auto-changelog-v3.yml` uses to push the changelog entry — i.e. the very push that should fire this trigger).
- Use `gh workflow run` instead of `actions/github-script` to dispatch `nightly-release-v3.yml` — fewer moving parts, no JS interpolation.
- Fetch `UNRELEASED_CHANGELOG.md` via the contents API instead of a full git checkout (saves a checkout on every push).

Net: 138 lines → 55 lines, same intended behaviour, no startup_failure.

## Test plan
- [ ] After merge, CI parses the workflow successfully (workflow's `name` field reads "Auto Release on Changelog Update", not the file path).
- [ ] On the next `auto-changelog-v3.yml` PR-merge commit that touches `v3/UNRELEASED_CHANGELOG.md`, this workflow runs and dispatches `nightly-release-v3.yml`.
- [ ] Manual `workflow_dispatch` with `dry_run: true` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Streamlined the automated release workflow for faster, more predictable runs.
  * Restricts workflow execution to a small allowlist for tighter control.
  * Detects changelog content directly to ensure releases only proceed when notes exist.
  * Uses a more direct dispatch method for reliability and passes dry-run/force flags through.
  * Removed redundant summary-generation steps to simplify logs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->