### PR TITLE
feat(v3/nsis): add user install scope for Windows NSIS installer

### DIFF
--- a/v3/internal/commands/build_assets/windows/Taskfile.yml
+++ b/v3/internal/commands/build_assets/windows/Taskfile.yml
@@ -100,8 +100,11 @@ tasks:
     summary: Packages the application
     cmds:
       - task: '{{if eq (.FORMAT | default "nsis") "msix"}}create:msix:package{{else}}create:nsis:installer{{end}}'
+        vars:
+          INSTALL_SCOPE: '{{.INSTALL_SCOPE | default "machine"}}'
     vars:
       FORMAT: '{{.FORMAT | default "nsis"}}'
+      INSTALL_SCOPE: '{{.INSTALL_SCOPE | default "machine"}}'
 
   generate:syso:
     summary: Generates Windows `.syso` file
@@ -119,15 +122,16 @@ tasks:
     cmds:
       # Create the Microsoft WebView2 bootstrapper if it doesn't exist
       - wails3 generate webview2bootstrapper -dir "{{.ROOT_DIR}}/build/windows/nsis"
-      - | 
+      - |
         {{if eq OS "windows"}}
-        makensis -DARG_WAILS_{{.ARG_FLAG}}_BINARY="{{.ROOT_DIR}}\{{.BIN_DIR}}\{{.APP_NAME}}.exe" project.nsi
+        makensis {{if eq .INSTALL_SCOPE "user"}}-DWAILS_INSTALL_SCOPE=user -DREQUEST_EXECUTION_LEVEL=user {{end}}-DARG_WAILS_{{.ARG_FLAG}}_BINARY="{{.ROOT_DIR}}\{{.BIN_DIR}}\{{.APP_NAME}}.exe" project.nsi
         {{else}}
-        makensis -DARG_WAILS_{{.ARG_FLAG}}_BINARY="{{.ROOT_DIR}}/{{.BIN_DIR}}/{{.APP_NAME}}.exe" project.nsi
+        makensis {{if eq .INSTALL_SCOPE "user"}}-DWAILS_INSTALL_SCOPE=user -DREQUEST_EXECUTION_LEVEL=user {{end}}-DARG_WAILS_{{.ARG_FLAG}}_BINARY="{{.ROOT_DIR}}/{{.BIN_DIR}}/{{.APP_NAME}}.exe" project.nsi
         {{end}}
     vars:
       ARCH: '{{.ARCH | default ARCH}}'
       ARG_FLAG: '{{if eq .ARCH "amd64"}}AMD64{{else}}ARM64{{end}}'
+      INSTALL_SCOPE: '{{.INSTALL_SCOPE | default "machine"}}'
 
   create:msix:package:
     summary: Creates an MSIX package
@@ -181,6 +185,10 @@ tasks:
       Password is retrieved from system keychain (run: wails3 setup signing)
     deps:
       - task: create:nsis:installer
+        vars:
+          INSTALL_SCOPE: '{{.INSTALL_SCOPE | default "machine"}}'
+    vars:
+      INSTALL_SCOPE: '{{.INSTALL_SCOPE | default "machine"}}'
     cmds:
       - wails3 tool sign --input "build/windows/nsis/{{.APP_NAME}}-installer.exe" {{if .SIGN_CERTIFICATE}}--certificate {{.SIGN_CERTIFICATE}}{{end}} {{if .SIGN_THUMBPRINT}}--thumbprint {{.SIGN_THUMBPRINT}}{{end}} {{if .TIMESTAMP_SERVER}}--timestamp {{.TIMESTAMP_SERVER}}{{end}}
     preconditions:

--- a/v3/internal/commands/build_assets/windows/nsis/project.nsi.tmpl
+++ b/v3/internal/commands/build_assets/windows/nsis/project.nsi.tmpl
@@ -72,7 +72,15 @@ ManifestDPIAware true
 
 Name "${INFO_PRODUCTNAME}"
 OutFile "..\..\..\bin\${INFO_PROJECTNAME}-${ARCH}-installer.exe" # Name of the installer's file.
-InstallDir "$PROGRAMFILES64\${INFO_COMPANYNAME}\${INFO_PRODUCTNAME}" # Default installing folder ($PROGRAMFILES is Program Files folder).
+!ifdef WAILS_INSTALL_SCOPE
+    !if "${WAILS_INSTALL_SCOPE}" == "user"
+        InstallDir "$LOCALAPPDATA\Programs\${INFO_PRODUCTNAME}"
+    !else
+        InstallDir "$PROGRAMFILES64\${INFO_COMPANYNAME}\${INFO_PRODUCTNAME}"
+    !endif
+!else
+    InstallDir "$PROGRAMFILES64\${INFO_COMPANYNAME}\${INFO_PRODUCTNAME}"
+!endif
 ShowInstDetails show # This will always show the installation details.
 
 Function .onInit

--- a/v3/internal/commands/updatable_build_assets/windows/nsis/wails_tools.nsh.tmpl
+++ b/v3/internal/commands/updatable_build_assets/windows/nsis/wails_tools.nsh.tmpl
@@ -115,23 +115,57 @@ RequestExecutionLevel "${REQUEST_EXECUTION_LEVEL}"
     WriteUninstaller "$INSTDIR\uninstall.exe"
 
     SetRegView 64
-    WriteRegStr HKLM "${UNINST_KEY}" "Publisher" "${INFO_COMPANYNAME}"
-    WriteRegStr HKLM "${UNINST_KEY}" "DisplayName" "${INFO_PRODUCTNAME}"
-    WriteRegStr HKLM "${UNINST_KEY}" "DisplayVersion" "${INFO_PRODUCTVERSION}"
-    WriteRegStr HKLM "${UNINST_KEY}" "DisplayIcon" "$INSTDIR\${PRODUCT_EXECUTABLE}"
-    WriteRegStr HKLM "${UNINST_KEY}" "UninstallString" "$\"$INSTDIR\uninstall.exe$\""
-    WriteRegStr HKLM "${UNINST_KEY}" "QuietUninstallString" "$\"$INSTDIR\uninstall.exe$\" /S"
+    !ifdef WAILS_INSTALL_SCOPE
+        !if "${WAILS_INSTALL_SCOPE}" == "user"
+            WriteRegStr HKCU "${UNINST_KEY}" "Publisher" "${INFO_COMPANYNAME}"
+            WriteRegStr HKCU "${UNINST_KEY}" "DisplayName" "${INFO_PRODUCTNAME}"
+            WriteRegStr HKCU "${UNINST_KEY}" "DisplayVersion" "${INFO_PRODUCTVERSION}"
+            WriteRegStr HKCU "${UNINST_KEY}" "DisplayIcon" "$INSTDIR\${PRODUCT_EXECUTABLE}"
+            WriteRegStr HKCU "${UNINST_KEY}" "UninstallString" "$\"$INSTDIR\uninstall.exe$\""
+            WriteRegStr HKCU "${UNINST_KEY}" "QuietUninstallString" "$\"$INSTDIR\uninstall.exe$\" /S"
 
-    ${GetSize} "$INSTDIR" "/S=0K" $0 $1 $2
-    IntFmt $0 "0x%08X" $0
-    WriteRegDWORD HKLM "${UNINST_KEY}" "EstimatedSize" "$0"
+            ${GetSize} "$INSTDIR" "/S=0K" $0 $1 $2
+            IntFmt $0 "0x%08X" $0
+            WriteRegDWORD HKCU "${UNINST_KEY}" "EstimatedSize" "$0"
+        !else
+            WriteRegStr HKLM "${UNINST_KEY}" "Publisher" "${INFO_COMPANYNAME}"
+            WriteRegStr HKLM "${UNINST_KEY}" "DisplayName" "${INFO_PRODUCTNAME}"
+            WriteRegStr HKLM "${UNINST_KEY}" "DisplayVersion" "${INFO_PRODUCTVERSION}"
+            WriteRegStr HKLM "${UNINST_KEY}" "DisplayIcon" "$INSTDIR\${PRODUCT_EXECUTABLE}"
+            WriteRegStr HKLM "${UNINST_KEY}" "UninstallString" "$\"$INSTDIR\uninstall.exe$\""
+            WriteRegStr HKLM "${UNINST_KEY}" "QuietUninstallString" "$\"$INSTDIR\uninstall.exe$\" /S"
+
+            ${GetSize} "$INSTDIR" "/S=0K" $0 $1 $2
+            IntFmt $0 "0x%08X" $0
+            WriteRegDWORD HKLM "${UNINST_KEY}" "EstimatedSize" "$0"
+        !endif
+    !else
+        WriteRegStr HKLM "${UNINST_KEY}" "Publisher" "${INFO_COMPANYNAME}"
+        WriteRegStr HKLM "${UNINST_KEY}" "DisplayName" "${INFO_PRODUCTNAME}"
+        WriteRegStr HKLM "${UNINST_KEY}" "DisplayVersion" "${INFO_PRODUCTVERSION}"
+        WriteRegStr HKLM "${UNINST_KEY}" "DisplayIcon" "$INSTDIR\${PRODUCT_EXECUTABLE}"
+        WriteRegStr HKLM "${UNINST_KEY}" "UninstallString" "$\"$INSTDIR\uninstall.exe$\""
+        WriteRegStr HKLM "${UNINST_KEY}" "QuietUninstallString" "$\"$INSTDIR\uninstall.exe$\" /S"
+
+        ${GetSize} "$INSTDIR" "/S=0K" $0 $1 $2
+        IntFmt $0 "0x%08X" $0
+        WriteRegDWORD HKLM "${UNINST_KEY}" "EstimatedSize" "$0"
+    !endif
 !macroend
 
 !macro wails.deleteUninstaller
     Delete "$INSTDIR\uninstall.exe"
 
     SetRegView 64
-    DeleteRegKey HKLM "${UNINST_KEY}"
+    !ifdef WAILS_INSTALL_SCOPE
+        !if "${WAILS_INSTALL_SCOPE}" == "user"
+            DeleteRegKey HKCU "${UNINST_KEY}"
+        !else
+            DeleteRegKey HKLM "${UNINST_KEY}"
+        !endif
+    !else
+        DeleteRegKey HKLM "${UNINST_KEY}"
+    !endif
 !macroend
 
 !macro wails.setShellContext


### PR DESCRIPTION
## Summary

Port of #5094 (v2) to v3.

Adds an `INSTALL_SCOPE` Taskfile variable (default: `machine`) to the Windows build. When set to `user`, the NSIS installer:

- Installs to `$LOCALAPPDATA\Programs\<ProductName>` instead of `$PROGRAMFILES64`
- Registers uninstall entries in `HKCU` instead of `HKLM`
- Runs without a UAC elevation prompt (`RequestExecutionLevel user`)

### Usage

```sh
# Build a user-scope installer (no UAC prompt)
task package INSTALL_SCOPE=user

# Default machine-scope installer (unchanged behaviour)
task package
```

### Files changed

- `v3/internal/commands/build_assets/windows/Taskfile.yml` — adds `INSTALL_SCOPE` var and forwards it through `package`, `create:nsis:installer`, and `sign:installer`
- `v3/internal/commands/build_assets/windows/nsis/project.nsi.tmpl` — conditional `InstallDir` based on scope
- `v3/internal/commands/updatable_build_assets/windows/nsis/wails_tools.nsh.tmpl` — conditional HKCU/HKLM registry writes in `wails.writeUninstaller` and `wails.deleteUninstaller`

Example `project.nsi` and `wails_tools.nsh` files in `v3/examples/` should be regenerated by running `wails3 update` in each example project after this merges.

### Backward compatibility

Default behaviour (`INSTALL_SCOPE=machine`) is unchanged — all existing builds continue to produce admin-scoped installers targeting `$PROGRAMFILES64` / `HKLM`.

Related: WAI-93
Closes wailsapp/wails#5094 (v3 port)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Windows installers now support configurable installation scope: per-user or system-wide
  * Per-user installations place application files in the user's local folder instead of Program Files
  * Registry entries are appropriately configured based on the selected installation scope

<!-- end of auto-generated comment: release notes by coderabbit.ai -->