### PR TITLE
fix(linux): apply WEBKIT_DISABLE_DMABUF_RENDERER on X11 for NVIDIA GPUs

### DIFF
--- a/docs/src/content/docs/guides/build/linux.mdx
+++ b/docs/src/content/docs/guides/build/linux.mdx
@@ -195,6 +195,20 @@ sudo pacman -S base-devel
 
 Alternatively, run `wails3 task setup:docker` and the build system will use Docker automatically.
 
+### Blank or white window on NVIDIA GPU
+
+On Linux with NVIDIA proprietary drivers, Wails apps may show a blank or white window on startup. This is caused by a WebKitGTK bug where the DMA-BUF renderer fails with `gbm_bo_map()` against the NVIDIA proprietary driver (affects X11 and Wayland, driver versions 377–580+, GPUs from the 10 series and older GT 710).
+
+**Wails applies `WEBKIT_DISABLE_DMABUF_RENDERER=1` automatically** when it detects the NVIDIA kernel module (`/sys/module/nvidia`), so most users will not need to do anything.
+
+If you still see a blank window (for example in a container where the module path is not visible), set the environment variable manually before launching your app:
+
+```bash
+WEBKIT_DISABLE_DMABUF_RENDERER=1 ./myapp
+```
+
+Related upstream bugs: [WebKit #262607](https://bugs.webkit.org/show_bug.cgi?id=262607), [WebKit #180739](https://bugs.webkit.org/show_bug.cgi?id=180739).
+
 ### AppImage strip compatibility
 
 On modern Linux distributions (Arch Linux, Fedora 39+, Ubuntu 24.04+), system libraries are compiled with `.relr.dyn` ELF sections for more efficient relocations. The `linuxdeploy` tool used to create AppImages bundles an older `strip` binary that cannot process these modern sections.

--- a/v3/pkg/application/application_linux.go
+++ b/v3/pkg/application/application_linux.go
@@ -59,12 +59,12 @@ func init() {
 		_ = os.Setenv("GDK_BACKEND", "x11")
 	}
 
-	// Disable DMA-BUF renderer on Wayland with NVIDIA to prevent "Error 71 (Protocol error)" crashes.
-	// This is a known WebKitGTK issue with NVIDIA proprietary drivers on Wayland.
+	// Disable DMA-BUF renderer on any session type with NVIDIA to prevent blank windows and
+	// "Error 71 (Protocol error)" crashes. NVIDIA proprietary drivers fail gbm_bo_map() when
+	// importing DMA-BUF, causing blank/white screens on both X11 and Wayland.
 	// See: https://bugs.webkit.org/show_bug.cgi?id=262607
-	if os.Getenv("WEBKIT_DISABLE_DMABUF_RENDERER") == "" &&
-		os.Getenv("XDG_SESSION_TYPE") == "wayland" &&
-		isNVIDIAGPU() {
+	// See: https://github.com/wailsapp/wails/issues/4985
+	if os.Getenv("WEBKIT_DISABLE_DMABUF_RENDERER") == "" && isNVIDIAGPU() {
 		_ = os.Setenv("WEBKIT_DISABLE_DMABUF_RENDERER", "1")
 	}
 }

--- a/v3/pkg/application/application_linux_gtk4.go
+++ b/v3/pkg/application/application_linux_gtk4.go
@@ -49,9 +49,12 @@ func init() {
 	fmt.Println("│  Please report issues: https://github.com/wailsapp/wails/issues/4957   │")
 	fmt.Println("└────────────────────────────────────────────────────────────────────────┘")
 
-	if os.Getenv("WEBKIT_DISABLE_DMABUF_RENDERER") == "" &&
-		os.Getenv("XDG_SESSION_TYPE") == "wayland" &&
-		isNVIDIAGPU() {
+	// Disable DMA-BUF renderer on any session type with NVIDIA to prevent blank windows and
+	// "Error 71 (Protocol error)" crashes. NVIDIA proprietary drivers fail gbm_bo_map() when
+	// importing DMA-BUF, causing blank/white screens on both X11 and Wayland.
+	// See: https://bugs.webkit.org/show_bug.cgi?id=262607
+	// See: https://github.com/wailsapp/wails/issues/4985
+	if os.Getenv("WEBKIT_DISABLE_DMABUF_RENDERER") == "" && isNVIDIAGPU() {
 		_ = os.Setenv("WEBKIT_DISABLE_DMABUF_RENDERER", "1")
 	}
 }

--- a/v3/pkg/application/linux_purego.go
+++ b/v3/pkg/application/linux_purego.go
@@ -233,6 +233,17 @@ var (
 func init() {
 	// needed for GTK4 to function
 	_ = os.Setenv("GDK_BACKEND", "x11")
+
+	// Disable DMA-BUF renderer on any session type with NVIDIA to prevent blank windows and
+	// "Error 71 (Protocol error)" crashes. NVIDIA proprietary drivers fail gbm_bo_map() when
+	// importing DMA-BUF, causing blank/white screens on both X11 and Wayland.
+	// See: https://bugs.webkit.org/show_bug.cgi?id=262607
+	// See: https://github.com/wailsapp/wails/issues/4985
+	if os.Getenv("WEBKIT_DISABLE_DMABUF_RENDERER") == "" {
+		if _, err := os.Stat("/sys/module/nvidia"); err == nil {
+			_ = os.Setenv("WEBKIT_DISABLE_DMABUF_RENDERER", "1")
+		}
+	}
 	var err error
 
 	// gtk, err = purego.Dlopen(gtk4, purego.RTLD_NOW|purego.RTLD_GLOBAL)


### PR DESCRIPTION
Closes #4985.

On Linux X11 with NVIDIA proprietary drivers (driver versions 377–580+, GPUs from the 10 series and GT 710), Wails apps render with a blank or white window. Root cause: WebKitGTK's DMA-BUF renderer calls `gbm_bo_map()` to import GPU buffers; the NVIDIA proprietary driver fails this call silently on both X11 and Wayland (upstream bugs WebKit #262607 and #180739).

## What changed

The workaround (`WEBKIT_DISABLE_DMABUF_RENDERER=1`) was already in `init()` for the GTK3 and GTK4 CGO build variants, but was guarded by `os.Getenv("XDG_SESSION_TYPE") == "wayland"`. This meant X11 users (the majority of affected reporters) never received the protection.

- `application_linux.go` and `application_linux_gtk4.go`: remove the session-type guard so the env var is set whenever `/sys/module/nvidia` is present, regardless of X11 or Wayland.
- `linux_purego.go`: add the NVIDIA detection — this variant had no protection at all.
- `docs/.../linux.mdx`: add Troubleshooting section documenting the automatic mitigation and the manual fallback.

Users who already set `WEBKIT_DISABLE_DMABUF_RENDERER` manually are unaffected — the `os.Getenv(...) == ""` guard is preserved.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed blank/white window display issue on Linux startup for systems with NVIDIA proprietary drivers through automatic workaround application.

* **Documentation**
  * Added troubleshooting section in Linux build guide addressing NVIDIA driver compatibility issues with manual configuration steps for containerized environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->