### PR TITLE
i18n: register all 8 translated locales in Starlight config

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -125,7 +125,15 @@ export default defineConfig({
       ],
       defaultLocale: "root",
       locales: {
-        root: { label: "English", lang: "en", dir: "ltr" },
+        root:    { label: "English",             lang: "en",    dir: "ltr" },
+        "zh-cn": { label: "简体中文",             lang: "zh-CN", dir: "ltr" },
+        "zh-tw": { label: "繁體中文",             lang: "zh-TW", dir: "ltr" },
+        ja:      { label: "日本語",               lang: "ja",    dir: "ltr" },
+        ko:      { label: "한국어",               lang: "ko",    dir: "ltr" },
+        ru:      { label: "Русский",             lang: "ru",    dir: "ltr" },
+        fr:      { label: "Français",            lang: "fr",    dir: "ltr" },
+        pt:      { label: "Português (Brasil)",  lang: "pt-BR", dir: "ltr" },
+        de:      { label: "Deutsch",             lang: "de",    dir: "ltr" },
       },
       plugins: [
         starlightImageZoom(),


### PR DESCRIPTION
Registers all 8 translated locales in `docs/astro.config.mjs` so the Starlight language switcher surfaces translated pages.

## Changes

**`docs/astro.config.mjs`** — adds 8 locale entries to the Starlight `locales` block:

| Locale key | Label | Lang tag |
|---|---|---|
| `zh-cn` | 简体中文 | zh-CN |
| `zh-tw` | 繁體中文 | zh-TW |
| `ja` | 日本語 | ja |
| `ko` | 한국어 | ko |
| `ru` | Русский | ru |
| `fr` | Français | fr |
| `pt` | Português (Brasil) | pt-BR |
| `de` | Deutsch | de |

Without these entries, translated `.mdx` files exist on disk but Starlight doesn't expose them through the language switcher (as noted in #5343).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Extended documentation language support to include Chinese (Simplified and Traditional), Japanese, Korean, Russian, French, Brazilian Portuguese, and German.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->