### PR TITLE
i18n(pt): add Portuguese translations 2026-05-04

### DIFF
--- a/docs/.translation-cache/pt.json
+++ b/docs/.translation-cache/pt.json
@@ -1,0 +1,22 @@
+{
+  "index.mdx": {
+    "hash": "8db97751a16d",
+    "translated_at": "2026-05-04T00:17:06Z"
+  },
+  "quick-start/why-wails.mdx": {
+    "hash": "053b3578f336",
+    "translated_at": "2026-05-04T00:17:41Z"
+  },
+  "quick-start/next-steps.mdx": {
+    "hash": "9b4cb8954865",
+    "translated_at": "2026-05-04T00:17:52Z"
+  },
+  "status.mdx": {
+    "hash": "916ecd7da4d4",
+    "translated_at": "2026-05-04T00:18:01Z"
+  },
+  "getting-started/installation.mdx": {
+    "hash": "8d33a6a61b02",
+    "translated_at": "2026-05-04T00:18:29Z"
+  }
+}

--- a/docs/src/content/docs/pt/getting-started/installation.mdx
+++ b/docs/src/content/docs/pt/getting-started/installation.mdx
@@ -1,0 +1,113 @@
+---
+title: Instalação
+description: Instale o Wails e configure seu ambiente de desenvolvimento
+sidebar:
+  order: 10
+---
+
+import { Tabs, TabItem } from "@astrojs/starlight/components";
+
+## Plataformas Suportadas
+
+- Windows 10/11 AMD64/ARM64
+- macOS 10.15+ AMD64 (Pode implantar para macOS 10.13+)
+- macOS 11.0+ ARM64
+- Ubuntu 24.04 AMD64/ARM64 (outros Linuxs também podem funcionar!)
+
+## Dependências
+
+O Wails possui várias dependências comuns que são necessárias antes da instalação:
+
+<Tabs>
+  <TabItem label="Go (pelo menos 1.24)" icon="seti:go">
+
+    Baixe o Go na [Página de Downloads do Go](https://go.dev/dl/).
+
+    Certifique-se de seguir as [instruções oficiais de instalação do Go](https://go.dev/doc/install). Você também precisará garantir que sua variável de ambiente `PATH` inclua o caminho para o diretório `~/go/bin`. Reinicie seu terminal e execute as seguintes verificações:
+
+    - Verifique se o Go está instalado corretamente: `go version`
+    - Verifique se `~/go/bin` está na sua variável PATH
+        - Mac / Linux: `echo $PATH | grep go/bin`
+        - Windows: `$env:PATH -split ';' | Where-Object { $_ -like '*\go\bin' }`
+
+  </TabItem>
+
+  <TabItem label="npm (Opcional)" icon="seti:npm">
+
+    Embora o Wails não exija que o npm esteja instalado, ele é necessário na maioria dos modelos embutidos.
+
+    Baixe o instalador mais recente do Node na [Página de Downloads do Node](https://nodejs.org/en/download/). É melhor usar a versão mais recente, pois é contra ela que geralmente testamos.
+
+    Execute `npm --version` para verificar.
+
+      :::note
+      Se você preferir um gerenciador de pacotes diferente do npm, sinta-se à vontade para usá-lo. Você precisará atualizar os Taskfiles do projeto para usá-lo.
+      :::
+
+  </TabItem>
+
+</Tabs>
+
+## Dependências Específicas da Plataforma
+
+Você também precisará instalar dependências específicas da plataforma:
+
+<Tabs syncKey="platform">
+  <TabItem label="Mac" icon="apple">
+
+    O Wails requer que as ferramentas de linha de comando do xcode estejam instaladas. Isso pode ser feito executando:
+
+    ```sh
+    xcode-select --install
+    ```
+
+  </TabItem>
+  <TabItem label="Windows" icon="seti:windows">
+
+    O Wails requer que o [WebView2 Runtime](https://developer.microsoft.com/en-us/microsoft-edge/webview2/) esteja instalado. Quase todas as instalações do Windows já terão isso instalado. Você pode verificar usando o comando `wails doctor`.
+
+  </TabItem>
+  <TabItem label="Linux" icon="linux">
+
+    O Linux requer as ferramentas de compilação `gcc` padrão, além de `gtk3` e `webkit2gtk`. Execute <code>wails doctor</code> após a instalação para ver como instalar as dependências. Se sua distribuição ou gerenciador de pacotes não for suportado, avise-nos no Discord.
+
+  </TabItem>
+
+</Tabs>
+
+## Instalação
+
+Para instalar a CLI do Wails usando Go Modules, execute os seguintes comandos:
+
+```shell
+go install -v github.com/wailsapp/wails/v3/cmd/wails3@latest
+```
+
+Se você deseja instalar a versão de desenvolvimento mais recente, execute os seguintes
+comandos:
+
+```shell
+git clone https://github.com/wailsapp/wails.git
+cd wails
+cd v3/cmd/wails3
+go install
+```
+
+Ao usar a versão de desenvolvimento, todos os projetos gerados usarão a diretiva
+[replace](https://go.dev/ref/mod#go-mod-file-replace) do Go para garantir que
+os projetos usem a versão de desenvolvimento do Wails.
+
+## Verificação do Sistema
+
+Executar `wails3 doctor` verificará se você tem as dependências corretas
+instaladas. Se não tiver, ele informará o que está faltando e ajudará a resolver
+qualquer problema.
+
+## O comando `wails3` parece estar ausente?
+
+Se seu sistema estiver relatando que o comando `wails3` está ausente, verifique o
+seguinte:
+
+- Certifique-se de ter seguido o `guia de instalação do Go` acima corretamente e
+  que o diretório `go/bin` esteja na variável de ambiente `PATH`.
+- Feche/Reabra os terminais atuais para aplicar a nova variável `PATH`.

--- a/docs/src/content/docs/pt/index.mdx
+++ b/docs/src/content/docs/pt/index.mdx
@@ -275,7 +275,7 @@ cd myapp && wails3 dev
 
 ## Próximos Passos
 
-Próximo: [Crie um aplicativo completo](/tutorials/03-notes-vanilla), explore os [exemplos](https://github.com/wailsapp/wails/tree/master/v3/examples) ou consulte a [referência da API](/reference/application). Migrando da v2? Consulte o [guia de atualização](/migration/v2-to-v3).
+Próximo: [](/pt/quick-start/next-steps), explore os [exemplos](https://github.com/wailsapp/wails/tree/master/v3/examples) ou consulte a [referência da API](/reference/application). Migrando da v2? Consulte o [guia de atualização](/migration/v2-to-v3).
 
 
 :::note[Pronto para Produção]

--- a/docs/src/content/docs/pt/index.mdx
+++ b/docs/src/content/docs/pt/index.mdx
@@ -1,0 +1,294 @@
+---
+title: Crie Aplicativos Desktop com Go
+description: "Aplicativos desktop nativos usando Go e tecnologias web"
+banner:
+    content: |
+        O Wails v3 está em ALFA. <a href="https://wails.io">Documentação v2</a>
+template: splash
+hero:
+  tagline: Crie aplicativos desktop bonitos e performáticos usando Go e tecnologias web modernas. Um único código. Três plataformas. Sem navegadores.
+  image:
+    dark: ../../assets/wails-logo-dark.svg
+    light: ../../assets/wails-logo-light.svg
+    alt: Logotipo do Wails
+  actions:
+    - text: Começar
+      link: /quick-start/installation
+      icon: right-arrow
+      variant: primary
+    - text: Ver Tutorial
+      link: /tutorials/03-notes-vanilla
+      icon: open-book
+      variant: secondary
+---
+{/* Updated 2025-11-23 */}
+import { Tabs, TabItem, Card, CardGrid } from "@astrojs/starlight/components";
+
+<style>{`
+  /* Row 1 - Fastest */
+  body::after {
+    content: '';
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 200%;
+    height: 33.33vh;
+    opacity: 0.08;
+    z-index: -1;
+    background:
+      url('/showcase-images/tiny-rdm1.webp') 0px center / auto 80% no-repeat,
+      url('/showcase-images/gamestacker.webp') 550px center / auto 80% no-repeat,
+      url('/showcase-images/scriptbar.webp') 1100px center / auto 80% no-repeat,
+      url('/showcase-images/minesweeper-xp.webp') 1650px center / auto 80% no-repeat,
+      url('/showcase-images/wailsterm.webp') 2200px center / auto 80% no-repeat,
+      url('/showcase-images/modalfilemanager.webp') 2750px center / auto 80% no-repeat,
+      url('/showcase-images/ytd.webp') 3300px center / auto 80% no-repeat,
+      url('/showcase-images/filehound.webp') 3850px center / auto 80% no-repeat,
+      url('/showcase-images/edex-ui.webp') 4400px center / auto 80% no-repeat,
+      url('/showcase-images/tiny-rdm1.webp') 4950px center / auto 80% no-repeat,
+      url('/showcase-images/gamestacker.webp') 5500px center / auto 80% no-repeat,
+      url('/showcase-images/scriptbar.webp') 6050px center / auto 80% no-repeat,
+      url('/showcase-images/minesweeper-xp.webp') 6600px center / auto 80% no-repeat,
+      url('/showcase-images/wailsterm.webp') 7150px center / auto 80% no-repeat,
+      url('/showcase-images/modalfilemanager.webp') 7700px center / auto 80% no-repeat,
+      url('/showcase-images/ytd.webp') 8250px center / auto 80% no-repeat,
+      url('/showcase-images/filehound.webp') 8800px center / auto 80% no-repeat,
+      url('/showcase-images/edex-ui.webp') 9350px center / auto 80% no-repeat;
+    animation: scroll-row1 40s linear infinite;
+    filter: blur(0.5px);
+    pointer-events: none;
+  }
+  
+  /* Gradient overlay - highest z-index */
+  html::before {
+    content: '';
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: 
+      linear-gradient(to bottom, var(--sl-color-bg) 0%, transparent 15%, transparent 85%, var(--sl-color-bg) 100%),
+      linear-gradient(to right, var(--sl-color-bg) 0%, transparent 10%, transparent 90%, var(--sl-color-bg) 100%);
+    z-index: 0;
+    pointer-events: none;
+  }
+  
+  /* Row 2 - Medium Speed */
+  html::after {
+    content: '';
+    position: fixed;
+    top: 33.33vh;
+    left: 0;
+    width: 200%;
+    height: 33.33vh;
+    opacity: 0.08;
+    z-index: -2;
+    background:
+      url('/showcase-images/tiny-rdm2.webp') 0px center / auto 80% no-repeat,
+      url('/showcase-images/mollywallet.webp') 550px center / auto 80% no-repeat,
+      url('/showcase-images/optimus.webp') 1100px center / auto 80% no-repeat,
+      url('/showcase-images/cfntracker.webp') 1650px center / auto 80% no-repeat,
+      url('/showcase-images/riftshare-main.webp') 2200px center / auto 80% no-repeat,
+      url('/showcase-images/minecraft-mod-updater.webp') 2750px center / auto 80% no-repeat,
+      url('/showcase-images/resizem.webp') 3300px center / auto 80% no-repeat,
+      url('/showcase-images/mchat.webp') 3850px center / auto 80% no-repeat,
+      url('/showcase-images/tiny-rdm2.webp') 4400px center / auto 80% no-repeat,
+      url('/showcase-images/mollywallet.webp') 4950px center / auto 80% no-repeat,
+      url('/showcase-images/optimus.webp') 5500px center / auto 80% no-repeat,
+      url('/showcase-images/cfntracker.webp') 6050px center / auto 80% no-repeat,
+      url('/showcase-images/riftshare-main.webp') 6600px center / auto 80% no-repeat,
+      url('/showcase-images/minecraft-mod-updater.webp') 7150px center / auto 80% no-repeat,
+      url('/showcase-images/resizem.webp') 7700px center / auto 80% no-repeat,
+      url('/showcase-images/mchat.webp') 8250px center / auto 80% no-repeat;
+    animation: scroll-row2 25s linear infinite;
+    filter: blur(0.5px);
+    pointer-events: none;
+  }
+  
+  /* Row 3 - Slowest */
+  body::before {
+    content: '';
+    position: fixed;
+    top: 66.66vh;
+    left: 0;
+    width: 200%;
+    height: 33.34vh;
+    opacity: 0.08;
+    z-index: -2;
+    background:
+      url('/showcase-images/portfall.webp') 0px center / auto 80% no-repeat,
+      url('/showcase-images/encrypteasy.webp') 550px center / auto 80% no-repeat,
+      url('/showcase-images/gamestacker.webp') 1100px center / auto 80% no-repeat,
+      url('/showcase-images/varly2.webp') 1650px center / auto 80% no-repeat,
+      url('/showcase-images/hiposter.webp') 2200px center / auto 80% no-repeat,
+      url('/showcase-images/october.webp') 2750px center / auto 80% no-repeat,
+      url('/showcase-images/wombat.webp') 3300px center / auto 80% no-repeat,
+      url('/showcase-images/portfall.webp') 3850px center / auto 80% no-repeat,
+      url('/showcase-images/encrypteasy.webp') 4400px center / auto 80% no-repeat,
+      url('/showcase-images/gamestacker.webp') 4950px center / auto 80% no-repeat,
+      url('/showcase-images/varly2.webp') 5500px center / auto 80% no-repeat,
+      url('/showcase-images/hiposter.webp') 6050px center / auto 80% no-repeat,
+      url('/showcase-images/october.webp') 6600px center / auto 80% no-repeat,
+      url('/showcase-images/wombat.webp') 7150px center / auto 80% no-repeat;
+    animation: scroll-row3 50s linear infinite;
+    filter: blur(0.5px);
+    pointer-events: none;
+  }
+  
+  /* Hero padding */
+  .hero {
+    padding-top: 3rem !important;
+    padding-bottom: 2rem !important;
+  }
+  
+  @keyframes scroll-row1 {
+    from { transform: translateX(0); }
+    to { transform: translateX(-50%); }
+  }
+  
+  @keyframes scroll-row2 {
+    from { transform: translateX(0); }
+    to { transform: translateX(-50%); }
+  }
+  
+  @keyframes scroll-row3 {
+    from { transform: translateX(0); }
+    to { transform: translateX(-50%); }
+  }
+  
+  .small-buttons {
+    display: flex;
+    gap: 0.75rem;
+    flex-wrap: wrap;
+    margin-top: 1rem;
+  }
+  
+  .small-buttons a {
+    display: inline-block;
+    padding: 0.5rem 1rem;
+    font-size: 0.875rem;
+    border-radius: 6px;
+    text-decoration: none;
+    background: var(--sl-color-gray-6);
+    color: var(--sl-color-white);
+    border: 1px solid var(--sl-color-gray-5);
+    transition: all 0.2s;
+  }
+  
+  .small-buttons a:hover {
+    background: var(--sl-color-gray-5);
+    border-color: var(--sl-color-accent);
+  }
+  
+  /* Round card corners and add translucent blur effect */
+  .card {
+    border-radius: 12px;
+    background: rgba(var(--sl-color-gray-6-rgb), 0.6) !important;
+    backdrop-filter: blur(10px);
+    -webkit-backdrop-filter: blur(10px);
+  }
+`}</style>
+
+## Início Rápido
+
+<Tabs syncKey="os">
+  <TabItem label="macOS" icon="apple">
+```bash
+# Instale o Wails
+go install github.com/wailsapp/wails/v3/cmd/wails3@latest
+
+# Crie seu aplicativo
+wails3 init -n myapp -t vanilla
+
+# Execute com recarregamento em tempo real
+cd myapp && wails3 dev
+```
+  </TabItem>
+  
+  <TabItem label="Windows" icon="seti:windows">
+```powershell
+# Instale o Wails
+go install github.com/wailsapp/wails/v3/cmd/wails3@latest
+
+# Crie seu aplicativo
+wails3 init -n myapp -t vanilla
+
+# Execute com recarregamento em tempo real
+cd myapp; wails3 dev
+```
+  </TabItem>
+  
+  <TabItem label="Linux" icon="linux">
+```bash
+# Instale o Wails
+go install github.com/wailsapp/wails/v3/cmd/wails3@latest
+
+# Crie seu aplicativo
+wails3 init -n myapp -t vanilla
+
+# Execute com recarregamento em tempo real
+cd myapp && wails3 dev
+```
+  </TabItem>
+</Tabs>
+
+**Seu aplicativo está agora em execução** com recarregamento em tempo real e ligações Go-JS seguras em tempo de compilação.
+
+
+## Por que Wails?
+
+<CardGrid>
+  <Card title="Performance que o Usuário Nota" icon="rocket">
+    - Binários de ~15MB vs 150MB do Electron
+    - Memória base de ~10MB vs 100MB+
+    - Tempo de inicialização &lt;0.5s vs 2-3s
+    - Renderização nativa usando WebView do SO
+    - Sem sobrecarga de navegador embutido
+  </Card>
+  
+  <Card title="Experiência do Desenvolvedor" icon="setting">
+    - Um único código Go para todas as plataformas
+    - Qualquer framework web - React, Vue, Svelte
+    - Recarregamento em tempo real durante o desenvolvimento
+    - Ligações geradas automaticamente para chamar Go facilmente do Javascript
+    - IPC em memória. Sem portas de rede
+  </Card>
+  
+  <Card title="Pronto para Produção" icon="approve-check">
+    - Múltiplas janelas com ciclos de vida
+    - Menus nativos e bandeja do sistema
+    - Diálogos de arquivo nativos da plataforma
+    - Integração com o sistema e atalhos
+    - Ferramentas de assinatura de código e empacotamento
+  </Card>
+  
+  <Card title="Nativo Multiplataforma" icon="laptop">
+    - Código único para Windows, macOS e Linux
+    - Recursos específicos da plataforma quando necessário
+    - Sem compromissos na experiência do usuário
+    - Implante em todas as plataformas a partir de uma única build
+    - Suporte para mobile em breve...
+  </Card>
+</CardGrid>
+
+
+## Próximos Passos
+
+Próximo: [Crie um aplicativo completo](/tutorials/03-notes-vanilla), explore os [exemplos](https://github.com/wailsapp/wails/tree/master/v3/examples) ou consulte a [referência da API](/reference/application). Migrando da v2? Consulte o [guia de atualização](/migration/v2-to-v3).
+
+
+:::note[Pronto para Produção]
+O Wails v3 está em **ALFA**. A API é *razoavelmente* estável e aplicativos já estão em uso em produção. Estamos refinando a documentação e as ferramentas antes do lançamento final.
+:::
+
+<Card title="Apoie o Desenvolvimento do Wails" icon="heart">
+  O Wails é gratuito e de código aberto, construído por desenvolvedores para desenvolvedores. Se o Wails ajuda você a criar aplicativos incríveis, considere apoiar seu desenvolvimento contínuo.
+
+  Seu patrocínio ajuda a manter o projeto, melhorar a documentação e desenvolver novos recursos que beneficiam toda a comunidade.
+
+  [Torne-se um Patrocinador →](https://github.com/sponsors/leaanthony)
+</Card>
+
+
+---

--- a/docs/src/content/docs/pt/index.mdx
+++ b/docs/src/content/docs/pt/index.mdx
@@ -8,8 +8,8 @@ template: splash
 hero:
   tagline: Crie aplicativos desktop bonitos e performáticos usando Go e tecnologias web modernas. Um único código. Três plataformas. Sem navegadores.
   image:
-    dark: ../../assets/wails-logo-dark.svg
-    light: ../../assets/wails-logo-light.svg
+    dark: ../../../assets/wails-logo-dark.svg
+    light: ../../../assets/wails-logo-light.svg
     alt: Logotipo do Wails
   actions:
     - text: Começar

--- a/docs/src/content/docs/pt/index.mdx
+++ b/docs/src/content/docs/pt/index.mdx
@@ -13,7 +13,7 @@ hero:
     alt: Logotipo do Wails
   actions:
     - text: Começar
-      link: /quick-start/installation
+      link: /pt/getting-started/installation
       icon: right-arrow
       variant: primary
     - text: Ver Tutorial
@@ -289,6 +289,3 @@ O Wails v3 está em **ALFA**. A API é *razoavelmente* estável e aplicativos j�
 
   [Torne-se um Patrocinador →](https://github.com/sponsors/leaanthony)
 </Card>
-
-
----

--- a/docs/src/content/docs/pt/quick-start/next-steps.mdx
+++ b/docs/src/content/docs/pt/quick-start/next-steps.mdx
@@ -1,0 +1,34 @@
+---
+title: Próximos Passos
+description: Para onde ir após criar seu primeiro aplicativo
+sidebar:
+  order: 4
+---
+
+Você criou seu primeiro aplicativo Wails e já entende os conceitos básicos. Aqui estão os próximos passos.
+
+## Aprenda Mais
+
+Pratique criando aplicações completas:
+
+- [Aplicativo TODO](/tutorials/02-todo-vanilla) - Operações CRUD, gerenciamento de estado, interface moderna
+- [Todos os Tutoriais](/tutorials/overview) - Aplicativos de notas, painéis, aplicativos na bandeja do sistema e mais
+
+## Recursos
+
+O Wails oferece capacidades nativas para desktop:
+
+- [Windows](/features/windows/basics) - Múltiplas janelas, janelas sem bordas, posicionamento
+- [Menus](/features/menus/application) - Menus do aplicativo, menus de contexto, bandeja do sistema
+- [Diálogos](/features/dialogs/file) - Abrir/salvar arquivos, diálogos de mensagem
+- [Eventos](/features/events/system) - Comunicação entre componentes
+- [Bindings](/features/bindings/methods) - Chamadas tipo-seguras entre Go e JavaScript
+- [Área de Transferência](/features/clipboard) - Operações de copiar/colar
+- [Arrastar e Soltar](/features/drag-and-drop/files) - Arrastar e soltar arquivos
+- [Teclado](/features/keyboard) - Atalhos globais
+
+## Obtenha Ajuda
+
+- [Discord](https://discord.gg/JDdSxwjhGf) - Faça perguntas, compartilhe projetos
+- [Exemplos](https://github.com/wailsapp/wails/tree/master/v3/examples) - Mais de 50 exemplos funcionais
+- [Referência da API](/reference/overview) - Documentação completa

--- a/docs/src/content/docs/pt/quick-start/why-wails.mdx
+++ b/docs/src/content/docs/pt/quick-start/why-wails.mdx
@@ -5,7 +5,7 @@ sidebar:
   order: 1
 ---
 
-O Wais combina **a performance e simplicidade do Go** com **a flexibilidade de interfaces web modernas**, permitindo que você construa aplicativos de desktop nativos e bonitos com as ferramentas que você já conhece.
+O Wails combina **a performance e simplicidade do Go** com **a flexibilidade de interfaces web modernas**, permitindo que você construa aplicativos de desktop nativos e bonitos com as ferramentas que você já conhece.
 
 ## Performance que os Usuários Percebem
 

--- a/docs/src/content/docs/pt/quick-start/why-wails.mdx
+++ b/docs/src/content/docs/pt/quick-start/why-wails.mdx
@@ -119,7 +119,7 @@ Essa arquitetura simples permite que código JavaScript chame funções Go diret
 Agora que você entende o que o Wails oferece, vamos configurá-lo:
 
 1. **Instale o Wails** - Configure seu ambiente de desenvolvimento em 5 minutos  
-   [Guia de Instalação →](/quick-start/installation)
+   [Guia de Instalação →](/pt/getting-started/installation)
 
 2. **Crie seu Primeiro App** - Crie um aplicativo funcional e entenda os conceitos básicos  
    [Tutorial do Primeiro App →](/quick-start/first-app)

--- a/docs/src/content/docs/pt/quick-start/why-wails.mdx
+++ b/docs/src/content/docs/pt/quick-start/why-wails.mdx
@@ -1,0 +1,134 @@
+---
+title: Por que Wails?
+description: Entenda por que o Wails é a escolha certa para seu aplicativo de desktop
+sidebar:
+  order: 1
+---
+
+O Wais combina **a performance e simplicidade do Go** com **a flexibilidade de interfaces web modernas**, permitindo que você construa aplicativos de desktop nativos e bonitos com as ferramentas que você já conhece.
+
+## Performance que os Usuários Percebem
+
+**Aplicativos Wails:**
+- **Binários de ~15MB** (vs. 150MB do Electron)
+- **Memória base de ~10MB** (vs. 100MB+ do Electron)
+- **Tempo de inicialização &lt;0.5s** (vs. 2-3s do Electron)
+- **Renderização nativa** usando o WebView fornecido pelo SO
+
+Os usuários percebem seu aplicativo como rápido, leve e profissional.
+
+## Experiência do Desenvolvedor
+
+**Escreva uma vez, execute em qualquer lugar:**
+- Um único código-fonte em Go para Windows, macOS e Linux
+- Use qualquer framework web (React, Vue, Svelte, JS puro)
+- Hot reload durante o desenvolvimento
+- Bindings de TypeScript gerados automaticamente a partir do código Go
+
+Entregue produtos mais rápido com menos código para manter.
+
+## Recursos Prontos para Produção
+
+**Tudo o que você precisa:**
+- Múltiplas janelas com ciclos de vida independentes
+- Menus nativos (aplicação, contexto, bandeja do sistema)
+- Diálogos de arquivos com interface nativa da plataforma
+- Integração com o sistema (notificações, área de transferência, atalhos de teclado)
+- Assinatura de código e empacotamento para todas as plataformas
+
+Construa aplicativos profissionais, não protótipos.
+
+## Desenvolvimento Mais Rápido
+
+- **Um código-fonte, três plataformas** - Escreva uma vez, compile para Windows, macOS e Linux
+- **Use habilidades existentes** - Go para o backend, HTML/CSS/JS para a interface
+- **Feedback instantâneo** - Hot reload durante o desenvolvimento, tempos de compilação medidos em segundos
+- **Binários pequenos** - Aplicativos de 15MB significam builds mais rápidas, downloads mais rápidos e iterações mais ágeis
+
+## Quando Escolher o Wails
+
+**O Wails é Perfeito Para:**
+
+- **Aplicativos empresariais** (CRM, inventário, dashboards, ferramentas administrativas)
+- **Ferramentas para desenvolvedores** (clientes de banco de dados, testadores de API, ferramentas de deploy)
+- **Aplicativos de produtividade** (tomada de notas, gerenciadores de tarefas, rastreadores de tempo)
+- **Ferramentas criativas** (editores de imagem, processadores de vídeo, utilitários de design)
+- **Ferramentas internas** (aplicativos específicos da empresa, ferramentas de automação)
+
+## Casos de Sucesso no Mundo Real
+
+:::tip[Aplicativos em Produção]
+O Wails alimenta aplicativos reais usados por milhares de usuários:
+- **Ferramentas de gerenciamento de banco de dados** com interfaces complexas
+- **Dashboards financeiros** processando dados em tempo real
+- **Ferramentas de edição de vídeo** com performance nativa
+- **Utilitários de desenvolvimento** usados por equipes de engenharia
+
+[Veja o showcase →](/community/showcase)
+:::
+
+## Como o Wails Funciona
+
+Diferente do Electron, que empacota um navegador inteiro e o runtime do Node.js, o Wails adota uma abordagem fundamentalmente diferente: seu código Go é compilado em um binário nativo, e sua interface roda no WebView embutido do sistema operacional. Essa arquitetura entrega os binários pequenos, inicialização rápida e baixo uso de memória que fazem os aplicativos Wails parecerem nativos.
+
+### Arquitetura
+
+Os aplicativos Wails consistem em duas partes principais que se comunicam perfeitamente: um backend em Go lidando com a lógica de negócios e operações do sistema, e um frontend baseado na web para sua interface do usuário. O WebView fornecido pelo SO renderiza sua interface sem empacotar um navegador, enquanto a camada de bindings fornece comunicação segura entre Go e JavaScript.
+
+<div style="display: flex; justify-content: center; align-items: center; margin: 2rem 0;">
+<div style="max-width: 600px;">
+
+```d2
+direction: down
+
+Application: {
+Go: "Go Backend" {
+  shape: rectangle
+  style.fill: "#00ADD8"
+}
+WebView: "Native WebView" {
+  shape: rectangle
+  style.fill: "#3B82F6"
+
+    Frontend: "Sua Interface\n(React/Vue/etc)" {
+      shape: rectangle
+      style.fill: "#8B5CF6"
+    }
+
+}
+Go <-> WebView: "Bindings & Eventos"
+}
+
+
+
+```
+
+</div>
+</div>
+
+Essa arquitetura simples permite que código JavaScript chame funções Go diretamente (através de bindings gerados automaticamente), enquanto o Go pode enviar eventos e dados de volta ao frontend. Ambas as camadas se comunicam através de uma ponte eficiente em memória com overhead de sub-milissegundo.
+
+**Como o Wails alcança a performance:**
+1. **Sem runtime empacotado** - Usa o binário compilado do Go
+2. **WebView nativo** - Motor de renderização fornecido pelo SO
+3. **Ponte direta Go ↔ JS** - Comunicação em memória, sem overhead de rede
+4. **Binário compilado** - Inicialização instantânea, sem compilação JIT
+
+## Próximos Passos
+
+Agora que você entende o que o Wails oferece, vamos configurá-lo:
+
+1. **Instale o Wails** - Configure seu ambiente de desenvolvimento em 5 minutos  
+   [Guia de Instalação →](/quick-start/installation)
+
+2. **Crie seu Primeiro App** - Crie um aplicativo funcional e entenda os conceitos básicos  
+   [Tutorial do Primeiro App →](/quick-start/first-app)
+
+3. **Explore os Recursos** - Descubra o que o Wails pode fazer pelo seu aplicativo  
+   [Visão Geral dos Recursos →](/quick-start/next-steps)
+
+---
+
+**Ainda tem dúvidas?** Junte-se à nossa [comunidade no Discord](https://discord.gg/JDdSxwjhGf) e pergunte à equipe diretamente.
+
+---

--- a/docs/src/content/docs/pt/quick-start/why-wails.mdx
+++ b/docs/src/content/docs/pt/quick-start/why-wails.mdx
@@ -125,10 +125,8 @@ Agora que você entende o que o Wails oferece, vamos configurá-lo:
    [Tutorial do Primeiro App →](/quick-start/first-app)
 
 3. **Explore os Recursos** - Descubra o que o Wails pode fazer pelo seu aplicativo  
-   [Visão Geral dos Recursos →](/quick-start/next-steps)
+   [Visão Geral dos Recursos →](/pt/quick-start/next-steps)
 
 ---
 
 **Ainda tem dúvidas?** Junte-se à nossa [comunidade no Discord](https://discord.gg/JDdSxwjhGf) e pergunte à equipe diretamente.
-
----

--- a/docs/src/content/docs/pt/status.mdx
+++ b/docs/src/content/docs/pt/status.mdx
@@ -1,0 +1,25 @@
+---
+title: Roteiro
+description: Status do projeto Wails v3, recursos planejados e como contribuir
+---
+
+## Status Atual: Alpha
+
+Confira o [Changelog](./changelog) para ver o status mais recente.
+
+Nosso objetivo é alcançar o status Beta. Este roteiro descreve os principais recursos e melhorias que precisamos implementar antes de fazer a transição para o Beta. Por favor, note que este é um documento vivo e pode ser atualizado conforme as prioridades mudam ou novos insights surgem.
+
+## Como Você Pode Contribuir
+
+- Teste a versão alpha mais recente e relate quaisquer problemas
+- Contribua com a documentação e exemplos
+- Participe das discussões e forneça feedback sobre os recursos propostos
+- Envie pull requests para correções de bugs ou novos recursos
+
+Agradecemos as contribuições da comunidade. Se você quiser ajudar com algum desses objetivos ou tiver sugestões para o roteiro, por favor, abra uma issue ou participe das discussões da nossa comunidade.
+
+## Feedback e Atualizações
+
+Este roteiro está sujeito a alterações com base no feedback da comunidade e nas prioridades do projeto. Vamos atualizá-lo regularmente para refletir nosso progresso e quaisquer mudanças de direção. Seu input é valioso para moldar o futuro do Wails! O roteiro é um documento vivo e está sujeito a mudanças. Se você tiver alguma sugestão, por favor, abra uma issue. Cada marco terá um conjunto de objetivos que estamos buscando alcançar. Esses objetivos estão sujeitos a alterações.
+
+---

--- a/docs/src/content/docs/pt/status.mdx
+++ b/docs/src/content/docs/pt/status.mdx
@@ -21,5 +21,3 @@ Agradecemos as contribuições da comunidade. Se você quiser ajudar com algum d
 ## Feedback e Atualizações
 
 Este roteiro está sujeito a alterações com base no feedback da comunidade e nas prioridades do projeto. Vamos atualizá-lo regularmente para refletir nosso progresso e quaisquer mudanças de direção. Seu input é valioso para moldar o futuro do Wails! O roteiro é um documento vivo e está sujeito a mudanças. Se você tiver alguma sugestão, por favor, abra uma issue. Cada marco terá um conjunto de objetivos que estamos buscando alcançar. Esses objetivos estão sujeitos a alterações.
-
----


### PR DESCRIPTION
## Summary

Automated translation update for **Portuguese (Brazilian)** (`pt`) documentation.

- **Files translated:** 5
- **Translation model:** qwen3.6:35b (Ollama)
- **Date:** 2026-05-04
- **Branch:** `i18n/pt-2026-05-04`

## QA Scores

| Metric | Value |
|--------|-------|
| Average Score | 0.960 |
| Files Scored | 5 |

### Files Requiring Review (score < 0.75)
None ✅

### All File Scores
| File | Score | Notes |
|------|-------|-------|
| getting-started/installation.mdx | 1.000 | |
| index.mdx | 0.900 | Code block 1 content was modified |
| quick-start/next-steps.mdx | 1.000 | |
| quick-start/why-wails.mdx | 0.900 | Code block 1 content was modified |
| status.mdx | 1.000 | |

---
*Generated by Wails Doc Translator agent (automated weekly i18n run)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Portuguese docs expanded: new pages for Installation (platform-specific steps, CLI install, verification, troubleshooting), Why Wails (features and architecture), Next Steps, and Status/Roadmap. Includes quick-start commands for macOS/Windows/Linux and production notes (Alpha). 
  * Translation cache updated for several Portuguese documentation pages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->