### PR TITLE
fix(v3/linux): filter and bounds-check signals in linuxSystemTray.run

### DIFF
--- a/v3/UNRELEASED_CHANGELOG.md
+++ b/v3/UNRELEASED_CHANGELOG.md
@@ -26,6 +26,7 @@ After processing, the content will be moved to the main changelog and this file 
 
 ## Fixed
 <!-- Bug fixes -->
+- Fix Linux systray crash when an unrelated dbus signal lands on its shared session-bus channel (#5344).
 
 ## Deprecated
 <!-- Soon-to-be removed features -->

--- a/v3/pkg/application/systemtray_linux.go
+++ b/v3/pkg/application/systemtray_linux.go
@@ -20,8 +20,10 @@ import (
 )
 
 const (
-	itemPath = "/StatusNotifierItem"
-	menuPath = "/StatusNotifierMenu"
+	itemPath                  = "/StatusNotifierItem"
+	menuPath                  = "/StatusNotifierMenu"
+	dbusNameOwnerChanged      = "org.freedesktop.DBus.NameOwnerChanged"
+	dbusStatusNotifierWatcher = "org.kde.StatusNotifierWatcher"
 )
 
 type linuxSystemTray struct {
@@ -283,6 +285,23 @@ func (s *linuxSystemTray) bounds() (*Rect, error) {
 
 }
 
+// shouldReregisterOnNameOwnerChanged reports whether sig is a NameOwnerChanged
+// signal whose new-owner field is set. Filters out other signals multiplexed
+// onto the shared SessionBus connection (see #5344).
+func shouldReregisterOnNameOwnerChanged(sig *dbus.Signal) bool {
+	if sig == nil || sig.Name != dbusNameOwnerChanged {
+		return false
+	}
+	if len(sig.Body) < 3 {
+		return false
+	}
+	if name, ok := sig.Body[0].(string); !ok || name != dbusStatusNotifierWatcher {
+		return false
+	}
+	newOwner, ok := sig.Body[2].(string)
+	return ok && newOwner != ""
+}
+
 func (s *linuxSystemTray) run() {
 	conn, err := dbus.SessionBus()
 	if err != nil {
@@ -358,7 +377,7 @@ func (s *linuxSystemTray) run() {
 			dbus.WithMatchInterface("org.freedesktop.DBus"),
 			dbus.WithMatchSender("org.freedesktop.DBus"),
 			dbus.WithMatchMember("NameOwnerChanged"),
-			dbus.WithMatchArg(0, "org.kde.StatusNotifierWatcher"),
+			dbus.WithMatchArg(0, dbusStatusNotifierWatcher),
 		); err != nil {
 			globalApplication.error("systray error: failed to register signal matching: %w", err)
 			return
@@ -373,8 +392,7 @@ func (s *linuxSystemTray) run() {
 				if sig == nil {
 					return // We get a nil signal when closing the window.
 				}
-				// sig.Body has the args, which are [name old_owner new_owner]
-				if sig.Body[2] != "" {
+				if shouldReregisterOnNameOwnerChanged(sig) {
 					s.register()
 				}
 
@@ -606,8 +624,8 @@ func (s *linuxSystemTray) update(i *systrayMenuItem) {
 }
 
 func (s *linuxSystemTray) register() bool {
-	obj := s.conn.Object("org.kde.StatusNotifierWatcher", "/StatusNotifierWatcher")
-	call := obj.Call("org.kde.StatusNotifierWatcher.RegisterStatusNotifierItem", 0, itemPath)
+	obj := s.conn.Object(dbusStatusNotifierWatcher, "/StatusNotifierWatcher")
+	call := obj.Call(dbusStatusNotifierWatcher+".RegisterStatusNotifierItem", 0, itemPath)
 	if call.Err != nil {
 		globalApplication.error("systray error: failed to register: %w", call.Err)
 		return false

--- a/v3/pkg/application/systemtray_linux_signal_test.go
+++ b/v3/pkg/application/systemtray_linux_signal_test.go
@@ -1,0 +1,142 @@
+//go:build linux && !android && !server
+
+package application
+
+import (
+	"testing"
+
+	"github.com/godbus/dbus/v5"
+)
+
+// Regression test for #5344 — the filter must reject every signal that
+// isn't NameOwnerChanged with a 3-element body before any Body[2] indexing.
+func TestShouldReregisterOnNameOwnerChanged(t *testing.T) {
+	cases := []struct {
+		name string
+		sig  *dbus.Signal
+		want bool
+	}{
+		{
+			name: "nil signal",
+			sig:  nil,
+			want: false,
+		},
+		{
+			name: "Notifications.ActionInvoked (2 args, observed in #5344)",
+			sig: &dbus.Signal{
+				Name: "org.freedesktop.Notifications.ActionInvoked",
+				Body: []interface{}{uint32(0x3d), "default"},
+			},
+			want: false,
+		},
+		{
+			name: "Notifications.NotificationClosed (2 args, observed in #5344)",
+			sig: &dbus.Signal{
+				Name: "org.freedesktop.Notifications.NotificationClosed",
+				Body: []interface{}{uint32(0x3d), uint32(2)},
+			},
+			want: false,
+		},
+		{
+			name: "Local.Disconnected (0 args)",
+			sig: &dbus.Signal{
+				Name: "org.freedesktop.DBus.Local.Disconnected",
+				Body: []interface{}{},
+			},
+			want: false,
+		},
+		{
+			name: "NameAcquired (1 arg, similar matching path)",
+			sig: &dbus.Signal{
+				Name: "org.freedesktop.DBus.NameAcquired",
+				Body: []interface{}{":1.42"},
+			},
+			want: false,
+		},
+		{
+			name: "NameOwnerChanged with malformed short body (1 arg)",
+			sig: &dbus.Signal{
+				Name: dbusNameOwnerChanged,
+				Body: []interface{}{dbusStatusNotifierWatcher},
+			},
+			want: false,
+		},
+		{
+			// Pins the length-guard boundary: weakening `< 3` to `< 2` panics here.
+			name: "NameOwnerChanged with malformed short body (2 args, boundary)",
+			sig: &dbus.Signal{
+				Name: dbusNameOwnerChanged,
+				Body: []interface{}{dbusStatusNotifierWatcher, ":1.42"},
+			},
+			want: false,
+		},
+		{
+			// Pins the type assertion: non-string Body[2] must not register.
+			name: "NameOwnerChanged with non-string new owner (spec violation)",
+			sig: &dbus.Signal{
+				Name: dbusNameOwnerChanged,
+				Body: []interface{}{dbusStatusNotifierWatcher, "", uint32(42)},
+			},
+			want: false,
+		},
+		{
+			name: "NameOwnerChanged with empty new owner (watcher disappeared)",
+			sig: &dbus.Signal{
+				Name: dbusNameOwnerChanged,
+				Body: []interface{}{dbusStatusNotifierWatcher, ":1.42", ""},
+			},
+			want: false,
+		},
+		{
+			name: "NameOwnerChanged with populated new owner (watcher restarted)",
+			sig: &dbus.Signal{
+				Name: dbusNameOwnerChanged,
+				Body: []interface{}{dbusStatusNotifierWatcher, "", ":1.99"},
+			},
+			want: true,
+		},
+		{
+			// Pins the Body[0] guard: a NameOwnerChanged for a different
+			// bus name (e.g. some unrelated process taking a name) must
+			// not trigger a re-register on our watcher.
+			name: "NameOwnerChanged for a different bus name (must NOT trigger register)",
+			sig: &dbus.Signal{
+				Name: dbusNameOwnerChanged,
+				Body: []interface{}{"org.freedesktop.Notifications", "", ":1.50"},
+			},
+			want: false,
+		},
+		{
+			// Pins the Body[0] type assertion: a non-string watched-name
+			// (spec violation) must not trigger.
+			name: "NameOwnerChanged with non-string Body[0] (spec violation)",
+			sig: &dbus.Signal{
+				Name: dbusNameOwnerChanged,
+				Body: []interface{}{uint32(1), "", ":1.50"},
+			},
+			want: false,
+		},
+		{
+			// Pins the name guard: PropertiesChanged has the same 3-arg
+			// shape, so removing the name filter flips this case to true.
+			name: "PropertiesChanged (3 args, non-empty Body[2]) must NOT trigger register",
+			sig: &dbus.Signal{
+				Name: "org.freedesktop.DBus.Properties.PropertiesChanged",
+				Body: []interface{}{
+					"com.canonical.dbusmenu",
+					map[string]dbus.Variant{},
+					[]string{"Version"},
+				},
+			},
+			want: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := shouldReregisterOnNameOwnerChanged(tc.sig); got != tc.want {
+				t.Errorf("shouldReregisterOnNameOwnerChanged(%+v) = %v, want %v",
+					tc.sig, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
# Description

Fixes #5344

`linuxSystemTray.run`'s signal-handling goroutine indexed `sig.Body[2]` unconditionally, assuming the NameOwnerChanged shape `[name, old_owner, new_owner]`. But `conn.Signal(sc)` in godbus delivers every signal the connection receives — `dbus.SessionBus()` returns a process-wide singleton, so any other subscriber in the same app gets multiplexed onto the same channel. Notably, desktop-notification handlers subscribed to `org.freedesktop.Notifications.ActionInvoked` / `NotificationClosed` (both 2-element bodies) cause `Body[2]` to panic; `defaultPanicHandler` then exits the process.

This PR:

- Extracts the gate into `shouldReregisterOnNameOwnerChanged(*dbus.Signal) bool` — filters by signal name, bounds-checks the body, and type-asserts the new-owner field as a string (rejecting spec-violating non-string variants instead of falsely triggering re-registration via the original interface-vs-string `!= ""` quirk).
- Centralises the signal name in a `dbusNameOwnerChanged` const so the helper, godoc, and tests share one source of truth.
- Replaces the inline indexing in `run()` with a single helper call; the rest of the goroutine and its `handlePanic` cleanup are unchanged.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [ ] Windows
- [ ] macOS
- [x] Linux

Ubuntu 24.04 base (Linux Mint 22.x), Cinnamon on X11, Linux 6.17, Go 1.26.1.

New file `v3/pkg/application/systemtray_linux_signal_test.go` covers 11 cases:

- nil
- `org.freedesktop.Notifications.ActionInvoked` (2 args, captured live in #5344)
- `org.freedesktop.Notifications.NotificationClosed` (2 args, captured live in #5344)
- `org.freedesktop.DBus.Local.Disconnected` (0 args)
- `org.freedesktop.DBus.NameAcquired` (1 arg)
- NameOwnerChanged with malformed 1-arg body
- NameOwnerChanged with 2-arg body — locks down the length-guard boundary; mutating `< 3` to `< 2` panics this case
- NameOwnerChanged with non-string `Body[2]` — locks down the type-assert added in this change
- NameOwnerChanged with empty new-owner (watcher disappeared)
- NameOwnerChanged with populated new-owner (watcher restarted) — the only case expecting `true`
- `org.freedesktop.DBus.Properties.PropertiesChanged` with 3-element body and non-empty `Body[2]` — discriminating case that locks down the name guard; removing the `sig.Name != dbusNameOwnerChanged` filter makes this case flip to `true` and the suite go red. Real-world relevance: `prop.Export` attached to the same connection emits exactly this signal whenever a property changes (e.g. dbusmenu `Version` on every refresh).

```
$ go test -run TestShouldReregisterOnNameOwnerChanged -count=1 -v ./v3/pkg/application/
=== RUN   TestShouldReregisterOnNameOwnerChanged
--- PASS: TestShouldReregisterOnNameOwnerChanged (0.00s)
    [11 sub-tests, all PASS]
```

Reverted each guard individually to confirm the suite catches the regression: removing the name filter fails the PropertiesChanged case; weakening the length guard `< 3 → < 2` panics the 2-arg boundary case; removing the type assertion would let the non-string Body[2] case slip through.

# Checklist:

- [x] My code follows the general coding style of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a Linux system tray crash where unrelated DBus signals could cause the tray to crash, improving stability and reliability.

* **Tests**
  * Added a Linux-only regression test covering various system tray signal scenarios to prevent regressions and ensure safer signal handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->