### PR TITLE
fix(server): add missing SetScreen method to BrowserWindow

### DIFF
--- a/v3/pkg/application/browser_window.go
+++ b/v3/pkg/application/browser_window.go
@@ -65,6 +65,7 @@ func (b *BrowserWindow) ForceReload()                                 {}
 func (b *BrowserWindow) Fullscreen() Window                           { return b }
 func (b *BrowserWindow) GetBorderSizes() *LRTB                        { return nil }
 func (b *BrowserWindow) GetScreen() (*Screen, error)                  { return nil, nil }
+func (b *BrowserWindow) SetScreen(screen *Screen) Window              { return b }
 func (b *BrowserWindow) GetZoom() float64                             { return 1.0 }
 func (b *BrowserWindow) handleDragAndDropMessage(filenames []string, dropTarget *DropTargetDetails) {}
 func (b *BrowserWindow) InitiateFrontendDropProcessing(filenames []string, x int, y int) {}


### PR DESCRIPTION
Closes #5262.

BrowserWindow was missing `SetScreen(screen *Screen) Window`, which was added to the `Window` interface in #5067. This caused a compile error when building with `-tags server`.

The fix follows the existing no-op pattern for methods that have no meaning for browser clients.

**Verified**: `go build -tags server ./v3/pkg/application/` and `go build -tags server ./v3/examples/dock/` both pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Browser windows now support the `SetScreen` method for configuring screen settings. The method returns the window instance, enabling method chaining patterns for fluent API usage. This provides developers with a more flexible and integrated approach to window and screen configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->