### PR TITLE
fix(darwin): add `DisableEscapeExitsFullscreen` opt-in to `mac.Options`

### DIFF
--- a/v2/internal/frontend/desktop/darwin/Application.h
+++ b/v2/internal/frontend/desktop/darwin/Application.h
@@ -17,7 +17,7 @@
 #define WindowStartsMinimised 2
 #define WindowStartsFullscreen 3
 
-WailsContext* Create(const char* title, int width, int height, int frameless, int resizable, int zoomable, int fullscreen, int fullSizeContent, int hideTitleBar, int titlebarAppearsTransparent, int hideTitle, int useToolbar, int hideToolbarSeparator, int webviewIsTransparent, int alwaysOnTop, int hideWindowOnClose, const char *appearance, int windowIsTranslucent, int contentProtection, int devtoolsEnabled, int defaultContextMenuEnabled, int windowStartState, int startsHidden, int minWidth, int minHeight, int maxWidth, int maxHeight, bool fraudulentWebsiteWarningEnabled, struct Preferences preferences, int singleInstanceLockEnabled, const char* singleInstanceUniqueId, bool enableDragAndDrop, bool disableWebViewDragAndDrop);
+WailsContext* Create(const char* title, int width, int height, int frameless, int resizable, int zoomable, int fullscreen, int fullSizeContent, int hideTitleBar, int titlebarAppearsTransparent, int hideTitle, int useToolbar, int hideToolbarSeparator, int webviewIsTransparent, int alwaysOnTop, int hideWindowOnClose, const char *appearance, int windowIsTranslucent, int contentProtection, int devtoolsEnabled, int defaultContextMenuEnabled, int windowStartState, int startsHidden, int minWidth, int minHeight, int maxWidth, int maxHeight, bool fraudulentWebsiteWarningEnabled, struct Preferences preferences, int singleInstanceLockEnabled, const char* singleInstanceUniqueId, bool enableDragAndDrop, bool disableWebViewDragAndDrop, int disableEscapeExitsFullscreen);
 void Run(void*, const char* url);
 
 void SetTitle(void* ctx, const char *title);

--- a/v2/internal/frontend/desktop/darwin/Application.m
+++ b/v2/internal/frontend/desktop/darwin/Application.m
@@ -14,7 +14,7 @@
 #import "WailsMenu.h"
 #import "WailsMenuItem.h"
 
-WailsContext* Create(const char* title, int width, int height, int frameless, int resizable, int zoomable, int fullscreen, int fullSizeContent, int hideTitleBar, int titlebarAppearsTransparent, int hideTitle, int useToolbar, int hideToolbarSeparator, int webviewIsTransparent, int alwaysOnTop, int hideWindowOnClose, const char *appearance, int windowIsTranslucent, int contentProtection, int devtoolsEnabled, int defaultContextMenuEnabled, int windowStartState, int startsHidden, int minWidth, int minHeight, int maxWidth, int maxHeight, bool fraudulentWebsiteWarningEnabled, struct Preferences preferences, int singleInstanceLockEnabled, const char* singleInstanceUniqueId, bool enableDragAndDrop, bool disableWebViewDragAndDrop) {
+WailsContext* Create(const char* title, int width, int height, int frameless, int resizable, int zoomable, int fullscreen, int fullSizeContent, int hideTitleBar, int titlebarAppearsTransparent, int hideTitle, int useToolbar, int hideToolbarSeparator, int webviewIsTransparent, int alwaysOnTop, int hideWindowOnClose, const char *appearance, int windowIsTranslucent, int contentProtection, int devtoolsEnabled, int defaultContextMenuEnabled, int windowStartState, int startsHidden, int minWidth, int minHeight, int maxWidth, int maxHeight, bool fraudulentWebsiteWarningEnabled, struct Preferences preferences, int singleInstanceLockEnabled, const char* singleInstanceUniqueId, bool enableDragAndDrop, bool disableWebViewDragAndDrop, int disableEscapeExitsFullscreen) {
 
     [NSApplication sharedApplication];
 
@@ -27,7 +27,7 @@ WailsContext* Create(const char* title, int width, int height, int frameless, in
         fullscreen = 1;
     }
 
-    [result CreateWindow:width :height :frameless :resizable :zoomable :fullscreen :fullSizeContent :hideTitleBar :titlebarAppearsTransparent :hideTitle :useToolbar :hideToolbarSeparator :webviewIsTransparent :hideWindowOnClose :safeInit(appearance) :windowIsTranslucent :minWidth :minHeight :maxWidth :maxHeight :fraudulentWebsiteWarningEnabled :preferences :enableDragAndDrop :disableWebViewDragAndDrop];
+    [result CreateWindow:width :height :frameless :resizable :zoomable :fullscreen :fullSizeContent :hideTitleBar :titlebarAppearsTransparent :hideTitle :useToolbar :hideToolbarSeparator :webviewIsTransparent :hideWindowOnClose :safeInit(appearance) :windowIsTranslucent :minWidth :minHeight :maxWidth :maxHeight :fraudulentWebsiteWarningEnabled :preferences :enableDragAndDrop :disableWebViewDragAndDrop :disableEscapeExitsFullscreen];
     [result SetTitle:safeInit(title)];
     [result Center];
 

--- a/v2/internal/frontend/desktop/darwin/WailsContext.h
+++ b/v2/internal/frontend/desktop/darwin/WailsContext.h
@@ -24,6 +24,7 @@
 
 @property NSSize userMinSize;
 @property NSSize userMaxSize;
+@property bool disableEscapeExitsFullscreen;
 
 - (BOOL) canBecomeKeyWindow;
 - (void) applyWindowConstraints;
@@ -65,7 +66,7 @@ struct Preferences {
   bool *fullscreenEnabled;
 };
 
-- (void) CreateWindow:(int)width :(int)height :(bool)frameless :(bool)resizable :(bool)zoomable :(bool)fullscreen :(bool)fullSizeContent :(bool)hideTitleBar :(bool)titlebarAppearsTransparent  :(bool)hideTitle :(bool)useToolbar :(bool)hideToolbarSeparator :(bool)webviewIsTransparent :(bool)hideWindowOnClose :(NSString *)appearance :(bool)windowIsTranslucent :(int)minWidth :(int)minHeight :(int)maxWidth :(int)maxHeight :(bool)fraudulentWebsiteWarningEnabled :(struct Preferences)preferences :(bool)enableDragAndDrop :(bool)disableWebViewDragAndDrop;
+- (void) CreateWindow:(int)width :(int)height :(bool)frameless :(bool)resizable :(bool)zoomable :(bool)fullscreen :(bool)fullSizeContent :(bool)hideTitleBar :(bool)titlebarAppearsTransparent  :(bool)hideTitle :(bool)useToolbar :(bool)hideToolbarSeparator :(bool)webviewIsTransparent :(bool)hideWindowOnClose :(NSString *)appearance :(bool)windowIsTranslucent :(int)minWidth :(int)minHeight :(int)maxWidth :(int)maxHeight :(bool)fraudulentWebsiteWarningEnabled :(struct Preferences)preferences :(bool)enableDragAndDrop :(bool)disableWebViewDragAndDrop :(bool)disableEscapeExitsFullscreen;
 - (void) SetSize:(int)width :(int)height;
 - (void) SetPosition:(int)x :(int) y;
 - (void) SetMinSize:(int)minWidth :(int)minHeight;

--- a/v2/internal/frontend/desktop/darwin/WailsContext.m
+++ b/v2/internal/frontend/desktop/darwin/WailsContext.m
@@ -35,6 +35,14 @@ typedef void (^schemeTaskCaller)(id<WKURLSchemeTask>);
     [self setMaxSize:NSMakeSize(FLT_MAX, FLT_MAX)];
 }
 
+- (void)cancelOperation:(id)sender {
+    if (self.disableEscapeExitsFullscreen &&
+        (self.styleMask & NSWindowStyleMaskFullScreen) == NSWindowStyleMaskFullScreen) {
+        return;
+    }
+    [super cancelOperation:sender];
+}
+
 @end
 
 // Notifications
@@ -145,7 +153,7 @@ extern void didReceiveNotificationResponse(const char *jsonPayload, const char* 
     return NO;
 }
 
-- (void) CreateWindow:(int)width :(int)height :(bool)frameless :(bool)resizable :(bool)zoomable :(bool)fullscreen :(bool)fullSizeContent :(bool)hideTitleBar :(bool)titlebarAppearsTransparent :(bool)hideTitle :(bool)useToolbar :(bool)hideToolbarSeparator :(bool)webviewIsTransparent :(bool)hideWindowOnClose :(NSString*)appearance :(bool)windowIsTranslucent :(int)minWidth :(int)minHeight :(int)maxWidth :(int)maxHeight :(bool)fraudulentWebsiteWarningEnabled :(struct Preferences)preferences :(bool)enableDragAndDrop :(bool)disableWebViewDragAndDrop  {
+- (void) CreateWindow:(int)width :(int)height :(bool)frameless :(bool)resizable :(bool)zoomable :(bool)fullscreen :(bool)fullSizeContent :(bool)hideTitleBar :(bool)titlebarAppearsTransparent :(bool)hideTitle :(bool)useToolbar :(bool)hideToolbarSeparator :(bool)webviewIsTransparent :(bool)hideWindowOnClose :(NSString*)appearance :(bool)windowIsTranslucent :(int)minWidth :(int)minHeight :(int)maxWidth :(int)maxHeight :(bool)fraudulentWebsiteWarningEnabled :(struct Preferences)preferences :(bool)enableDragAndDrop :(bool)disableWebViewDragAndDrop :(bool)disableEscapeExitsFullscreen {
     NSWindowStyleMask styleMask = 0;
 
     if( !frameless ) {
@@ -167,6 +175,7 @@ extern void didReceiveNotificationResponse(const char *jsonPayload, const char* 
 
     self.mainWindow = [[WailsWindow alloc] initWithContentRect:NSMakeRect(0, 0, width, height)
                                                       styleMask:styleMask backing:NSBackingStoreBuffered defer:NO];
+    self.mainWindow.disableEscapeExitsFullscreen = disableEscapeExitsFullscreen;
     if (!frameless && useToolbar) {
         id toolbar = [[NSToolbar alloc] initWithIdentifier:@"wails.toolbar"];
         [toolbar autorelease];

--- a/v2/internal/frontend/desktop/darwin/window.go
+++ b/v2/internal/frontend/desktop/darwin/window.go
@@ -64,6 +64,7 @@ func NewWindow(frontendOptions *options.App, debug bool, devtools bool) *Window 
 
 	var fullSizeContent, hideTitleBar, zoomable, hideTitle, useToolbar, webviewIsTransparent C.int
 	var titlebarAppearsTransparent, hideToolbarSeparator, windowIsTranslucent, contentProtection C.int
+	var disableEscapeExitsFullscreen C.int
 	var appearance, title *C.char
 	var preferences C.struct_Preferences
 
@@ -118,6 +119,7 @@ func NewWindow(frontendOptions *options.App, debug bool, devtools bool) *Window 
 		windowIsTranslucent = bool2Cint(mac.WindowIsTranslucent)
 		webviewIsTransparent = bool2Cint(mac.WebviewIsTransparent)
 		contentProtection = bool2Cint(mac.ContentProtection)
+		disableEscapeExitsFullscreen = bool2Cint(mac.DisableEscapeExitsFullscreen)
 
 		appearance = c.String(string(mac.Appearance))
 	}
@@ -126,6 +128,7 @@ func NewWindow(frontendOptions *options.App, debug bool, devtools bool) *Window 
 		alwaysOnTop, hideWindowOnClose, appearance, windowIsTranslucent, contentProtection, devtoolsEnabled, defaultContextMenuEnabled,
 		windowStartState, startsHidden, minWidth, minHeight, maxWidth, maxHeight, enableFraudulentWebsiteWarnings,
 		preferences, singleInstanceEnabled, singleInstanceUniqueId, enableDragAndDrop, disableWebViewDragAndDrop,
+		disableEscapeExitsFullscreen,
 	)
 
 	// Create menu

--- a/v2/pkg/options/mac/mac.go
+++ b/v2/pkg/options/mac/mac.go
@@ -28,4 +28,9 @@ type Options struct {
 	OnFileOpen func(filePath string) `json:"-"`
 	OnUrlOpen  func(filePath string) `json:"-"`
 	// URLHandlers          map[string]func(string)
+
+	// DisableEscapeExitsFullscreen prevents the Escape key from exiting fullscreen mode.
+	// When true, web content can handle the Escape key (e.g., to close modals) without
+	// triggering the macOS system behaviour that exits the fullscreen window.
+	DisableEscapeExitsFullscreen bool
 }

--- a/v2/test/4649/test_esc_fullscreen.go
+++ b/v2/test/4649/test_esc_fullscreen.go
@@ -1,0 +1,41 @@
+//go:build darwin
+// +build darwin
+
+package main
+
+import (
+	"fmt"
+	"os"
+)
+
+// This is a manual test program for issue #4649.
+// Run on macOS: go run v2/test/4649/test_esc_fullscreen.go
+//
+// Expected behavior when mac.DisableEscapeExitsFullscreen is true:
+// 1. Window opens in fullscreen mode
+// 2. Pressing Esc should NOT exit fullscreen
+// 3. Pressing Cmd+Ctrl+F should toggle fullscreen (exit)
+// 4. When DisableEscapeExitsFullscreen is false (default), Esc exits fullscreen normally
+//
+// The fix adds a DisableEscapeExitsFullscreen option to mac.Options.
+// When true, WailsWindow.cancelOperation: swallows the Esc event while
+// fullscreen, allowing web content to handle it (e.g., closing modals).
+// When false (the default), system behavior is preserved unchanged.
+
+func main() {
+	fmt.Println("Test for issue #4649: Esc key behaviour in fullscreen on macOS")
+	fmt.Println("")
+	fmt.Println("This test must be run on macOS.")
+	fmt.Println("Set mac.Options{DisableEscapeExitsFullscreen: true} to opt in.")
+	fmt.Println("")
+	fmt.Println("Manual verification steps (with DisableEscapeExitsFullscreen: true):")
+	fmt.Println("1. Create a wails v2 app with a fullscreen window and the option set")
+	fmt.Println("2. Add an HTML modal dialog")
+	fmt.Println("3. Press Esc - the modal should close but NOT exit fullscreen")
+	fmt.Println("4. The window should remain in fullscreen mode")
+	fmt.Println("")
+	fmt.Println("Manual verification steps (with DisableEscapeExitsFullscreen: false / default):")
+	fmt.Println("1. Same app without the option")
+	fmt.Println("2. Press Esc in fullscreen - the window should EXIT fullscreen (default macOS behavior)")
+	os.Exit(0)
+}

--- a/v2/test/4649/test_esc_fullscreen.go
+++ b/v2/test/4649/test_esc_fullscreen.go
@@ -11,7 +11,7 @@ import (
 // This is a manual test program for issue #4649.
 // Run on macOS: go run v2/test/4649/test_esc_fullscreen.go
 //
-// Expected behavior when mac.DisableEscapeExitsFullscreen is true:
+// Expected behavior when mac.Options.DisableEscapeExitsFullscreen is true:
 // 1. Window opens in fullscreen mode
 // 2. Pressing Esc should NOT exit fullscreen
 // 3. Pressing Cmd+Ctrl+F should toggle fullscreen (exit)


### PR DESCRIPTION
fix(darwin): add `DisableEscapeExitsFullscreen` opt-in to `mac.Options`

PR #5242 overrides `cancelOperation:` in `WailsWindow` unconditionally,
which means Escape can never exit fullscreen for any Wails v2 app — even
ones that don't need that behaviour.  This PR refactors the override to
be opt-in via a new Mac-only option.

## What changed

**`v2/pkg/options/mac/mac.go`**
```go
// DisableEscapeExitsFullscreen prevents the Escape key from exiting
// fullscreen mode.  When true, web content can handle the Escape key
// (e.g. to close modals) without triggering the macOS system behaviour
// that exits the fullscreen window.
DisableEscapeExitsFullscreen bool
```

**`v2/internal/frontend/desktop/darwin/WailsContext.m`** — `cancelOperation:` is guarded:
```objc
- (void)cancelOperation:(id)sender {
    if (self.disableEscapeExitsFullscreen &&
        (self.styleMask & NSWindowStyleMaskFullScreen) == NSWindowStyleMaskFullScreen) {
        return;
    }
    [super cancelOperation:sender];
}
```

The flag is threaded through the C bridge:
`window.go` → `Application.h/.m` (`Create()` signature) → `WailsContext.h/.m` (`CreateWindow:` signature + `WailsWindow` property).

## Behaviour

| Option | Escape in fullscreen |
|---|---|
| `DisableEscapeExitsFullscreen: false` (default) | exits fullscreen (unchanged macOS behaviour) |
| `DisableEscapeExitsFullscreen: true` | swallowed; JS `keydown` handlers still fire |

## Usage

```go
&options.App{
    Mac: &mac.Options{
        DisableEscapeExitsFullscreen: true,
    },
}
```

## Files

- `v2/pkg/options/mac/mac.go` — new option field
- `v2/internal/frontend/desktop/darwin/window.go` — read + pass to C
- `v2/internal/frontend/desktop/darwin/Application.h/.m` — updated `Create()` signature
- `v2/internal/frontend/desktop/darwin/WailsContext.h/.m` — `WailsWindow` property, conditional guard, updated `CreateWindow:` signature
- `v2/test/4649/test_esc_fullscreen.go` — updated test docs

Closes #4649
Supersedes #5242

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a macOS option to disable Escape exiting fullscreen, so web content can handle the Escape key while fullscreen is preserved; configurable per window.

* **Tests**
  * Added a macOS-only manual test program with guidance to verify Escape-key behavior in fullscreen scenarios (option enabled vs default).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->