### PR TITLE
fix(release): point release script at master, drop v3-alpha references

### DIFF
--- a/v3/tasks/release/release.go
+++ b/v3/tasks/release/release.go
@@ -20,9 +20,9 @@ import (
 const (
 	versionFile          = "../../internal/version/version.txt"
 	changelogFile        = "../../../docs/src/content/docs/changelog.mdx"
-	defaultReleaseBranch = "v3-alpha"
+	defaultReleaseBranch = "master"
 	defaultReleaseTitle  = "Wails %s"
-	defaultReleaseTarget = "v3-alpha"
+	defaultReleaseTarget = "master"
 	githubDefaultAPI     = "https://api.github.com"
 	githubAPIVersion     = "2022-11-28"
 )
@@ -52,7 +52,7 @@ func getUnreleasedChangelogTemplate() string {
 	return `# Unreleased Changes
 
 <!-- 
-This file is used to collect changelog entries for the next v3-alpha release.
+This file is used to collect changelog entries for the next v3 alpha release.
 Add your changes under the appropriate sections below.
 
 Guidelines:
@@ -661,7 +661,7 @@ func buildReleaseBody(version, changelogContent string) string {
 		"",
 		"---",
 		"",
-		"🤖 This is an automated nightly release generated from the latest changes in the v3-alpha branch.",
+		"🤖 This is an automated nightly release generated from the latest changes on master.",
 		"",
 		"**Installation:**",
 		"```bash",

--- a/v3/tasks/release/release_test.go
+++ b/v3/tasks/release/release_test.go
@@ -47,7 +47,7 @@ func TestExtractChangelogContent_EmptySections(t *testing.T) {
 	testContent := `# Unreleased Changes
 
 <!-- 
-This file is used to collect changelog entries for the next v3-alpha release.
+This file is used to collect changelog entries for the next v3 alpha release.
 -->
 
 ## Added

--- a/v3/tasks/release/test_simple.bat
+++ b/v3/tasks/release/test_simple.bat
@@ -17,7 +17,7 @@ REM Create a test UNRELEASED_CHANGELOG.md
 echo # Unreleased Changes > UNRELEASED_CHANGELOG.md
 echo. >> UNRELEASED_CHANGELOG.md
 echo ^<^!-- >> UNRELEASED_CHANGELOG.md
-echo This file is used to collect changelog entries for the next v3-alpha release. >> UNRELEASED_CHANGELOG.md
+echo This file is used to collect changelog entries for the next v3 alpha release. >> UNRELEASED_CHANGELOG.md
 echo --^> >> UNRELEASED_CHANGELOG.md
 echo. >> UNRELEASED_CHANGELOG.md
 echo ## Added >> UNRELEASED_CHANGELOG.md

--- a/v3/tasks/release/test_simple.sh
+++ b/v3/tasks/release/test_simple.sh
@@ -14,7 +14,7 @@ cat > UNRELEASED_CHANGELOG.md << 'EOF'
 # Unreleased Changes
 
 <!-- 
-This file is used to collect changelog entries for the next v3-alpha release.
+This file is used to collect changelog entries for the next v3 alpha release.
 -->
 
 ## Added


### PR DESCRIPTION
## Summary
The v3 release dry-run succeeded but masked **two functional bugs** that would break a real release run:

| Constant | Was | Now | Effect |
|---|---|---|---|
| `defaultReleaseBranch` | `"v3-alpha"` | `"master"` | `--branch` flag default; controls where the release script pushes tags and changelog-move commits. Old default would push to a deleted branch. |
| `defaultReleaseTarget` | `"v3-alpha"` | `"master"` | `--target` flag default; the `target_commitish` for the GitHub Release API call. Old default would target a deleted ref. |

In `--dry-run` mode neither flag is used, which is why the workflow run on master tip `f9beb6a6` reported success.

## Cosmetic at the same time
- UNRELEASED_CHANGELOG.md template comment: "next v3-alpha release" → "next v3 alpha release".
- Release-notes footer (visible to anyone reading a published release): "automated nightly release generated from the latest changes in the v3-alpha branch" → "...on master".
- Test fixtures (`release_test.go`, `test_simple.bat`, `test_simple.sh`) updated to match.

## Test plan
- [x] `go test ./...` in `v3/tasks/release` passes locally with the new strings.
- [ ] After merge: re-run `nightly-release-v3.yml` dry-run; release notes preview should show the new footer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release automation to use `master` branch instead of `v3-alpha` as the primary release target
  * Adjusted release documentation naming conventions

* **Tests**
  * Updated test scripts and configurations to reflect changes in the release process

<!-- end of auto-generated comment: release notes by coderabbit.ai -->