### PR TITLE
fix(workflows): use pull_request_target for auto-changelog-v3

### DIFF
--- a/.github/workflows/auto-changelog-v3.yml
+++ b/.github/workflows/auto-changelog-v3.yml
@@ -1,7 +1,7 @@
 name: Auto Changelog (v3)
 
 on:
-  pull_request:
+  pull_request_target:
     branches: [ master ]
     types: [ closed ]
   workflow_dispatch:


### PR DESCRIPTION
## Summary
Fixes auto-changelog-v3 silently failing on every external contributor PR.

## Root cause
The current `pull_request: closed` trigger runs in the **fork's context** when a PR comes from a fork. GitHub strips secrets in that context, so `OPENROUTER_API_KEY` is empty and `v3/scripts/auto-changelog.go` exits with:
```
❌ Required env vars: PR_NUMBER, GITHUB_TOKEN, OPENROUTER_API_KEY, GITHUB_REPOSITORY
```
Reproduced just now on the auto-run for #5265 (AkagiYui's fork PR).

## Fix
Switch to `pull_request_target`, which fires on the same events but runs in **base-repo context with secrets attached**.

## Why this is safe here (despite `pull_request_target`'s usual risks)
- The workflow already gates on `github.event.pull_request.merged == true` (so it only runs on real merges).
- It explicitly checks out `master` (never fork code).
- It only queries the GitHub API for PR metadata and runs a Go script that lives in `master`.

So the typical `pull_request_target` footgun — running fork-supplied code with elevated permissions — does **not** apply.

## Test plan
- [ ] Manually dispatched `auto-changelog-v3.yml` with `pr_number: 5265` (companion run) to backfill the missing entry for #5265.
- [ ] After this PR merges, the next external-contributor PR's merge should produce an auto-changelog commit on master automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal workflow configuration for pull request handling on the main branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->