### PR TITLE
i18n(zh-tw): add translations batch 2 2026-05-07

### DIFF
--- a/docs/src/content/docs/zh-tw/community/links.md
+++ b/docs/src/content/docs/zh-tw/community/links.md
@@ -1,0 +1,27 @@
+---
+title: 連結
+description: 社群精選的 Wails 相關連結與資源
+---
+
+本頁面提供與社群相關的連結列表。
+
+:::tip[如何提交連結]
+
+您可以點擊此頁面底部的「編輯頁面」來提交 PR。
+
+:::
+
+## Awesome Wails
+
+[官方精選連結列表](https://github.com/wailsapp/awesome-wails)，收錄所有與 Wails 相關的資源。
+
+## 支援管道
+
+- [Wails Discord 伺服器](https://discord.gg/bdj28QNHmT)
+- [Github Issues](https://github.com/wailsapp/wails/issues)
+
+## 社群媒體
+
+- [Twitter](https://x.com/wailsapp)
+- [Wails 中文社群 QQ 群組](https://qm.qq.com/cgi-bin/qm/qr?k=PmIURne5hFGNd7QWzW5qd6FV-INEjNJv&jump_from=webapi) -
+  群組號碼：1067173054

--- a/docs/src/content/docs/zh-tw/community/templates.md
+++ b/docs/src/content/docs/zh-tw/community/templates.md
@@ -1,0 +1,135 @@
+---
+title: 範本
+description: Wails 的專案範本與起始套件
+---
+
+:::caution
+
+此頁面可能已過時，不適用於 Wails v3。
+
+:::
+
+<!-- TODO: Update this link -->
+
+此頁面提供社群支援的範本列表。若要建立您自己的
+範本，請參閱 [Templates](https://wails.io/docs/guides/templates)
+指南。
+
+:::tip[如何提交範本]
+
+您可以點擊底部的 `Edit this page` 來新增您的範本。
+
+:::
+
+要使用這些範本，請執行
+`wails init -n "Your Project Name" -t [下方的連結[@version]]`
+
+如果沒有版本後綴，則預設使用 main 分支的程式碼範本。
+如果有版本後綴，則使用對應此版本標籤的程式碼範本。
+
+範例：
+`wails init -n "Your Project Name" -t https://github.com/misitebao/wails-template-vue`
+
+:::danger[注意]
+
+**Wails 專案不維護、不負責亦不對第三方範本承擔任何責任！**
+
+如果您對某個範本不確定，請檢查 `package.json` 和 `wails.json`，
+以了解執行了哪些腳本以及安裝了哪些套件。
+
+:::
+
+## Vue
+
+- [wails-template-vue](https://github.com/misitebao/wails-template-vue) - 基於 Vue 生態系的 Wails
+  範本（整合 TypeScript、深色主題、
+  國際化、單頁路由、TailwindCSS）
+- [wails-template-quasar-js](https://github.com/sgosiaco/wails-template-quasar-js) -
+  使用 JavaScript + Quasar V2 的範本（Vue 3、Vite、Sass、Pinia、ESLint、
+  Prettier）
+- [wails-template-quasar-ts](https://github.com/sgosiaco/wails-template-quasar-ts) -
+  使用 TypeScript + Quasar V2 的範本（Vue 3、Vite、Sass、Pinia、ESLint、
+  Prettier、Composition API 搭配 &lt;script setup&gt;）
+- [wails-template-naive](https://github.com/tk103331/wails-template-naive) -
+  基於 Naive UI（一個 Vue 3 元件庫）的 Wails 範本
+- [wails-template-nuxt](https://github.com/gornius/wails-template-nuxt) - 使用乾淨的 Nuxt3 和 TypeScript 的 Wails
+  範本，並為 wails js
+  runtime 提供自動導入功能
+- [Wails-Tool-Template](https://github.com/xisuo67/Wails-Tool-Template) - 使用 Vue+TypeScript+Vite+Element-plus(仿网易云) 的 Wails
+  範本
+
+## Angular
+
+- [wails-template-angular](https://github.com/mateothegreat/wails-template-angular) -
+  Angular 15+ 功能豐富且已準備好投入生產環境。
+- [wails-angular-template](https://github.com/TAINCER/wails-angular-template) -
+  使用 TypeScript、Sass、熱重載、程式碼分割和 i18n 的 Angular
+
+## React
+
+- [wails-react-template](https://github.com/AlienRecall/wails-react-template) -
+  使用 reactjs 的範本
+- [wails-react-template](https://github.com/flin7/wails-react-template) - 支援即時開發的
+  React 最小化範本
+- [wails-template-nextjs](https://github.com/LGiki/wails-template-nextjs) - 使用 Next.js 和 TypeScript 的
+  範本
+- [wails-template-nextjs-app-router](https://github.com/thisisvk-in/wails-template-nextjs-app-router) -
+  使用 Next.js 和 TypeScript 並搭配 App router 的
+  範本
+- [wails-template-nextjs-app-router-src](https://github.com/edai-git/wails-template-nextjs-app-router) -
+  使用 Next.js 和 TypeScript 並搭配 App router src + 範例的
+  範本
+- [wails-vite-react-ts-tailwind-template](https://github.com/hotafrika/wails-vite-react-ts-tailwind-template) -
+  用於 React + TypeScript + Vite + TailwindCSS 的
+  範本
+- [wails-vite-react-ts-tailwind-shadcnui-template](https://github.com/Mahcks/wails-vite-react-tailwind-shadcnui-ts) -
+  使用 Vite、React、TypeScript、TailwindCSS 和 shadcn/ui 的
+  範本
+
+## Svelte
+
+- [wails-svelte-template](https://github.com/raitonoberu/wails-svelte-template) -
+  使用 Svelte 的範本
+- [wails-vite-svelte-template](https://github.com/BillBuilt/wails-vite-svelte-template) -
+  使用 Svelte 和 Vite 的範本
+- [wails-vite-svelte-tailwind-template](https://github.com/BillBuilt/wails-vite-svelte-tailwind-template) -
+  使用 Svelte 和 Vite 並搭配 TailwindCSS v3 的
+  範本
+- [wails-svelte-tailwind-vite-template](https://github.com/PylotLight/wails-vite-svelte-tailwind-template/tree/master) -
+  使用 Svelte v4.2.0 和 Vite 並搭配 TailwindCSS v3.3.3 的更新版範本
+- [wails-sveltekit-template](https://github.com/h8gi/wails-sveltekit-template) -
+  使用 SvelteKit 的範本
+- [wails-template-shadcn-svelte](https://github.com/xijaja/wails-template-shadcn-svelte) -
+  使用 Sveltekit 和 Shadcn-Svelte 的範本
+
+## Solid
+
+- [wails-template-vite-solid-ts](https://github.com/xijaja/wails-template-solid-ts) -
+  使用 Solid + Ts + Vite 的範本
+- [wails-template-vite-solid-js](https://github.com/xijaja/wails-template-solid-js) -
+  使用 Solid + Js + Vite 的範本
+
+## Elm
+
+- [wails-elm-template](https://github.com/benjamin-thomas/wails-elm-template) -
+  使用函數式程式設計和**快速**熱重載
+  設定來開發您的 GUI 應用程式 :tada: :rocket:
+- [wails-template-elm-tailwind](https://github.com/rnice01/wails-template-elm-tailwind) -
+  結合 Elm + Tailwind CSS + Wails 的力量 :muscle:！支援熱重載。
+
+## HTMX
+
+- [wails-htmx-templ-chi-tailwind](https://github.com/PylotLight/wails-hmtx-templ-template) -
+  使用純 htmx 的獨特組合來實現互動性，並使用 templ 來
+  建立元件和表單
+
+## 純 JavaScript (Vanilla)
+
+- [wails-pure-js-template](https://github.com/KiddoV/wails-pure-js-template) - 僅包含基本 JavaScript、HTML 和 CSS 的
+  範本
+
+## Lit (web components)
+
+- [wails-lit-shoelace-esbuild-template](https://github.com/Braincompiler/wails-lit-shoelace-esbuild-template) -
+  Wails 範本，為前端提供 lit、Shoelace 元件庫 +
+  預先設定的 prettier 和 typescript。

--- a/docs/src/content/docs/zh-tw/concepts/architecture.mdx
+++ b/docs/src/content/docs/zh-tw/concepts/architecture.mdx
@@ -1,0 +1,328 @@
+---
+title: Wails 運作原理
+description: 了解 Wails 架構及其如何實現原生效能
+sidebar:
+  order: 1
+---
+
+import { Tabs, TabItem } from "@astrojs/starlight/components";
+
+Wails 是一個用於構建桌面應用程式的框架，採用 **Go 作為後端** 和 **Web 技術作為前端**。但與 Electron 不同，Wails 並未捆綁瀏覽器，而是使用 **作業系統的原生 WebView**。
+
+```d2
+direction: right
+
+User: "User" {
+  shape: person
+  style.fill: "#3B82F6"
+}
+
+Application: "Your Wails Application" {
+  Frontend: "Frontend\n(HTML/CSS/JS)" {
+    shape: rectangle
+    style.fill: "#8B5CF6"
+  }
+  
+  Runtime: "Wails Runtime" {
+    Bridge: "Message Bridge" {
+      shape: diamond
+      style.fill: "#10B981"
+    }
+    
+    Bindings: "Type-Safe Bindings" {
+      shape: rectangle
+      style.fill: "#10B981"
+    }
+  }
+  
+  Backend: "Go Backend" {
+    Services: "Your Services" {
+      shape: rectangle
+      style.fill: "#00ADD8"
+    }
+    
+    NativeAPIs: "OS APIs" {
+      shape: rectangle
+      style.fill: "#00ADD8"
+    }
+  }
+}
+
+OS: "Operating System" {
+  WebView: "Native WebView\n(WebKit/WebView2/WebKitGTK)" {
+    shape: rectangle
+    style.fill: "#6B7280"
+  }
+  
+  SystemAPIs: "System APIs\n(Windows/macOS/Linux)" {
+    shape: rectangle
+    style.fill: "#6B7280"
+  }
+}
+
+User -> Application.Frontend: "Interacts with UI"
+Application.Frontend <-> Application.Runtime.Bridge: "JSON messages"
+Application.Runtime.Bridge <-> Application.Backend.Services: "Direct function calls"
+Application.Runtime.Bindings -> Application.Frontend: "TypeScript definitions"
+Application.Frontend -> OS.WebView: "Renders in"
+Application.Backend.NativeAPIs -> OS.SystemAPIs: "Native calls"
+```
+
+**與 Electron 的主要差異：**
+
+| 面向 | Wails | Electron |
+|--------|-------|----------|
+| **瀏覽器** | 作業系統提供的 WebView | 捆綁 Chromium（約 100MB） |
+| **後端** | Go（編譯後） | Node.js（解釋執行） |
+| **通訊** | 記憶體橋接 | IPC（進程間通訊） |
+| **套件大小** | 約 15MB | 約 150MB |
+| **記憶體佔用** | 約 10MB | 約 100MB+ |
+| **啟動速度** | &lt;0.5 秒 | 2-3 秒 |
+
+## 核心元件
+
+### 1. 原生 WebView
+
+Wails 使用作業系統內建的網頁渲染引擎：
+
+<Tabs syncKey="platform">
+  <TabItem label="Windows" icon="seti:windows">
+    **WebView2**（Microsoft Edge WebView2）
+    - 基於 Chromium（與 Edge 瀏覽器相同）
+    - 預裝於 Windows 10/11
+    - 透過 Windows Update 自動更新
+    - 完整支援現代網頁標準
+  </TabItem>
+
+  <TabItem label="macOS" icon="apple">
+    **WebKit**（Safari 的渲染引擎）
+    - 內建於 macOS
+    - 與 Safari 瀏覽器使用相同引擎
+    - 優異的效能與電池續航力
+    - 完整支援現代網頁標準
+  </TabItem>
+
+  <TabItem label="Linux" icon="linux">
+    **WebKitGTK**（WebKit 的 GTK 端口）
+    - 透過套件管理器安裝
+    - 與 GNOME Web (Epiphany) 使用相同引擎
+    - 良好的標準支援
+    - 輕量且高效能
+  </TabItem>
+</Tabs>
+
+**這為什麼重要：**
+- **無捆綁瀏覽器** → 應用程式體積更小
+- **作業系統原生** → 更好的整合與效能
+- **自動更新** → 從作業系統更新獲得安全修補
+- **熟悉的渲染** → 與系統瀏覽器相同
+
+### 2. Wails 橋接器
+
+橋接器是 Wails 的核心——它實現了 Go 與 JavaScript 之間的**直接通訊**。
+
+```d2
+direction: down
+
+Frontend: "Frontend (JavaScript)" {
+  shape: rectangle
+  style.fill: "#8B5CF6"
+}
+
+Bridge: "Wails Bridge" {
+  Encoder: "JSON Encoder" {
+    shape: rectangle
+  }
+  
+  Router: "Method Router" {
+    shape: diamond
+    style.fill: "#10B981"
+  }
+  
+  Decoder: "JSON Decoder" {
+    shape: rectangle
+  }
+}
+
+Backend: "Backend (Go)" {
+  Services: "Registered Services" {
+    shape: rectangle
+    style.fill: "#00ADD8"
+  }
+}
+
+Frontend -> Bridge.Encoder: "1. Call Go method\nGreet('Alice')"
+Bridge.Encoder -> Bridge.Router: "2. Encode to JSON\n{method: 'Greet', args: ['Alice']}"
+Bridge.Router -> Backend.Services: "3. Route to service\nGreetService.Greet('Alice')"
+Backend.Services -> Bridge.Decoder: "4. Return result\n'Hello, Alice!'"
+Bridge.Decoder -> Frontend: "5. Decode to JS\nPromise resolves"
+```
+
+**運作方式：**
+
+1. **前端呼叫 Go 方法**（透過自動產生的繫結）
+2. **橋接器將呼叫編碼為 JSON**（方法名稱 + 參數）
+3. **路由器在已註冊的服務中找到 Go 方法**
+4. **Go 方法執行並返回值**
+5. **橋接器解碼結果並傳回前端**
+6. **JavaScript 中的 Promise 解析**並獲得結果
+
+**效能特性：**
+- **記憶體內**：無網路開銷，無 HTTP
+- **零複製**（在可能的情况下，針對大量資料）
+- **預設非同步**：兩側均非阻塞
+- **型別安全**：自動產生 TypeScript 定義
+
+### 3. 服務系統
+
+服務是向後端暴露 Go 功能的推薦方式。
+
+```go
+// Define a service (just a regular Go struct)
+type GreetService struct {
+    prefix string
+}
+
+// Methods with exported names are automatically available
+func (g *GreetService) Greet(name string) string {
+    return g.prefix + name + "!"
+}
+
+func (g *GreetService) GetTime() time.Time {
+    return time.Now()
+}
+
+// Register the service
+app := application.New(application.Options{
+    Services: []application.Service{
+        application.NewService(&GreetService{prefix: "Hello, "}),
+    },
+})
+```
+
+**服務發現：**
+- Wails 在啟動時**掃描您的結構體**
+- **公開方法**可從前端呼叫
+- **型別資訊**被提取用於 TypeScript 繫結
+- **錯誤處理**是自動的（Go 錯誤 → JS 異常）
+
+**產生的 TypeScript 繫結：**
+```typescript
+// Auto-generated in frontend/bindings/GreetService.ts
+export function Greet(name: string): Promise<string>
+export function GetTime(): Promise<Date>
+```
+
+**為什麼使用服務？**
+- **型別安全**：完整的 TypeScript 支援
+- **自動發現**：無需手動註冊方法
+- **組織良好**：分組相關功能
+- **可測試**：服務只是 Go 結構體
+
+[了解更多關於服務 →](/features/bindings/services)
+
+### 4. 事件系統
+
+事件實現元件之間的**發布/訂閱通訊**。
+
+```d2
+direction: right
+
+GoService: "Go Service" {
+  shape: rectangle
+  style.fill: "#00ADD8"
+}
+
+EventBus: "Event Bus" {
+  shape: cylinder
+  style.fill: "#10B981"
+}
+
+Frontend1: "Window 1" {
+  shape: rectangle
+  style.fill: "#8B5CF6"
+}
+
+Frontend2: "Window 2" {
+  shape: rectangle
+  style.fill: "#8B5CF6"
+}
+
+GoService -> EventBus: "Emit('data-updated', data)"
+EventBus -> Frontend1: "Notify subscribers"
+EventBus -> Frontend2: "Notify subscribers"
+Frontend1 -> EventBus: "On('data-updated', handler)"
+Frontend2 -> EventBus: "On('data-updated', handler)"
+```
+
+**使用情境：**
+- **視窗通訊**：一個視窗通知其他視窗
+- **背景任務**：Go 服務通知 UI 進度
+- **狀態同步**：保持多個視窗同步
+- **鬆耦合**：元件不需要直接參考
+
+**範例：**
+```go
+// Go: Emit an event
+app.Event.Emit("user-logged-in", user)
+```
+
+```javascript
+// JavaScript: Listen for event
+import { Events } from '@wailsio/runtime'
+
+Events.On('user-logged-in', (user) => {
+    console.log('User logged in:', user)
+})
+```
+
+[了解更多關於事件 →](/features/events/system)
+
+## 應用程式生命週期
+
+了解生命週期可幫助您知道何時初始化資源和清理。
+
+```d2
+direction: down
+
+Start: "Application Start" {
+  shape: oval
+  style.fill: "#10B981"
+}
+
+Init: "Initialisation" {
+  Create: "Create Application" {
+    shape: rectangle
+  }
+  
+  Register: "Register Services" {
+    shape: rectangle
+  }
+  
+  Setup: "Setup Windows/Menus" {
+    shape: rectangle
+  }
+}
+
+Run: "Event Loop" {
+  Events: "Process Events" {
+    shape: rectangle
+  }
+  
+  Messages: "Handle Messages" {
+    shape: rectangle
+  }
+  
+  Render: "Update UI" {
+    shape: rectangle
+  }
+}
+
+Shutdown: "Shutdown" {
+  Cleanup: "Cleanup Resources" {
+    shape: rectangle
+  }
+  
+  Save: "Save State" {---
+
+**對架構有疑問？** 請在 [Discord](https://discord.gg/JDdSxwjhGf) 提問或查看 [API 參考文件](/reference/overview)。

--- a/docs/src/content/docs/zh-tw/concepts/bridge.mdx
+++ b/docs/src/content/docs/zh-tw/concepts/bridge.mdx
@@ -1,0 +1,391 @@
+---
+title: Go-Frontend Bridge
+description: 深入探討 Wails 如何實現 Go 與 JavaScript 之間的直接通訊
+sidebar:
+  order: 3
+---
+
+import { Tabs, TabItem } from "@astrojs/starlight/components";
+
+## Go 與 JavaScript 的直接通訊
+
+Wails 提供 Go 與 JavaScript 之間**直接的記憶體橋接**，實現無縫通訊，無需 HTTP 開銷、程序邊界或序列化瓶頸。
+
+## 整體概覽
+
+```d2
+direction: right
+
+Frontend: "Frontend (JavaScript)" {
+  UI: "React/Vue/Vanilla" {
+    shape: rectangle
+    style.fill: "#8B5CF6"
+  }
+  
+  Bindings: "Auto-Generated Bindings" {
+    shape: rectangle
+    style.fill: "#A78BFA"
+  }
+}
+
+Bridge: "Wails Bridge" {
+  Encoder: "JSON Encoder" {
+    shape: rectangle
+    style.fill: "#10B981"
+  }
+  
+  Router: "Method Router" {
+    shape: diamond
+    style.fill: "#10B981"
+  }
+  
+  Decoder: "JSON Decoder" {
+    shape: rectangle
+    style.fill: "#10B981"
+  }
+  
+  TypeGen: "Type Generator" {
+    shape: rectangle
+    style.fill: "#10B981"
+  }
+}
+
+Backend: "Backend (Go)" {
+  Services: "Your Services" {
+    shape: rectangle
+    style.fill: "#00ADD8"
+  }
+  
+  Registry: "Service Registry" {
+    shape: rectangle
+    style.fill: "#00ADD8"
+  }
+}
+
+Frontend.UI -> Frontend.Bindings: "import { Method }"
+Frontend.Bindings -> Bridge.Encoder: "Call Method('arg')"
+Bridge.Encoder -> Bridge.Router: "Encode to JSON"
+Bridge.Router -> Backend.Registry: "Find service"
+Backend.Registry -> Backend.Services: "Invoke method"
+Backend.Services -> Bridge.Decoder: "Return result"
+Bridge.Decoder -> Frontend.Bindings: "Decode to JS"
+Frontend.Bindings -> Frontend.UI: "Promise resolves"
+Bridge.TypeGen -> Frontend.Bindings: "Generate types"
+```
+
+**關鍵洞察：** 無需 HTTP、無需 IPC、無需程序邊界。僅有**直接函式呼叫**與**型別安全**。
+
+## 運作原理：逐步說明
+
+### 1. 服務註冊（啟動階段）
+
+當您的應用程式啟動時，Wails 會掃描您的服務：
+
+```go
+type GreetService struct {
+    prefix string
+}
+
+func (g *GreetService) Greet(name string) string {
+    return g.prefix + name + "!"
+}
+
+func (g *GreetService) Add(a, b int) int {
+    return a + b
+}
+
+// Register service
+app := application.New(application.Options{
+    Services: []application.Service{
+        application.NewService(&GreetService{prefix: "Hello, "}),
+    },
+})
+```
+
+**Wails 所做的操作：**
+1. **掃描結構體**以尋找公開方法
+2. **提取型別資訊**（參數、回傳型別）
+3. **建立註冊表**，將方法名稱對應至函式
+4. **產生 TypeScript 繫結**，包含完整的型別定義
+
+### 2. 繫結產生（編譯階段）
+
+Wails 會自動產生 TypeScript 繫結：
+
+```typescript
+// Auto-generated: frontend/bindings/GreetService.ts
+export function Greet(name: string): Promise<string>
+export function Add(a: number, b: number): Promise<number>
+```
+
+**型別對應：**
+
+| Go 型別 | TypeScript 型別 |
+|---------|-----------------|
+| `string` | `string` |
+| `int`, `int32`, `int64` | `number` |
+| `float32`, `float64` | `number` |
+| `bool` | `boolean` |
+| `[]T` | `T[]` |
+| `map[string]T` | `Record<string, T>` |
+| `struct` | `interface` |
+| `time.Time` | `Date` |
+| `error` | Exception (thrown) |
+
+### 3. 前端呼叫（執行階段）
+
+開發者從 JavaScript 呼叫 Go 方法：
+
+```javascript
+import { Greet, Add } from './bindings/GreetService'
+
+// Call Go from JavaScript
+const greeting = await Greet("World")
+console.log(greeting)  // "Hello, World!"
+
+const sum = await Add(5, 3)
+console.log(sum)  // 8
+```
+
+**發生的過程：**
+1. **呼叫繫結函式** - `Greet("World")`
+2. **建立訊息** - `{ service: "GreetService", method: "Greet", args: ["World"] }`
+3. **傳送給橋接器** - 透過 WebView 的 JavaScript 橋接
+4. **回傳 Promise** - 等待回應
+
+### 4. 橋接器處理（執行階段）
+
+橋接器接收訊息並進行處理：
+
+```d2
+direction: down
+
+Receive: "Receive Message" {
+  shape: rectangle
+  style.fill: "#10B981"
+}
+
+Parse: "Parse JSON" {
+  shape: rectangle
+}
+
+Validate: "Validate" {
+  Check: "Service exists?" {
+    shape: diamond
+  }
+  
+  CheckMethod: "Method exists?" {
+    shape: diamond
+  }
+  
+  CheckTypes: "Types correct?" {
+    shape: diamond
+  }
+}
+
+Invoke: "Invoke Go Method" {
+  shape: rectangle
+  style.fill: "#00ADD8"
+}
+
+Encode: "Encode Result" {
+  shape: rectangle
+}
+
+Send: "Send Response" {
+  shape: rectangle
+  style.fill: "#10B981"
+}
+
+Error: "Send Error" {
+  shape: rectangle
+  style.fill: "#EF4444"
+}
+
+Receive -> Parse
+Parse -> Validate.Check
+Validate.Check -> Validate.CheckMethod: "Yes"
+Validate.Check -> Error: "No"
+Validate.CheckMethod -> Validate.CheckTypes: "Yes"
+Validate.CheckMethod -> Error: "No"
+Validate.CheckTypes -> Invoke: "Yes"
+Validate.CheckTypes -> Error: "No"
+Invoke -> Encode: "Success"
+Invoke -> Error: "Error"
+Encode -> Send
+```
+
+**安全性：** 僅註冊的服務與公開方法可被呼叫。
+
+### 5. Go 執行（執行階段）
+
+Go 方法執行：
+
+```go
+func (g *GreetService) Greet(name string) string {
+    // This runs in Go
+    return g.prefix + name + "!"
+}
+```
+
+**執行環境：**
+- 在 **goroutine** 中執行（非阻塞）
+- 可存取**所有 Go 功能**（檔案系統、網路、資料庫）
+- 可自由呼叫**其他 Go 程式碼**
+- 回傳結果或錯誤
+
+### 6. 回應（執行階段）
+
+結果傳送回 JavaScript：
+
+```javascript
+// Promise resolves with result
+const greeting = await Greet("World")
+// greeting = "Hello, World!"
+```
+
+**錯誤處理：**
+
+```go
+func (g *GreetService) Divide(a, b float64) (float64, error) {
+    if b == 0 {
+        return 0, errors.New("division by zero")
+    }
+    return a / b, nil
+}
+```
+
+```javascript
+try {
+    const result = await Divide(10, 0)
+} catch (error) {
+    console.error("Go error:", error)  // "division by zero"
+}
+```
+
+## 效能特性
+
+### 速度
+
+**典型呼叫開銷：** &lt;1ms
+
+```
+Frontend Call → Bridge → Go Execution → Bridge → Frontend Response
+     ↓            ↓           ↓            ↓            ↓
+   &lt;0.1ms      &lt;0.1ms      [varies]     &lt;0.1ms      &lt;0.1ms
+```
+
+**與其他方案比較：**
+- **HTTP/REST：** 5-50ms（網路堆疊、序列化）
+- **IPC：** 1-10ms（程序邊界、編組）
+- **Wails Bridge：** &lt;1ms（記憶體內、直接呼叫）
+
+### 記憶體
+
+**每次呼叫開銷：** 約 1KB（訊息緩衝區）
+
+**零拷貝最佳化：** 大型資料（&gt;1MB）在可能的情況下使用共用記憶體。
+
+### 併發
+
+**呼叫是併發的：**
+- 每次呼叫在其自己的 goroutine 中執行
+- 多個呼叫可同時執行
+- 呼叫之間無阻塞
+
+```javascript
+// These run concurrently
+const [result1, result2, result3] = await Promise.all([
+    SlowOperation1(),
+    SlowOperation2(),
+    SlowOperation3(),
+])
+```
+
+## 型別系統
+
+### 支援的型別
+
+#### 基本型別
+
+```go
+// Go
+func Example(
+    s string,
+    i int,
+    f float64,
+    b bool,
+) (string, int, float64, bool) {
+    return s, i, f, b
+}
+```
+
+```typescript
+// TypeScript (auto-generated)
+function Example(
+    s: string,
+    i: number,
+    f: number,
+    b: boolean,
+): Promise<[string, number, number, boolean]>
+```
+
+#### 切片與陣列
+
+```go
+// Go
+func Sum(numbers []int) int {
+    total := 0
+    for _, n := range numbers {
+        total += n
+    }
+    return total
+}
+```
+
+```typescript
+// TypeScript
+function Sum(numbers: number[]): Promise<number>
+
+// Usage
+const total = await Sum([1, 2, 3, 4, 5])  // 15
+```
+
+#### 映射
+
+```go
+// Go
+func GetConfig() map[string]interface{} {
+    return map[string]interface{}{
+        "theme": "dark",
+        "fontSize": 14,
+        "enabled": true,
+    }
+}
+```
+
+```typescript
+// TypeScript
+function GetConfig(): Promise<Record<string, any>>
+
+// Usage
+const config = await GetConfig()
+console.log(config.theme)  // "dark"
+```
+
+#### 結構體
+
+```go
+// Go
+type User struct {
+    ID    int    `json:"id"`
+    Name  string `json:"name"`
+    Email string `json:"email"`
+}
+
+func GetUser(id int) (*User, error) {
+    return &User{
+        ID:    id,
+        Name:  "Alice",---
+
+**對橋接器有疑問？** 請在 [Discord](https://discord.gg/JDdSxwjhGf) 提問，或查看 [繫結範例](https://github.com/wailsapp/wails/tree/master/v3/examples/binding)。

--- a/docs/src/content/docs/zh-tw/concepts/build-system.mdx
+++ b/docs/src/content/docs/zh-tw/concepts/build-system.mdx
@@ -1,0 +1,424 @@
+---
+title: 建置系統
+description: 了解 Wails 如何建置和封裝您的應用程式
+sidebar:
+  order: 4
+---
+
+import { Tabs, TabItem } from "@astrojs/starlight/components";
+
+## 統一的建置系統
+
+Wails 提供**統一的建置系統**，它會編譯 Go 程式碼、封裝前端資源、將所有內容嵌入單一可執行檔，並處理平台特定的建置——只需一個指令即可完成。
+
+```bash
+wails3 build
+```
+
+**輸出：** 內含所有內容的原生可執行檔。
+
+## 建置流程概覽
+
+{/*
+TODO: 修復 D2 圖表生成或將其嵌入為圖片。
+之前的 D2 程式碼區塊在建置管線中導致了 MDX 解析錯誤。
+*/}
+
+**[建置流程圖表佔位符]**
+
+
+## 建置階段
+
+### 1. 分析階段
+
+Wails 掃描您的 Go 程式碼以了解您的服務：
+
+```go
+type GreetService struct {
+    prefix string
+}
+
+func (g *GreetService) Greet(name string) string {
+    return g.prefix + name + "!"
+}
+```
+
+**Wails 提取的內容：**
+- 服務名稱：`GreetService`
+- 方法名稱：`Greet`
+- 參數類型：`string`
+- 返回類型：`string`
+
+**用途：** 生成 TypeScript 綁定
+
+### 2. 生成階段
+
+#### TypeScript 綁定
+
+Wails 生成類型安全的綁定：
+
+```typescript
+// Auto-generated: frontend/bindings/GreetService.ts
+export function Greet(name: string): Promise<string> {
+    return window.wails.Call('GreetService.Greet', name)
+}
+```
+
+**優點：**
+- 完整的類型安全
+- IDE 自動完成
+- 編譯時錯誤檢查
+- JSDoc 註解
+
+#### 前端建置
+
+您的前端打包工具會執行（Vite、webpack 等）：
+
+```bash
+# Vite 範例
+vite build --outDir dist
+```
+
+**發生什麼事：**
+- JavaScript/TypeScript 被編譯
+- CSS 被處理並壓縮
+- 資源被最佳化
+- 產生原始碼對應（僅開發環境）
+- 輸出到 `frontend/dist/`
+
+### 3. 編譯階段
+
+#### Go 編譯
+
+Go 程式碼會以最佳化方式編譯：
+
+```bash
+go build -ldflags="-s -w" -o myapp.exe
+```
+
+**旗標：**
+- `-s`：移除符號表
+- `-w`：移除 DWARF 除錯資訊
+- 結果：更小的二進位檔（減少約 30%）
+
+**平台特定：**
+- Windows：嵌入圖示的 `.exe`
+- macOS：`.app` 套件結構
+- Linux：ELF 二進位檔
+
+#### 資源嵌入
+
+前端資源被嵌入到 Go 二進位檔中：
+
+```go
+//go:embed frontend/dist
+var assets embed.FS
+```
+
+**結果：** 單一可執行檔，所有內容都在內部。
+
+### 4. 輸出
+
+**單一原生二進位檔：**
+- Windows：`myapp.exe`（約 15MB）
+- macOS：`myapp.app`（約 15MB）
+- Linux：`myapp`（約 15MB）
+
+**無需依賴**（除了系統 WebView）。
+
+## 開發環境與生產環境
+
+<Tabs syncKey="mode">
+  <TabItem label="開發環境 (wails3 dev)" icon="seti:config">
+    **針對速度最佳化：**
+    
+    ```bash
+    wails3 dev
+    ```
+    
+    **發生什麼事：**
+    1. 啟動前端開發伺服器（Vite 在 port 5173 上）
+    2. 編譯未最佳化的 Go 程式碼
+    3. 啟動應用程式並指向開發伺服器
+    4. 啟用熱重載
+    5. 包含原始碼對應
+    
+    **特性：**
+    - **快速重建**（前端變更少於 1 秒）
+    - **不嵌入資源**（從開發伺服器提供）
+    - **包含除錯符號**
+    - **啟用原始碼對應**
+    - **詳細日誌記錄**
+    
+    **檔案大小：** 較大（包含除錯符號約 50MB）
+  </TabItem>
+
+  <TabItem label="生產環境 (wails3 build)" icon="rocket">
+    **針對大小和效能最佳化：**
+    
+    ```bash
+    wails3 build
+    ```
+    
+    **發生什麼事：**
+    1. 為生產環境建置前端（已壓縮）
+    2. 以最佳化方式編譯 Go
+    3. 移除除錯符號
+    4. 嵌入資源
+    5. 建立單一二進位檔
+    
+    **特性：**
+    - **最佳化程式碼**（已壓縮、已搖樹優化）
+    - **資源已嵌入**（無外部檔案）
+    - **已移除除錯符號**
+    - **無原始碼對應**
+    - **最小化日誌記錄**
+    
+    **檔案大小：** 較小（約 15MB）
+  </TabItem>
+</Tabs>
+
+## 建置指令
+
+### 基本建置
+
+```bash
+wails3 build
+```
+
+**輸出：** `build/bin/myapp[.exe]`
+
+### 為特定平台建置
+
+```bash
+# 為 Windows 建置（從任何作業系統）
+wails3 build -platform windows/amd64
+
+# 為 macOS 建置
+wails3 build -platform darwin/amd64
+wails3 build -platform darwin/arm64
+
+# 為 Linux 建置
+wails3 build -platform linux/amd64
+```
+
+**交叉編譯：** 從任何平台為任何平台建置。
+
+### 使用選項建置
+
+```bash
+# 自訂輸出目錄
+wails3 build -o ./dist/myapp
+
+# 跳過前端建置（使用現有的）
+wails3 build -skipbindings
+
+# 乾淨建置（移除快取）
+wails3 build -clean
+
+# 詳細輸出
+wails3 build -v
+```
+
+### 建置模式
+
+```bash
+# 除錯建置（包含符號）
+wails3 build -debug
+
+# 生產建置（預設，已最佳化）
+wails3 build
+
+# 開發建置（快速，未最佳化）
+wails3 build -devbuild
+```
+
+## 建置設定
+
+### Taskfile.yml
+
+Wails 使用 [Taskfile](https://taskfile.dev/) 進行建置設定：
+
+```yaml
+# Taskfile.yml
+version: '3'
+
+tasks:
+  build:
+    desc: 建置應用程式
+    cmds:
+      - wails3 build
+  
+  build:windows:
+    desc: 為 Windows 建置
+    cmds:
+      - wails3 build -platform windows/amd64
+  
+  build:macos:
+    desc: 為 macOS 建置（通用）
+    cmds:
+      - wails3 build -platform darwin/amd64
+      - wails3 build -platform darwin/arm64
+      - lipo -create -output build/bin/myapp.app build/bin/myapp-amd64.app build/bin/myapp-arm64.app
+  
+  build:linux:
+    desc: 為 Linux 建置
+    cmds:
+      - wails3 build -platform linux/amd64
+```
+
+**執行任務：**
+
+```bash
+task build:windows
+task build:macos
+task build:linux
+```
+
+### 建置選項檔案
+
+建立 `build/build.json` 以進行持久化設定：
+
+```json
+{
+  "name": "My Application",
+  "version": "1.0.0",
+  "author": "Your Name",
+  "description": "Application description",
+  "icon": "build/appicon.png",
+  "outputFilename": "myapp",
+  "platforms": ["windows/amd64", "darwin/amd64", "linux/amd64"],
+  "frontend": {
+    "dir": "./frontend",
+    "install": "npm install",
+    "build": "npm run build",
+    "dev": "npm run dev"
+  },
+  "go": {
+    "ldflags": "-s -w -X main.version={{.Version}}"
+  }
+}
+```
+
+## 資源嵌入
+
+### 運作方式
+
+Wails 使用 Go 的 `embed` 套件：
+
+```go
+package main
+
+import (
+    "embed"
+    "github.com/wailsapp/wails/v3/pkg/application"
+)
+
+//go:embed frontend/dist
+var assets embed.FS
+
+func main() {
+    app := application.New(application.Options{
+        Name:   "My App",
+        Assets: application.AssetOptions{
+            Handler: application.AssetFileServerFS(assets),
+        },
+    })
+    
+    app.Window.New()
+    app.Run()
+}
+```
+
+**在建置時：**
+1. 前端建置到 `frontend/dist/`
+2. `//go:embed` 指令包含檔案
+3. 檔案編譯進二進位檔
+4. 二進位檔包含所有內容
+
+**在執行時：**
+1. 應用程式啟動
+2. 資源從記憶體提供
+3. 資源無需磁碟 I/O
+4. 載入速度快
+
+### 自訂資源
+
+嵌入其他檔案：
+
+```go
+//go:embed frontend/dist
+var frontendAssets embed.FS
+
+//go:embed data/*.json
+var dataAssets embed.FS
+
+//go:embed templates/*.html
+var templateAssets embed.FS
+```
+
+## 建置最佳化
+
+### 前端最佳化
+
+**Vite（預設）：**
+
+```javascript
+// vite.config.js
+export default {
+  build: {
+    minify: 'terser',
+    terserOptions: {
+      compress: {
+        drop_console: true,  // 移除 console.log
+        drop_debugger: true,
+      },
+    },
+    rollupOptions: {
+      output: {
+        manualChunks: {
+          vendor: ['react', 'react-dom'],  // 分離供應商套件
+        },
+      },
+    },
+  },
+}
+```
+
+**結果：**
+- JavaScript 已壓縮（減少約 70%）
+- CSS 已壓縮（減少約 60%）
+- 影像已最佳化
+- 已套用搖樹優化
+
+### Go 最佳化
+
+**編譯器旗標：**
+
+```bash
+-ldflags="-s -w"
+```
+
+- `-s`：移除符號表（減少約 10%）
+- `-w`：移除 DWARF 除錯資訊（減少約 20%）
+
+**其他最佳化：**
+
+```bash
+-ldflags="-s -w -X main.version=1.0.0"
+```
+
+- `-X`：在建置時設定變數值
+- 適用於版本號、建置日期
+
+### 二進位檔壓縮
+
+**UPX（選用）：**
+
+```bash
+# 建置後
+upx --best build/bin/myapp.exe
+```
+
+**結果：**
+- 大小減少約 50%**有關建置的問題？** 請在 [Discord](https://discord.gg/JDdSxwjhGf) 提問，或查看 [建置範例](https://github.com/wailsapp/wails/tree/master/v3/examples/build)。

--- a/docs/src/content/docs/zh-tw/concepts/lifecycle.mdx
+++ b/docs/src/content/docs/zh-tw/concepts/lifecycle.mdx
@@ -1,0 +1,368 @@
+---
+title: 應用程式生命週期
+description: 了解從啟動到關閉的 Wails 應用程式生命週期
+sidebar:
+  order: 2
+---
+
+import { Tabs, TabItem } from "@astrojs/starlight/components";
+
+## 理解應用程式生命週期
+
+桌面應用程式具有從啟動到關閉的生命週期。Wails v3 提供了 **服務 (Services)**、**事件 (Events)** 和 **鉤子 (Hooks)** 來有效管理此生命週期。
+
+## 生命週期階段
+
+```d2
+direction: down
+
+Start: "Application Start" {
+  shape: oval
+  style.fill: "#10B981"
+}
+
+Init: "Initialisation" {
+  Parse: "Parse Options" {
+    shape: rectangle
+  }
+  Register: "Register Services" {
+    shape: rectangle
+  }
+  Setup: "Setup Runtime" {
+    shape: rectangle
+  }
+}
+
+AppRun: "app.Run()" {
+  shape: rectangle
+  style.fill: "#3B82F6"
+}
+
+ServiceStartup: "Service Startup" {
+  shape: rectangle
+  style.fill: "#8B5CF6"
+}
+
+EventLoop: "Event Loop" {
+  Process: "Process Events" {
+    shape: rectangle
+  }
+  Handle: "Handle Messages" {
+    shape: rectangle
+  }
+  Update: "Update UI" {
+    shape: rectangle
+  }
+}
+
+QuitSignal: "Quit Signal" {
+  shape: diamond
+  style.fill: "#F59E0B"
+}
+
+ShouldQuit: "ShouldQuit Check" {
+  shape: rectangle
+  style.fill: "#3B82F6"
+}
+
+OnShutdown: "OnShutdown Callbacks" {
+  shape: rectangle
+  style.fill: "#3B82F6"
+}
+
+ServiceShutdown: "Service Shutdown" {
+  shape: rectangle
+  style.fill: "#8B5CF6"
+}
+
+Cleanup: "Cleanup" {
+  Close: "Close Windows" {
+    shape: rectangle
+  }
+  Release: "Release Resources" {
+    shape: rectangle
+  }
+}
+
+End: "Application End" {
+  shape: oval
+  style.fill: "#EF4444"
+}
+
+Start -> Init.Parse
+Init.Parse -> Init.Register
+Init.Register -> Init.Setup
+Init.Setup -> AppRun
+AppRun -> ServiceStartup
+ServiceStartup -> EventLoop.Process
+EventLoop.Process -> EventLoop.Handle
+EventLoop.Handle -> EventLoop.Update
+EventLoop.Update -> EventLoop.Process: "Loop"
+EventLoop.Process -> QuitSignal: "User quits"
+QuitSignal -> ShouldQuit: "Check allowed?"
+ShouldQuit -> EventLoop.Process: "Denied"
+ShouldQuit -> OnShutdown: "Allowed"
+OnShutdown -> ServiceShutdown
+ServiceShutdown -> Cleanup.Close
+Cleanup.Close -> Cleanup.Release
+Cleanup.Release -> End
+```
+
+### 1. 建立應用程式
+
+使用 `application.New()` 建立您的應用程式：
+
+```go
+app := application.New(application.Options{
+    Name:        "My App",
+    Description: "An application built with Wails",
+    Services: []application.Service{
+        application.NewService(&MyService{}),
+    },
+    Assets: application.AssetOptions{
+        Handler: application.BundledAssetFileServer(assets),
+    },
+})
+```
+
+**發生什麼事：**
+1. 解析並驗證選項
+2. 註冊服務（但尚未啟動）
+3. 設定資產伺服器
+4. 設定執行階段 (Runtime)
+
+### 2. 執行應用程式
+
+呼叫 `app.Run()` 以啟動應用程式：
+
+```go
+err := app.Run()  // Blocks until quit
+if err != nil {
+    log.Fatal(err)
+}
+```
+
+**發生什麼事：**
+1. 依註冊順序啟動服務
+2. 啟用事件監聽器
+3. 可以建立視窗
+4. 開始事件迴圈
+
+### 3. 事件迴圈
+
+應用程式進入事件迴圈，在此期間它花費大部分時間：
+
+- 處理作業系統事件（滑鼠、鍵盤、視窗事件）
+- 處理 Go 到 JS 的訊息
+- 執行 JS 到 Go 的呼叫
+- 渲染 UI 更新
+
+### 4. 關閉
+
+當應用程式退出時：
+
+1. 檢查 `ShouldQuit` 回呼（如果已設定）
+2. 執行 `OnShutdown` 回呼
+3. 以反向順序關閉服務
+4. 關閉視窗
+5. 釋放資源
+
+## 服務生命週期
+
+服務是 Wails v3 中管理生命週期的主要方式。它們透過介面提供啟動和關閉鉤子。有關服務的完整文件，請參閱 [服務指南](/features/bindings/services)。
+
+### 建立服務
+
+```go
+type MyService struct {
+    db *sql.DB
+}
+
+// ServiceStartup is called when the application starts
+func (s *MyService) ServiceStartup(ctx context.Context, options application.ServiceOptions) error {
+    var err error
+    s.db, err = sql.Open("sqlite3", "app.db")
+    if err != nil {
+        return err  // Startup aborts if error returned
+    }
+
+    // Run migrations
+    if err := s.runMigrations(); err != nil {
+        return err
+    }
+
+    return nil
+}
+
+// ServiceShutdown is called when the application shuts down
+func (s *MyService) ServiceShutdown() error {
+    if s.db != nil {
+        return s.db.Close()
+    }
+    return nil
+}
+```
+
+### 註冊服務
+
+```go
+app := application.New(application.Options{
+    Services: []application.Service{
+        application.NewService(&MyService{}),
+        application.NewService(&AnotherService{}),
+    },
+})
+```
+
+**重點：**
+- 服務依註冊順序啟動
+- 服務以**反向**註冊順序關閉
+- 如果服務的 `ServiceStartup` 傳回錯誤，應用程式將中止
+- 傳遞給 `ServiceStartup` 的 `ctx` 在關閉開始時會被取消
+
+### 使用應用程式上下文
+
+傳遞給 `ServiceStartup` 的上下文在應用程式的整個生命週期內都有效：
+
+```go
+func (s *MyService) ServiceStartup(ctx context.Context, options application.ServiceOptions) error {
+    // Start a background task that respects shutdown
+    go func() {
+        ticker := time.NewTicker(5 * time.Minute)
+        defer ticker.Stop()
+
+        for {
+            select {
+            case <-ticker.C:
+                s.performBackgroundSync()
+            case <-ctx.Done():
+                // Application is shutting down
+                return
+            }
+        }
+    }()
+
+    return nil
+}
+```
+
+您也可以從應用程式實例存取上下文：
+
+```go
+app := application.Get()
+ctx := app.Context()
+```
+
+## 應用程式層級鉤子
+
+這些是 `application.Options` 中的便利回呼，讓您可以掛鉤到應用程式生命週期，而無需建立完整服務。它們對於簡單的清理任務、退出確認，或當您需要在關閉序列的特定點執行程式碼時非常有用。
+
+對於具有啟動邏輯、依賴注入或狀態資源的更複雜生命週期管理，請改用 [服務](#services-lifecycle)。
+
+### ShouldQuit
+
+`ShouldQuit` 回呼會在請求退出時被呼叫——無論是由使用者關閉最後一個視窗、按下 Cmd+Q (macOS) / Alt+F4 (Windows)，或以程式設計方式呼叫 `app.Quit()`。
+
+**傳回值：**
+- 傳回 `true` 以允許退出繼續進行（應用程式將關閉）
+- 傳回 `false` 以取消退出（應用程式繼續執行）
+
+這是您攔截退出請求並選擇性地阻止它們的機會，例如提示使用者關於未儲存的變更：
+
+```go
+app := application.New(application.Options{
+    ShouldQuit: func() bool {
+        if !hasUnsavedChanges() {
+            return true  // No unsaved changes, allow quit
+        }
+
+        // Prompt the user
+        result, _ := application.QuestionDialog().
+            SetTitle("Unsaved Changes").
+            SetMessage("You have unsaved changes. Quit anyway?").
+            AddButton("Quit", "quit").
+            AddButton("Cancel", "cancel").
+            Show()
+
+        // Only quit if user clicked "Quit"
+        return result == "quit"
+    },
+})
+```
+
+如果未設定 `ShouldQuit`，應用程式將在請求時立即退出。
+
+**ShouldQuit 被呼叫時：**
+- 使用者關閉最後一個視窗（除非設定了 `DisableQuitOnLastWindowClosed`）
+- 使用者在 macOS 上按下 Cmd+Q
+- 使用者在 Windows 上按下 Alt+F4（當焦點在最後一個視窗上時）
+- 程式碼呼叫 `app.Quit()`
+
+**ShouldQuit 未被呼叫時：**
+- 程序被終止 (SIGKILL、工作管理員強制退出)
+- 直接呼叫 `os.Exit()`
+
+### OnShutdown
+
+`OnShutdown` 回呼在應用程式確認要退出時被呼叫（在 `ShouldQuit` 傳回 `true` 之後，如果已設定）。用於清理任務，例如儲存狀態、關閉資料庫連線或釋放資源。
+
+```go
+app := application.New(application.Options{
+    OnShutdown: func() {
+        // Save application state
+        saveState()
+
+        // Close connections------|------|
+| macOS | 應用程式繼續執行（選單列保持存在） |
+| Windows | 應用程式退出 |
+| Linux | 應用程式退出 |
+
+macOS 遵循原生平台慣例，即使沒有視窗，應用程式通常仍會活躍於選單列中。Windows 和 Linux 預設會退出。
+
+**使所有平台在最後一個視窗關閉時退出：**
+
+```go
+app := application.New(application.Options{
+    Mac: application.MacOptions{
+        ApplicationShouldTerminateAfterLastWindowClosed: true,
+    },
+})
+```
+
+**使所有平台在最後一個視窗關閉時繼續執行：**
+
+這對於系統匣應用程式或應在背景保持執行的應用程式很有用。
+
+```go
+app := application.New(application.Options{
+    Windows: application.WindowsOptions{
+        DisableQuitOnLastWindowClosed: true,
+    },
+    Linux: application.LinuxOptions{
+        DisableQuitOnLastWindowClosed: true,
+    },
+})
+```
+
+## 常見模式
+
+### 模式 1：資料庫服務
+
+```go
+type DatabaseService struct {
+    db *sql.DB
+}
+
+func (s *DatabaseService) ServiceStartup(ctx context.Context, options application.ServiceOptions) error {
+    var err error
+    s.db, err = sql.Open("sqlite3", "app.db")
+    if err != nil {
+        return fmt.Errorf("failed to open database: %w", err)
+    }
+
+    if err := s.db.PingContext(ctx); err != nil {
+        return fmt.Errorf("failed to connect to database: %w", err)
+    }
+
+    return nil
+}**對生命週期有疑問？** 請在 [Discord](https://discord.gg/JDdSxwjhGf) 提問或查看 [範例](https://github.com/wailsapp/wails/tree/master/v3/examples)。

--- a/docs/src/content/docs/zh-tw/concepts/manager-api.mdx
+++ b/docs/src/content/docs/zh-tw/concepts/manager-api.mdx
@@ -1,0 +1,266 @@
+---
+title: Manager API
+description: 結構化的 API 組織與專注的管理器介面
+sidebar:
+  order: 2
+---
+
+import { Tabs, TabItem } from "@astrojs/starlight/components";
+
+Wails v3 的 Manager API 提供了一種有組織且易於發現的方式，透過專注的管理器結構體來存取應用程式的功能。這個新的 API 結構將相關方法分組，同時完全維持與傳統 App API 的向後相容性。
+
+## 概述
+
+Manager API 將應用程式功能組織成十一個專注的領域：
+
+- **`app.Window`** - 視窗建立、管理與回調
+- **`app.ContextMenu`** - 右鍵選單註冊與管理
+- **`app.KeyBinding`** - 全域快捷鍵管理
+- **`app.Browser`** - 瀏覽器整合（開啟 URL 和檔案）
+- **`app.Env`** - 環境資訊與系統狀態
+- **`app.Dialog`** - 檔案與訊息對話框操作
+- **`app.Event`** - 自訂事件處理與應用程式事件
+- **`app.Menu`** - 應用程式選單管理
+- **`app.Screen`** - 螢幕管理與座標轉換
+- **`app.Clipboard`** - 剪貼簿文字操作
+- **`app.SystemTray`** - 系統匣圖示建立與管理
+
+## 優點
+
+- **更好的可發現性** - IDE 自動完成功能顯示有組織的 API 介面
+- **改善的程式碼組織** - 相關方法分組在一起
+- **增強的可維護性** - 各管理器之間的關注點分離
+- **未來可擴展性** - 更容易向特定領域新增新功能
+
+## 使用方式
+
+Manager API 提供對所有應用程式功能的有組織存取：
+
+```go
+// 事件與自訂事件處理
+app.Event.Emit("custom", data)
+app.Event.On("custom", func(e *CustomEvent) { ... })
+
+// 視窗管理
+window, _ := app.Window.GetByName("main")
+app.Window.OnCreate(func(window Window) { ... })
+
+// 瀏覽器整合
+app.Browser.OpenURL("https://wails.io")
+
+// 選單管理
+menu := app.Menu.New()
+app.Menu.Set(menu)
+
+// 系統匣
+systray := app.SystemTray.New()
+```
+
+## 管理器參考
+
+### 視窗管理器
+
+管理視窗建立、擷取與生命週期回調。
+
+```go
+// 建立視窗
+window := app.Window.New()
+window := app.Window.NewWithOptions(options)
+current := app.Window.Current()
+
+// 尋找視窗
+window, exists := app.Window.GetByName("main")
+windows := app.Window.GetAll()
+
+// 視窗回調
+app.Window.OnCreate(func(window Window) {
+    // 處理視窗建立
+})
+```
+
+### 事件管理器
+
+處理自訂事件與應用程式事件監聽。
+
+```go
+// 自訂事件
+app.Event.Emit("userAction", data)
+cancelFunc := app.Event.On("userAction", func(e *CustomEvent) {
+    // 處理事件
+})
+app.Event.Off("userAction")
+app.Event.Reset() // 移除所有監聽器
+
+// 應用程式事件
+app.Event.OnApplicationEvent(events.Common.ThemeChanged, func(e *ApplicationEvent) {
+    // 處理系統主題變更
+})
+```
+
+### 瀏覽器管理器
+
+提供開啟 URL 和檔案的瀏覽器整合。
+
+```go
+// 在預設瀏覽器中開啟 URL 和檔案
+err := app.Browser.OpenURL("https://wails.io")
+err := app.Browser.OpenFile("/path/to/document.pdf")
+```
+
+### 環境管理器
+
+存取系統環境資訊。
+
+```go
+// 取得環境資訊
+env := app.Env.Info()
+fmt.Printf("OS: %s, Arch: %s\n", env.OS, env.Arch)
+
+// 檢查系統主題
+if app.Env.IsDarkMode() {
+    // 深色模式已啟用
+}
+
+// 開啟檔案管理器
+err := app.Env.OpenFileManager("/path/to/folder", false)
+```
+
+### 對話框管理器
+
+有組織地存取檔案與訊息對話框。
+
+```go
+// 檔案對話框
+result, err := app.Dialog.OpenFile().
+    AddFilter("Text Files", "*.txt").
+    PromptForSingleSelection()
+
+result, err = app.Dialog.SaveFile().
+    SetDefaultFilename("document.txt").
+    PromptForSingleSelection()
+
+// 訊息對話框
+app.Dialog.Info().
+    SetTitle("Information").
+    SetMessage("Operation completed successfully").
+    Show()
+
+app.Dialog.Error().
+    SetTitle("Error").  
+    SetMessage("An error occurred").
+    Show()
+```
+
+### 選單管理器
+
+應用程式選單的建立與管理。
+
+```go
+// 建立並設定應用程式選單
+menu := app.Menu.New()
+fileMenu := menu.AddSubmenu("File")
+fileMenu.Add("New").OnClick(func(ctx *Context) {
+    // 處理選單點擊
+})
+
+app.Menu.Set(menu)
+
+// 顯示關於對話框
+app.Menu.ShowAbout()
+```
+
+### 快捷鍵管理器
+
+全域快捷鍵的動態管理。
+
+```go
+// 新增快捷鍵
+app.KeyBinding.Add("ctrl+n", func(window *WebviewWindow) {
+    // 處理 Ctrl+N
+})
+
+app.KeyBinding.Add("ctrl+q", func(window *WebviewWindow) {
+    app.Quit()
+})
+
+// 移除快捷鍵
+app.KeyBinding.Remove("ctrl+n")
+
+// 取得所有快捷鍵
+bindings := app.KeyBinding.GetAll()
+```
+
+### 右鍵選單管理器
+
+進階右鍵選單管理（適用於函式庫作者）。
+
+```go
+// 建立並註冊右鍵選單
+menu := app.ContextMenu.New()
+app.ContextMenu.Add("myMenu", menu)
+
+// 擷取右鍵選單
+menu, exists := app.ContextMenu.Get("myMenu")
+
+// 移除右鍵選單
+app.ContextMenu.Remove("myMenu")
+```
+
+### 螢幕管理器
+
+多監視器設定的螢幕管理與座標轉換。
+
+```go
+// 取得螢幕資訊
+screens := app.Screen.GetAll()
+primary := app.Screen.GetPrimary()
+
+// 座標轉換
+physicalPoint := app.Screen.DipToPhysicalPoint(logicalPoint)
+logicalPoint := app.Screen.PhysicalToDipPoint(physicalPoint)
+
+// 螢幕偵測
+screen := app.Screen.ScreenNearestDipPoint(point)
+screen = app.Screen.ScreenNearestDipRect(rect)
+```
+
+### 剪貼簿管理器
+
+用於讀取和寫入文字的剪貼簿操作。
+
+```go
+// 設定文字到剪貼簿
+success := app.Clipboard.SetText("Hello World")
+if !success {
+    // 處理錯誤
+}
+
+// 從剪貼簿取得文字
+text, ok := app.Clipboard.Text()
+if !ok {
+    // 處理錯誤
+} else {
+    // 使用文字
+}
+```
+
+### 系統匣管理器
+
+系統匣圖示的建立與管理。
+
+```go
+// 建立系統匣
+systray := app.SystemTray.New()
+systray.SetLabel("My App")
+systray.SetIcon(iconBytes)
+
+// 新增選單到系統匣
+menu := app.Menu.New()
+menu.Add("Open").OnClick(func(ctx *Context) {
+    // 處理點擊
+})
+systray.SetMenu(menu)
+
+// 完成時銷毀系統匣
+systray.Destroy()
+```

--- a/docs/src/content/docs/zh-tw/contributing.mdx
+++ b/docs/src/content/docs/zh-tw/contributing.mdx
@@ -1,0 +1,275 @@
+---
+title: 貢獻指南
+description: 為 Wails 做出貢獻
+sidebar:
+  order: 100
+---
+
+import { Card, CardGrid } from "@astrojs/starlight/components";
+
+## 歡迎貢獻者！
+
+我們歡迎大家為 Wails 做出貢獻！無論您是修復錯誤、新增功能，還是改善文件，您的幫助都備受感激。
+
+## 貢獻方式
+
+### 1. 回報問題
+
+發現了錯誤嗎？[開啟一個 issue](https://github.com/wailsapp/wails/issues/new)，並包含：
+- 清晰的描述
+- 重現步驟
+- 預期行為與實際行為的對比
+- 系統資訊
+- 程式碼範例
+
+### 2. 改善文件
+
+我們始終歡迎文件方面的改善：
+- 修正錯字和錯誤
+- 新增範例
+- 釐清說明
+- 翻譯內容
+
+### 3. 提交程式碼
+
+透過 pull request 提交程式碼：
+- 錯誤修復
+- 新功能
+- 效能改進
+- 測試
+
+## 開始使用
+
+### Fork 並複製
+
+```bash
+# 在 GitHub 上 fork 儲存庫
+# 然後複製您的 fork
+git clone https://github.com/YOUR_USERNAME/wails.git
+cd wails
+
+# 新增上游遠端倉庫
+git remote add upstream https://github.com/wailsapp/wails.git
+```
+
+### 從原始碼建置
+
+```bash
+# 安裝相依性
+go mod download
+
+# 建置 Wails CLI
+cd v3/cmd/wails3
+go build
+
+# 測試您的建置
+./wails3 version
+```
+
+### 執行測試
+
+```bash
+# 執行所有測試
+go test ./...
+
+# 執行特定套件測試
+go test ./v3/pkg/application
+
+# 執行並包含覆蓋率
+go test -cover ./...
+```
+
+## 進行變更
+
+### 建立分支
+
+```bash
+# 更新 main
+git checkout main
+git pull upstream main
+
+# 建立功能分支
+git checkout -b feature/my-feature
+```
+
+### 進行您的變更
+
+1. **撰寫程式碼**，遵循 Go 的慣例
+2. **新增測試**以涵蓋新功能
+3. **更新文件**（如有需要）
+4. **執行測試**以確保沒有破壞現有功能
+5. **提交變更**，並附上清晰的訊息
+
+### 提交訊息指南
+
+```bash
+# 良好的提交訊息
+git commit -m "fix: resolve window focus issue on macOS"
+git commit -m "feat: add support for custom window chrome"
+git commit -m "docs: improve bindings documentation"
+
+# 使用慣用提交格式 (conventional commits)：
+# - feat: 新功能
+# - fix: 錯誤修復
+# - docs: 文件
+# - test: 測試
+# - refactor: 程式碼重構
+# - chore: 維護
+```
+
+### 提交 Pull Request
+
+```bash
+# 推送到您的 fork
+git push origin feature/my-feature
+
+# 在 GitHub 上開啟 pull request
+# 提供清晰的描述
+# 關聯相關的 issues
+```
+
+## Pull Request 指南
+
+### 良好的 PR 描述
+
+```markdown
+## 描述
+簡短描述所做的變更
+
+## 變更內容
+- 新增了功能 X
+- 修復了錯誤 Y
+- 更新了文件
+
+## 測試
+- 在 macOS 14 上測試
+- 在 Windows 11 上測試
+- 所有測試通過
+
+## 相關 Issues
+Fixes #123
+```
+
+### PR 檢查清單
+
+- [ ] 程式碼遵循 Go 慣例
+- [ ] 已新增/更新測試
+- [ ] 文件已更新
+- [ ] 所有測試通過
+- [ ] 沒有破壞性變更（或有文件說明）
+- [ ] 提交訊息清晰
+
+## 程式碼指南
+
+### Go 程式碼風格
+
+```go
+// ✅ 良好：清晰、有文件說明、有測試
+// ProcessData 處理輸入資料並回傳結果。
+// 如果資料無效，則回傳錯誤。
+func ProcessData(data string) (string, error) {
+    if data == "" {
+        return "", errors.New("data cannot be empty")
+    }
+    
+    result := process(data)
+    return result, nil
+}
+
+// ❌ 不佳：無文件說明、無錯誤處理
+func ProcessData(data string) string {
+    return process(data)
+}
+```
+
+### 測試
+
+```go
+func TestProcessData(t *testing.T) {
+    tests := []struct {
+        name    string
+        input   string
+        want    string
+        wantErr bool
+    }{
+        {"valid input", "test", "processed", false},
+        {"empty input", "", "", true},
+    }
+    
+    for _, tt := range tests {
+        t.Run(tt.name, func(t *testing.T) {
+            got, err := ProcessData(tt.input)
+            if (err != nil) != tt.wantErr {
+                t.Errorf("ProcessData() error = %v, wantErr %v", err, tt.wantErr)
+                return
+            }
+            if got != tt.want {
+                t.Errorf("ProcessData() = %v, want %v", got, tt.want)
+            }
+        })
+    }
+}
+```
+
+## 文件
+
+### 撰寫文件
+
+文件使用 Starlight (Astro) 撰寫：
+
+```bash
+cd docs
+npm install
+npm run dev
+```
+
+### 文件風格
+
+- 使用國際英文拼寫
+- 從問題開始說明
+- 提供可運作的範例
+- 包含疑難排解
+- 交叉引用相關內容
+
+## 社群
+
+### 取得協助
+
+- **Discord：** [加入我們的社群](https://discord.gg/JDdSxwjhGf)
+- **GitHub Discussions：** 提問
+- **GitHub Issues：** 回報錯誤
+
+### 行為準則
+
+請保持尊重、包容且專業。我們都在這裡共同建構優秀的軟體。
+
+## 認可
+
+貢獻者將被認可於：
+- 版本釋出筆記
+- 貢獻者名單
+- GitHub insights
+
+感謝您為 Wails 做出的貢獻！🎉
+
+## 下一步
+
+<CardGrid>
+  <Card title="GitHub 儲存庫" icon="github">
+    瀏覽 Wails 儲存庫。
+    
+    [在 GitHub 上檢視 →](https://github.com/wailsapp/wails)
+  </Card>
+
+  <Card title="Discord 社群" icon="discord">
+    加入社群。
+    
+    [加入 Discord →](https://discord.gg/JDdSxwjhGf)
+  </Card>
+
+  <Card title="文件" icon="open-book">
+    閱讀文件。
+    
+    [瀏覽文件 →](/zh-tw/quick-start/why-wails)
+  </Card>
+</CardGrid>

--- a/docs/src/content/docs/zh-tw/contributing/architecture/bindings.mdx
+++ b/docs/src/content/docs/zh-tw/contributing/architecture/bindings.mdx
@@ -1,0 +1,156 @@
+---
+title: 綁定系統
+description: 綁定系統如何收集、處理並生成 JavaScript/TypeScript 程式碼
+sidebar:
+  order: 1
+---
+
+import { FileTree } from "@astrojs/starlight/components";
+
+本指南說明 Wails 綁定系統的內部運作方式，為希望了解自動程式碼生成背後機制的開發者提供見解。
+
+## 架構概覽
+
+Wails 綁定系統由三個主要組件構成：
+
+1. **收集（Collection）**：分析 Go 程式碼，提取關於服務、模型及其他宣告的資訊
+2. **配置（Configuration）**：管理綁定生成過程的設定與選項
+3. **渲染（Rendering）**：根據收集的資訊生成 JavaScript/TypeScript 程式碼
+
+<FileTree>
+- internal/generator/
+  - collect/     # 套件分析與資訊提取
+  - config/      # 配置結構與介面
+  - render/      # JS/TS 程式碼生成
+</FileTree>
+
+## 收集流程
+
+收集流程負責分析 Go 套件並提取關於服務、模型及其他宣告的資訊。這由 `collect` 套件處理。
+
+### 主要組件
+
+- **Collector**：管理套件資訊並快取已收集的資料
+- **Package**：代表正在分析的 Go 套件，並儲存已收集的服務、模型與指令
+- **Service**：收集服務類型及其方法的資訊
+- **Model**：收集模型類型的詳細資訊，包括欄位、值與型別參數
+- **Directive**：解析並解釋 Go 原始碼中的 `//wails:` 指令
+
+### 收集流程
+
+1. Collector 掃描專案中指定的 Go 套件
+2. 識別服務類型（具有將暴露給前端的結構體方法）
+3. 對於每個服務，收集其方法的資訊
+4. 識別模型類型（作為服務方法參數或回傳值的結構體）
+5. 對於每個模型，收集其欄位與型別參數的資訊
+6. 處理程式碼中找到的任何 `//wails:` 指令
+
+## 渲染流程
+
+渲染流程負責根據收集的資訊生成 JavaScript/TypeScript 程式碼。這由 `render` 套件處理。
+
+### 主要組件
+
+- **Renderer**：協調服務、模型與索引檔案的渲染
+- **Module**：代表單一生成的 JavaScript/TypeScript 模組
+- **Templates**：用於程式碼生成的文字範本
+
+### 渲染流程
+
+1. 對於每個服務，Renderer 生成一個 JavaScript/TypeScript 檔案，其中的函式對應服務方法
+2. 對於每個模型，Renderer 生成一個 JavaScript/TypeScript 類別，對應模型結構體
+3. Renderer 生成索引檔案，重新匯出所有服務與模型
+4. Renderer 套用由 `//wails:inject` 指令指定的自訂程式碼注入
+
+## 型別對應
+
+綁定系統最重要的面向之一是 Go 型別如何對應到 JavaScript/TypeScript 型別。以下是對應的摘要：
+
+| Go 型別 | JavaScript 型別 | TypeScript 型別 |
+|---------|----------------|----------------|
+| `bool` | `boolean` | `boolean` |
+| `int`, `int8`, `int16`, `int32`, `int64`, `uint`, `uint8`, `uint16`, `uint32`, `uint64`, `float32`, `float64` | `number` | `number` |
+| `string` | `string` | `string` |
+| `[]byte` | `Uint8Array` | `Uint8Array` |
+| `[]T` | `Array<T>` | `T[]` |
+| `map[K]V` | `Object` | `Record<K, V>` |
+| `struct` | `Object` | 自訂類別 |
+| `interface{}` | `any` | `any` |
+| `*T` | `T \| null` | `T \| null` |
+| `func` | 不支援 | 不支援 |
+| `chan` | 不支援 | 不支援 |
+
+## 指令系統
+
+綁定系統支援多個可用於自訂生成程式碼的指令。這些指令以註解形式新增至您的 Go 程式碼中。
+
+### 可用指令
+
+- `//wails:inject`：將自訂 JavaScript/TypeScript 程式碼注入生成的綁定中
+- `//wails:include`：將額外檔案包含在生成的綁定中
+- `//wails:internal`：將類型或方法標記為內部，防止其暴露給前端
+- `//wails:ignore`：在綁定生成期間完全忽略某個方法
+- `//wails:id`：指定方法的自訂 ID，覆蓋預設的雜湊 ID
+
+### 指令處理
+
+1. 在收集階段，Collector 識別並解析 Go 程式碼中的指令
+2. 指令會與對應的宣告（服務、方法、模型等）一起儲存
+3. 在渲染階段，Renderer 套用指令來自訂生成的程式碼
+
+## 進階功能
+
+### 條件式程式碼生成
+
+綁定系統支援使用兩字元條件前綴的條件式程式碼生成，適用於 `include` 和 `inject` 指令：
+
+```
+<language><style>:<content>
+```
+
+其中：
+- `<language>` 可以是：
+  - `*` - JavaScript 與 TypeScript
+  - `j` - 僅 JavaScript
+  - `t` - 僅 TypeScript
+
+- `<style>` 可以是：
+  - `*` - 類別與介面
+  - `c` - 僅類別
+  - `i` - 僅介面
+
+例如：
+```go
+//wails:inject j*:console.log("JavaScript only");
+//wails:inject t*:console.log("TypeScript only");
+```
+
+### 自訂方法 ID
+
+預設情況下，方法由雜湊 ID 識別。然而，您可以使用 `//wails:id` 指令指定自訂 ID：
+
+```go
+//wails:id 42
+func (s *Service) CustomIDMethod() {}
+```
+
+這在重構程式碼時對於維持相容性很有用。
+
+## 效能考量
+
+綁定生成器設計為高效，但仍有幾點需要注意：
+
+1. 首次執行會較慢，因為它會建立要掃描的套件快取
+2. 後續執行會較快，因為它們使用快取的資訊
+3. 生成器會處理專案中的所有套件，對於大型專案來說可能耗時
+4. 您可以使用 `-clean` 旗標在生成前清理輸出目錄
+
+## 除錯
+
+如果您在綁定生成過程中遇到問題，可以使用 `-v` 旗標啟用除錯輸出：
+
+```bash
+wails3 generate bindings -v
+```
+
+這將提供關於收集與渲染流程的詳細資訊，有助於識別問題的來源。

--- a/docs/src/content/docs/zh-tw/credits.mdx
+++ b/docs/src/content/docs/zh-tw/credits.mdx
@@ -1,0 +1,55 @@
+---
+title: 致謝
+description: 感謝 Wails 背後的貢獻者與專案
+---
+
+{/* Import the auto-generated contributors file */}
+
+import Contributors from "../../../assets/contributors.html";
+
+- [Lea Anthony](https://github.com/leaanthony) - 專案負責人、主要開發者
+- [Stffabi](https://github.com/stffabi) - 技術負責人、開發者與維護者
+- [Travis McLane](https://github.com/tmclane) - 跨編譯工作、MacOS 測試
+- [Atterpac](https://github.com/atterpac) - 開發者、支援專家、核心動力
+- [Simon Thomas](mailto:enquiries@wails.io) - 成長黑客
+- [Lyimmi](https://github.com/Lyimmi) - Linux 相關事務
+- [fbbdev](https://github.com/fbbdev) - Bindings Generator 專家與核心貢獻者
+
+## 贊助商
+<br/>
+<a href="https://zsa.io/">
+    <img
+        src="/sponsors/zsa.png"
+        style={{ margin: "auto", width: "400px" }}
+        alt="ZSA"
+    />
+</a>
+<img
+  src="https://wails.io/img/sponsors.svg"
+  style={{ margin: "auto", width: "100%", "max-width": "1600px;" }}
+  alt="Sponsors"
+/>
+特別感謝：
+<img
+  src="/sponsors/jetbrains-grayscale.webp"
+  style={{ margin: "auto", width: "100px" }}
+  alt="JetBrains"
+/>
+
+## 貢獻者
+
+<Contributors />
+
+## 特別提及
+
+- [John Chadwick](https://github.com/jchv) - 他在 [go-webview2](https://github.com/jchv/go-webview2) 和
+  [go-winloader](https://github.com/jchv/go-winloader) 上的傑出工作，使得 Windows
+  版本成為可能。
+- [Tad Vizbaras](https://github.com/tadvi) - 他的 winc 專案是邁向純 Go 語言 Wails 的第一步。
+- [Mat Ryer](https://github.com/matryer) - 提供建議、支援與歡樂時光。
+- [Byron Chris](https://github.com/bh90210) - 對本專案長期以來的貢獻。
+- [Dustin Krysak](https://wiki.ubuntu.com/bashfulrobot) - 他的支援與回饋至關重要。
+- [Justen Walker](https://github.com/justenwalker/) - 協助解決讓 v2 順利釋出的 COM
+  相關問題。
+- [Wang, Chi](https://github.com/patr0nus/) - DeskGap 專案對 Wails v2 的方向產生了巨大影響。
+- [Serge Zaitsev](https://github.com/zserge) - 雖然 Wails 並未使用 Webview 專案，但它仍是靈感的來源。

--- a/docs/src/content/docs/zh-tw/faq.mdx
+++ b/docs/src/content/docs/zh-tw/faq.mdx
@@ -1,0 +1,260 @@
+---
+title: 常見問題
+description: 關於 Wails 的常見問題
+sidebar:
+  order: 99
+---
+
+## 一般資訊
+
+### 什麼是 Wails？
+
+Wails 是一個使用 Go 和 Web 技術來建構桌面應用程式的框架。它提供原生作業系統整合，同時允許您使用 HTML、CSS 和 JavaScript 來建構使用者介面。
+
+### Wails 與 Electron 相比如何？
+
+**Wails：**
+- 記憶體使用量約 10MB
+- 二進位檔案大小約 15MB
+- 原生效能
+- Go 後端
+
+**Electron：**
+- 記憶體使用量約 100MB+
+- 二進位檔案大小約 150MB+
+- Chromium 額外負荷
+- Node.js 後端
+
+### Wails 已準備好用於生產環境嗎？
+
+是的！Wails v3 適合用於生產環境的應用程式。許多公司都使用 Wails 來建構他們的桌面應用程式。
+
+### Wails 支援哪些平台？
+
+- Windows (7+)
+- macOS (10.13+)
+- Linux (GTK3)
+
+## 開發
+
+### 我需要懂 Go 嗎？
+
+基本的 Go 知識會有所幫助，但並非必要。您可以從簡單的服務開始，並在開發過程中學習。
+
+### 我可以使用我最喜歡的前端框架嗎？
+
+可以！Wails 與以下框架相容：
+- Vanilla JavaScript
+- React
+- Vue
+- Svelte
+- 任何能建置為 HTML/CSS/JS 的框架
+
+### 我如何從 JavaScript 呼叫 Go 函式？
+
+使用繫結（bindings）：
+
+```go
+// Go
+func (s *Service) Greet(name string) string {
+    return "Hello " + name
+}
+```
+
+```javascript
+// JavaScript
+import { Greet } from './bindings/myapp/service'
+const message = await Greet("World")
+```
+
+### 我可以使用 TypeScript 嗎？
+
+可以！Wails 會自動產生 TypeScript 定義。
+
+### 我如何除錯我的應用程式？
+
+使用您瀏覽器的開發者工具：
+- 右鍵點擊 → 檢查元素
+- 或在視窗選項中啟用開發者工具
+
+## 建置與分發
+
+### 我如何為生產環境進行建置？
+
+```bash
+wails3 build
+```
+
+您的應用程式將位於 `build/bin/` 中。
+
+### 我可以進行跨平台編譯嗎？
+
+可以！為其他平台進行建置：
+
+```bash
+wails3 build -platform windows/amd64
+wails3 build -platform darwin/universal
+wails3 build -platform linux/amd64
+```
+
+### 我如何建立安裝程式？
+
+使用平台特定的工具：
+- Windows：NSIS 或 WiX
+- macOS：建立 DMG
+- Linux：DEB/RPM 套件
+
+請參閱 [安裝程式指南](/guides/installers)。
+
+### 我如何為我的應用程式進行程式碼簽署？
+
+**macOS：**
+```bash
+codesign --deep --force --sign "Developer ID" MyApp.app
+```
+
+**Windows：**
+使用 SignTool 與您的憑證。
+
+## 功能
+
+### 我可以建立多個視窗嗎？
+
+可以！Wails v3 具有原生多視窗支援：
+
+```go
+window1 := app.Window.New()
+window2 := app.Window.New()
+```
+
+### Wails 支援系統匣（System Tray）嗎？
+
+可以！建立系統匣應用程式：
+
+```go
+tray := app.SystemTray.New()
+tray.SetIcon(iconBytes)
+tray.SetMenu(menu)
+```
+
+### 我可以使用原生對話框嗎？
+
+可以！Wails 提供原生對話框：
+
+```go
+path, _ := app.Dialog.OpenFile().
+    SetTitle("Select File").
+    PromptForSingleSelection()
+```
+
+### Wails 支援自動更新嗎？
+
+Wails 本身不包含自動更新功能，但您可以自行實作或使用第三方函式庫。
+
+## 效能
+
+### 為什麼我的二進位檔案很大？
+
+Go 二進位檔案包含執行階段（runtime）。若要減少大小：
+
+```bash
+wails3 build -ldflags "-s -w"
+```
+
+### 我如何提升效能？
+
+- 對大型資料集進行分頁
+- 快取昂貴的作業
+- 使用事件進行更新
+- 最佳化前端套件
+- 對您的程式碼進行分析（Profile）
+
+請參閱 [效能指南](/guides/performance)。
+
+### Wails 支援熱重載（Hot Reload）嗎？
+
+可以！使用開發模式：
+
+```bash
+wails3 dev
+```
+
+## 疑難排解
+
+### 我的繫結無法運作
+
+重新產生繫結：
+
+```bash
+wails3 generate bindings
+```
+
+### 視窗沒有出現
+
+檢查您是否有呼叫 `Show()`：
+
+```go
+window := app.Window.New()
+window.Show()  // 別忘了這個！
+```
+
+### 事件沒有觸發
+
+確保事件名稱完全相符：
+
+```go
+// Go
+app.Event.Emit("my-event", data)
+
+// JavaScript
+OnEvent("my-event", handler)  // 必須相符
+```
+
+### 建置失敗
+
+常見解決方案：
+- 執行 `go mod tidy`
+- 檢查 `wails.json` 設定
+- 驗證前端建置：`cd frontend && npm run build`
+- 更新 Wails：`go install github.com/wailsapp/wails/v3/cmd/wails3@latest`
+
+## 遷移
+
+### 我應該從 v2 遷移至 v3 嗎？
+
+v3 提供：
+- 更好的效能
+- 多視窗支援
+- 改進的 API
+- 更好的開發者體驗
+
+請參閱 [遷移指南](/migration/v2-to-v3)。
+
+### v2 還會繼續維護嗎？
+
+是的，v2 將獲得關鍵更新。
+
+### 我可以並行執行 v2 和 v3 嗎？
+
+可以，它們使用不同的匯入路徑。
+
+## 社群
+
+### 我如何取得協助？
+
+- [Discord 社群](https://discord.gg/JDdSxwjhGf)
+- [GitHub Discussions](https://github.com/wailsapp/wails/discussions)
+- [GitHub Issues](https://github.com/wailsapp/wails/issues)
+
+### 我如何貢獻？
+
+請參閱 [貢獻指南](/contributing)。
+
+### 我可以在哪裡找到範例？
+
+- [官方範例](https://github.com/wailsapp/wails/tree/master/v3/examples)
+- [社群範例](https://github.com/topics/wails)
+
+## 還有其他問題嗎？
+
+在 [Discord](https://discord.gg/JDdSxwjhGf) 提問或 [開啟討論](https://github.com/wailsapp/wails/discussions)。

--- a/docs/src/content/docs/zh-tw/feedback.mdx
+++ b/docs/src/content/docs/zh-tw/feedback.mdx
@@ -1,0 +1,84 @@
+---
+title: v3 Alpha 回饋
+description: 如何為 Wails v3 提供回饋並回報問題
+sidebar:
+  order: 40
+---
+
+import { Tabs, TabItem } from "@astrojs/starlight/components";
+
+我們歡迎（並鼓勵）您提供回饋！在建立新的票證或文章之前，請先搜尋現有的內容。以下是提供回饋的不同方式：
+
+<Tabs>
+  <TabItem label="錯誤" icon="error">
+
+    如果您發現了錯誤，請在 Discord 的 [v3 Alpha 回饋](https://discord.gg/bdj28QNHmT) 頻道中發文告知我們。
+
+    - 文章應清楚說明錯誤內容，並提供簡單的可重現範例。如果文件不清楚說明 *應該* 發生什麼情況，請在文章中包含該資訊。
+    - 文章應加上 `Bug` 標籤。
+    - 請在文章中附上 `wails doctor` 的輸出結果。
+    - 如果該錯誤的行為與現有文件不符，例如視窗無法正確調整大小，請執行以下操作：
+      - 更新 `v3/example` 目錄中的現有範例，或在 `v3/examples` 資料夾中建立一個能清楚顯示問題的新範例。
+      - 開啟一個標題為 `[v3 alpha test] <錯誤描述>` 的 [PR](https://github.com/wailsapp/wails/pulls)。
+      - 請在文章中附上該 PR 的連結。
+
+    :::caution
+
+    _請記住_，非預期的行為不一定是錯誤——它可能只是沒有按照您的預期運作。請使用 `Suggestions` 來回報這類情況。
+
+    :::
+
+  </TabItem>
+
+  <TabItem label="修復" icon="approve-check">
+
+    如果您有修復錯誤或更新文件的方案，請執行以下操作：
+
+    - 在 [Wails 儲存庫](https://github.com/wailsapp/wails) 上開啟一個 pull request。PR 的標題應以 `[v3 alpha]` 開頭。
+    - 在 [v3 Alpha 回饋](https://discord.gg/bdj28QNHmT) 頻道中建立一篇文章。
+    - 文章應加上 `PR` 標籤。
+    - 請在文章中附上該 PR 的連結。
+
+  </TabItem>
+
+  <TabItem label="建議" icon="puzzle" id="abc">
+
+    如果您有任何建議，請在 Discord 的 [v3 Alpha 回饋](https://discord.gg/bdj28QNHmT) 頻道中發文告知我們：
+
+    - 文章應加上 `Suggestion` 標籤。
+
+    如果您有任何問題，歡迎隨時在 [Discord](https://discord.gg/bdj28QNHmT) 上與我們聯繫。
+
+  </TabItem>
+
+  <TabItem label="按讚" icon="star">
+
+    - 可以使用 :thumbsup: 表情符號對文章進行「按讚」。請對您認為優先的文章進行按讚。
+    - 請 *不要* 僅添加 "+1" 或「我也是」之類的留言。
+    - 如果文章還有更多內容可以補充，例如「此錯誤也影響 ARM 版本」或「另一個選項是....」，歡迎隨時留言。
+
+  </TabItem>
+
+</Tabs>
+
+已知問題列表及進行中的工作可於 [此處](https://github.com/orgs/wailsapp/projects/6) 查看。
+
+## 我們希望獲得回饋的主題
+
+- API
+  - 是否容易使用？
+  - 是否符合您的預期？
+  - 是否缺少任何功能？
+  - 是否有應該移除的部分？
+  - Go 和 JS 之間是否一致？
+- 建置系統
+  - 是否容易使用？
+  - 我們能否改進它？
+- 範例
+  - 是否清晰？
+  - 是否涵蓋了基本內容？
+- 功能
+  - 缺少哪些功能？
+  - 哪些功能是不需要的？
+- 文件
+  - 哪些部分可以更清晰？

--- a/docs/src/content/docs/zh-tw/getting-started/your-first-app.mdx
+++ b/docs/src/content/docs/zh-tw/getting-started/your-first-app.mdx
@@ -1,0 +1,257 @@
+---
+title: 你的第一個應用程式
+description: 逐步建立你的第一個 Wails 桌面應用程式
+sidebar:
+  order: 20
+---
+
+import { Tabs, TabItem } from "@astrojs/starlight/components";
+import { Badge } from '@astrojs/starlight/components';
+import { Steps } from "@astrojs/starlight/components";
+import { FileTree } from '@astrojs/starlight/components';
+
+import wails_init from '../../../../assets/wails_init.mp4';
+import wails_build from '../../../../assets/wails_build.mp4';
+import wails_dev from '../../../../assets/wails_dev.mp4';
+
+
+本指南將展示如何建立你的第一個 Wails v3 應用程式，涵蓋專案設定、建置與開發工作流程。
+
+<br/>
+<br/>
+
+<Steps>
+
+1.  ## 建立新專案
+
+    開啟終端機並執行以下指令來建立新的 Wails 專案：
+
+    ```bash
+    wails3 init -n myfirstapp
+    ```
+
+    此指令會建立一個名為 `myfirstapp` 的新目錄，其中包含所有必要的檔案。
+
+      <video src={wails_init} controls></video> 
+
+2.  ## 探索專案結構
+
+    進入 `myfirstapp` 目錄。你會看到多個檔案與資料夾：
+
+    <FileTree>
+    - build/           包含建置流程所使用的檔案
+        - appicon.png  應用程式圖示
+        - config.yml   建置設定
+        - Taskfile.yml 建置任務
+        - darwin/      macOS 專屬建置檔案
+            - Info.dev.plist 開發環境設定
+            - Info.plist    生產環境設定
+            - Taskfile.yml  macOS 建置任務
+            - icons.icns    macOS 應用程式圖示
+        - linux/       Linux 專屬建置檔案
+            - Taskfile.yml  Linux 建置任務
+            - appimage/     AppImage 封裝
+                - build.sh  AppImage 建置腳本
+            - nfpm/        NFPM 封裝
+                - nfpm.yaml 套件設定
+                - scripts/  建置腳本
+        - windows/     Windows 專屬建置檔案
+            - Taskfile.yml        Windows 建置任務
+            - icon.ico           Windows 應用程式圖示
+            - info.json          應用程式中繼資料
+            - wails.exe.manifest Windows 設定檔
+            - nsis/              NSIS 安裝程式檔案
+                - project.nsi                    NSIS 專案檔案
+                - wails_tools.nsh               NSIS 輔助腳本
+    - frontend/        前端應用程式檔案
+        - index.html   主要 HTML 檔案
+        - main.js      主要 JavaScript 檔案
+        - package.json NPM 套件設定
+        - public/      靜態資源
+        - Inter Font License.txt 字型授權
+    - .gitignore      Git 忽略檔案
+    - README.md       專案文件
+    - Taskfile.yml    專案任務
+    - go.mod          Go 模組檔案
+    - go.sum          Go 模組校驗和
+    - greetservice.go 問候服務
+    - main.go         主要應用程式程式碼
+    </FileTree>
+
+    花點時間探索這些檔案，並熟悉其結構。
+
+    :::note
+    雖然 Wails v3 使用 [Task](https://taskfile.dev/) 作為預設的建置系統，但你也可以使用 `make` 或其他替代建置系統。
+    :::
+
+3.  ## 建置你的應用程式
+
+    要建置你的應用程式，請執行：
+
+    ```bash
+    wails3 build
+    ```
+
+    此指令會編譯你的應用程式的除錯版本，並將其儲存至新的 `bin` 目錄中。
+
+    :::note
+    `wails3 build` 是 `wails3 task build` 的縮寫，會執行 `Taskfile.yml` 中的 `build` 任務。
+    :::
+
+        <video src={wails_build} controls></video> 
+
+
+    建置完成後，你可以像執行一般應用程式一樣執行它：
+
+
+    <Tabs syncKey="platform">
+
+      <TabItem label="Mac" icon="apple">
+
+        ```sh
+        ./bin/myfirstapp
+        ```
+
+          </TabItem>
+
+      <TabItem label="Windows" icon="seti:windows">
+
+        ```sh
+        bin\myfirstapp.exe
+        ```
+
+          </TabItem>
+
+      <TabItem label="Linux" icon="linux">
+
+        ```sh
+        ./bin/myfirstapp
+        ```
+
+          </TabItem>
+
+    </Tabs>
+
+    你會看到一個簡單的介面，這是你的應用程式的起點。由於這是除錯版本，你也會在控制台視窗中看到記錄。這對於除錯非常有用。
+
+4.  ## 開發模式
+
+    我們也可以以開發模式執行應用程式。此模式允許你修改前端程式碼，並即時看到變更反映在執行的應用程式中，而無需重新建置整個應用程式。
+
+    1. 開啟新的終端機視窗。
+    2. 執行 `wails3 dev`。應用程式將以除錯模式編譯並執行。
+    3. 在你偏好的編輯器中開啟 `frontend/index.html`。
+    4. 編輯程式碼，將 `Please enter your name below` 改為
+       `Please enter your name below!!!`。
+    5. 儲存檔案。
+
+    此變更會立即反映在你的應用程式中。
+
+    對後端程式碼的任何變更都會觸發重新建置：
+
+    1. 開啟 `greetservice.go`。
+    2. 將包含 `return "Hello " + name + "!"` 的行改為
+       `return "Hello there " + name + "!"`。
+    3. 儲存檔案。
+
+    應用程式將在幾秒內更新。
+
+        <video src={wails_dev} controls></video>
+
+5.  ## 封裝你的應用程式
+
+        一旦你的應用程式準備好分發，你可以建立平台專屬的套件：
+
+          <Tabs syncKey="platform">
+
+    <TabItem label="Mac" icon="apple">
+
+              要建立 `.app` 套件：
+
+              ```bash
+              wails3 package
+              ```
+
+              這將建立生產版本，並將其封裝成 `bin` 目錄中的 `.app` 套件。
+
+            </TabItem>
+            <TabItem label="Windows" icon="seti:windows">
+
+              要建立 NSIS 安裝程式：
+
+              ```bash
+              wails3 package
+              ```
+
+              這將建立生產版本，並將其封裝成 `bin` 目錄中的 NSIS 安裝程式。
+
+            </TabItem>
+            <TabItem label="Linux" icon="linux">
+
+              Wails 支援多種 Linux 分發的套件格式：
+
+              ```bash
+              # 建立所有套件類型 (AppImage, deb, rpm, 和 Arch Linux)
+              wails3 package
+
+              # 或建立特定套件類型
+              wails3 task linux:create:appimage  # AppImage 格式
+              wails3 task linux:create:deb       # Debian 套件
+              wails3 task linux:create:rpm       # Red Hat 套件
+              wails3 task linux:create:aur       # Arch Linux 套件
+              ```
+
+            </TabItem>
+
+          </Tabs>
+
+        有關封裝選項與設定的更多詳細資訊，請查看我們的 [封裝指南](/guides/packaging)。
+
+6.  ## 設定版本控制與模組名稱
+
+    你的專案已建立，但模組名稱為佔位符 `changeme`。建議將其更新以符合你的儲存庫 URL：
+
+    1. 在 GitHub（或你偏好的 Git 主機）上建立新儲存庫
+    2. 在你的專案目錄中初始化 git：
+       ```bash
+       git init
+       git add .
+       git commit -m "Initial commit"
+       ```
+    3. 設定你的遠端儲存庫（替換為你的儲存庫 URL）：
+       ```bash
+       git remote add origin https://github.com/username/myfirstapp.git
+       ```
+    4. 更新 `go.mod` 中的模組名稱以符合你的儲存庫 URL：
+       ```bash
+       go mod edit -module github.com/username/myfirstapp
+       ```
+    5. 推送你的程式碼：
+       ```bash
+       git push -u origin main
+       ```
+
+    這可確保你的 Go 模組名稱符合 Go 的模組命名慣例，並使分享程式碼變得更容易。:::tip[專業提示]
+您可以透過在建立專案時使用 `-git` 旗標，自動化所有初始化步驟：
+```bash
+wails3 init -n myfirstapp -git github.com/username/myfirstapp
+```
+此功能支援各種 Git URL 格式：
+- HTTPS: `https://github.com/username/project`
+- SSH: `git@github.com:username/project` 或 `ssh://git@github.com/username/project`
+- Git 協定: `git://github.com/username/project`
+- 檔案系統: `file:///path/to/project.git`
+:::
+
+</Steps>
+
+## 恭喜！
+
+您剛剛建立、開發並打包了您的第一個 Wails 應用程式。
+這只是您使用 Wails v3 所能達成成就的開始。
+
+## 下一步
+
+如果您是 Wails 的新手，我們建議您接著閱讀我們的教學課程，這將是一份實用的指南，帶領您了解 Wails 的各項功能。第一個教學課程為 [建立服務](/tutorials/01-creating-a-service)。
+
+如果您是進階使用者，請查看我們的 [指南](/guides)，以獲取有關如何使用 Wails 的更詳細資訊。

--- a/docs/src/content/docs/zh-tw/quick-start/first-app.mdx
+++ b/docs/src/content/docs/zh-tw/quick-start/first-app.mdx
@@ -1,0 +1,270 @@
+---
+title: 你的第一個應用程式
+description: 在 10 分鐘內建立一個可運作的 Wails 應用程式
+sidebar:
+  order: 3
+---
+
+import { Tabs, TabItem, Steps } from "@astrojs/starlight/components";
+
+我們將建立一個簡單的問候應用程式，以展示 Wails 的核心概念：
+- 使用 Go 後端管理邏輯
+- 前端呼叫 Go 函式
+- 型別安全的繫結（Type-safe bindings）
+- 開發期間的熱重載（Hot reload）
+
+**完成時間：** 10 分鐘
+
+:::tip[Windows 11 使用者的效能建議]
+考慮使用 [Dev Drive](https://learn.microsoft.com/en-us/windows/dev-drive/) 來儲存你的專案。Dev Drive 針對開發者工作負載進行了最佳化，與一般的 NTFS 磁碟機相比，可以將建置時間和磁碟存取速度提升高達 30%。
+:::
+
+## 建立你的專案
+
+<Steps>
+
+1. **產生專案**
+
+   ```bash
+   wails3 init -n myapp
+   cd myapp
+   ```
+
+   這會建立一個使用預設 Vanilla + Vite 範本的新專案（純 HTML/CSS/JS 搭配 Vite 打包器）。
+
+   :::tip[其他範本]
+   嘗試使用 `-t react`、`-t vue` 或 `-t svelte` 來選擇你偏好的框架。
+   執行 `wails3 init -l` 以查看所有可用的範本。
+   :::
+
+2. **了解專案結構**
+
+   ```
+   myapp/
+   ├── main.go              # 應用程式進入點
+   ├── greetservice.go      # 問候服務
+   ├── frontend/            # 你的 UI 程式碼
+   │   ├── index.html       # HTML 進入點
+   │   ├── src/
+   │   │   └── main.js      # 前端 JavaScript
+   │   ├── public/
+   │   │   └── style.css    # 樣式
+   │   ├── package.json     # 前端相依性
+   │   └── vite.config.js   # Vite 打包器設定
+   ├── build/               # 建置設定
+   └── Taskfile.yml         # 建置任務
+   ```
+
+3. **執行應用程式**
+
+   ```bash
+   wails3 dev
+   ```
+
+   :::note[首次執行]
+   首次執行可能需要比預期更長的時間，因為它會安裝前端相依性、產生繫結等。後續的執行速度會快得多。
+   :::
+
+   應用程式開啟後會顯示問候介面。輸入你的名字並點擊「Greet」— Go 後端會處理你的輸入並回傳問候語。
+
+</Steps>
+
+## 運作原理
+
+讓我們了解讓這一切運作的程式碼。
+
+### Go 後端
+
+開啟 `greetservice.go`：
+
+```go title="greetservice.go"
+package main
+
+import (
+	"fmt"
+)
+
+type GreetService struct{}
+
+func (g *GreetService) Greet(name string) string {
+	return fmt.Sprintf("Hello %s, It's show time!", name)
+}
+```
+
+**關鍵概念：**
+
+1. **服務（Service）** - 具有公開方法的 Go 結構體
+2. **公開方法** - `Greet` 是大寫的，這使得前端可以存取它
+3. **簡單的邏輯** - 接收名字，回傳問候語
+4. **型別安全** - 輸入和輸出的型別都已定義
+
+:::tip[了解服務與繫結]
+**服務（Services）** 是自包含的 Go 模組，用於向你的前端暴露功能。它們只是具有公開方法的普通 Go 結構體，你可以在應用程式設定的 `Services` 欄位中註冊它們。
+
+**繫結（Bindings）** 是自動產生的 TypeScript/JavaScript SDK，讓你的前端能夠呼叫這些服務。當你執行 `wails3 dev` 或 `wails3 build` 時，Wails 會分析你註冊的服務，並在 `frontend/bindings/` 中產生型別安全的繫結。
+
+可以將服務視為你的後端 API，而將繫結視為與之溝通的用戶端程式庫。
+:::
+
+### 註冊服務
+
+開啟 `main.go` 並找到服務註冊處：
+
+```go title="main.go" {4-6}
+err := application.New(application.Options{
+    Name: "myapp",
+    Services: []application.Service{
+        application.NewService(&GreetService{}),
+    },
+    // ... other options
+})
+```
+
+這將你的 `GreetService` 註冊到 Wails，使其所有公開方法對前端可用。
+
+### 前端
+
+開啟 `frontend/src/main.js`：
+
+```javascript title="frontend/src/main.js"
+import {GreetService} from "../bindings/changeme";
+
+window.greet = async () => {
+    const nameElement = document.getElementById('name');
+    const resultElement = document.getElementById('result');
+
+    const name = nameElement.value;
+    if (!name) {
+        return;
+    }
+
+    try {
+        const result = await GreetService.Greet(name);
+        resultElement.innerText = result;
+    } catch (err) {
+        console.error(err);
+    }
+};
+```
+
+**關鍵概念：**
+
+1. **自動產生的繫結** - `GreetService` 從產生的程式碼中匯入
+2. **型別安全的呼叫** - 方法名稱和簽章與你的 Go 程式碼相符
+3. **預設為非同步** - 所有 Go 呼叫都回傳 Promises
+4. **錯誤處理** - Go 的錯誤會在 try/catch 中被捕獲
+
+:::note[繫結在哪裡？]
+產生的繫結位於 `frontend/bindings/`。當你執行 `wails3 dev` 或 `wails3 build` 時，它們會自動建立。
+
+**切勿手動編輯這些檔案** — 它們會在每次建置時重新產生。
+:::
+
+## 自訂你的應用程式
+
+讓我們新增一個新功能來了解工作流程。
+
+### 新增「問候多人」功能
+
+<Steps>
+
+1. **將方法新增到 GreetService**
+
+   將以下程式碼新增到 `greetservice.go`：
+
+   ```go title="greetservice.go"
+   func (g *GreetService) GreetMany(names []string) []string {
+       greetings := make([]string, len(names))
+       for i, name := range names {
+           greetings[i] = fmt.Sprintf("Hello %s!", name)
+       }
+       return greetings
+   }
+   ```
+
+2. **應用程式將自動重新建置**
+
+   儲存檔案，`wails3 dev` 將自動重新建置你的 Go 程式碼並重新啟動應用程式。
+
+   :::note[自動重新建置]
+   Go 程式碼的變更會觸發自動重新建置和重新啟動。前端變更會熱重載而無需重新啟動。
+   :::
+
+3. **在前端中使用它**
+
+   將以下程式碼新增到 `frontend/src/main.js`：
+
+   ```javascript title="frontend/src/main.js"
+   window.greetMany = async () => {
+       const names = ['Alice', 'Bob', 'Charlie'];
+       const greetings = await GreetService.GreetMany(names);
+       console.log(greetings);
+   };
+   ```
+
+   開啟瀏覽器主控台並呼叫 `greetMany()` — 你將看到問候語的陣列。
+
+</Steps>
+
+## 為生產環境建置
+
+當你準備好要分發你的應用程式時：
+
+```bash
+wails3 build
+```
+
+**這會做什麼：**
+- 使用最佳化編譯 Go 程式碼
+- 為生產環境建置前端（已最小化）
+- 在 `build/bin/` 中建立原生可執行檔
+
+<Tabs syncKey="os">
+  <TabItem label="Windows" icon="seti:windows">
+    **輸出：** `build/bin/myapp.exe`
+
+    雙擊即可執行。不需要任何相依性（WebView2 是 Windows 的一部分）。
+  </TabItem>
+
+  <TabItem label="macOS" icon="apple">
+    **輸出：** `build/bin/myapp.app`
+
+    拖曳至「應用程式」資料夾或雙擊執行。
+  </TabItem>
+
+  <TabItem label="Linux" icon="linux">
+    **輸出：** `build/bin/myapp`
+
+    使用 `./build/bin/myapp` 執行，或為你的啟動器建立 `.desktop` 檔案。
+  </TabItem>
+</Tabs>
+
+:::tip[跨平台建置]
+想要為其他平台建置？請參閱 [跨平台建置 →](/guides/build/cross-platform)
+:::
+
+## 我們學到了什麼
+
+**專案結構**
+- `main.go` 用於 Go 後端
+- `frontend/` 用於 UI 程式碼
+- `Taskfile.yml` 用於建置任務
+
+**服務（Services）**
+- 建立具有公開方法的 Go 結構體
+- 使用 `application.NewService()` 進行註冊
+- 方法自動在前端可用
+
+**繫結（Bindings）**
+- 自動產生的 TypeScript 定義
+- 型別安全的函式呼叫
+- 預設為非同步（Promises）
+
+**開發工作流程**
+- `wails3 dev` 用於熱重載
+- Go 變更會自動重新建置和重新啟動
+- 前端變更會立即熱重載
+
+---
+
+**有問題嗎？** 加入 [Discord](https://discord.gg/JDdSxwjhGf) 並向社群提問。

--- a/docs/src/content/docs/zh-tw/quick-start/installation.mdx
+++ b/docs/src/content/docs/zh-tw/quick-start/installation.mdx
@@ -1,0 +1,327 @@
+---
+title: 安裝
+description: 安裝 Wails 並準備好來建置應用程式
+sidebar:
+  order: 2
+---
+
+import { Card, CardGrid, Tabs, TabItem, Steps } from "@astrojs/starlight/components";
+
+## 快速安裝（5 分鐘）
+
+:::tip[TL;DR - 有經驗的開發者]
+```bash
+# 安裝 Go 1.25+，然後：
+go install github.com/wailsapp/wails/v3/cmd/wails3@latest
+wails3 doctor  # 驗證安裝
+```
+
+如果 `wails3 doctor` 通過，你就完成了。[跳至第一個應用程式 →](/zh-tw/quick-start/first-app)
+:::
+
+## 逐步安裝
+
+<Steps>
+
+1. **安裝 Go（必要）**
+
+   Wails 需要 Go 1.25 或更高版本。
+
+   <Tabs syncKey="os">
+     <TabItem label="Windows" icon="seti:windows">
+       從 **[go.dev/dl](https://go.dev/dl/)** 下載 Windows 安裝程式並執行。
+
+       **驗證安裝：**
+       ```powershell
+       go version  # 應顯示 1.25 或更高版本
+       ```
+
+       **檢查 PATH：**
+       ```powershell
+       $env:PATH -split ';' | Where-Object { $_ -like '*\go\bin' }
+       ```
+
+       如果為空，請將 `C:\Users\YourName\go\bin` 加入你的 PATH。
+     </TabItem>
+
+     <TabItem label="macOS" icon="apple">
+       **選項 1：官方安裝程式**
+
+       從 **[go.dev/dl](https://go.dev/dl/)** 下載 macOS 安裝程式（.pkg 檔案）並執行。
+
+       **選項 2：Homebrew**
+       ```bash
+       brew install go
+       ```
+
+       **驗證安裝：**
+       ```bash
+       go version  # 應顯示 1.25 或更高版本
+       echo $PATH | grep go/bin  # 應顯示 ~/go/bin
+       ```
+
+       如果 `~/go/bin` 不在 PATH 中，請將其加入 `~/.zshrc` 或 `~/.bash_profile`：
+       ```bash
+       export PATH=$PATH:~/go/bin
+       ```
+     </TabItem>
+
+     <TabItem label="Linux" icon="linux">
+       **選項 1：官方壓縮檔**
+
+       從 **[go.dev/dl](https://go.dev/dl/)** 下載 Linux 壓縮檔，然後：
+       ```bash
+       sudo rm -rf /usr/local/go
+       sudo tar -C /usr/local -xzf go1.25.linux-amd64.tar.gz
+       ```
+
+       **選項 2：套件管理器**
+       ```bash
+       # Ubuntu/Debian
+       sudo apt install golang-go
+
+       # Fedora
+       sudo dnf install golang
+
+       # Arch
+       sudo pacman -S go
+       ```
+
+       **加入 PATH**（加入 `~/.bashrc` 或 `~/.zshrc`）：
+       ```bash
+       export PATH=$PATH:/usr/local/go/bin:~/go/bin
+       source ~/.bashrc  # 重新載入
+       ```
+
+       **驗證：**
+       ```bash
+       go version
+       echo $PATH | grep go/bin
+       ```
+     </TabItem>
+   </Tabs>
+
+2. **安裝平台相依套件**
+
+   <Tabs syncKey="os">
+     <TabItem label="Windows" icon="seti:windows">
+       **WebView2 Runtime**（通常已預先安裝）
+
+       Windows 10/11 預設包含 WebView2。如果遺漏：
+       - 從 [Microsoft](https://developer.microsoft.com/microsoft-edge/webview2/) 下載
+       - 或稍後執行 `wails3 doctor`——它會引導你完成
+
+       **就這些！** 不需要其他相依套件。
+
+       :::tip[Windows 11 效能提示]
+       考慮使用 [Dev Drive](https://learn.microsoft.com/en-us/windows/dev-drive/) 來儲存你的專案。Dev Drives 針對開發者工作負載進行了最佳化，可以顯著提升建置時間和磁碟存取速度，最高可提升 30%。
+       :::
+     </TabItem>
+
+     <TabItem label="macOS" icon="apple">
+       **Xcode Command Line Tools**（必要）
+
+       ```bash
+       xcode-select --install
+       ```
+
+       在出現的對話框中點擊「Install」。
+
+       **驗證：**
+       ```bash
+       xcode-select -p  # 應顯示 /Library/Developer/CommandLineTools
+       ```
+
+       **就這些！** macOS 預設包含 WebKit。
+     </TabItem>
+
+     <TabItem label="Linux" icon="linux">
+       **建置工具和 WebKit**
+
+       :::caution[最低發行版版本]
+       Wails v3 需要 **WebKitGTK 4.1**（使用 libsoup3）。僅提供 4.0 的較舊發行版——Ubuntu 20.04、Debian 11、RHEL 8/9 及其衍生版本——不支援。
+       :::
+
+       <Tabs syncKey="distro">
+         <TabItem label="Ubuntu/Debian">
+           需要 Ubuntu 22.04+ 或 Debian 12+。
+           ```bash
+           sudo apt update
+           sudo apt install build-essential pkg-config libgtk-3-dev libwebkit2gtk-4.1-dev
+           ```
+         </TabItem>
+
+         <TabItem label="Fedora">
+           ```bash
+           sudo dnf install gcc pkg-config gtk3-devel webkit2gtk4.1-devel
+           ```
+         </TabItem>
+
+         <TabItem label="Arch">
+           ```bash
+           sudo pacman -S base-devel gtk3 webkit2gtk-4.1
+           ```
+         </TabItem>
+
+         <TabItem label="openSUSE">
+           ```bash
+           sudo zypper install gcc pkg-config gtk3-devel webkit2gtk3-devel
+           ```
+         </TabItem>
+
+         <TabItem label="Gentoo">
+           ```bash
+           sudo emerge --ask net-libs/webkit-gtk:4.1
+           ```
+         </TabItem>
+
+         <TabItem label="NixOS">
+           將其加入你的 `shell.nix` 或 `devShell`：
+           ```nix
+           buildInputs = with pkgs; [ webkitgtk_4_1 gtk3 pkg-config gcc ];
+           ```
+         </TabItem>
+
+         <TabItem label="Other">
+           安裝 Wails 後執行 `wails3 doctor`——它會顯示你的發行版所需的精確套件。
+         </TabItem>
+       </Tabs>
+
+       :::note[選用：GTK4 支援]
+       Wails 也有實驗性的 GTK4 / WebKitGTK 6.0 支援。如果你想使用 GTK4 建置，請安裝你發行版的額外相依套件，並使用 `wails3 build -tags gtk4` 進行建置。詳情請見 [Linux Packaging - GTK4](/guides/build/linux#gtk4-support-experimental)。
+       :::
+     </TabItem>
+   </Tabs>
+
+3. **安裝 Wails CLI**
+
+   ```bash
+   go install github.com/wailsapp/wails/v3/cmd/wails3@latest
+   ```
+
+   這會將 `wails3` 指令安裝到 `~/go/bin`（或在 Windows 上為 `%USERPROFILE%\go\bin`）。
+
+4. **驗證安裝**
+
+   ```bash
+   wails3 doctor
+   ```
+
+   **預期輸出（或類似）：**
+   ```
+   Wails (v3.0.0-dev)  Wails Doctor
+
+   # System
+
+   ┌──────────────────────────────────────────────────┐
+   | Name          | MacOS                            |
+   | Version       | 26.0                             |
+   | ID            | 25A354                           |
+   | Branding      | MacOS 26.0                       |
+   | Platform      | darwin                           |
+   | Architecture  | arm64                            |
+   | Apple Silicon | true                             |
+   | CPU           | Apple M2 Pro                     |
+   | CPU 1         | Apple M2 Pro                     |
+   | CPU 2         | Apple M2 Pro                     |
+   | GPU           | 16 cores, Metal Support: Metal 4 |
+   | Memory        | 16 GB                            |
+   └──────────────────────────────────────────────────┘
+
+   # Build Environment
+
+   ┌─────────────┬─────────────────┐
+   | Wails CLI   | v3.0.0-alpha.40 |
+   | Go Version  | go1.24.6        |
+   └─────────────┴─────────────────┘
+
+   # Dependencies
+
+   ┌─────────────────┬─────────────────────────────────────────────────┐
+   | npm             | 11.6.2                                          |
+   | *NSIS           | Not Installed. Install with `brew install...`.  |
+   | Xcode cli tools | 2412                                            |
+   └─────────────────┴─────────────────────────────────────────────────┘
+
+   # Checking for issues
+
+   SUCCESS No issues found
+
+   # Diagnosis
+
+   SUCCESS Your system is ready for Wails development!
+   ```
+
+   :::note[如果找不到 `wails3` 指令]
+   你的 `~/go/bin` 不在 PATH 中。請參閱上面的步驟 1 來修復此問題，然後重新啟動你的終端機。
+   :::
+
+5. **安裝 npm（選用但建議）**
+
+   大多數 Wails 範本使用 npm 作為前端工具。
+
+   <Tabs syncKey="os">
+     <TabItem label="Windows" icon="seti:windows">
+       從 [nodejs.org](https://nodejs.org/) 下載並執行安裝程式。
+
+       **驗證：**
+       ```powershell
+       npm --version
+       ```
+     </TabItem>#### Go 版本過舊
+
+Wails v3 需要 Go 1.25+。如果您使用的是較舊版本：
+
+<Tabs syncKey="os">
+  <TabItem label="Windows/macOS" icon="seti:windows">
+    從 [go.dev/dl](https://go.dev/dl/) 下載最新版本並重新安裝。
+  </TabItem>
+
+  <TabItem label="Linux" icon="linux">
+    從 [go.dev/dl](https://go.dev/dl/) 下載最新的 tarball，然後執行：
+    ```bash
+    sudo rm -rf /usr/local/go
+    sudo tar -C /usr/local -xzf go1.25.linux-amd64.tar.gz
+    ```
+  </TabItem>
+</Tabs>
+
+## 開發版本（Bleeding Edge）
+
+想要使用來自主要開發分支的最新程式碼嗎？這讓您可以提前體驗新功能與修復，但也伴隨著錯誤與破壞性變更的風險。僅建議貢獻者或需要測試即將推出功能的人使用。
+
+```bash
+git clone https://github.com/wailsapp/wails.git
+cd wails
+git checkout v3
+cd v3/cmd/wails3
+go install
+```
+
+:::caution[開發版本]
+- 可能包含錯誤或破壞性變更
+- 建立的專案將使用 `replace` 指令指向本機 Wails
+- 僅建議貢獻者或測試新功能者使用
+:::
+
+## 下一步
+
+**安裝完成！** 您的系統已準備好進行 Wails 開發。
+
+<Card title="建立您的第一個應用程式" icon="rocket">
+  在 10 分鐘內建立一個可運作的應用程式。
+
+  [第一個應用程式教學 →](/zh-tw/quick-start/first-app)
+</Card>
+
+<Card title="探索範本" icon="open-book">
+  查看預設提供的內容。
+
+  ```bash
+  wails3 init -l  # 列出範本
+  ```
+</Card>
+
+---
+
+**遇到問題嗎？** 請在 [Discord](https://discord.gg/JDdSxwjhGf) 提問或[開啟一個 issue](https://github.com/wailsapp/wails/issues)。


### PR DESCRIPTION
Automated translation batch 2 for Traditional Chinese (繁體中文).

## Changes

Adds 15 translated pages not yet in the repo:

- `quick-start/installation.mdx` — Installation guide (was showing English)
- `quick-start/first-app.mdx` — Your First App (was showing English)
- `getting-started/your-first-app.mdx`
- `concepts/architecture.mdx`
- `concepts/bridge.mdx`
- `concepts/build-system.mdx`
- `concepts/lifecycle.mdx`
- `concepts/manager-api.mdx`
- `contributing.mdx`
- `contributing/architecture/bindings.mdx`
- `credits.mdx`
- `faq.mdx`
- `feedback.mdx`
- `community/links.md`
- `community/templates.md`

## QA Scores

All locales scored ≥ 0.97 avg COMET score across batch runs. No pages flagged for human review.

## Notes

Translated by automated pipeline using qwen3:30b (self-hosted Ollama). No code blocks or technical syntax translated.

🤖 Wails Doc Translator

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive Traditional Chinese documentation suite for Wails v3, including: quick-start and installation guides, detailed architectural concept guides (architecture, bridge, build system, lifecycle, and manager API), community resources featuring templates and links, contribution guidelines with binding architecture details, getting-started tutorials, frequently asked questions, credits acknowledgments, and feedback submission instructions for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->