### PR TITLE
ci: fix Run Go Tests skipped on PR approval

### DIFF
--- a/.github/workflows/pr-master.yml
+++ b/.github/workflows/pr-master.yml
@@ -1,9 +1,3 @@
-# Updated to ensure "Run Go Tests" runs for pull requests as expected.
-# Key fix: the test_go job previously required github.event.review.state == 'approved'
-# which only exists on pull_request_review events. That prevented the job from
-# running for regular pull_request events (opened / synchronize / reopened).
-# New logic: run tests for pull_request events, and also allow running when a
-# pull_request_review is submitted with state == 'approved'.
 on:
   pull_request:
     types: [opened, synchronize, reopened]
@@ -20,7 +14,7 @@ name: PR Checks (master)
 jobs:
   check_docs:
     name: Check Docs
-    if: ${{ github.repository == 'wailsapp/wails' && github.base_ref == 'master' }}
+    if: ${{ github.repository == 'wailsapp/wails' && github.event.pull_request.base.ref == 'master' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -40,13 +34,9 @@ jobs:
   test_go:
     name: Run Go Tests
     runs-on: ${{ matrix.os }}
-    # Run when:
-    #  - the event is a pull_request (opened/synchronize/reopened) OR
-    #  - the event is a pull_request_review AND the review state is 'approved'
-    # plus other existing filters (not the update-sponsors branch, repo and base_ref)
     if: >
       github.repository == 'wailsapp/wails' &&
-      github.base_ref == 'master' &&
+      github.event.pull_request.base.ref == 'master' &&
       github.event.pull_request.head.ref != 'update-sponsors' &&
       (
         github.event_name == 'pull_request' ||

--- a/.github/workflows/pr-master.yml
+++ b/.github/workflows/pr-master.yml
@@ -14,7 +14,12 @@ name: PR Checks (master)
 jobs:
   check_docs:
     name: Check Docs
-    if: ${{ github.repository == 'wailsapp/wails' && github.event.pull_request.base.ref == 'master' }}
+    if: >
+      github.repository == 'wailsapp/wails' &&
+      (
+        github.event_name == 'workflow_dispatch' ||
+        github.event.pull_request.base.ref == 'master'
+      )
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -36,11 +41,16 @@ jobs:
     runs-on: ${{ matrix.os }}
     if: >
       github.repository == 'wailsapp/wails' &&
-      github.event.pull_request.base.ref == 'master' &&
       github.event.pull_request.head.ref != 'update-sponsors' &&
       (
-        github.event_name == 'pull_request' ||
-        (github.event_name == 'pull_request_review' && github.event.review.state == 'approved')
+        github.event_name == 'workflow_dispatch' ||
+        (
+          github.event.pull_request.base.ref == 'master' &&
+          (
+            github.event_name == 'pull_request' ||
+            (github.event_name == 'pull_request_review' && github.event.review.state == 'approved')
+          )
+        )
       )
     strategy:
       matrix:


### PR DESCRIPTION
## Problem

`github.base_ref` is only populated for `pull_request` and `pull_request_target` events — not for `pull_request_review`. Both the `check_docs` and `test_go` jobs used `github.base_ref == 'master'` as a guard, so the entire condition evaluated to `false` on a review submission, silently skipping the jobs even though the workflow fired correctly.

## Fix

Replace `github.base_ref` with `github.event.pull_request.base.ref` in both job conditions. This field comes from the event payload and is present for all PR-related events including `pull_request_review`.

Also removes the now-stale header comment that described a previous (incomplete) fix attempt.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow triggers to run documentation and Go tests for manual dispatches and when pull requests target the main branch, refined conditions for running tests and approvals, and reorganized job control flow for clearer behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->