### PR TITLE
fix(linux): dispatch dialog GTK calls via InvokeAsync to fix GTK3 segfault

### DIFF
--- a/v3/pkg/application/dialogs_linux.go
+++ b/v3/pkg/application/dialogs_linux.go
@@ -38,7 +38,7 @@ func (m *linuxDialog) show() {
 		}
 	}
 
-	go func() {
+	InvokeAsync(func() {
 		response := runQuestionDialog(pointer(parent), m.dialog)
 		if response >= 0 && response < len(m.dialog.Buttons) {
 			button := m.dialog.Buttons[response]
@@ -49,7 +49,7 @@ func (m *linuxDialog) show() {
 				}()
 			}
 		}
-	}()
+	})
 }
 
 func newDialogImpl(d *MessageDialog) *linuxDialog {


### PR DESCRIPTION
Closes #5338

## Root cause

`linuxDialog.show()` launched `runQuestionDialog()` — which calls `gtk_dialog_run()` — from a bare goroutine. GTK3 is not thread-safe; all GTK/GDK calls must run on the GLib main thread. Running them from an arbitrary OS thread is undefined behaviour and causes segfaults.

Commit 5dc3e21 (GTK4 support, PR #4958) replaced the correct `InvokeAsync` call with a bare `go func()`, breaking GTK3 users.

## Fix

Replace `go func() { ... }()` with `InvokeAsync(func() { ... })` in `linuxDialog.show()`. This matches the pattern already used by `showAboutDialog` in the same file, which was unchanged and works correctly.

The inner `go func()` for user button callbacks is preserved — those are not GTK calls and are correct to run on a goroutine.

```diff
-	go func() {
+	InvokeAsync(func() {
 		response := runQuestionDialog(pointer(parent), m.dialog)
 		if response >= 0 && response < len(m.dialog.Buttons) {
 			button := m.dialog.Buttons[response]
 			if button.Callback != nil {
 				go func() {
 					defer handlePanic()
 					button.Callback()
 				}()
 			}
 		}
-	}()
+	})
```

## Testing

- Verified on Ubuntu 24.04 / GTK 3.24.41 / webkit2gtk 2.50.4
- `go test ./v3/pkg/application/` — all 170+ tests pass
- Fixed binary (`dialogs-basic` example) builds cleanly with `CGO_ENABLED=1`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved dialog-response handling execution on Linux for better reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->