### PR TITLE
menu_linux/gtk4: silently ignore Update before menu init

### DIFF
--- a/v3/pkg/application/menu_linux.go
+++ b/v3/pkg/application/menu_linux.go
@@ -20,6 +20,9 @@ func (m *linuxMenu) run() {
 }
 
 func (m *linuxMenu) update() {
+	if m == nil || m.menu == nil {
+		return // Silently ignore update if menu is not initialized.
+	}
 	m.processMenu(m.menu)
 }
 

--- a/v3/pkg/application/menu_linux_gtk4.go
+++ b/v3/pkg/application/menu_linux_gtk4.go
@@ -21,6 +21,9 @@ func (m *linuxMenu) run() {
 }
 
 func (m *linuxMenu) update() {
+	if m == nil || m.menu == nil {
+		return // Silently ignore update if menu is not initialized.
+	}
 	m.processMenu(m.menu)
 }
 


### PR DESCRIPTION
Closes #5290. `Menu.Update()` called before the application enters running state segfaults; gate on `m == nil || m.menu == nil`. Restores commit 044756a from the v3-alpha-bugfix/mega-menu-fixes branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a stability issue on Linux where menu operations could fail if the menu system wasn't properly initialized.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->