### PR TITLE
fix(icons): emit warning instead of silent no-op when Assets.car generation is unsupported

### DIFF
--- a/v3/internal/commands/icons.go
+++ b/v3/internal/commands/icons.go
@@ -30,8 +30,8 @@ type IconsOptions struct {
 	Sizes             string `description:"The sizes to generate in .ico file (comma separated)" default:"256,128,64,48,32,16"`
 	WindowsFilename   string `description:"The output filename for the Windows icon"`
 	MacFilename       string `description:"The output filename for the Mac icon bundle"`
-	IconComposerInput string `description:"The input Icon Composer file (.icon)"`
-	MacAssetDir       string `description:"The output directory for the Mac assets (Assets.car and icons.icns)"`
+	IconComposerInput string `description:"The input Icon Composer file (.icon) [requires macOS 26 or later with Xcode CLT actool 26+]"`
+	MacAssetDir       string `description:"The output directory for the Mac assets (Assets.car and icons.icns) [requires macOS 26 or later with Xcode CLT actool 26+]"`
 }
 
 func GenerateIcons(options *IconsOptions) error {
@@ -74,7 +74,8 @@ func GenerateIcons(options *IconsOptions) error {
 					if options.Input == "" {
 						return fmt.Errorf("icon composer input requires macOS for mac asset generation: %w", err)
 					}
-					// Fallback to input-based generation will run below
+					// Warn but fall through to input-based generation
+					fmt.Fprintf(os.Stderr, "Warning: %s\n", err)
 				} else {
 					return err
 				}
@@ -161,57 +162,57 @@ func generateMacIcon(iconData []byte, options *IconsOptions) error {
 func generateMacAsset(options *IconsOptions) error {
 	//Check if running on darwin (macOS), because this will only run on a mac
 	if runtime.GOOS != "darwin" {
-		return ErrMacAssetNotSupported
+		return fmt.Errorf("Assets.car generation is only supported on macOS (current platform: %s): %w", runtime.GOOS, ErrMacAssetNotSupported)
 	}
 	// Get system info, because this will only run on macOS 26 or later
 	info, err := operatingsystem.Info()
 	if err != nil {
-		return ErrMacAssetNotSupported
+		return fmt.Errorf("Assets.car generation requires macOS 26 or later (failed to get system info): %w", ErrMacAssetNotSupported)
 	}
 	majorStr, _, found := strings.Cut(info.Version, ".")
 	if !found {
-		return ErrMacAssetNotSupported
+		return fmt.Errorf("Assets.car generation requires macOS 26 or later (failed to parse version %q): %w", info.Version, ErrMacAssetNotSupported)
 	}
 	major, err := strconv.Atoi(majorStr)
 	if err != nil {
-		return ErrMacAssetNotSupported
+		return fmt.Errorf("Assets.car generation requires macOS 26 or later (failed to parse version %q): %w", info.Version, ErrMacAssetNotSupported)
 	}
 	if major < 26 {
-		return ErrMacAssetNotSupported
+		return fmt.Errorf("Assets.car generation requires macOS 26 or later (current version: %s): %w", info.Version, ErrMacAssetNotSupported)
 	}
 
 	cmd := exec.Command("/usr/bin/actool", "--version")
 	versionPlist, err := cmd.Output()
 	if err != nil {
-		return ErrMacAssetNotSupported
+		return fmt.Errorf("Assets.car generation requires actool 26 or later (actool not found at /usr/bin/actool — install Xcode): %w", ErrMacAssetNotSupported)
 	}
 
 	// Parse the plist to extract short-bundle-version
 	var plistData map[string]any
 	if _, err := plist.Unmarshal(versionPlist, &plistData); err != nil {
-		return ErrMacAssetNotSupported
+		return fmt.Errorf("Assets.car generation requires actool 26 or later (failed to parse actool version output): %w", ErrMacAssetNotSupported)
 	}
 
 	// Navigate to com.apple.actool.version -> short-bundle-version
 	actoolVersion, ok := plistData["com.apple.actool.version"].(map[string]any)
 	if !ok {
-		return ErrMacAssetNotSupported
+		return fmt.Errorf("Assets.car generation requires actool 26 or later (com.apple.actool.version not found in output): %w", ErrMacAssetNotSupported)
 	}
 
 	shortVersion, ok := actoolVersion["short-bundle-version"].(string)
 	if !ok {
-		return ErrMacAssetNotSupported
+		return fmt.Errorf("Assets.car generation requires actool 26 or later (short-bundle-version not found in output): %w", ErrMacAssetNotSupported)
 	}
 
 	// Parse the major version number (e.g., "26.2" -> 26)
 	actoolMajorStr, _, _ := strings.Cut(shortVersion, ".")
 	actoolMajor, err := strconv.Atoi(actoolMajorStr)
 	if err != nil {
-		return ErrMacAssetNotSupported
+		return fmt.Errorf("Assets.car generation requires actool 26 or later (failed to parse actool version %q): %w", shortVersion, ErrMacAssetNotSupported)
 	}
 
 	if actoolMajor < 26 {
-		return ErrMacAssetNotSupported
+		return fmt.Errorf("Assets.car generation requires actool 26 or later (current actool version: %s): %w", shortVersion, ErrMacAssetNotSupported)
 	}
 
 	// Convert paths to absolute paths (required for actool)

--- a/v3/internal/commands/icons_test.go
+++ b/v3/internal/commands/icons_test.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"testing"
@@ -315,8 +316,13 @@ func TestGenerateIcon(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if tt.requireDarwin && (runtime.GOOS != "darwin" || os.Getenv("CI") != "") {
-				t.Skip("Assets.car generation is only supported on macOS and not in CI")
+			if tt.requireDarwin {
+				if runtime.GOOS != "darwin" || os.Getenv("CI") != "" {
+					t.Skip("Assets.car generation is only supported on macOS and not in CI")
+				}
+				if exec.Command("/usr/bin/actool", "--version").Run() != nil {
+					t.Skip("actool not functional — install full Xcode (Xcode CLT alone is not sufficient)")
+				}
 			}
 
 			options := tt.setup()
@@ -331,5 +337,36 @@ func TestGenerateIcon(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// TestGenerateIconsFallthrough verifies that when both -input and -iconcomposerinput are
+// provided but Assets.car generation is unsupported, GenerateIcons still produces the
+// requested .ico file without returning an error.
+func TestGenerateIconsFallthrough(t *testing.T) {
+	_, thisFile, _, _ := runtime.Caller(0)
+	localDir := filepath.Dir(thisFile)
+	exampleIcon := filepath.Join(localDir, "build_assets", "appicon.png")
+	exampleIconFile := filepath.Join(localDir, "build_assets", "appicon.icon")
+	tmpDir := t.TempDir()
+	icoOut := filepath.Join(tmpDir, "appicon.ico")
+
+	options := &IconsOptions{
+		Input:             exampleIcon,
+		WindowsFilename:   icoOut,
+		IconComposerInput: exampleIconFile,
+		MacAssetDir:       tmpDir,
+	}
+
+	if err := GenerateIcons(options); err != nil {
+		t.Fatalf("GenerateIcons() unexpected error: %v", err)
+	}
+
+	f, err := os.Stat(icoOut)
+	if err != nil {
+		t.Fatalf("expected %s to exist: %v", icoOut, err)
+	}
+	if f.Size() == 0 {
+		t.Fatal("appicon.ico is empty")
 	}
 }


### PR DESCRIPTION
Closes #5260.

## Problem

`wails3 generate icons -iconcomposerinput appicon.icon -macassetdir darwin` exited 0 with no output when Assets.car couldn't be generated (wrong platform, macOS < 26, or actool unavailable). Users assumed the command worked because there was no error, but `darwin/Assets.car` was never updated.

## Changes

**`v3/internal/commands/icons.go`**
- Each bare `return ErrMacAssetNotSupported` in `generateMacAsset()` is now a descriptive `fmt.Errorf("...: %w", ErrMacAssetNotSupported)`, covering platform, macOS version, actool availability, and actool version. `errors.Is(err, ErrMacAssetNotSupported)` semantics preserved via `%w`.
- `GenerateIcons()` now prints `Warning: <reason>` to stderr on the fallthrough path instead of silently swallowing the error.
- `-iconcomposerinput` and `-macassetdir` flag descriptions mention the macOS 26 + Xcode actool 26+ requirement.

**`v3/internal/commands/icons_test.go`**
- `requireDarwin` skip also checks actool functionality (handles macOS 26 machines with CLT but not full Xcode).
- New `TestGenerateIconsFallthrough`: verifies `.ico` is still produced when Assets.car is unavailable.

## Before

```
$ wails3 generate icons -input appicon.png -macfilename darwin/icons.icns \
  -windowsfilename windows/icon.ico \
  -iconcomposerinput appicon.icon -macassetdir darwin
$   # exit 0, no output, Assets.car unchanged — silent no-op
```

## After

```
$ wails3 generate icons -input appicon.png -macfilename darwin/icons.icns \
  -windowsfilename windows/icon.ico \
  -iconcomposerinput appicon.icon -macassetdir darwin
Warning: Assets.car generation requires actool 26 or later (actool not found at /usr/bin/actool — install Xcode): mac asset generation is only supported on macOS
$   # exit 0, .icns and .ico regenerated, warning explains why Assets.car was skipped
```

## Test results

```
go test ./internal/commands/ -run "TestGenerateIcon|TestGenerateIconsFallthrough" -v -count=1
--- PASS: TestGenerateIcon (0.29s)  — 10 pass, 1 skip (actool not functional)
--- PASS: TestGenerateIconsFallthrough (0.09s)
PASS  ok  github.com/wailsapp/wails/v3/internal/commands  1.034s
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Icon generation now falls back to alternative formats when macOS asset generation is unavailable.

* **Bug Fixes**
  * Improved error handling and warnings when macOS 26+ with Xcode CLT 26+ is required.
  * Updated system requirements documentation.

* **Tests**
  * Added test coverage for icon generation fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->