### PR TITLE
fix(v3): implement BrowserWindow.SetScreen to fix `-tags server` build

### DIFF
--- a/v3/pkg/application/browser_window.go
+++ b/v3/pkg/application/browser_window.go
@@ -104,6 +104,7 @@ func (b *BrowserWindow) SetMinSize(minWidth, minHeight int) Window    { return b
 func (b *BrowserWindow) SetRelativePosition(x, y int) Window          { return b }
 func (b *BrowserWindow) SetResizable(b2 bool) Window                  { return b }
 func (b *BrowserWindow) SetIgnoreMouseEvents(ignore bool) Window      { return b }
+func (b *BrowserWindow) SetScreen(screen *Screen) Window              { return b }
 func (b *BrowserWindow) SetSize(width, height int) Window             { return b }
 func (b *BrowserWindow) SetTitle(title string) Window                 { return b }
 func (b *BrowserWindow) SetURL(s string) Window                       { return b }


### PR DESCRIPTION
<!--

*********************************************************************
*               PLEASE READ BEFORE SUBMITTING YOUR PR               *
*     YOUR PR MAY BE REJECTED IF IT DOES NOT FOLLOW THESE STEPS     *
*********************************************************************

- *DO NOT* submit bugs for a source install of v3, ONLY tagged versions, e.g. v3.0.0-alpha.11
- *DO NOT* submit PRs for v3 alpha enhancements, unless you have opened a post on the discord channel.
  All enhancements must be discussed first.
  The feedback guide for v3 is here: https://v3alpha.wails.io/getting-started/feedback/

- Before submitting your PR, please ensure you have created and linked the PR to an issue.
- If a relevant issue already exists, please reference it in your PR by including `Fixes #<issue number>` in your PR description.
- Please fill in the checklists.

-->

# Description

PR #5067 added `SetScreen(screen *Screen) Window` to the `Window` interface but did not update `BrowserWindow` (the server-mode adapter in `v3/pkg/application/browser_window.go`, gated by `//go:build server`). As a result, `*BrowserWindow` no longer satisfies `Window` and any build with `-tags server` fails to compile, breaking the documented headless / test-automation workflow.

This PR adds a no-op `SetScreen` implementation on `*BrowserWindow` that returns the receiver, matching the existing fluent no-op pattern already used by sibling setters like `SetTitle`, `SetMinSize`, and `SetMaxSize`. Moving a browser client to a particular native screen isn't a meaningful operation, so a no-op is the correct behavior here, consistent with how the rest of the server-mode adapter handles native-only window operations.

Fixes [#5262](https://github.com/wailsapp/wails/issues/5262).

No new dependencies.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Reproduced the failure on `master` and verified the fix with:

```bash
cd v3/examples/dock
go build -tags server .   # fails before, succeeds after
go build .                # default (non-server) build still succeeds
```

# How Has This Been Tested?
  
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration using `wails doctor`.

- [ ] Windows
- [X] macOS
- [ ] Linux
      
If you checked Linux, please specify the distro and version.
  
## Test Configuration

```
 Wails (v3.0.0-alpha.79)  Wails Doctor

# System

┌──────────────────────────────────────────────────┐
| Name          | MacOS                            |
| Version       | 15.7.4                           |
| ID            | 24G517                           |
| Branding      | Sequoia                          |
| Platform      | darwin                           |
| Architecture  | arm64                            |
| Apple Silicon | true                             |
| CPU           | Apple M1 Pro                     |
| CPU 1         | Apple M1 Pro                     |
| CPU 2         | Apple M1 Pro                     |
| GPU           | 16 cores, Metal Support: Metal 3 |
| Memory        | 32 GB                            |
└──────────────────────────────────────────────────┘

# Build Environment

┌────────────────────────────────┐
| Wails CLI    | v3.0.0-alpha.79 |
| Go Version   | go1.25.1        |
| -buildmode   | exe             |
| -compiler    | gc              |
| CGO_CFLAGS   |                 |
| CGO_CPPFLAGS |                 |
| CGO_CXXFLAGS |                 |
| CGO_ENABLED  | 1               |
| CGO_LDFLAGS  |                 |
| GOARCH       | arm64           |
| GOARM64      | v8.0            |
| GOOS         | darwin          |
└────────────────────────────────┘

# Dependencies

┌──────────────────────────────────────────────────────────────────────────────┐
| npm             | 10.9.4                                                     |
| *NSIS           | Not Installed. Install with `brew install makensis`.       |
| Xcode cli tools | 2410                                                       |
| docker          | *Docker version 29.0.1, build eedd969 (daemon not running) |
|                                                                              |
└────────────────────────── * - Optional Dependency ───────────────────────────┘

# Checking for issues

 SUCCESS  No issues found
```

# Checklist:

- [ ] (v2 only) I have updated `website/src/pages/changelog.mdx` with details of this PR (v3 changelog entries are added automatically)
- [X] My code follows the general coding style of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas (N/A)
- [ ] I have made corresponding changes to the documentation (N/A)
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (N/A)
- [X] New and existing unit tests pass locally with my changes
   - One pre-existing failure in internal/commands (TestGenerateIcon) requires full Xcode.app for actool; unrelated to this change.

## Pre-existing failures unrelated to this change

While running the test suite to verify this PR, two pre-existing failures surfaced. Both reproduce on master without the patch applied:

- **`TestGenerateIcon`** in `v3/internal/commands` — fails with `mac asset generation is only supported on macOS` despite running on macOS. Appears to require the full Xcode.app bundle (for `actool`); my local environment only has Xcode CLI tools installed.
- **`go vet` failure** in `v3/pkg/application/websocket_server.go:67` — `(*App).error call has arguments but no formatting directives`. Only surfaces under `-tags server`, which suggests another instance of the same server-mode bit-rot that #5262 is fixing. Worth a follow-up PR.

Neither failure is in code touched by this PR, and `go test -tags server -vet=off ./...` passes cleanly otherwise.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended browser window API with a new chainable method for screen configuration capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->