### PR TITLE
fix(windows): prevent crash on WebView2 focus during dev hot-reload

### DIFF
--- a/v3/pkg/application/application_windows.go
+++ b/v3/pkg/application/application_windows.go
@@ -361,8 +361,18 @@ func setupDPIAwareness() error {
 	// Check if DPI awareness has already been set (e.g., via application manifest).
 	// Windows only allows setting DPI awareness once per process - either via manifest
 	// or API, not both. If already set, skip the API call to avoid "Access is denied" errors.
-	// See: https://github.com/wailsapp/wails/issues/4803
-	if w32.HasGetProcessDpiAwarenessFunc() {
+	// See: https://github.com/wailsapp/wails/issues/4803 and #4835
+
+	// Prefer the newer GetThreadDpiAwarenessContext (Windows 10 1607+) over the older
+	// GetProcessDpiAwareness (SHCORE) because a manifest entry with permonitorv2 sets the
+	// context via SetProcessDpiAwarenessContext, which GetProcessDpiAwareness may not reflect.
+	if w32.HasGetThreadDpiAwarenessContextFunc() && w32.HasAreDpiAwarenessContextsEqualFunc() {
+		ctx := w32.GetThreadDpiAwarenessContext()
+		if !w32.AreDpiAwarenessContextsEqual(ctx, w32.DPI_AWARENESS_CONTEXT_UNAWARE) {
+			// DPI awareness already set (likely via manifest), skip API call
+			return nil
+		}
+	} else if w32.HasGetProcessDpiAwarenessFunc() {
 		awareness, err := w32.GetProcessDpiAwareness()
 		if err == nil && awareness != w32.PROCESS_DPI_UNAWARE {
 			// DPI awareness already set (likely via manifest), skip API call

--- a/v3/pkg/application/webview_window_windows.go
+++ b/v3/pkg/application/webview_window_windows.go
@@ -867,7 +867,9 @@ func (w *windowsWebviewWindow) unminimise() {
 
 func (w *windowsWebviewWindow) maximise() {
 	w32.ShowWindow(w.hwnd, w32.SW_MAXIMIZE)
-	w.chromium.Focus()
+	if w.chromium.GetController() != nil {
+		w.chromium.Focus()
+	}
 }
 
 func (w *windowsWebviewWindow) unmaximise() {
@@ -877,7 +879,9 @@ func (w *windowsWebviewWindow) unmaximise() {
 
 func (w *windowsWebviewWindow) restore() {
 	w32.ShowWindow(w.hwnd, w32.SW_RESTORE)
-	w.chromium.Focus()
+	if w.chromium.GetController() != nil {
+		w.chromium.Focus()
+	}
 }
 
 func (w *windowsWebviewWindow) fullscreen() {
@@ -924,7 +928,9 @@ func (w *windowsWebviewWindow) fullscreen() {
 	// Hide the menubar in fullscreen mode
 	w32.SetMenu(w.hwnd, 0)
 
-	w.chromium.Focus()
+	if w.chromium.GetController() != nil {
+		w.chromium.Focus()
+	}
 	w.parent.emit(events.Windows.WindowFullscreen)
 }
 
@@ -994,6 +1000,14 @@ func (w *windowsWebviewWindow) focus() {
 	}
 	if w.isMinimised() {
 		w.unminimise()
+	}
+
+	// Guard against calling Focus when the WebView2 controller is not yet
+	// initialized or has already been torn down (e.g. during dev hot-reload).
+	// go-webview2's Focus() calls os.Exit(1) on any MoveFocus error, so we
+	// must not call it when the controller is in a nil/invalid state.
+	if w.chromium.GetController() == nil {
+		return
 	}
 
 	w.focusingChromium = true

--- a/v3/pkg/w32/user32.go
+++ b/v3/pkg/w32/user32.go
@@ -139,7 +139,9 @@ var (
 	procGetDpiForSystem               = moduser32.NewProc("GetDpiForSystem")
 	procGetDpiForWindow               = moduser32.NewProc("GetDpiForWindow")
 	procSetProcessDPIAware            = moduser32.NewProc("SetProcessDPIAware")
-	procSetProcessDpiAwarenessContext = moduser32.NewProc("SetProcessDpiAwarenessContext")
+	procSetProcessDpiAwarenessContext  = moduser32.NewProc("SetProcessDpiAwarenessContext")
+	procGetThreadDpiAwarenessContext   = moduser32.NewProc("GetThreadDpiAwarenessContext")
+	procAreDpiAwarenessContextsEqual   = moduser32.NewProc("AreDpiAwarenessContextsEqual")
 	procEnumDisplayMonitors           = moduser32.NewProc("EnumDisplayMonitors")
 	procEnumDisplayDevices            = moduser32.NewProc("EnumDisplayDevicesW")
 	procEnumDisplaySettings           = moduser32.NewProc("EnumDisplaySettingsW")
@@ -419,6 +421,27 @@ func SetProcessDpiAwarenessContext(ctx uintptr) error {
 		return fmt.Errorf("SetProcessDpiAwarenessContext failed %d: %v %v", status, r, err)
 	}
 	return nil
+}
+
+func HasGetThreadDpiAwarenessContextFunc() bool {
+	return procGetThreadDpiAwarenessContext.Find() == nil
+}
+
+// GetThreadDpiAwarenessContext returns the DPI awareness context for the current thread.
+// Available on Windows 10 version 1607 and later.
+func GetThreadDpiAwarenessContext() uintptr {
+	ctx, _, _ := procGetThreadDpiAwarenessContext.Call()
+	return ctx
+}
+
+func HasAreDpiAwarenessContextsEqualFunc() bool {
+	return procAreDpiAwarenessContextsEqual.Find() == nil
+}
+
+// AreDpiAwarenessContextsEqual compares two DPI awareness context values.
+func AreDpiAwarenessContextsEqual(ctx1, ctx2 uintptr) bool {
+	ret, _, _ := procAreDpiAwarenessContextsEqual.Call(ctx1, ctx2)
+	return ret != 0
 }
 
 func GetForegroundWindow() HWND {


### PR DESCRIPTION
Fixes #4835

## Summary

- Fix 1: Add `GetThreadDpiAwarenessContext` + `AreDpiAwarenessContextsEqual` to w32; use them in `setupDPIAwareness` to reliably detect permonitorv2 manifest-set DPI awareness before calling `SetProcessDpiAwarenessContext`.
- Fix 2: Guard all four `chromium.Focus()` call sites with `GetController() != nil`. go-webview2 calls `os.Exit(1)` on any MoveFocus error, so calling Focus when the controller is nil or mid-init is fatal.

## Test plan
- [ ] `wails3 dev` on Windows 10/11: save a .go file, hot-reload must not crash
- [ ] Normal maximise/restore/fullscreen focus still works

?? Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed potential WebView display issues during window state transitions.
  * Enhanced DPI awareness handling on Windows for improved high-resolution display support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->