### PR TITLE
feat(v3): add mac.DisableEscapeExitsFullscreen opt-in for fullscreen Esc

### DIFF
--- a/v3/pkg/application/webview_window_darwin.go
+++ b/v3/pkg/application/webview_window_darwin.go
@@ -703,6 +703,11 @@ void windowSetShadow(void* nsWindow, bool hasShadow) {
 	[(WebviewWindow*)nsWindow setHasShadow:hasShadow];
 }
 
+// Set whether the Escape key should be prevented from exiting fullscreen
+void windowSetDisableEscapeExitsFullscreen(void* nsWindow, bool disable) {
+	[(WebviewWindow*)nsWindow setDisableEscapeExitsFullscreen:disable];
+}
+
 
 
 // windowClose closes the current window
@@ -1350,6 +1355,9 @@ func (w *macosWebviewWindow) run() {
 			C.bool(options.EnableFileDrop),
 			w.getWebviewPreferences(),
 		)
+		if macOptions.DisableEscapeExitsFullscreen {
+			C.windowSetDisableEscapeExitsFullscreen(w.nsWindow, C.bool(true))
+		}
 		w.setTitle(options.Title)
 		w.setResizable(!options.DisableResize)
 		if options.MinWidth != 0 || options.MinHeight != 0 {

--- a/v3/pkg/application/webview_window_darwin.h
+++ b/v3/pkg/application/webview_window_darwin.h
@@ -15,6 +15,7 @@
 - (WebviewWindow*) initWithContentRect:(NSRect)contentRect styleMask:(NSUInteger)windowStyle backing:(NSBackingStoreType)bufferingType defer:(BOOL)deferCreation;
 
 @property (assign) WKWebView* webView; // We already retain WKWebView since it's part of the Window.
+@property BOOL disableEscapeExitsFullscreen;
 
 @end
 

--- a/v3/pkg/application/webview_window_darwin.m
+++ b/v3/pkg/application/webview_window_darwin.m
@@ -191,6 +191,13 @@ typedef NS_ENUM(NSInteger, MacLiquidGlassStyle) {
 - (BOOL) resignFirstResponder {
     return YES;
 }
+- (void) cancelOperation:(id)sender {
+    if (self.disableEscapeExitsFullscreen &&
+        (self.styleMask & NSWindowStyleMaskFullScreen) == NSWindowStyleMaskFullScreen) {
+        return;
+    }
+    [super cancelOperation:sender];
+}
 - (void) setDelegate:(id<NSWindowDelegate>) delegate {
     [delegate retain];
     [super setDelegate: delegate];

--- a/v3/pkg/application/webview_window_options.go
+++ b/v3/pkg/application/webview_window_options.go
@@ -491,6 +491,12 @@ type MacWindow struct {
 
 	// LiquidGlass contains configuration for the Liquid Glass effect
 	LiquidGlass MacLiquidGlass
+
+	// DisableEscapeExitsFullscreen prevents the Escape key from exiting fullscreen mode.
+	// When true, Esc keypresses are swallowed while the window is fullscreen, allowing
+	// web content (e.g. modals with Esc-to-close behaviour) to handle Esc directly.
+	// Default false preserves standard macOS behaviour where Esc exits fullscreen.
+	DisableEscapeExitsFullscreen bool
 }
 
 type MacWindowLevel string


### PR DESCRIPTION
## Summary

Ports `DisableEscapeExitsFullscreen` from v2 (PR #5242) to v3.

When `Mac.DisableEscapeExitsFullscreen: true`, the Escape key is swallowed while the window is fullscreen, allowing web content (modals, custom Esc handlers) to consume it. Default `false` preserves standard macOS behaviour (Esc exits fullscreen) for all existing apps.

## Implementation

**`cancelOperation:` override on `WebviewWindow`** checks both the flag and `NSWindowStyleMaskFullScreen` before deciding whether to call `[super cancelOperation:sender]`:

```objc
- (void) cancelOperation:(id)sender {
    if (self.disableEscapeExitsFullscreen &&
        (self.styleMask & NSWindowStyleMaskFullScreen) == NSWindowStyleMaskFullScreen) {
        return;
    }
    [super cancelOperation:sender];
}
```

## Files changed (4, +22/-0)

| File | Change |
|---|---|
| `v3/pkg/application/webview_window_options.go` | Added `DisableEscapeExitsFullscreen bool` to `MacWindow` struct |
| `v3/pkg/application/webview_window_darwin.h` | Added `@property BOOL disableEscapeExitsFullscreen` to `WebviewWindow` |
| `v3/pkg/application/webview_window_darwin.m` | Added `cancelOperation:` override |
| `v3/pkg/application/webview_window_darwin.go` | Added C bridge `windowSetDisableEscapeExitsFullscreen()`; called at window creation when flag is true |

## Usage

```go
app.NewWebviewWindowWithOptions(application.WebviewWindowOptions{
    Mac: application.MacWindow{
        // When true: Esc is swallowed while fullscreen so web content can handle it.
        // Default false → standard macOS behaviour (Esc exits fullscreen).
        DisableEscapeExitsFullscreen: true,
    },
})
```

## Notes

- Default `false` — zero breaking change for existing apps.
- This is a 1-for-1 port of the v2 implementation (commit `eaf56c932`) already reviewed and merged via PR #5242.
- Build verified: `go build ./v3/pkg/application` — clean, no errors or warnings.

Ports v2 PR #5242.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new macOS configuration option to prevent the Escape key from exiting fullscreen mode, enabling custom fullscreen behavior handling on supported platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->