### PR TITLE
docs(v3): replace Alpha placeholder README with Beta landing page

### DIFF
--- a/v3/README.md
+++ b/v3/README.md
@@ -1,9 +1,31 @@
-# v3 Alpha
+# Wails v3 Beta
 
-Thanks for wanting to help out with testing/developing Wails v3! This guide will help you get started.
+Wails v3 is in public Beta. The core APIs are stable and ready for building real applications.
+
+## Supported Platforms
+
+| Platform | Status |
+|---|---|
+| macOS 12+ | Supported |
+| Windows 10+ | Supported |
+| Linux (GTK3) | Supported (default) |
+| Linux (GTK4) | Experimental — build with `-tags gtk4` |
+
+**Not in this Beta:** iOS and Android support is planned for a post-Beta release. WebAssembly is not in scope for v3.
+
+## API Stability
+
+The packages listed in [STABILITY.md](STABILITY.md) have stable APIs. Breaking changes will be documented in the changelog. Everything under `internal/` remains unstable.
 
 ## Getting Started
 
-All the instructions for getting started are in the v3 documentation directory: `mkdocs-website`. 
-Please read the README.md file in that directory for more information.
+Full documentation is available at **https://v3.wails.io**.
 
+## Migrating from v2
+
+See the [v2 → v3 migration guide](https://v3.wails.io/guides/migrating/) for a step-by-step walkthrough of the breaking changes and how to update your application.
+
+## Known Limitations
+
+- **Wayland — window positioning:** The Wayland protocol does not expose an API for absolute window placement. `SetPosition` and related calls are a no-op on compositors that do not support `xdg-shell` position hints. Use X11/XWayland if you need deterministic positioning.
+- **GTK4 — hardware testing:** Phase-10 hardware compatibility testing for GTK4 is still in progress. Expect rough edges on some GPU/driver combinations.

--- a/v3/STABILITY.md
+++ b/v3/STABILITY.md
@@ -1,0 +1,12 @@
+# Wails v3 API Stability
+
+The following packages have stable APIs as of the Beta release. Breaking changes in these packages will be noted in the changelog and avoided wherever possible.
+
+| Package | Notes |
+|---|---|
+| `github.com/wailsapp/wails/v3/pkg/application` | Core application, window, and menu APIs |
+| `github.com/wailsapp/wails/v3/pkg/events` | Application and window event constants |
+| `github.com/wailsapp/wails/v3/pkg/services` | Built-in service interfaces |
+| `github.com/wailsapp/wails/v3/pkg/icons` | Icon loading helpers |
+
+Packages not listed above (including anything under `internal/`) are **unstable** and may change without notice.


### PR DESCRIPTION
## Summary

- Rewrites `v3/README.md` (was 8 lines pointing at a non-existent mkdocs path) with a proper Beta landing page covering supported platforms, out-of-scope items, API stability, getting-started and migration links, and known limitations
- Adds `v3/STABILITY.md` listing the packages with stable APIs that the new README references

## Content checklist

- [x] Beta scope: macOS 12+, Windows 10+, Linux GTK3/GTK4
- [x] Not in Beta: iOS, Android, WebAssembly
- [x] Stability: links to new `STABILITY.md`
- [x] Getting started: links to https://v3.wails.io
- [x] v2 migration: links to migration guide
- [x] Known limitations: Wayland positioning no-op; GTK4 hardware testing pending
- [x] Under 100 lines (31 lines)

🤖 Generated with [Claude Code](https://claude.com/claude-code)