### PR TITLE
i18n(pt): add translations batch 2 2026-05-07

### DIFF
--- a/docs/src/content/docs/pt/community/links.md
+++ b/docs/src/content/docs/pt/community/links.md
@@ -1,0 +1,28 @@
+---
+title: Links
+description: Links e recursos curados pela comunidade para Wails
+---
+
+Esta página serve como uma lista de links relacionados à comunidade.
+
+:::tip[Como Enviar um Link]
+
+Você pode clicar em `Editar página` na parte inferior desta página para enviar um PR.
+
+:::
+
+## Awesome Wails
+
+A [lista definitiva](https://github.com/wailsapp/awesome-wails) de links
+relacionados ao Wails.
+
+## Canais de Suporte
+
+- [Servidor Discord do Wails](https://discord.gg/bdj28QNHmT)
+- [Issues do Github](https://github.com/wailsapp/wails/issues)
+
+## Redes Sociais
+
+- [Twitter](https://x.com/wailsapp)
+- [Grupo QQ da Comunidade Chinesa do Wails](https://qm.qq.com/cgi-bin/qm/qr?k=PmIURne5hFGNd7QWzW5qd6FV-INEjNJv&jump_from=webapi) -
+  Número do grupo: 1067173054

--- a/docs/src/content/docs/pt/community/templates.md
+++ b/docs/src/content/docs/pt/community/templates.md
@@ -1,0 +1,131 @@
+---
+title: Modelos
+description: Modelos de projeto e kits iniciais para Wails
+---
+
+:::caution
+
+Esta página pode estar desatualizada para o Wails v3.
+
+:::
+
+<!-- TODO: Update this link -->
+
+Esta página serve como uma lista de modelos suportados pela comunidade. Para criar seu próprio
+modelo, consulte o guia [Modelos](https://wails.io/docs/guides/templates).
+
+:::tip[Como Submeter um Modelo]
+
+Você pode clicar em `Editar esta página` na parte inferior para incluir seus modelos.
+
+:::
+
+Para usar estes modelos, execute
+`wails init -n "Nome do Seu Projeto" -t [o link abaixo[@version]]`
+
+Se não houver sufixo de versão, o modelo de código do branch principal é usado por padrão.
+Se houver um sufixo de versão, o modelo de código correspondente à tag desta
+versão é usado.
+
+Exemplo:
+`wails init -n "Nome do Seu Projeto" -t https://github.com/misitebao/wails-template-vue`
+
+:::danger[Atenção]
+
+**O projeto Wails não mantém, não é responsável nem tem responsabilidade por modelos de terceiros!**
+
+Se você tiver dúvidas sobre um modelo, inspecione `package.json` e `wails.json` para
+ver quais scripts são executados e quais pacotes estão instalados.
+
+:::
+
+## Vue
+
+- [wails-template-vue](https://github.com/misitebao/wails-template-vue) - Modelo Wails
+  baseado na ecologia Vue (TypeScript integrado, tema escuro,
+  internacionalização, roteamento de página única, TailwindCSS)
+- [wails-template-quasar-js](https://github.com/sgosiaco/wails-template-quasar-js) -
+  Um modelo usando JavaScript + Quasar V2 (Vue 3, Vite, Sass, Pinia, ESLint,
+  Prettier)
+- [wails-template-quasar-ts](https://github.com/sgosiaco/wails-template-quasar-ts) -
+  Um modelo usando TypeScript + Quasar V2 (Vue 3, Vite, Sass, Pinia, ESLint,
+  Prettier, Composition API com &lt;script setup&gt;)
+- [wails-template-naive](https://github.com/tk103331/wails-template-naive) -
+  Modelo Wails baseado no Naive UI (Uma biblioteca de componentes Vue 3)
+- [wails-template-nuxt](https://github.com/gornius/wails-template-nuxt) - Modelo Wails
+  usando Nuxt3 limpo e TypeScript com importação automática para o
+  runtime JS do Wails
+- [Wails-Tool-Template](https://github.com/xisuo67/Wails-Tool-Template) - Modelo Wails
+  usando Vue+TypeScript+Vite+Element-plus (inspirado no NetEase Cloud)
+
+## Angular
+
+- [wails-template-angular](https://github.com/mateothegreat/wails-template-angular) -
+  Angular 15+ repleto de recursos e pronto para produção.
+- [wails-angular-template](https://github.com/TAINCER/wails-angular-template) -
+  Angular com TypeScript, Sass, Hot-Reload, Code-Splitting e i18n
+
+## React
+
+- [wails-react-template](https://github.com/AlienRecall/wails-react-template) -
+  Um modelo usando reactjs
+- [wails-react-template](https://github.com/flin7/wails-react-template) - Um
+  modelo minimalista para React que suporta desenvolvimento em tempo real
+- [wails-template-nextjs](https://github.com/LGiki/wails-template-nextjs) - Um
+  modelo usando Next.js e TypeScript
+- [wails-template-nextjs-app-router](https://github.com/thisisvk-in/wails-template-nextjs-app-router) -
+  Um modelo usando Next.js e TypeScript com roteador de aplicativo
+- [wails-template-nextjs-app-router-src](https://github.com/edai-git/wails-template-nextjs-app-router) -
+  Um modelo usando Next.js e TypeScript com roteador de aplicativo src + exemplo
+- [wails-vite-react-ts-tailwind-template](https://github.com/hotafrika/wails-vite-react-ts-tailwind-template) -
+  Um modelo para React + TypeScript + Vite + TailwindCSS
+- [wails-vite-react-ts-tailwind-shadcnui-template](https://github.com/Mahcks/wails-vite-react-tailwind-shadcnui-ts) -
+  Um modelo com Vite, React, TypeScript, TailwindCSS e shadcn/ui
+
+## Svelte
+
+- [wails-svelte-template](https://github.com/raitonoberu/wails-svelte-template) -
+  Um modelo usando Svelte
+- [wails-vite-svelte-template](https://github.com/BillBuilt/wails-vite-svelte-template) -
+  Um modelo usando Svelte e Vite
+- [wails-vite-svelte-tailwind-template](https://github.com/BillBuilt/wails-vite-svelte-tailwind-template) -
+  Um modelo usando Svelte e Vite com TailwindCSS v3
+- [wails-svelte-tailwind-vite-template](https://github.com/PylotLight/wails-vite-svelte-tailwind-template/tree/master) -
+  Um modelo atualizado usando Svelte v4.2.0 e Vite com TailwindCSS v3.3.3
+- [wails-sveltekit-template](https://github.com/h8gi/wails-sveltekit-template) -
+  Um modelo usando SvelteKit
+- [wails-template-shadcn-svelte](https://github.com/xijaja/wails-template-shadcn-svelte) -
+  Um modelo usando Sveltekit e Shadcn-Svelte
+
+## Solid
+
+- [wails-template-vite-solid-ts](https://github.com/xijaja/wails-template-solid-ts) -
+  Um modelo usando Solid + Ts + Vite
+- [wails-template-vite-solid-js](https://github.com/xijaja/wails-template-solid-js) -
+  Um modelo usando Solid + Js + Vite
+
+## Elm
+
+- [wails-elm-template](https://github.com/benjamin-thomas/wails-elm-template) -
+  Desenvolva seu aplicativo GUI com programação funcional e uma configuração de
+  hot-reload **rápida** :tada: :rocket:
+- [wails-template-elm-tailwind](https://github.com/rnice01/wails-template-elm-tailwind) -
+  Combine os poderes :muscle: de Elm + Tailwind CSS + Wails! Hot reloading
+  suportado.
+
+## HTMX
+
+- [wails-htmx-templ-chi-tailwind](https://github.com/PylotLight/wails-hmtx-templ-template) -
+  Use uma combinação única de htmx puro para interatividade mais templ para
+  criação de componentes e formulários
+
+## JavaScript Puro (Vanilla)
+
+- [wails-pure-js-template](https://github.com/KiddoV/wails-pure-js-template) - Um
+  modelo com nada além de JavaScript básico, HTML e CSS
+
+## Lit (web components)
+
+- [wails-lit-shoelace-esbuild-template](https://github.com/Braincompiler/wails-lit-shoelace-esbuild-template) -
+  Modelo Wails fornecendo ao frontend lit, biblioteca de componentes Shoelace +
+  prettier e typescript pré-configurados.

--- a/docs/src/content/docs/pt/concepts/architecture.mdx
+++ b/docs/src/content/docs/pt/concepts/architecture.mdx
@@ -1,0 +1,328 @@
+---
+title: Como o Wails funciona
+description: Entendendo a arquitetura do Wails e como ele alcança desempenho nativo
+sidebar:
+  order: 1
+---
+
+import { Tabs, TabItem } from "@astrojs/starlight/components";
+
+O Wails é um framework para construir aplicativos de desktop usando **Go para o backend** e **tecnologias web para o frontend**. Mas, ao contrário do Electron, o Wails não empacota um navegador; ele usa o **WebView nativo do sistema operacional**.
+
+```d2
+direction: right
+
+User: "User" {
+  shape: person
+  style.fill: "#3B82F6"
+}
+
+Application: "Your Wails Application" {
+  Frontend: "Frontend\n(HTML/CSS/JS)" {
+    shape: rectangle
+    style.fill: "#8B5CF6"
+  }
+  
+  Runtime: "Wails Runtime" {
+    Bridge: "Message Bridge" {
+      shape: diamond
+      style.fill: "#10B981"
+    }
+    
+    Bindings: "Type-Safe Bindings" {
+      shape: rectangle
+      style.fill: "#10B981"
+    }
+  }
+  
+  Backend: "Go Backend" {
+    Services: "Your Services" {
+      shape: rectangle
+      style.fill: "#00ADD8"
+    }
+    
+    NativeAPIs: "OS APIs" {
+      shape: rectangle
+      style.fill: "#00ADD8"
+    }
+  }
+}
+
+OS: "Operating System" {
+  WebView: "Native WebView\n(WebKit/WebView2/WebKitGTK)" {
+    shape: rectangle
+    style.fill: "#6B7280"
+  }
+  
+  SystemAPIs: "System APIs\n(Windows/macOS/Linux)" {
+    shape: rectangle
+    style.fill: "#6B7280"
+  }
+}
+
+User -> Application.Frontend: "Interacts with UI"
+Application.Frontend <-> Application.Runtime.Bridge: "JSON messages"
+Application.Runtime.Bridge <-> Application.Backend.Services: "Direct function calls"
+Application.Runtime.Bindings -> Application.Frontend: "TypeScript definitions"
+Application.Frontend -> OS.WebView: "Renders in"
+Application.Backend.NativeAPIs -> OS.SystemAPIs: "Native calls"
+```
+
+**Diferenças principais em relação ao Electron:**
+
+| Aspecto | Wails | Electron |
+|--------|-------|----------|
+| **Navegador** | WebView fornecido pelo SO | Chromium empacotado (~100MB) |
+| **Backend** | Go (compilado) | Node.js (interpretado) |
+| **Comunicação** | Bridge em memória | IPC (inter-processo) |
+| **Tamanho do pacote** | ~15MB | ~150MB |
+| **Memória** | ~10MB | ~100MB+ |
+| **Inicialização** | &lt;0,5s | 2-3s |
+
+## Componentes Principais
+
+### 1. WebView Nativo
+
+O Wails usa o mecanismo de renderização web integrado ao sistema operacional:
+
+<Tabs syncKey="platform">
+  <TabItem label="Windows" icon="seti:windows">
+    **WebView2** (Microsoft Edge WebView2)
+    - Baseado no Chromium (mesmo do navegador Edge)
+    - Pré-instalado no Windows 10/11
+    - Atualizações automáticas via Windows Update
+    - Suporte completo aos padrões web modernos
+  </TabItem>
+
+  <TabItem label="macOS" icon="apple">
+    **WebKit** (mecanismo de renderização do Safari)
+    - Integrado ao macOS
+    - Mesmo motor do navegador Safari
+    - Excelente desempenho e eficiência energética
+    - Suporte completo aos padrões web modernos
+  </TabItem>
+
+  <TabItem label="Linux" icon="linux">
+    **WebKitGTK** (porta GTK do WebKit)
+    - Instalado via gerenciador de pacotes
+    - Mesmo motor do GNOME Web (Epiphany)
+    - Bom suporte aos padrões
+    - Leve e performático
+  </TabItem>
+</Tabs>
+
+**Por que isso importa:**
+- **Sem navegador empacotado** → Tamanho do aplicativo menor
+- **Nativo do SO** → Melhor integração e desempenho
+- **Atualizações automáticas** → Correções de segurança via atualizações do SO
+- **Renderização familiar** → Igual ao navegador do sistema
+
+### 2. O Bridge do Wails
+
+O bridge é o coração do Wails; ele permite **comunicação direta** entre Go e JavaScript.
+
+```d2
+direction: down
+
+Frontend: "Frontend (JavaScript)" {
+  shape: rectangle
+  style.fill: "#8B5CF6"
+}
+
+Bridge: "Wails Bridge" {
+  Encoder: "JSON Encoder" {
+    shape: rectangle
+  }
+  
+  Router: "Method Router" {
+    shape: diamond
+    style.fill: "#10B981"
+  }
+  
+  Decoder: "JSON Decoder" {
+    shape: rectangle
+  }
+}
+
+Backend: "Backend (Go)" {
+  Services: "Registered Services" {
+    shape: rectangle
+    style.fill: "#00ADD8"
+  }
+}
+
+Frontend -> Bridge.Encoder: "1. Call Go method\nGreet('Alice')"
+Bridge.Encoder -> Bridge.Router: "2. Encode to JSON\n{method: 'Greet', args: ['Alice']}"
+Bridge.Router -> Backend.Services: "3. Route to service\nGreetService.Greet('Alice')"
+Backend.Services -> Bridge.Decoder: "4. Return result\n'Hello, Alice!'"
+Bridge.Decoder -> Frontend: "5. Decode to JS\nPromise resolves"
+```
+
+**Como funciona:**
+
+1. **Frontend chama um método Go** (via binding auto-gerado)
+2. **Bridge codifica a chamada** para JSON (nome do método + argumentos)
+3. **Router encontra o método Go** nos serviços registrados
+4. **Método Go executa** e retorna um valor
+5. **Bridge decodifica o resultado** e envia de volta ao frontend
+6. **Promise é resolvida** no JavaScript com o resultado
+
+**Características de desempenho:**
+- **Em memória**: Sem sobrecarga de rede, sem HTTP
+- **Zero-copy** quando possível (para grandes volumes de dados)
+- **Assíncrono por padrão**: Não bloqueante em ambos os lados
+- **Tipado com segurança**: Definições de TypeScript geradas automaticamente
+
+### 3. Sistema de Serviços
+
+Os serviços são a maneira recomendada de expor funcionalidade do Go para o frontend.
+
+```go
+// Define a service (just a regular Go struct)
+type GreetService struct {
+    prefix string
+}
+
+// Methods with exported names are automatically available
+func (g *GreetService) Greet(name string) string {
+    return g.prefix + name + "!"
+}
+
+func (g *GreetService) GetTime() time.Time {
+    return time.Now()
+}
+
+// Register the service
+app := application.New(application.Options{
+    Services: []application.Service{
+        application.NewService(&GreetService{prefix: "Hello, "}),
+    },
+})
+```
+
+**Descoberta de serviços:**
+- O Wails **varre sua struct** na inicialização
+- **Métodos exportados** tornam-se chamáveis do frontend
+- **Informações de tipo** são extraídas para bindings de TypeScript
+- **Tratamento de erros** é automático (erros do Go → exceções JS)
+
+**Binding de TypeScript gerado:**
+```typescript
+// Auto-generated in frontend/bindings/GreetService.ts
+export function Greet(name: string): Promise<string>
+export function GetTime(): Promise<Date>
+```
+
+**Por que serviços?**
+- **Tipado com segurança**: Suporte completo ao TypeScript
+- **Descoberta automática**: Sem registro manual de métodos
+- **Organizado**: Agrupe funcionalidades relacionadas
+- **Testável**: Serviços são apenas structs Go
+
+[Mais informações sobre serviços →](/features/bindings/services)
+
+### 4. Sistema de Eventos
+
+Os eventos permitem **comunicação pub/sub** entre componentes.
+
+```d2
+direction: right
+
+GoService: "Go Service" {
+  shape: rectangle
+  style.fill: "#00ADD8"
+}
+
+EventBus: "Event Bus" {
+  shape: cylinder
+  style.fill: "#10B981"
+}
+
+Frontend1: "Window 1" {
+  shape: rectangle
+  style.fill: "#8B5CF6"
+}
+
+Frontend2: "Window 2" {
+  shape: rectangle
+  style.fill: "#8B5CF6"
+}
+
+GoService -> EventBus: "Emit('data-updated', data)"
+EventBus -> Frontend1: "Notify subscribers"
+EventBus -> Frontend2: "Notify subscribers"
+Frontend1 -> EventBus: "On('data-updated', handler)"
+Frontend2 -> EventBus: "On('data-updated', handler)"
+```
+
+**Casos de uso:**
+- **Comunicação entre janelas**: Uma janela notifica as outras
+- **Tarefas em segundo plano**: Serviço Go notifica a UI sobre o progresso
+- **Sincronização de estado**: Mantém múltiplas janelas sincronizadas
+- **Acoplamento fraco**: Componentes não precisam de referências diretas
+
+**Exemplo:**
+```go
+// Go: Emit an event
+app.Event.Emit("user-logged-in", user)
+```
+
+```javascript
+// JavaScript: Listen for event
+import { Events } from '@wailsio/runtime'
+
+Events.On('user-logged-in', (user) => {
+    console.log('User logged in:', user)
+})
+```
+
+[Mais informações sobre eventos →](/features/events/system)
+
+## Ciclo de Vida do Aplicativo
+
+Entender o ciclo de vida ajuda você a saber quando inicializar recursos e fazer a limpeza.
+
+```d2
+direction: down
+
+Start: "Application Start" {
+  shape: oval
+  style.fill: "#10B981"
+}
+
+Init: "Initialisation" {
+  Create: "Create Application" {
+    shape: rectangle
+  }
+  
+  Register: "Register Services" {
+    shape: rectangle
+  }
+  
+  Setup: "Setup Windows/Menus" {
+    shape: rectangle
+  }
+}
+
+Run: "Event Loop" {
+  Events: "Process Events" {
+    shape: rectangle
+  }
+  
+  Messages: "Handle Messages" {
+    shape: rectangle
+  }
+  
+  Render: "Update UI" {
+    shape: rectangle
+  }
+}
+
+Shutdown: "Shutdown" {
+  Cleanup: "Cleanup Resources" {
+    shape: rectangle
+  }
+  
+  Save: "Save State" {---
+
+**Dúvidas sobre a arquitetura?** Pergunte no [Discord](https://discord.gg/JDdSxwjhGf) ou consulte a [referência da API](/reference/overview).

--- a/docs/src/content/docs/pt/concepts/bridge.mdx
+++ b/docs/src/content/docs/pt/concepts/bridge.mdx
@@ -1,0 +1,391 @@
+---
+title: Ponte Go-Frontend
+description: Mergulho profundo em como o Wails permite comunicação direta entre Go e JavaScript
+sidebar:
+  order: 3
+---
+
+import { Tabs, TabItem } from "@astrojs/starlight/components";
+
+## Comunicação Direta Go-JavaScript
+
+O Wails fornece uma **ponte direta em memória** entre Go e JavaScript, permitindo comunicação perfeita sem sobrecarga de HTTP, limites de processo ou gargalos de serialização.
+
+## Visão Geral
+
+```d2
+direction: right
+
+Frontend: "Frontend (JavaScript)" {
+  UI: "React/Vue/Vanilla" {
+    shape: rectangle
+    style.fill: "#8B5CF6"
+  }
+  
+  Bindings: "Auto-Generated Bindings" {
+    shape: rectangle
+    style.fill: "#A78BFA"
+  }
+}
+
+Bridge: "Wails Bridge" {
+  Encoder: "JSON Encoder" {
+    shape: rectangle
+    style.fill: "#10B981"
+  }
+  
+  Router: "Method Router" {
+    shape: diamond
+    style.fill: "#10B981"
+  }
+  
+  Decoder: "JSON Decoder" {
+    shape: rectangle
+    style.fill: "#10B981"
+  }
+  
+  TypeGen: "Type Generator" {
+    shape: rectangle
+    style.fill: "#10B981"
+  }
+}
+
+Backend: "Backend (Go)" {
+  Services: "Your Services" {
+    shape: rectangle
+    style.fill: "#00ADD8"
+  }
+  
+  Registry: "Service Registry" {
+    shape: rectangle
+    style.fill: "#00ADD8"
+  }
+}
+
+Frontend.UI -> Frontend.Bindings: "import { Method }"
+Frontend.Bindings -> Bridge.Encoder: "Call Method('arg')"
+Bridge.Encoder -> Bridge.Router: "Encode to JSON"
+Bridge.Router -> Backend.Registry: "Find service"
+Backend.Registry -> Backend.Services: "Invoke method"
+Backend.Services -> Bridge.Decoder: "Return result"
+Bridge.Decoder -> Frontend.Bindings: "Decode to JS"
+Frontend.Bindings -> Frontend.UI: "Promise resolves"
+Bridge.TypeGen -> Frontend.Bindings: "Generate types"
+```
+
+**Insight principal:** Sem HTTP, sem IPC, sem limites de processo. Apenas **chamadas de função diretas** com **segurança de tipos**.
+
+## Como Funciona: Passo a Passo
+
+### 1. Registro de Serviço (Inicialização)
+
+Quando sua aplicação inicia, o Wails escaneia seus serviços:
+
+```go
+type GreetService struct {
+    prefix string
+}
+
+func (g *GreetService) Greet(name string) string {
+    return g.prefix + name + "!"
+}
+
+func (g *GreetService) Add(a, b int) int {
+    return a + b
+}
+
+// Register service
+app := application.New(application.Options{
+    Services: []application.Service{
+        application.NewService(&GreetService{prefix: "Hello, "}),
+    },
+})
+```
+
+**O que o Wails faz:**
+1. **Escaneia a estrutura** em busca de métodos exportados
+2. **Extrai informações de tipo** (parâmetros, tipos de retorno)
+3. **Constrói um registro** mapeando nomes de métodos para funções
+4. **Gera bindings de TypeScript** com definições de tipo completas
+
+### 2. Geração de Bindings (Tempo de Compilação)
+
+O Wails gera bindings de TypeScript automaticamente:
+
+```typescript
+// Auto-generated: frontend/bindings/GreetService.ts
+export function Greet(name: string): Promise<string>
+export function Add(a: number, b: number): Promise<number>
+```
+
+**Mapeamento de tipos:**
+
+| Tipo Go | Tipo TypeScript |
+|---------|-----------------|
+| `string` | `string` |
+| `int`, `int32`, `int64` | `number` |
+| `float32`, `float64` | `number` |
+| `bool` | `boolean` |
+| `[]T` | `T[]` |
+| `map[string]T` | `Record<string, T>` |
+| `struct` | `interface` |
+| `time.Time` | `Date` |
+| `error` | Exceção (lançada) |
+
+### 3. Chamada no Frontend (Tempo de Execução)
+
+O desenvolvedor chama o método Go do JavaScript:
+
+```javascript
+import { Greet, Add } from './bindings/GreetService'
+
+// Call Go from JavaScript
+const greeting = await Greet("World")
+console.log(greeting)  // "Hello, World!"
+
+const sum = await Add(5, 3)
+console.log(sum)  // 8
+```
+
+**O que acontece:**
+1. **Função de binding chamada** - `Greet("World")`
+2. **Mensagem criada** - `{ service: "GreetService", method: "Greet", args: ["World"] }`
+3. **Enviada para a ponte** - Via ponte JavaScript do WebView
+4. **Promise retornada** - Aguarda resposta
+
+### 4. Processamento da Ponte (Tempo de Execução)
+
+A ponte recebe a mensagem e a processa:
+
+```d2
+direction: down
+
+Receive: "Receive Message" {
+  shape: rectangle
+  style.fill: "#10B981"
+}
+
+Parse: "Parse JSON" {
+  shape: rectangle
+}
+
+Validate: "Validate" {
+  Check: "Service exists?" {
+    shape: diamond
+  }
+  
+  CheckMethod: "Method exists?" {
+    shape: diamond
+  }
+  
+  CheckTypes: "Types correct?" {
+    shape: diamond
+  }
+}
+
+Invoke: "Invoke Go Method" {
+  shape: rectangle
+  style.fill: "#00ADD8"
+}
+
+Encode: "Encode Result" {
+  shape: rectangle
+}
+
+Send: "Send Response" {
+  shape: rectangle
+  style.fill: "#10B981"
+}
+
+Error: "Send Error" {
+  shape: rectangle
+  style.fill: "#EF4444"
+}
+
+Receive -> Parse
+Parse -> Validate.Check
+Validate.Check -> Validate.CheckMethod: "Yes"
+Validate.Check -> Error: "No"
+Validate.CheckMethod -> Validate.CheckTypes: "Yes"
+Validate.CheckMethod -> Error: "No"
+Validate.CheckTypes -> Invoke: "Yes"
+Validate.CheckTypes -> Error: "No"
+Invoke -> Encode: "Success"
+Invoke -> Error: "Error"
+Encode -> Send
+```
+
+**Segurança:** Apenas serviços registrados e métodos exportados são chamáveis.
+
+### 5. Execução Go (Tempo de Execução)
+
+O método Go é executado:
+
+```go
+func (g *GreetService) Greet(name string) string {
+    // This runs in Go
+    return g.prefix + name + "!"
+}
+```
+
+**Contexto de execução:**
+- Executa em uma **goroutine** (não bloqueante)
+- Tem acesso a **todos os recursos do Go** (sistema de arquivos, rede, bancos de dados)
+- Pode chamar **outro código Go** livremente
+- Retorna resultado ou erro
+
+### 6. Resposta (Tempo de Execução)
+
+O resultado é enviado de volta ao JavaScript:
+
+```javascript
+// Promise resolves with result
+const greeting = await Greet("World")
+// greeting = "Hello, World!"
+```
+
+**Tratamento de erros:**
+
+```go
+func (g *GreetService) Divide(a, b float64) (float64, error) {
+    if b == 0 {
+        return 0, errors.New("division by zero")
+    }
+    return a / b, nil
+}
+```
+
+```javascript
+try {
+    const result = await Divide(10, 0)
+} catch (error) {
+    console.error("Go error:", error)  // "division by zero"
+}
+```
+
+## Características de Desempenho
+
+### Velocidade
+
+**Sobrecarga típica de chamada:** &lt;1ms
+
+```
+Frontend Call → Bridge → Go Execution → Bridge → Frontend Response
+     ↓            ↓           ↓            ↓            ↓
+   &lt;0.1ms      &lt;0.1ms      [varies]     &lt;0.1ms      &lt;0.1ms
+```
+
+**Comparado a alternativas:**
+- **HTTP/REST:** 5-50ms (stack de rede, serialização)
+- **IPC:** 1-10ms (limites de processo, marshalling)
+- **Wails Bridge:** &lt;1ms (em memória, chamada direta)
+
+### Memória
+
+**Sobrecarga por chamada:** ~1KB (buffer de mensagem)
+
+**Otimização zero-copy:** Dados grandes (&gt;1MB) usam memória compartilhada quando possível.
+
+### Concorrência
+
+**Chamadas são concorrentes:**
+- Cada chamada executa em sua própria goroutine
+- Múltiplas chamadas podem executar simultaneamente
+- Sem bloqueio entre chamadas
+
+```javascript
+// These run concurrently
+const [result1, result2, result3] = await Promise.all([
+    SlowOperation1(),
+    SlowOperation2(),
+    SlowOperation3(),
+])
+```
+
+## Sistema de Tipos
+
+### Tipos Suportados
+
+#### Primitivos
+
+```go
+// Go
+func Example(
+    s string,
+    i int,
+    f float64,
+    b bool,
+) (string, int, float64, bool) {
+    return s, i, f, b
+}
+```
+
+```typescript
+// TypeScript (auto-generated)
+function Example(
+    s: string,
+    i: number,
+    f: number,
+    b: boolean,
+): Promise<[string, number, number, boolean]>
+```
+
+#### Fatias e Arrays
+
+```go
+// Go
+func Sum(numbers []int) int {
+    total := 0
+    for _, n := range numbers {
+        total += n
+    }
+    return total
+}
+```
+
+```typescript
+// TypeScript
+function Sum(numbers: number[]): Promise<number>
+
+// Usage
+const total = await Sum([1, 2, 3, 4, 5])  // 15
+```
+
+#### Mapas
+
+```go
+// Go
+func GetConfig() map[string]interface{} {
+    return map[string]interface{}{
+        "theme": "dark",
+        "fontSize": 14,
+        "enabled": true,
+    }
+}
+```
+
+```typescript
+// TypeScript
+function GetConfig(): Promise<Record<string, any>>
+
+// Usage
+const config = await GetConfig()
+console.log(config.theme)  // "dark"
+```
+
+#### Estruturas
+
+```go
+// Go
+type User struct {
+    ID    int    `json:"id"`
+    Name  string `json:"name"`
+    Email string `json:"email"`
+}
+
+func GetUser(id int) (*User, error) {
+    return &User{
+        ID:    id,
+        Name:  "Alice",---
+
+**Dúvidas sobre a ponte?** Pergunte no [Discord](https://discord.gg/JDdSxwjhGf) ou verifique os [exemplos de binding](https://github.com/wailsapp/wails/tree/master/v3/examples/binding).

--- a/docs/src/content/docs/pt/concepts/build-system.mdx
+++ b/docs/src/content/docs/pt/concepts/build-system.mdx
@@ -1,0 +1,424 @@
+---
+title: Sistema de Build
+description: Entenda como o Wails compila e empacota seu aplicativo
+sidebar:
+  order: 4
+---
+
+import { Tabs, TabItem } from "@astrojs/starlight/components";
+
+## Sistema de Build Unificado
+
+O Wails oferece um **sistema de build unificado** que compila código Go, empaceta ativos do frontend, embute tudo em um único executável e lida com builds específicos de plataforma — tudo com um único comando.
+
+```bash
+wails3 build
+```
+
+**Saída:** Executável nativo com tudo embutido.
+
+## Visão Geral do Processo de Build
+
+{/*
+TODO: Corrigir a geração do diagrama D2 ou incorporar como imagem.
+O bloco de código D2 anterior estava causando erros de análise MDX no pipeline de build.
+*/}
+
+**[Espaço Reservado para Diagrama do Processo de Build]**
+
+
+## Fases do Build
+
+### 1. Fase de Análise
+
+O Wails analisa seu código Go para entender seus serviços:
+
+```go
+type GreetService struct {
+    prefix string
+}
+
+func (g *GreetService) Greet(name string) string {
+    return g.prefix + name + "!"
+}
+```
+
+**O que o Wails extrai:**
+- Nome do serviço: `GreetService`
+- Nome do método: `Greet`
+- Tipos de parâmetro: `string`
+- Tipos de retorno: `string`
+
+**Usado para:** Gerar bindings de TypeScript
+
+### 2. Fase de Geração
+
+#### Bindings de TypeScript
+
+O Wails gera bindings com tipagem segura:
+
+```typescript
+// Auto-generated: frontend/bindings/GreetService.ts
+export function Greet(name: string): Promise<string> {
+    return window.wails.Call('GreetService.Greet', name)
+}
+```
+
+**Benefícios:**
+- Segurança de tipos completa
+- Autocompletar na IDE
+- Erros em tempo de compilação
+- Comentários JSDoc
+
+#### Build do Frontend
+
+Seu bundler de frontend é executado (Vite, webpack, etc.):
+
+```bash
+# Exemplo do Vite
+vite build --outDir dist
+```
+
+**O que acontece:**
+- JavaScript/TypeScript compilado
+- CSS processado e minificado
+- Otimização de ativos
+- Mapas de origem gerados (apenas dev)
+- Saída para `frontend/dist/`
+
+### 3. Fase de Compilação
+
+#### Compilação Go
+
+O código Go é compilado com otimizações:
+
+```bash
+go build -ldflags="-s -w" -o myapp.exe
+```
+
+**Flags:**
+- `-s`: Remove a tabela de símbolos
+- `-w`: Remove informações de depuração DWARF
+- Resultado: Binário menor (~30% de redução)
+
+**Específico da plataforma:**
+- Windows: `.exe` com ícone embutido
+- macOS: Estrutura de bundle `.app`
+- Linux: Binário ELF
+
+#### Embutimento de Ativos
+
+Os ativos do frontend são embutidos no binário Go:
+
+```go
+//go:embed frontend/dist
+var assets embed.FS
+```
+
+**Resultado:** Executável único com tudo dentro.
+
+### 4. Saída
+
+**Único binário nativo:**
+- Windows: `myapp.exe` (~15MB)
+- macOS: `myapp.app` (~15MB)
+- Linux: `myapp` (~15MB)
+
+**Sem dependências** (exceto o WebView do sistema).
+
+## Desenvolvimento vs Produção
+
+<Tabs syncKey="mode">
+  <TabItem label="Desenvolvimento (wails3 dev)" icon="seti:config">
+    **Otimizado para velocidade:**
+    
+    ```bash
+    wails3 dev
+    ```
+    
+    **O que acontece:**
+    1. Inicia o servidor de desenvolvimento do frontend (Vite na porta 5173)
+    2. Compila o Go sem otimizações
+    3. Inicia o aplicativo apontando para o servidor de desenvolvimento
+    4. Habilita hot reload
+    5. Inclui mapas de origem
+    
+    **Características:**
+    - **Recompilações rápidas** (&lt;1s para alterações no frontend)
+    - **Sem embutimento de ativos** (servidos pelo servidor de desenvolvimento)
+    - **Símbolos de depuração** incluídos
+    - **Mapas de origem** habilitados
+    - **Logs verbosos**
+    
+    **Tamanho do arquivo:** Maior (~50MB com símbolos de depuração)
+  </TabItem>
+
+  <TabItem label="Produção (wails3 build)" icon="rocket">
+    **Otimizado para tamanho e desempenho:**
+    
+    ```bash
+    wails3 build
+    ```
+    
+    **O que acontece:**
+    1. Compila o frontend para produção (minificado)
+    2. Compila o Go com otimizações
+    3. Remove símbolos de depuração
+    4. Embute os ativos
+    5. Cria um binário único
+    
+    **Características:**
+    - **Código otimizado** (minificado, tree-shaken)
+    - **Ativos embutidos** (sem arquivos externos)
+    - **Símbolos de depuração removidos**
+    - **Sem mapas de origem**
+    - **Logs mínimos**
+    
+    **Tamanho do arquivo:** Menor (~15MB)
+  </TabItem>
+</Tabs>
+
+## Comandos de Build
+
+### Build Básico
+
+```bash
+wails3 build
+```
+
+**Saída:** `build/bin/myapp[.exe]`
+
+### Build para Plataforma Específica
+
+```bash
+# Build para Windows (de qualquer OS)
+wails3 build -platform windows/amd64
+
+# Build para macOS
+wails3 build -platform darwin/amd64
+wails3 build -platform darwin/arm64
+
+# Build para Linux
+wails3 build -platform linux/amd64
+```
+
+**Compilação cruzada:** Compile para qualquer plataforma a partir de qualquer plataforma.
+
+### Build com Opções
+
+```bash
+# Diretório de saída personalizado
+wails3 build -o ./dist/myapp
+
+# Pular build do frontend (usar existente)
+wails3 build -skipbindings
+
+# Build limpo (remover cache)
+wails3 build -clean
+
+# Saída verbosa
+wails3 build -v
+```
+
+### Modos de Build
+
+```bash
+# Build de depuração (inclui símbolos)
+wails3 build -debug
+
+# Build de produção (padrão, otimizado)
+wails3 build
+
+# Build de desenvolvimento (rápido, não otimizado)
+wails3 build -devbuild
+```
+
+## Configuração de Build
+
+### Taskfile.yml
+
+O Wails usa [Taskfile](https://taskfile.dev/) para configuração de build:
+
+```yaml
+# Taskfile.yml
+version: '3'
+
+tasks:
+  build:
+    desc: Build the application
+    cmds:
+      - wails3 build
+  
+  build:windows:
+    desc: Build for Windows
+    cmds:
+      - wails3 build -platform windows/amd64
+  
+  build:macos:
+    desc: Build for macOS (Universal)
+    cmds:
+      - wails3 build -platform darwin/amd64
+      - wails3 build -platform darwin/arm64
+      - lipo -create -output build/bin/myapp.app build/bin/myapp-amd64.app build/bin/myapp-arm64.app
+  
+  build:linux:
+    desc: Build for Linux
+    cmds:
+      - wails3 build -platform linux/amd64
+```
+
+**Executar tarefas:**
+
+```bash
+task build:windows
+task build:macos
+task build:linux
+```
+
+### Arquivo de Opções de Build
+
+Crie `build/build.json` para configuração persistente:
+
+```json
+{
+  "name": "My Application",
+  "version": "1.0.0",
+  "author": "Your Name",
+  "description": "Application description",
+  "icon": "build/appicon.png",
+  "outputFilename": "myapp",
+  "platforms": ["windows/amd64", "darwin/amd64", "linux/amd64"],
+  "frontend": {
+    "dir": "./frontend",
+    "install": "npm install",
+    "build": "npm run build",
+    "dev": "npm run dev"
+  },
+  "go": {
+    "ldflags": "-s -w -X main.version={{.Version}}"
+  }
+}
+```
+
+## Embutimento de Ativos
+
+### Como Funciona
+
+O Wails usa o pacote `embed` do Go:
+
+```go
+package main
+
+import (
+    "embed"
+    "github.com/wailsapp/wails/v3/pkg/application"
+)
+
+//go:embed frontend/dist
+var assets embed.FS
+
+func main() {
+    app := application.New(application.Options{
+        Name:   "My App",
+        Assets: application.AssetOptions{
+            Handler: application.AssetFileServerFS(assets),
+        },
+    })
+    
+    app.Window.New()
+    app.Run()
+}
+```
+
+**No momento do build:**
+1. Frontend construído em `frontend/dist/`
+2. Diretiva `//go:embed` inclui os arquivos
+3. Arquivos compilados no binário
+4. Binário contém tudo
+
+**Em tempo de execução:**
+1. App inicia
+2. Ativos servidos da memória
+3. Sem E/S de disco para ativos
+4. Carregamento rápido
+
+### Ativos Personalizados
+
+Incorpore arquivos adicionais:
+
+```go
+//go:embed frontend/dist
+var frontendAssets embed.FS
+
+//go:embed data/*.json
+var dataAssets embed.FS
+
+//go:embed templates/*.html
+var templateAssets embed.FS
+```
+
+## Otimizações de Build
+
+### Otimizações de Frontend
+
+**Vite (padrão):**
+
+```javascript
+// vite.config.js
+export default {
+  build: {
+    minify: 'terser',
+    terserOptions: {
+      compress: {
+        drop_console: true,  // Remove console.log
+        drop_debugger: true,
+      },
+    },
+    rollupOptions: {
+      output: {
+        manualChunks: {
+          vendor: ['react', 'react-dom'],  // Separa bundle de vendor
+        },
+      },
+    },
+  },
+}
+```
+
+**Resultados:**
+- JavaScript minificado (~70% de redução)
+- CSS minificado (~60% de redução)
+- Imagens otimizadas
+- Tree-shaking aplicado
+
+### Otimizações Go
+
+**Flags do compilador:**
+
+```bash
+-ldflags="-s -w"
+```
+
+- `-s`: Remove tabela de símbolos (~10% de redução)
+- `-w`: Remove informações de depuração DWARF (~20% de redução)
+
+**Otimizações adicionais:**
+
+```bash
+-ldflags="-s -w -X main.version=1.0.0"
+```
+
+- `-X`: Define valores de variáveis no momento do build
+- Útil para números de versão, datas de build
+
+### Compressão de Binário
+
+**UPX (opcional):**
+
+```bash
+# Após o build
+upx --best build/bin/myapp.exe
+```
+
+**Resultados:**
+- ~50% de redução de tamanho**Dúvidas sobre builds?** Pergunte no [Discord](https://discord.gg/JDdSxwjhGf) ou verifique os [exemplos de build](https://github.com/wailsapp/wails/tree/master/v3/examples/build).

--- a/docs/src/content/docs/pt/concepts/lifecycle.mdx
+++ b/docs/src/content/docs/pt/concepts/lifecycle.mdx
@@ -1,0 +1,368 @@
+---
+title: Ciclo de Vida da Aplicação
+description: Compreendendo o ciclo de vida da aplicação Wails, desde a inicialização até o encerramento
+sidebar:
+  order: 2
+---
+
+import { Tabs, TabItem } from "@astrojs/starlight/components";
+
+## Compreendendo o Ciclo de Vida da Aplicação
+
+Aplicações desktop possuem um ciclo de vida que vai da inicialização até o encerramento. O Wails v3 fornece **serviços**, **eventos** e **hooks** para gerenciar esse ciclo de forma eficaz.
+
+## As Etapas do Ciclo de Vida
+
+```d2
+direction: down
+
+Start: "Application Start" {
+  shape: oval
+  style.fill: "#10B981"
+}
+
+Init: "Initialisation" {
+  Parse: "Parse Options" {
+    shape: rectangle
+  }
+  Register: "Register Services" {
+    shape: rectangle
+  }
+  Setup: "Setup Runtime" {
+    shape: rectangle
+  }
+}
+
+AppRun: "app.Run()" {
+  shape: rectangle
+  style.fill: "#3B82F6"
+}
+
+ServiceStartup: "Service Startup" {
+  shape: rectangle
+  style.fill: "#8B5CF6"
+}
+
+EventLoop: "Event Loop" {
+  Process: "Process Events" {
+    shape: rectangle
+  }
+  Handle: "Handle Messages" {
+    shape: rectangle
+  }
+  Update: "Update UI" {
+    shape: rectangle
+  }
+}
+
+QuitSignal: "Quit Signal" {
+  shape: diamond
+  style.fill: "#F59E0B"
+}
+
+ShouldQuit: "ShouldQuit Check" {
+  shape: rectangle
+  style.fill: "#3B82F6"
+}
+
+OnShutdown: "OnShutdown Callbacks" {
+  shape: rectangle
+  style.fill: "#3B82F6"
+}
+
+ServiceShutdown: "Service Shutdown" {
+  shape: rectangle
+  style.fill: "#8B5CF6"
+}
+
+Cleanup: "Cleanup" {
+  Close: "Close Windows" {
+    shape: rectangle
+  }
+  Release: "Release Resources" {
+    shape: rectangle
+  }
+}
+
+End: "Application End" {
+  shape: oval
+  style.fill: "#EF4444"
+}
+
+Start -> Init.Parse
+Init.Parse -> Init.Register
+Init.Register -> Init.Setup
+Init.Setup -> AppRun
+AppRun -> ServiceStartup
+ServiceStartup -> EventLoop.Process
+EventLoop.Process -> EventLoop.Handle
+EventLoop.Handle -> EventLoop.Update
+EventLoop.Update -> EventLoop.Process: "Loop"
+EventLoop.Process -> QuitSignal: "User quits"
+QuitSignal -> ShouldQuit: "Check allowed?"
+ShouldQuit -> EventLoop.Process: "Denied"
+ShouldQuit -> OnShutdown: "Allowed"
+OnShutdown -> ServiceShutdown
+ServiceShutdown -> Cleanup.Close
+Cleanup.Close -> Cleanup.Release
+Cleanup.Release -> End
+```
+
+### 1. Criação da Aplicação
+
+Crie sua aplicação com `application.New()`:
+
+```go
+app := application.New(application.Options{
+    Name:        "My App",
+    Description: "An application built with Wails",
+    Services: []application.Service{
+        application.NewService(&MyService{}),
+    },
+    Assets: application.AssetOptions{
+        Handler: application.BundledAssetFileServer(assets),
+    },
+})
+```
+
+**O que acontece:**
+1. As opções são analisadas e validadas
+2. Os serviços são registrados (mas ainda não iniciados)
+3. O servidor de assets é configurado
+4. O runtime é configurado
+
+### 2. Executando a Aplicação
+
+Chame `app.Run()` para iniciar a aplicação:
+
+```go
+err := app.Run()  // Blocks until quit
+if err != nil {
+    log.Fatal(err)
+}
+```
+
+**O que acontece:**
+1. Os serviços são iniciados na ordem de registro
+2. Os ouvintes de eventos são ativados
+3. As janelas podem ser criadas
+4. O loop de eventos começa
+
+### 3. Loop de Eventos
+
+A aplicação entra no loop de eventos, onde passa a maior parte do seu tempo:
+
+- Eventos do SO são processados (mouse, teclado, eventos de janela)
+- Mensagens de Go para JS são tratadas
+- Chamadas de JS para Go são executadas
+- Atualizações de UI são renderizadas
+
+### 4. Encerramento
+
+Quando a aplicação é encerrada:
+
+1. O callback `ShouldQuit` é verificado (se definido)
+2. Os callbacks `OnShutdown` são executados
+3. Os serviços são encerrados na ordem inversa de registro
+4. As janelas são fechadas
+5. Os recursos são liberados
+
+## Ciclo de Vida dos Serviços
+
+Os serviços são a principal maneira de gerenciar o ciclo de vida no Wails v3. Eles fornecem hooks de inicialização e encerramento através de interfaces. Para documentação completa sobre serviços, consulte o [Guia de Serviços](/features/bindings/services).
+
+### Criando um Serviço
+
+```go
+type MyService struct {
+    db *sql.DB
+}
+
+// ServiceStartup is called when the application starts
+func (s *MyService) ServiceStartup(ctx context.Context, options application.ServiceOptions) error {
+    var err error
+    s.db, err = sql.Open("sqlite3", "app.db")
+    if err != nil {
+        return err  // Startup aborts if error returned
+    }
+
+    // Run migrations
+    if err := s.runMigrations(); err != nil {
+        return err
+    }
+
+    return nil
+}
+
+// ServiceShutdown is called when the application shuts down
+func (s *MyService) ServiceShutdown() error {
+    if s.db != nil {
+        return s.db.Close()
+    }
+    return nil
+}
+```
+
+### Registrando Serviços
+
+```go
+app := application.New(application.Options{
+    Services: []application.Service{
+        application.NewService(&MyService{}),
+        application.NewService(&AnotherService{}),
+    },
+})
+```
+
+**Pontos principais:**
+- Os serviços iniciam na ordem de registro
+- Os serviços são encerrados na ordem **inversa** de registro
+- Se o `ServiceStartup` de um serviço retornar um erro, a aplicação é abortada
+- O `ctx` passado para `ServiceStartup` é cancelado quando o encerramento começa
+
+### Usando o Contexto da Aplicação
+
+O contexto passado para `ServiceStartup` é válido durante toda a vida da aplicação:
+
+```go
+func (s *MyService) ServiceStartup(ctx context.Context, options application.ServiceOptions) error {
+    // Start a background task that respects shutdown
+    go func() {
+        ticker := time.NewTicker(5 * time.Minute)
+        defer ticker.Stop()
+
+        for {
+            select {
+            case <-ticker.C:
+                s.performBackgroundSync()
+            case <-ctx.Done():
+                // Application is shutting down
+                return
+            }
+        }
+    }()
+
+    return nil
+}
+```
+
+Você também pode acessar o contexto a partir da instância da aplicação:
+
+```go
+app := application.Get()
+ctx := app.Context()
+```
+
+## Hooks de Nível da Aplicação
+
+Estes são callbacks de conveniência em `application.Options` que permitem integrar-se ao ciclo de vida da aplicação sem criar um serviço completo. Eles são úteis para tarefas simples de limpeza, confirmação de encerramento ou quando você precisa executar código em pontos específicos da sequência de encerramento.
+
+Para gerenciamento de ciclo de vida mais complexo com lógica de inicialização, injeção de dependência ou recursos com estado, use [Serviços](#services-lifecycle) em vez disso.
+
+### ShouldQuit
+
+O callback `ShouldQuit` é chamado sempre que um encerramento é solicitado — seja pelo usuário fechando a última janela, pressionando Cmd+Q (macOS) / Alt+F4 (Windows) ou chamando `app.Quit()` programaticamente.
+
+**Valor de retorno:**
+- Retorne `true` para permitir que o encerramento prossiga (a aplicação será desligada)
+- Retorne `false` para cancelar o encerramento (a aplicação continua em execução)
+
+Esta é sua oportunidade de interceptar solicitações de encerramento e opcionalmente impedi-las, por exemplo, para solicitar ao usuário sobre alterações não salvas:
+
+```go
+app := application.New(application.Options{
+    ShouldQuit: func() bool {
+        if !hasUnsavedChanges() {
+            return true  // No unsaved changes, allow quit
+        }
+
+        // Prompt the user
+        result, _ := application.QuestionDialog().
+            SetTitle("Unsaved Changes").
+            SetMessage("You have unsaved changes. Quit anyway?").
+            AddButton("Quit", "quit").
+            AddButton("Cancel", "cancel").
+            Show()
+
+        // Only quit if user clicked "Quit"
+        return result == "quit"
+    },
+})
+```
+
+Se `ShouldQuit` não estiver definido, a aplicação será encerrada imediatamente quando solicitado.
+
+**Quando ShouldQuit é chamado:**
+- O usuário fecha a última janela (a menos que `DisableQuitOnLastWindowClosed` esteja definido)
+- O usuário pressiona Cmd+Q no macOS
+- O usuário pressiona Alt+F4 no Windows (quando focado na última janela)
+- O código chama `app.Quit()`
+
+**Quando ShouldQuit NÃO é chamado:**
+- O processo é morto (SIGKILL, encerramento forçado pelo Gerenciador de Tarefas)
+- `os.Exit()` é chamado diretamente
+
+### OnShutdown
+
+O callback `OnShutdown` é chamado quando a aplicação é confirmada como estando em encerramento (após `ShouldQuit` retornar `true`, se definido). Use isso para tarefas de limpeza, como salvar o estado, fechar conexões de banco de dados ou liberar recursos.
+
+```go
+app := application.New(application.Options{
+    OnShutdown: func() {
+        // Save application state
+        saveState()
+
+        // Close connections----------|--------------------------------|
+| macOS | A aplicação continua em execução (a barra de menu permanece) |
+| Windows | A aplicação encerra |
+| Linux | A aplicação encerra |
+
+O macOS segue as convenções nativas da plataforma, onde as aplicações geralmente permanecem ativas na barra de menu mesmo sem janelas abertas. Windows e Linux encerram por padrão.
+
+**Fazer todas as plataformas encerrarem quando a última janela fechar:**
+
+```go
+app := application.New(application.Options{
+    Mac: application.MacOptions{
+        ApplicationShouldTerminateAfterLastWindowClosed: true,
+    },
+})
+```
+
+**Fazer todas as plataformas permanecerem em execução quando a última janela fechar:**
+
+Isso é útil para aplicações de bandeja do sistema ou aplicações que devem permanecer em execução em segundo plano.
+
+```go
+app := application.New(application.Options{
+    Windows: application.WindowsOptions{
+        DisableQuitOnLastWindowClosed: true,
+    },
+    Linux: application.LinuxOptions{
+        DisableQuitOnLastWindowClosed: true,
+    },
+})
+```
+
+## Padrões Comuns
+
+### Padrão 1: Serviço de Banco de Dados
+
+```go
+type DatabaseService struct {
+    db *sql.DB
+}
+
+func (s *DatabaseService) ServiceStartup(ctx context.Context, options application.ServiceOptions) error {
+    var err error
+    s.db, err = sql.Open("sqlite3", "app.db")
+    if err != nil {
+        return fmt.Errorf("falha ao abrir banco de dados: %w", err)
+    }
+
+    if err := s.db.PingContext(ctx); err != nil {
+        return fmt.Errorf("falha ao conectar ao banco de dados: %w", err)
+    }
+
+    return nil
+}**Dúvidas sobre o ciclo de vida?** Pergunte no [Discord](https://discord.gg/JDdSxwjhGf) ou verifique os [exemplos](https://github.com/wailsapp/wails/tree/master/v3/examples).

--- a/docs/src/content/docs/pt/concepts/manager-api.mdx
+++ b/docs/src/content/docs/pt/concepts/manager-api.mdx
@@ -1,0 +1,266 @@
+---
+title: API do Gerenciador
+description: Estrutura de API organizada com interfaces de gerenciador focadas
+sidebar:
+  order: 2
+---
+
+import { Tabs, TabItem } from "@astrojs/starlight/components";
+
+A API do Gerenciador do Wails v3 oferece uma maneira organizada e descoberta de acessar a funcionalidade do aplicativo por meio de estruturas de gerenciador focadas. Esta nova estrutura de API agrupa métodos relacionados, mantendo total compatibilidade com a API tradicional do App.
+
+## Visão Geral
+
+A API do Gerenciador organiza a funcionalidade do aplicativo em onze áreas focadas:
+
+- **`app.Window`** - Criação, gerenciamento e callbacks de janelas
+- **`app.ContextMenu`** - Registro e gerenciamento de menus de contexto
+- **`app.KeyBinding`** - Gerenciamento de associações de teclas globais
+- **`app.Browser`** - Integração com navegador (abertura de URLs e arquivos)
+- **`app.Env`** - Informações de ambiente e estado do sistema
+- **`app.Dialog`** - Operações de diálogo de arquivos e mensagens
+- **`app.Event`** - Manipulação de eventos personalizados e eventos do aplicativo
+- **`app.Menu`** - Gerenciamento do menu do aplicativo
+- **`app.Screen`** - Gerenciamento de telas e transformações de coordenadas
+- **`app.Clipboard`** - Operações de texto da área de transferência
+- **`app.SystemTray`** - Criação e gerenciamento de ícones na bandeja do sistema
+
+## Benefícios
+
+- **Melhor descoberta** - O preenchimento automático do IDE mostra a superfície da API organizada
+- **Organização de código aprimorada** - Métodos relacionados agrupados
+- **Manutenibilidade aprimorada** - Separação de responsabilidades entre gerenciadores
+- **Extensibilidade futura** - Mais fácil adicionar novos recursos a áreas específicas
+
+## Uso
+
+A API do Gerenciador fornece acesso organizado a toda a funcionalidade do aplicativo:
+
+```go
+// Eventos e manipulação de eventos personalizados
+app.Event.Emit("custom", data)
+app.Event.On("custom", func(e *CustomEvent) { ... })
+
+// Gerenciamento de janelas
+window, _ := app.Window.GetByName("main")
+app.Window.OnCreate(func(window Window) { ... })
+
+// Integração com navegador
+app.Browser.OpenURL("https://wails.io")
+
+// Gerenciamento de menus
+menu := app.Menu.New()
+app.Menu.Set(menu)
+
+// Bandeja do sistema
+systray := app.SystemTray.New()
+```
+
+## Referência do Gerenciador
+
+### Gerenciador de Janelas
+
+Gerencia a criação, recuperação e callbacks de ciclo de vida de janelas.
+
+```go
+// Criar janelas
+window := app.Window.New()
+window := app.Window.NewWithOptions(options)
+current := app.Window.Current()
+
+// Encontrar janelas
+window, exists := app.Window.GetByName("main")
+windows := app.Window.GetAll()
+
+// Callbacks de janela
+app.Window.OnCreate(func(window Window) {
+    // Lidar com a criação da janela
+})
+```
+
+### Gerenciador de Eventos
+
+Lida com eventos personalizados e escuta de eventos do aplicativo.
+
+```go
+// Eventos personalizados
+app.Event.Emit("userAction", data)
+cancelFunc := app.Event.On("userAction", func(e *CustomEvent) {
+    // Lidar com o evento
+})
+app.Event.Off("userAction")
+app.Event.Reset() // Remover todos os ouvintes
+
+// Eventos do aplicativo
+app.Event.OnApplicationEvent(events.Common.ThemeChanged, func(e *ApplicationEvent) {
+    // Lidar com a mudança de tema do sistema
+})
+```
+
+### Gerenciador de Navegador
+
+Fornece integração com navegador para abrir URLs e arquivos.
+
+```go
+// Abrir URLs e arquivos no navegador padrão
+err := app.Browser.OpenURL("https://wails.io")
+err := app.Browser.OpenFile("/path/to/document.pdf")
+```
+
+### Gerenciador de Ambiente
+
+Acesso a informações do ambiente do sistema.
+
+```go
+// Obter informações do ambiente
+env := app.Env.Info()
+fmt.Printf("OS: %s, Arch: %s\n", env.OS, env.Arch)
+
+// Verificar o tema do sistema
+if app.Env.IsDarkMode() {
+    // O modo escuro está ativo
+}
+
+// Abrir o gerenciador de arquivos
+err := app.Env.OpenFileManager("/path/to/folder", false)
+```
+
+### Gerenciador de Diálogos
+
+Acesso organizado a diálogos de arquivos e mensagens.
+
+```go
+// Diálogos de arquivos
+result, err := app.Dialog.OpenFile().
+    AddFilter("Text Files", "*.txt").
+    PromptForSingleSelection()
+
+result, err = app.Dialog.SaveFile().
+    SetDefaultFilename("document.txt").
+    PromptForSingleSelection()
+
+// Diálogos de mensagens
+app.Dialog.Info().
+    SetTitle("Information").
+    SetMessage("Operation completed successfully").
+    Show()
+
+app.Dialog.Error().
+    SetTitle("Error").  
+    SetMessage("An error occurred").
+    Show()
+```
+
+### Gerenciador de Menus
+
+Criação e gerenciamento de menus do aplicativo.
+
+```go
+// Criar e definir o menu do aplicativo
+menu := app.Menu.New()
+fileMenu := menu.AddSubmenu("File")
+fileMenu.Add("New").OnClick(func(ctx *Context) {
+    // Lidar com o clique no menu
+})
+
+app.Menu.Set(menu)
+
+// Exibir diálogo Sobre
+app.Menu.ShowAbout()
+```
+
+### Gerenciador de Associações de Teclas
+
+Gerenciamento dinâmico de associações de teclas globais.
+
+```go
+// Adicionar associações de teclas
+app.KeyBinding.Add("ctrl+n", func(window *WebviewWindow) {
+    // Lidar com Ctrl+N
+})
+
+app.KeyBinding.Add("ctrl+q", func(window *WebviewWindow) {
+    app.Quit()
+})
+
+// Remover associações de teclas
+app.KeyBinding.Remove("ctrl+n")
+
+// Obter todas as associações
+bindings := app.KeyBinding.GetAll()
+```
+
+### Gerenciador de Menus de Contexto
+
+Gerenciamento avançado de menus de contexto (para autores de bibliotecas).
+
+```go
+// Criar e registrar menu de contexto
+menu := app.ContextMenu.New()
+app.ContextMenu.Add("myMenu", menu)
+
+// Recuperar menu de contexto
+menu, exists := app.ContextMenu.Get("myMenu")
+
+// Remover menu de contexto
+app.ContextMenu.Remove("myMenu")
+```
+
+### Gerenciador de Telas
+
+Gerenciamento de telas e transformações de coordenadas para configurações de múltiplos monitores.
+
+```go
+// Obter informações da tela
+screens := app.Screen.GetAll()
+primary := app.Screen.GetPrimary()
+
+// Transformações de coordenadas
+physicalPoint := app.Screen.DipToPhysicalPoint(logicalPoint)
+logicalPoint := app.Screen.PhysicalToDipPoint(physicalPoint)
+
+// Detecção de tela
+screen := app.Screen.ScreenNearestDipPoint(point)
+screen = app.Screen.ScreenNearestDipRect(rect)
+```
+
+### Gerenciador da Área de Transferência
+
+Operações da área de transferência para leitura e gravação de texto.
+
+```go
+// Definir texto na área de transferência
+success := app.Clipboard.SetText("Hello World")
+if !success {
+    // Lidar com o erro
+}
+
+// Obter texto da área de transferência
+text, ok := app.Clipboard.Text()
+if !ok {
+    // Lidar com o erro
+} else {
+    // Usar o texto
+}
+```
+
+### Gerenciador da Bandeja do Sistema
+
+Criação e gerenciamento de ícones na bandeja do sistema.
+
+```go
+// Criar bandeja do sistema
+systray := app.SystemTray.New()
+systray.SetLabel("My App")
+systray.SetIcon(iconBytes)
+
+// Adicionar menu à bandeja do sistema
+menu := app.Menu.New()
+menu.Add("Open").OnClick(func(ctx *Context) {
+    // Lidar com o clique
+})
+systray.SetMenu(menu)
+
+// Destruir a bandeja do sistema quando terminar
+systray.Destroy()
+```

--- a/docs/src/content/docs/pt/contributing.mdx
+++ b/docs/src/content/docs/pt/contributing.mdx
@@ -1,0 +1,275 @@
+---
+title: Contribuindo
+description: Contribua com o Wails
+sidebar:
+  order: 100
+---
+
+import { Card, CardGrid } from "@astrojs/starlight/components";
+
+## Bem-vindos, Contribuidores!
+
+Agradecemos suas contribuições para o Wails! Seja corrigindo bugs, adicionando recursos ou melhorando a documentação, seu apoio é muito apreciado.
+
+## Formas de Contribuir
+
+### 1. Relatar Problemas
+
+Encontrou um bug? [Abra uma issue](https://github.com/wailsapp/wails/issues/new) com:
+- Descrição clara
+- Passos para reproduzir
+- Comportamento esperado vs. real
+- Informações do sistema
+- Exemplos de código
+
+### 2. Melhorar a Documentação
+
+Melhorias na documentação são sempre bem-vindas:
+- Corrigir erros de digitação e imprecisões
+- Adicionar exemplos
+- Esclarecer explicações
+- Traduzir conteúdo
+
+### 3. Enviar Código
+
+Contribua com código através de pull requests:
+- Correções de bugs
+- Novos recursos
+- Melhorias de desempenho
+- Testes
+
+## Começando
+
+### Fork e Clone
+
+```bash
+# Faça um fork do repositório no GitHub
+# Em seguida, clone seu fork
+git clone https://github.com/YOUR_USERNAME/wails.git
+cd wails
+
+# Adicione o repositório original (upstream)
+git remote add upstream https://github.com/wailsapp/wails.git
+```
+
+### Compilar a partir do código-fonte
+
+```bash
+# Instale as dependências
+go mod download
+
+# Compile a CLI do Wails
+cd v3/cmd/wails3
+go build
+
+# Teste sua compilação
+./wails3 version
+```
+
+### Executar Testes
+
+```bash
+# Execute todos os testes
+go test ./...
+
+# Execute testes de pacotes específicos
+go test ./v3/pkg/application
+
+# Execute com cobertura de código
+go test -cover ./...
+```
+
+## Fazendo Alterações
+
+### Criar um Branch
+
+```bash
+# Atualize a main
+git checkout main
+git pull upstream main
+
+# Crie um branch para a nova funcionalidade
+git checkout -b feature/my-feature
+```
+
+### Faça suas Alterações
+
+1. **Escreva código** seguindo as convenções do Go
+2. **Adicione testes** para a nova funcionalidade
+3. **Atualize a documentação** se necessário
+4. **Execute os testes** para garantir que nada quebre
+5. **Faça o commit das alterações** com mensagens claras
+
+### Diretrizes para Commits
+
+```bash
+# Bons commits
+git commit -m "fix: resolve window focus issue on macOS"
+git commit -m "feat: add support for custom window chrome"
+git commit -m "docs: improve bindings documentation"
+
+# Use commits convencionais:
+# - feat: Nova funcionalidade
+# - fix: Correção de bug
+# - docs: Documentação
+# - test: Testes
+# - refactor: Refatoração de código
+# - chore: Manutenção
+```
+
+### Enviar Pull Request
+
+```bash
+# Envie para seu fork
+git push origin feature/my-feature
+
+# Abra o pull request no GitHub
+# Forneça uma descrição clara
+# Referencie as issues relacionadas
+```
+
+## Diretrizes para Pull Requests
+
+### Boa Descrição de PR
+
+```markdown
+## Descrição
+Breve descrição das alterações
+
+## Alterações
+- Adicionada a funcionalidade X
+- Corrigido o bug Y
+- Documentação atualizada
+
+## Testes
+- Testado no macOS 14
+- Testado no Windows 11
+- Todos os testes passando
+
+## Issues Relacionadas
+Fixes #123
+```
+
+### Checklist do PR
+
+- [ ] O código segue as convenções do Go
+- [ ] Testes adicionados/atualizados
+- [ ] Documentação atualizada
+- [ ] Todos os testes passando
+- [ ] Sem breaking changes (ou documentadas)
+- [ ] Mensagens de commit claras
+
+## Diretrizes de Código
+
+### Estilo de Código Go
+
+```go
+// ✅ Bom: Claro, documentado, testado
+// ProcessData processa os dados de entrada e retorna o resultado.
+// Retorna um erro se os dados forem inválidos.
+func ProcessData(data string) (string, error) {
+    if data == "" {
+        return "", errors.New("data cannot be empty")
+    }
+    
+    result := process(data)
+    return result, nil
+}
+
+// ❌ Ruim: Sem documentação, sem tratamento de erros
+func ProcessData(data string) string {
+    return process(data)
+}
+```
+
+### Testes
+
+```go
+func TestProcessData(t *testing.T) {
+    tests := []struct {
+        name    string
+        input   string
+        want    string
+        wantErr bool
+    }{
+        {"valid input", "test", "processed", false},
+        {"empty input", "", "", true},
+    }
+    
+    for _, tt := range tests {
+        t.Run(tt.name, func(t *testing.T) {
+            got, err := ProcessData(tt.input)
+            if (err != nil) != tt.wantErr {
+                t.Errorf("ProcessData() error = %v, wantErr %v", err, tt.wantErr)
+                return
+            }
+            if got != tt.want {
+                t.Errorf("ProcessData() = %v, want %v", got, tt.want)
+            }
+        })
+    }
+}
+```
+
+## Documentação
+
+### Escrevendo Documentação
+
+A documentação usa Starlight (Astro):
+
+```bash
+cd docs
+npm install
+npm run dev
+```
+
+### Estilo da Documentação
+
+- Use ortografia do inglês internacional
+- Comece com o problema
+- Forneça exemplos funcionais
+- Inclua solução de problemas
+- Faça referências cruzadas com conteúdo relacionado
+
+## Comunidade
+
+### Obter Ajuda
+
+- **Discord:** [Junte-se à nossa comunidade](https://discord.gg/JDdSxwjhGf)
+- **GitHub Discussions:** Faça perguntas
+- **GitHub Issues:** Relate bugs
+
+### Código de Conduta
+
+Seja respeitoso, inclusivo e profissional. Estamos todos aqui para construir um ótimo software juntos.
+
+## Reconhecimento
+
+Os contribuidores são reconhecidos em:
+- Notas de lançamento
+- Lista de contribuidores
+- Insights do GitHub
+
+Obrigado por contribuir com o Wails! 🎉
+
+## Próximos Passos
+
+<CardGrid>
+  <Card title="Repositório GitHub" icon="github">
+    Visite o repositório do Wails.
+    
+    [Ver no GitHub →](https://github.com/wailsapp/wails)
+  </Card>
+
+  <Card title="Comunidade Discord" icon="discord">
+    Junte-se à comunidade.
+    
+    [Entrar no Discord →](https://discord.gg/JDdSxwjhGf)
+  </Card>
+
+  <Card title="Documentação" icon="open-book">
+    Leia a documentação.
+    
+    [Navegar pela Documentação →](/pt/quick-start/why-wails)
+  </Card>
+</CardGrid>

--- a/docs/src/content/docs/pt/contributing/architecture/bindings.mdx
+++ b/docs/src/content/docs/pt/contributing/architecture/bindings.mdx
@@ -1,0 +1,156 @@
+---
+title: Sistema de Bindings
+description: Como o sistema de bindings coleta, processa e gera código JavaScript/TypeScript
+sidebar:
+  order: 1
+---
+
+import { FileTree } from "@astrojs/starlight/components";
+
+Este guia explica como o sistema de bindings do Wails funciona internamente, fornecendo insights para desenvolvedores que desejam entender a mecânica por trás da geração automática de código.
+
+## Visão Geral da Arquitetura
+
+O sistema de bindings do Wails consiste em três componentes principais:
+
+1. **Coleta**: Analisa o código Go para extrair informações sobre serviços, modelos e outras declarações
+2. **Configuração**: Gerencia configurações e opções para o processo de geração de bindings
+3. **Renderização**: Gera código JavaScript/TypeScript com base nas informações coletadas
+
+<FileTree>
+- internal/generator/
+  - collect/     # Análise de pacotes e extração de informações
+  - config/      # Estruturas e interfaces de configuração
+  - render/      # Geração de código para JS/TS
+</FileTree>
+
+## Processo de Coleta
+
+O processo de coleta é responsável por analisar os pacotes Go e extrair informações sobre serviços, modelos e outras declarações. Isso é tratado pelo pacote `collect`.
+
+### Componentes Principais
+
+- **Collector**: Gerencia informações do pacote e armazena em cache os dados coletados
+- **Package**: Representa um pacote Go sendo analisado e armazena serviços, modelos e diretivas coletados
+- **Service**: Coleta informações sobre tipos de serviço e seus métodos
+- **Model**: Coleta informações detalhadas sobre tipos de modelo, incluindo campos, valores e parâmetros de tipo
+- **Directive**: Analisa e interpreta diretivas `//wails:` no código-fonte Go
+
+### Fluxo de Coleta
+
+1. O collector escaneia os pacotes Go especificados no projeto
+2. Ele identifica tipos de serviço (structs com métodos que serão expostos ao frontend)
+3. Para cada serviço, ele coleta informações sobre seus métodos
+4. Ele identifica tipos de modelo (structs usados como parâmetros ou valores de retorno em métodos de serviço)
+5. Para cada modelo, ele coleta informações sobre seus campos e parâmetros de tipo
+6. Ele processa quaisquer diretivas `//wails:` encontradas no código
+
+## Processo de Renderização
+
+O processo de renderização é responsável por gerar código JavaScript/TypeScript com base nas informações coletadas. Isso é tratado pelo pacote `render`.
+
+### Componentes Principais
+
+- **Renderer**: Orquestra a renderização de arquivos de serviço, modelo e índice
+- **Module**: Representa um único módulo JavaScript/TypeScript gerado
+- **Templates**: Modelos de texto usados para geração de código
+
+### Fluxo de Renderização
+
+1. Para cada serviço, o renderer gera um arquivo JavaScript/TypeScript com funções que espelham os métodos do serviço
+2. Para cada modelo, o renderer gera uma classe JavaScript/TypeScript que espelha a struct do modelo
+3. O renderer gera arquivos de índice que reexportam todos os serviços e modelos
+4. O renderer aplica quaisquer injeções de código customizadas especificadas pelas diretivas `//wails:inject`
+
+## Mapeamento de Tipos
+
+Um dos aspectos mais importantes do sistema de bindings é como os tipos Go são mapeados para tipos JavaScript/TypeScript. Aqui está um resumo do mapeamento:
+
+| Tipo Go | Tipo JavaScript | Tipo TypeScript |
+|---------|----------------|----------------|
+| `bool` | `boolean` | `boolean` |
+| `int`, `int8`, `int16`, `int32`, `int64`, `uint`, `uint8`, `uint16`, `uint32`, `uint64`, `float32`, `float64` | `number` | `number` |
+| `string` | `string` | `string` |
+| `[]byte` | `Uint8Array` | `Uint8Array` |
+| `[]T` | `Array<T>` | `T[]` |
+| `map[K]V` | `Object` | `Record<K, V>` |
+| `struct` | `Object` | Classe customizada |
+| `interface{}` | `any` | `any` |
+| `*T` | `T \| null` | `T \| null` |
+| `func` | Não suportado | Não suportado |
+| `chan` | Não suportado | Não suportado |
+
+## Sistema de Diretivas
+
+O sistema de bindings suporta várias diretivas que podem ser usadas para personalizar o código gerado. Essas diretivas são adicionadas como comentários no seu código Go.
+
+### Diretivas Disponíveis
+
+- `//wails:inject`: Injeta código JavaScript/TypeScript customizado nos bindings gerados
+- `//wails:include`: Inclui arquivos adicionais com os bindings gerados
+- `//wails:internal`: Marca um tipo ou método como interno, impedindo que seja exportado para o frontend
+- `//wails:ignore`: Ignora completamente um método durante a geração de bindings
+- `//wails:id`: Especifica um ID customizado para um método, substituindo o ID padrão baseado em hash
+
+### Processamento de Diretivas
+
+1. Durante a fase de coleta, o collector identifica e analisa diretivas no código Go
+2. As diretivas são armazenadas junto com as declarações correspondentes (serviços, métodos, modelos, etc.)
+3. Durante a fase de renderização, o renderer aplica as diretivas para personalizar o código gerado
+
+## Recursos Avançados
+
+### Geração de Código Condicional
+
+O sistema de bindings suporta geração de código condicional usando um prefixo de condição de dois caracteres para diretivas `include` e `inject`:
+
+```
+<language><style>:<content>
+```
+
+Onde:
+- `<language>` pode ser:
+  - `*` - Tanto JavaScript quanto TypeScript
+  - `j` - Apenas JavaScript
+  - `t` - Apenas TypeScript
+
+- `<style>` pode ser:
+  - `*` - Tanto classes quanto interfaces
+  - `c` - Apenas classes
+  - `i` - Apenas interfaces
+
+Por exemplo:
+```go
+//wails:inject j*:console.log("JavaScript only");
+//wails:inject t*:console.log("TypeScript only");
+```
+
+### IDs de Método Customizados
+
+Por padrão, os métodos são identificados por um ID baseado em hash. No entanto, você pode especificar um ID customizado usando a diretiva `//wails:id`:
+
+```go
+//wails:id 42
+func (s *Service) CustomIDMethod() {}
+```
+
+Isso pode ser útil para manter a compatibilidade ao refatorar o código.
+
+## Considerações de Desempenho
+
+O gerador de bindings foi projetado para ser eficiente, mas há alguns pontos a considerar:
+
+1. A primeira execução será mais lenta, pois constrói um cache de pacotes para escanear
+2. Execuções subsequentes serão mais rápidas, pois usam as informações em cache
+3. O gerador processa todos os pacotes do projeto, o que pode ser demorado para projetos grandes
+4. Você pode usar a flag `-clean` para limpar o diretório de saída antes da geração
+
+## Depuração
+
+Se você encontrar problemas com a geração de bindings, pode usar a flag `-v` para habilitar a saída de depuração:
+
+```bash
+wails3 generate bindings -v
+```
+
+Isso fornecerá informações detalhadas sobre o processo de coleta e renderização, o que pode ajudar a identificar a origem do problema.

--- a/docs/src/content/docs/pt/credits.mdx
+++ b/docs/src/content/docs/pt/credits.mdx
@@ -1,0 +1,60 @@
+---
+title: Créditos
+description: Reconheça os contribuidores e projetos por trás do Wails
+---
+
+{/* Import the auto-generated contributors file */}
+
+import Contributors from "../../../assets/contributors.html";
+
+- [Lea Anthony](https://github.com/leaanthony) - Proprietário do projeto, desenvolvedor principal
+- [Stffabi](https://github.com/stffabi) - Líder técnico, desenvolvedor e mantenedor
+- [Travis McLane](https://github.com/tmclane) - Trabalho de compilação cruzada, testes no MacOS
+- [Atterpac](https://github.com/atterpac) - Desenvolvedor, especialista em suporte, força motriz
+- [Simon Thomas](mailto:enquiries@wails.io) - Growth Hacker
+- [Lyimmi](https://github.com/Lyimmi) - Tudo relacionado ao Linux
+- [fbbdev](https://github.com/fbbdev) - Especialista em Gerador de Bindings e contribuidor principal
+
+## Patrocinadores
+<br/>
+<a href="https://zsa.io/">
+    <img
+        src="/sponsors/zsa.png"
+        style={{ margin: "auto", width: "400px" }}
+        alt="ZSA"
+    />
+</a>
+<img
+  src="https://wails.io/img/sponsors.svg"
+  style={{ margin: "auto", width: "100%", "max-width": "1600px;" }}
+  alt="Sponsors"
+/>
+Agradecimentos especiais:
+<img
+  src="/sponsors/jetbrains-grayscale.webp"
+  style={{ margin: "auto", width: "100px" }}
+  alt="JetBrains"
+/>
+
+## Contribuidores
+
+<Contributors />
+
+## Menções Especiais
+
+- [John Chadwick](https://github.com/jchv) - Seu incrível trabalho no
+  [go-webview2](https://github.com/jchv/go-webview2) e no
+  [go-winloader](https://github.com/jchv/go-winloader) tornou possível a versão para Windows.
+- [Tad Vizbaras](https://github.com/tadvi) - Seu projeto winc foi o primeiro passo
+  no caminho para um Wails puramente em Go.
+- [Mat Ryer](https://github.com/matryer) - Por conselhos, suporte e boas risadas.
+- [Byron Chris](https://github.com/bh90210) - Por suas contribuições de longo prazo a
+  este projeto.
+- [Dustin Krysak](https://wiki.ubuntu.com/bashfulrobot) - Seu apoio e
+  feedback foram inestimáveis.
+- [Justen Walker](https://github.com/justenwalker/) - Por ajudar a resolver os
+  problemas de COM que levaram a v2 à conclusão.
+- [Wang, Chi](https://github.com/patr0nus/) - O projeto DeskGap foi uma grande
+  influência na direção do Wails v2.
+- [Serge Zaitsev](https://github.com/zserge) - Embora o Wails não utilize o projeto
+  Webview, ele ainda é uma fonte de inspiração.

--- a/docs/src/content/docs/pt/faq.mdx
+++ b/docs/src/content/docs/pt/faq.mdx
@@ -1,0 +1,260 @@
+---
+title: Perguntas Frequentes
+description: Perguntas comuns sobre o Wails
+sidebar:
+  order: 99
+---
+
+## Geral
+
+### O que é o Wails?
+
+O Wails é um framework para construir aplicativos de desktop usando Go e tecnologias web. Ele oferece integração nativa com o sistema operacional, permitindo que você construa sua interface do usuário com HTML, CSS e JavaScript.
+
+### Como o Wails se compara ao Electron?
+
+**Wails:**
+- Uso de memória de ~10MB
+- Tamanho do binário de ~15MB
+- Desempenho nativo
+- Backend em Go
+
+**Electron:**
+- Uso de memória de ~100MB+
+- Tamanho do binário de ~150MB+
+- Sobrecarga do Chromium
+- Backend em Node.js
+
+### O Wails está pronto para produção?
+
+Sim! O Wails v3 é adequado para aplicativos de produção. Muitas empresas usam o Wails para seus aplicativos de desktop.
+
+### Quais plataformas o Wails suporta?
+
+- Windows (7+)
+- macOS (10.13+)
+- Linux (GTK3)
+
+## Desenvolvimento
+
+### Preciso saber Go?
+
+Conhecimento básico de Go é útil, mas não obrigatório. Você pode começar com serviços simples e aprender conforme avança.
+
+### Posso usar meu framework frontend favorito?
+
+Sim! O Wails funciona com:
+- JavaScript puro
+- React
+- Vue
+- Svelte
+- Qualquer framework que gere HTML/CSS/JS
+
+### Como chamo funções Go do JavaScript?
+
+Use os bindings:
+
+```go
+// Go
+func (s *Service) Greet(name string) string {
+    return "Hello " + name
+}
+```
+
+```javascript
+// JavaScript
+import { Greet } from './bindings/myapp/service'
+const message = await Greet("World")
+```
+
+### Posso usar TypeScript?
+
+Sim! O Wails gera definições de TypeScript automaticamente.
+
+### Como depuro meu aplicativo?
+
+Use as ferramentas de desenvolvedor do seu navegador:
+- Clique com o botão direito → Inspecionar Elemento
+- Ou ative as ferramentas de desenvolvedor nas opções da janela
+
+## Compilação e Distribuição
+
+### Como compilo para produção?
+
+```bash
+wails3 build
+```
+
+Seu aplicativo estará em `build/bin/`.
+
+### Posso compilar para outras plataformas?
+
+Sim! Compile para outras plataformas:
+
+```bash
+wails3 build -platform windows/amd64
+wails3 build -platform darwin/universal
+wails3 build -platform linux/amd64
+```
+
+### Como crio um instalador?
+
+Use ferramentas específicas da plataforma:
+- Windows: NSIS ou WiX
+- macOS: Crie um DMG
+- Linux: Pacotes DEB/RPM
+
+Veja o [Guia de Instaladores](/guides/installers).
+
+### Como assino digitalmente meu aplicativo?
+
+**macOS:**
+```bash
+codesign --deep --force --sign "Developer ID" MyApp.app
+```
+
+**Windows:**
+Use o SignTool com seu certificado.
+
+## Recursos
+
+### Posso criar múltiplas janelas?
+
+Sim! O Wails v3 tem suporte nativo para múltiplas janelas:
+
+```go
+window1 := app.Window.New()
+window2 := app.Window.New()
+```
+
+### O Wails suporta bandeja do sistema?
+
+Sim! Crie aplicativos para a bandeja do sistema:
+
+```go
+tray := app.SystemTray.New()
+tray.SetIcon(iconBytes)
+tray.SetMenu(menu)
+```
+
+### Posso usar diálogos nativos?
+
+Sim! O Wails fornece diálogos nativos:
+
+```go
+path, _ := app.Dialog.OpenFile().
+    SetTitle("Select File").
+    PromptForSingleSelection()
+```
+
+### O Wails suporta atualizações automáticas?
+
+O Wails não inclui funcionalidade de atualização automática, mas você pode implementá-la você mesmo ou usar bibliotecas de terceiros.
+
+## Desempenho
+
+### Por que meu binário é grande?
+
+Os binários Go incluem o tempo de execução. Reduza o tamanho:
+
+```bash
+wails3 build -ldflags "-s -w"
+```
+
+### Como melhoro o desempenho?
+
+- Use paginação para grandes conjuntos de dados
+- Armazene em cache operações custosas
+- Use eventos para atualizações
+- Otimize o bundle do frontend
+- Faça profiling do seu código
+
+Veja o [Guia de Desempenho](/guides/performance).
+
+### O Wails suporta hot reload?
+
+Sim! Use o modo de desenvolvimento:
+
+```bash
+wails3 dev
+```
+
+## Solução de Problemas
+
+### Meus bindings não estão funcionando
+
+Regere os bindings:
+
+```bash
+wails3 generate bindings
+```
+
+### A janela não aparece
+
+Verifique se você chamou `Show()`:
+
+```go
+window := app.Window.New()
+window.Show()  // Não se esqueça disso!
+```
+
+### Eventos não estão disparando
+
+Certifique-se de que os nomes dos eventos correspondam exatamente:
+
+```go
+// Go
+app.Event.Emit("my-event", data)
+
+// JavaScript
+OnEvent("my-event", handler)  // Deve corresponder
+```
+
+### A compilação falha
+
+Soluções comuns:
+- Execute `go mod tidy`
+- Verifique a configuração do `wails.json`
+- Verifique se o frontend foi compilado: `cd frontend && npm run build`
+- Atualize o Wails: `go install github.com/wailsapp/wails/v3/cmd/wails3@latest`
+
+## Migração
+
+### Devo migrar da v2 para a v3?
+
+A v3 oferece:
+- Melhor desempenho
+- Suporte a múltiplas janelas
+- API aprimorada
+- Melhor experiência de desenvolvimento
+
+Veja o [Guia de Migração](/migration/v2-to-v3).
+
+### A v2 será mantida?
+
+Sim, a v2 receberá atualizações críticas.
+
+### Posso executar a v2 e a v3 lado a lado?
+
+Sim, elas usam caminhos de importação diferentes.
+
+## Comunidade
+
+### Como obtenho ajuda?
+
+- [Comunidade no Discord](https://discord.gg/JDdSxwjhGf)
+- [Discussões no GitHub](https://github.com/wailsapp/wails/discussions)
+- [Issues no GitHub](https://github.com/wailsapp/wails/issues)
+
+### Como contribuo?
+
+Veja o [Guia de Contribuição](/contributing).
+
+### Onde encontro exemplos?
+
+- [Exemplos Oficiais](https://github.com/wailsapp/wails/tree/master/v3/examples)
+- [Exemplos da Comunidade](https://github.com/topics/wails)
+
+## Ainda Tem Perguntas?
+
+Pergunte no [Discord](https://discord.gg/JDdSxwjhGf) ou [abra uma discussão](https://github.com/wailsapp/wails/discussions).

--- a/docs/src/content/docs/pt/feedback.mdx
+++ b/docs/src/content/docs/pt/feedback.mdx
@@ -1,0 +1,87 @@
+---
+title: Feedback da Alpha v3
+description: Como fornecer feedback e relatar problemas para o Wails v3
+sidebar:
+  order: 40
+---
+
+import { Tabs, TabItem } from "@astrojs/starlight/components";
+
+Agradecemos (e incentivamos) o seu feedback! Por favor, procure por tickets ou
+posts existentes antes de criar novos. Aqui estão as diferentes formas de fornecer feedback:
+
+<Tabs>
+  <TabItem label="Bugs" icon="error">
+
+    Se você encontrar um bug, por favor, nos avise postando no canal [v3 Alpha Feedback](https://discord.gg/bdj28QNHmT) no Discord.
+
+    - O post deve declarar claramente qual é o bug e conter um exemplo reproduzível simples. Se a documentação não estiver clara sobre o que *deveria* acontecer, por favor, inclua isso no post.
+    - O post deve receber a tag `Bug`.
+    - Por favor, inclua a saída de `wails doctor` no seu post.
+    - Se o bug for um comportamento que não está alinhado com a documentação atual, por exemplo, uma janela que não redimensiona corretamente, por favor, faça o seguinte:
+      - Atualize um exemplo existente no diretório `v3/example` ou crie um novo exemplo na pasta `v3/examples` que mostre claramente o problema.
+      - Abra um [PR](https://github.com/wailsapp/wails/pulls) com o título `[v3 alpha test] <descrição do bug>`.
+      - Por favor, inclua um link para o PR no seu post.
+
+    :::caution
+
+    _Lembre-se_, comportamento inesperado não é necessariamente um bug - pode ser apenas que ele não faça
+    o que você espera. Use `Suggestions` para isso.
+
+    :::
+
+  </TabItem>
+
+  <TabItem label="Correções" icon="approve-check">
+
+    Se você tem uma correção para um bug ou uma atualização para a documentação, por favor, faça o seguinte:
+
+    - Abra um pull request no [repositório do Wails](https://github.com/wailsapp/wails). O título do PR deve começar com `[v3 alpha]`.
+    - Crie um post no canal [v3 Alpha Feedback](https://discord.gg/bdj28QNHmT).
+    - O post deve receber a tag `PR`.
+    - Por favor, inclua um link para o PR no seu post.
+
+  </TabItem>
+
+  <TabItem label="Sugestões" icon="puzzle" id="abc">
+
+    Se você tem uma sugestão, por favor, nos avise postando no canal [v3 Alpha Feedback](https://discord.gg/bdj28QNHmT) no Discord:
+
+    - O post deve receber a tag `Suggestion`.
+
+    Sinta-se à vontade para entrar em contato conosco no [Discord](https://discord.gg/bdj28QNHmT) se tiver alguma dúvida.
+
+  </TabItem>
+
+  <TabItem label="Votação positiva" icon="star">
+
+    - Posts podem ser "apoiados" usando o emoji :thumbsup:. Por favor, aplique isso a qualquer post que seja uma prioridade para você.
+    - Por favor, *não* adicione apenas comentários como "+1" ou "eu também".
+    - Sinta-se à vontade para comentar se houver mais algo a adicionar ao post, como "esse bug também afeta builds para ARM" ou "Outra opção seria ....."
+
+  </TabItem>
+
+</Tabs>
+
+Existe uma lista de problemas conhecidos e trabalhos em andamento que pode ser encontrada
+[aqui](https://github.com/orgs/wailsapp/projects/6).
+
+## Assuntos pelos quais estamos buscando feedback
+
+- A API
+  - É fácil de usar?
+  - Ela faz o que você espera?
+  - Está faltando algo?
+  - Há algo que deveria ser removido?
+  - É consistente entre Go e JS?
+- O sistema de build
+  - É fácil de usar?
+  - Podemos melhorá-lo?
+- Os exemplos
+  - São claros?
+  - Eles cobrem o básico?
+- Recursos
+  - Quais recursos estão faltando?
+  - Quais recursos não são necessários?
+- Documentação
+  - O que poderia ser mais claro?

--- a/docs/src/content/docs/pt/getting-started/your-first-app.mdx
+++ b/docs/src/content/docs/pt/getting-started/your-first-app.mdx
@@ -1,0 +1,270 @@
+---
+title: Seu Primeiro Aplicativo
+description: Crie seu primeiro aplicativo de desktop com Wails passo a passo
+sidebar:
+  order: 20
+---
+
+import { Tabs, TabItem } from "@astrojs/starlight/components";
+import { Badge } from '@astrojs/starlight/components';
+import { Steps } from "@astrojs/starlight/components";
+import { FileTree } from '@astrojs/starlight/components';
+
+import wails_init from '../../../../assets/wails_init.mp4';
+import wails_build from '../../../../assets/wails_build.mp4';
+import wails_dev from '../../../../assets/wails_dev.mp4';
+
+
+Este guia mostra como criar seu primeiro aplicativo Wails v3, cobrindo a configuração do projeto, a compilação e o fluxo de trabalho de desenvolvimento.
+
+<br/>
+<br/>
+
+<Steps>
+
+1.  ## Criando um Novo Projeto
+
+    Abra seu terminal e execute o seguinte comando para criar um novo projeto Wails:
+
+    ```bash
+    wails3 init -n myfirstapp
+    ```
+
+    Este comando cria um novo diretório chamado `myfirstapp` com todos os
+    arquivos necessários.
+
+      <video src={wails_init} controls></video> 
+
+2.  ## Explorando a Estrutura do Projeto
+
+    Navegue até o diretório `myfirstapp`. Você encontrará vários arquivos e
+    pastas:
+
+    <FileTree>
+    - build/           Contém arquivos usados pelo processo de compilação
+        - appicon.png  O ícone do aplicativo
+        - config.yml   Configuração de compilação
+        - Taskfile.yml Tarefas de compilação
+        - darwin/      Arquivos de compilação específicos para macOS
+            - Info.dev.plist Configuração de desenvolvimento
+            - Info.plist    Configuração de produção
+            - Taskfile.yml  Tarefas de compilação para macOS
+            - icons.icns    Ícone do aplicativo para macOS
+        - linux/       Arquivos de compilação específicos para Linux
+            - Taskfile.yml  Tarefas de compilação para Linux
+            - appimage/     Empacotamento AppImage
+                - build.sh  Script de compilação do AppImage
+            - nfpm/        Empacotamento NFPM
+                - nfpm.yaml Configuração do pacote
+                - scripts/  Scripts de compilação
+        - windows/     Arquivos de compilação específicos para Windows
+            - Taskfile.yml        Tarefas de compilação para Windows
+            - icon.ico           Ícone do aplicativo para Windows
+            - info.json          Metadados do aplicativo
+            - wails.exe.manifest Arquivo de manifesto do Windows
+            - nsis/              Arquivos do instalador NSIS
+                - project.nshi                    Arquivo do projeto NSIS
+                - wails_tools.nsh               Scripts auxiliares do NSIS
+    - frontend/        Arquivos do aplicativo frontend
+        - index.html   Arquivo HTML principal
+        - main.js      Arquivo JavaScript principal
+        - package.json Configuração do pacote NPM
+        - public/      Ativos estáticos
+        - Inter Font License.txt Licença da fonte
+    - .gitignore      Arquivo de ignorar do Git
+    - README.md       Documentação do projeto
+    - Taskfile.yml    Tarefas do projeto
+    - go.mod          Arquivo do módulo Go
+    - go.sum          Somas de verificação do módulo Go
+    - greetservice.go Serviço de saudação
+    - main.go         Código principal do aplicativo
+    </FileTree>
+
+    Reserve um momento para explorar esses arquivos e se familiarizar com a
+    estrutura.
+
+    :::note
+    Embora o Wails v3 use [Task](https://taskfile.dev/) como seu
+    sistema de compilação padrão, nada impede você de usar `make` ou qualquer outro
+    sistema de compilação alternativo.
+    :::
+
+3.  ## Compilando Seu Aplicativo
+
+    Para compilar seu aplicativo, execute:
+
+    ```bash
+    wails3 build
+    ```
+
+    Este comando compila uma versão de depuração do seu aplicativo e a salva em um
+    novo diretório `bin`.
+
+    :::note
+    `wails3 build` é uma abreviação para `wails3 task build` e executará a tarefa `build` em `Taskfile.yml`.
+    :::
+
+        <video src={wails_build} controls></video> 
+
+
+    Uma vez compilado, você pode executá-lo como faria com qualquer aplicativo normal:
+
+
+    <Tabs syncKey="platform">
+
+      <TabItem label="Mac" icon="apple">
+
+        ```sh
+        ./bin/myfirstapp
+        ```
+
+          </TabItem>
+
+      <TabItem label="Windows" icon="seti:windows">
+
+        ```sh
+        bin\myfirstapp.exe
+        ```
+
+          </TabItem>
+
+      <TabItem label="Linux" icon="linux">
+
+        ```sh
+        ./bin/myfirstapp
+        ```
+
+          </TabItem>
+
+    </Tabs>
+
+    Você verá uma interface simples, o ponto de partida para o seu aplicativo. Como é
+    a versão de depuração, você também verá logs na janela do console. Isso é
+    útil para fins de depuração.
+
+4.  ## Modo de Desenvolvimento
+
+    Também podemos executar o aplicativo no modo de desenvolvimento. Este modo permite que você
+    faça alterações no seu código frontend e veja as alterações refletidas no
+    aplicativo em execução sem precisar recompilar todo o aplicativo.
+
+    1. Abra uma nova janela de terminal.
+    2. Execute `wails3 dev`. O aplicativo será compilado e executado no modo de depuração.
+    3. Abra `frontend/index.html` no editor de sua escolha.
+    4. Edite o código e altere `Please enter your name below` para
+       `Please enter your name below!!!`.
+    5. Salve o arquivo.
+
+    Essa alteração será refletida no seu aplicativo imediatamente.
+
+    Quaisquer alterações no código do backend acionarão uma recompilação:
+
+    1. Abra `greetservice.go`.
+    2. Altere a linha que contém `return "Hello " + name + "!"` para
+       `return "Hello there " + name + "!"`.
+    3. Salve o arquivo.
+
+    O aplicativo será atualizado em questão de segundos.
+
+        <video src={wails_dev} controls></video>
+
+5.  ## Empacotando Seu Aplicativo
+
+        Quando seu aplicativo estiver pronto para distribuição, você pode criar
+        pacotes específicos para cada plataforma:
+
+          <Tabs syncKey="platform">
+
+    <TabItem label="Mac" icon="apple">
+
+              Para criar um bundle `.app`:
+
+              ```bash
+              wails3 package
+              ```
+
+              Isso criará uma compilação de produção e a empacotará em um bundle `.app` no diretório `bin`.
+
+            </TabItem>
+            <TabItem label="Windows" icon="seti:windows">
+
+              Para criar um instalador NSIS:
+
+              ```bash
+              wails3 package
+              ```
+
+              Isso criará uma compilação de produção e a empacotará em um instalador NSIS no diretório `bin`.
+
+            </TabItem>
+            <TabItem label="Linux" icon="linux">
+
+              O Wails suporta vários formatos de pacote para distribuição no Linux:
+
+              ```bash
+              # Cria todos os tipos de pacote (AppImage, deb, rpm e Arch Linux)
+              wails3 package
+
+              # Ou cria tipos de pacote específicos
+              wails3 task linux:create:appimage  # Formato AppImage
+              wails3 task linux:create:deb       # Pacote Debian
+              wails3 task linux:create:rpm       # Pacote Red Hat
+              wails3 task linux:create:aur       # Pacote Arch Linux
+              ```
+
+            </TabItem>
+
+          </Tabs>
+
+        Para informações mais detalhadas sobre opções de empacotamento e configuração,
+        confira nosso [Guia de Empacotamento](/guides/packaging).
+
+6.  ## Configurando Controle de Versão e Nome do Módulo
+
+    Seu projeto é criado com o nome de módulo placeholder `changeme`. É recomendável atualizá-lo para corresponder à URL do seu repositório:
+
+    1. Crie um novo repositório no GitHub (ou em seu serviço Git preferido)
+    2. Inicialize o git no diretório do seu projeto:
+       ```bash
+       git init
+       git add .
+       git commit -m "Initial commit"
+       ```
+    3. Defina seu repositório remoto (substitua pela URL do seu repositório):
+       ```bash
+       git remote add origin https://github.com/username/myfirstapp.git
+       ```
+    4. Atualize o nome do módulo em `go.mod` para corresponder à URL do seu repositório:
+       ```bash
+       go mod edit -module github.com/username/myfirstapp
+       ```
+    5. Envie seu código:
+       ```bash
+       git push -u origin main
+       ```
+
+    Isso garante que o nome do seu módulo Go esteja alinhado com as convenções de nomenclagem de módulos do Go e facilita o compartilhamento do seu código.:::tip[Dica]
+Você pode automatizar todas as etapas de inicialização usando a flag `-git` ao criar seu projeto:
+```bash
+wails3 init -n myfirstapp -git github.com/username/myfirstapp
+```
+Isso suporta vários formatos de URL do Git:
+- HTTPS: `https://github.com/username/project`
+- SSH: `git@github.com:username/project` ou `ssh://git@github.com/username/project`
+- Protocolo Git: `git://github.com/username/project`
+- Sistema de arquivos: `file:///path/to/project.git`
+:::
+
+</Steps>
+
+## Parabéns!
+
+Você acabou de criar, desenvolver e empacotar seu primeiro aplicativo Wails.
+Este é apenas o início do que você pode realizar com o Wails v3.
+
+## Próximos Passos
+
+Se você é novo no Wails, recomendamos ler nossos Tutoriais a seguir, que serão um guia prático através
+das várias funcionalidades do Wails. O primeiro tutorial é [Criando um Serviço](/tutorials/01-creating-a-service).
+
+Se você é um usuário mais avançado, confira nossos [Guias](/guides) para obter informações mais detalhadas sobre como usar o Wails.

--- a/docs/src/content/docs/pt/quick-start/first-app.mdx
+++ b/docs/src/content/docs/pt/quick-start/first-app.mdx
@@ -1,0 +1,270 @@
+---
+title: Seu Primeiro App
+description: Crie um aplicativo Wails funcional em 10 minutos
+sidebar:
+  order: 3
+---
+
+import { Tabs, TabItem, Steps } from "@astrojs/starlight/components";
+
+Vamos construir um simples aplicativo de saudação que demonstra os conceitos principais do Wails:
+- Backend em Go gerenciando a lógica
+- Frontend chamando funções do Go
+- Bindings com tipagem segura
+- Hot reload durante o desenvolvimento
+
+**Tempo para concluir:** 10 minutos
+
+:::tip[Dica de Performance para Usuários do Windows 11]
+Considere usar o [Dev Drive](https://learn.microsoft.com/en-us/windows/dev-drive/) para armazenar seus projetos. Os Dev Drives são otimizados para cargas de trabalho de desenvolvedores e podem melhorar significativamente os tempos de compilação e a velocidade de acesso ao disco em até 30% em comparação com drives NTFS comuns.
+:::
+
+## Crie Seu Projeto
+
+<Steps>
+
+1. **Gere o projeto**
+
+   ```bash
+   wails3 init -n myapp
+   cd myapp
+   ```
+
+   Isso cria um novo projeto com o modelo padrão Vanilla + Vite (HTML/CSS/JS puro com o bundler Vite).
+
+   :::tip[Outros Modelos]
+   Experimente `-t react`, `-t vue` ou `-t svelte` para seu framework preferido.
+   Execute `wails3 init -l` para ver todos os modelos disponíveis.
+   :::
+
+2. **Entenda a estrutura do projeto**
+
+   ```
+   myapp/
+   ├── main.go              # Ponto de entrada da aplicação
+   ├── greetservice.go      # Serviço de saudação
+   ├── frontend/            # Seu código de UI
+   │   ├── index.html       # Ponto de entrada HTML
+   │   ├── src/
+   │   │   └── main.js      # JavaScript do frontend
+   │   ├── public/
+   │   │   └── style.css    # Estilos
+   │   ├── package.json     # Dependências do frontend
+   │   └── vite.config.js   # Configuração do bundler Vite
+   ├── build/               # Configuração de build
+   └── Taskfile.yml         # Tarefas de build
+   ```
+
+3. **Execute o app**
+
+   ```bash
+   wails3 dev
+   ```
+
+   :::note[Primeira Execução]
+   A primeira execução pode demorar mais do que o esperado, pois instala dependências do frontend, gera bindings, etc. As execuções subsequentes são muito mais rápidas.
+   :::
+
+   O app abre mostrando uma interface de saudação. Digite seu nome e clique em "Greet" - o backend Go processa sua entrada e retorna uma saudação.
+
+</Steps>
+
+## Como Funciona
+
+Vamos entender o código que faz isso funcionar.
+
+### O Backend Go
+
+Abra `greetservice.go`:
+
+```go title="greetservice.go"
+package main
+
+import (
+	"fmt"
+)
+
+type GreetService struct{}
+
+func (g *GreetService) Greet(name string) string {
+	return fmt.Sprintf("Hello %s, It's show time!", name)
+}
+```
+
+**Conceitos principais:**
+
+1. **Service** - Uma struct Go com métodos exportados
+2. **Método exportado** - `Greet` está em maiúsculas, tornando-o disponível para o frontend
+3. **Lógica simples** - Recebe um nome e retorna uma saudação
+4. **Tipagem segura** - Os tipos de entrada e saída são definidos
+
+:::tip[Entendendo Services e Bindings]
+**Services** são módulos Go autônomos que expõem funcionalidade para o seu frontend. Eles são apenas structs Go comuns com métodos exportados que você registra no campo `Services` da configuração da sua aplicação.
+
+**Bindings** são o SDK TypeScript/JavaScript gerado automaticamente que permite ao seu frontend chamar esses services. Quando você executa `wails3 dev` ou `wails3 build`, o Wails analisa seus services registrados e gera bindings com tipagem segura em `frontend/bindings/`.
+
+Pense em services como sua API backend e bindings como a biblioteca cliente que se comunica com ela.
+:::
+
+### Registrando o Service
+
+Abra `main.go` e encontre o registro do service:
+
+```go title="main.go" {4-6}
+err := application.New(application.Options{
+    Name: "myapp",
+    Services: []application.Service{
+        application.NewService(&GreetService{}),
+    },
+    // ... outras opções
+})
+```
+
+Isso registra seu `GreetService` com o Wails, tornando todos os seus métodos exportados disponíveis para o frontend.
+
+### O Frontend
+
+Abra `frontend/src/main.js`:
+
+```javascript title="frontend/src/main.js"
+import {GreetService} from "../bindings/changeme";
+
+window.greet = async () => {
+    const nameElement = document.getElementById('name');
+    const resultElement = document.getElementById('result');
+
+    const name = nameElement.value;
+    if (!name) {
+        return;
+    }
+
+    try {
+        const result = await GreetService.Greet(name);
+        resultElement.innerText = result;
+    } catch (err) {
+        console.error(err);
+    }
+};
+```
+
+**Conceitos principais:**
+
+1. **Bindings gerados automaticamente** - `GreetService` é importado do código gerado
+2. **Chamadas com tipagem segura** - Os nomes dos métodos e suas assinaturas correspondem ao seu código Go
+3. **Assíncrono por padrão** - Todas as chamadas Go retornam Promises
+4. **Tratamento de erros** - Erros do Go são capturados em try/catch
+
+:::note[Onde estão os bindings?]
+Os bindings gerados estão em `frontend/bindings/`. Eles são criados automaticamente quando você executa `wails3 dev` ou `wails3 build`.
+
+**Nunca edite esses arquivos manualmente**—eles são regenerados a cada build.
+:::
+
+## Personalize Seu App
+
+Vamos adicionar um novo recurso para entender o fluxo de trabalho.
+
+### Adicione um Recurso "Greet Many"
+
+<Steps>
+
+1. **Adicione o método ao GreetService**
+
+   Adicione isto ao `greetservice.go`:
+
+   ```go title="greetservice.go"
+   func (g *GreetService) GreetMany(names []string) []string {
+       greetings := make([]string, len(names))
+       for i, name := range names {
+           greetings[i] = fmt.Sprintf("Hello %s!", name)
+       }
+       return greetings
+   }
+   ```
+
+2. **O app será reconstruído automaticamente**
+
+   Salve o arquivo e o `wails3 dev` reconstruirá automaticamente seu código Go e reiniciará o app.
+
+   :::note[Reconstrução Automática]
+   Alterações no código Go acionam uma reconstrução automática e reinício. Alterações no frontend têm hot reload sem reinício.
+   :::
+
+3. **Use-o no frontend**
+
+   Adicione isto ao `frontend/src/main.js`:
+
+   ```javascript title="frontend/src/main.js"
+   window.greetMany = async () => {
+       const names = ['Alice', 'Bob', 'Charlie'];
+       const greetings = await GreetService.GreetMany(names);
+       console.log(greetings);
+   };
+   ```
+
+   Abra o console do navegador e chame `greetMany()` - você verá o array de saudações.
+
+</Steps>
+
+## Compile para Produção
+
+Quando estiver pronto para distribuir seu app:
+
+```bash
+wails3 build
+```
+
+**O que isso faz:**
+- Compila o código Go com otimizações
+- Compila o frontend para produção (minificado)
+- Cria um executável nativo em `build/bin/`
+
+<Tabs syncKey="os">
+  <TabItem label="Windows" icon="seti:windows">
+    **Saída:** `build/bin/myapp.exe`
+
+    Clique duas vezes para executar. Nenhuma dependência necessária (WebView2 faz parte do Windows).
+  </TabItem>
+
+  <TabItem label="macOS" icon="apple">
+    **Saída:** `build/bin/myapp.app`
+
+    Arraste para a pasta Applications ou clique duas vezes para executar.
+  </TabItem>
+
+  <TabItem label="Linux" icon="linux">
+    **Saída:** `build/bin/myapp`
+
+    Execute com `./build/bin/myapp` ou crie um arquivo `.desktop` para seu lançador.
+  </TabItem>
+</Tabs>
+
+:::tip[Builds Multiplataforma]
+Quer compilar para outras plataformas? Veja [Builds Multiplataforma →](/guides/build/cross-platform)
+:::
+
+## O que aprendemos
+
+**Estrutura do Projeto**
+- `main.go` para o backend Go
+- `frontend/` para o código da UI
+- `Taskfile.yml` para tarefas de build
+
+**Services**
+- Crie structs Go com métodos exportados
+- Registre com `application.NewService()`
+- Métodos automaticamente disponíveis no frontend
+
+**Bindings**
+- Definições TypeScript geradas automaticamente
+- Chamadas de função com tipagem segura
+- Assíncrono por padrão (Promises)
+
+**Fluxo de Trabalho de Desenvolvimento**
+- `wails3 dev` para hot reload
+- Alterações no Go reconstruem e reiniciam automaticamente
+- Alterações no frontend têm hot reload instantâneo
+
+---
+
+**Perguntas?** Junte-se ao [Discord](https://discord.gg/JDdSxwjhGf) e pergunte à comunidade.

--- a/docs/src/content/docs/pt/quick-start/installation.mdx
+++ b/docs/src/content/docs/pt/quick-start/installation.mdx
@@ -1,0 +1,327 @@
+---
+title: Instalação
+description: Instale o Wails e prepare-se para criar aplicativos
+sidebar:
+  order: 2
+---
+
+import { Card, CardGrid, Tabs, TabItem, Steps } from "@astrojs/starlight/components";
+
+## Instalação Rápida (5 Minutos)
+
+:::tip[TL;DR - Desenvolvedores Experientes]
+```bash
+# Instale o Go 1.25+, depois:
+go install github.com/wailsapp/wails/v3/cmd/wails3@latest
+wails3 doctor  # Verifique a instalação
+```
+
+Se o `wails3 doctor` passar, você terminou. [Pule para o Primeiro App →](/pt/quick-start/first-app)
+:::
+
+## Instalação Passo a Passo
+
+<Steps>
+
+1. **Instale o Go (Obrigatório)**
+
+   O Wails requer Go 1.25 ou posterior.
+
+   <Tabs syncKey="os">
+     <TabItem label="Windows" icon="seti:windows">
+       Baixe o instalador do Windows em **[go.dev/dl](https://go.dev/dl/)** e execute-o.
+
+       **Verifique a instalação:**
+       ```powershell
+       go version  # Deve mostrar 1.25 ou posterior
+       ```
+
+       **Verifique o PATH:**
+       ```powershell
+       $env:PATH -split ';' | Where-Object { $_ -like '*\go\bin' }
+       ```
+
+       Se estiver vazio, adicione `C:\Users\YourName\go\bin` ao seu PATH.
+     </TabItem>
+
+     <TabItem label="macOS" icon="apple">
+       **Opção 1: Instalador Oficial**
+
+       Baixe o instalador do macOS (arquivo .pkg) em **[go.dev/dl](https://go.dev/dl/)** e execute-o.
+
+       **Opção 2: Homebrew**
+       ```bash
+       brew install go
+       ```
+
+       **Verifique a instalação:**
+       ```bash
+       go version  # Deve mostrar 1.25 ou posterior
+       echo $PATH | grep go/bin  # Deve mostrar ~/go/bin
+       ```
+
+       Se `~/go/bin` não estiver no PATH, adicione ao `~/.zshrc` ou `~/.bash_profile`:
+       ```bash
+       export PATH=$PATH:~/go/bin
+       ```
+     </TabItem>
+
+     <TabItem label="Linux" icon="linux">
+       **Opção 1: Tarball Oficial**
+
+       Baixe o tarball do Linux em **[go.dev/dl](https://go.dev/dl/)**, depois:
+       ```bash
+       sudo rm -rf /usr/local/go
+       sudo tar -C /usr/local -xzf go1.25.linux-amd64.tar.gz
+       ```
+
+       **Opção 2: Gerenciador de Pacotes**
+       ```bash
+       # Ubuntu/Debian
+       sudo apt install golang-go
+
+       # Fedora
+       sudo dnf install golang
+
+       # Arch
+       sudo pacman -S go
+       ```
+
+       **Adicione ao PATH** (adicione ao `~/.bashrc` ou `~/.zshrc`):
+       ```bash
+       export PATH=$PATH:/usr/local/go/bin:~/go/bin
+       source ~/.bashrc  # Recarregue
+       ```
+
+       **Verifique:**
+       ```bash
+       go version
+       echo $PATH | grep go/bin
+       ```
+     </TabItem>
+   </Tabs>
+
+2. **Instale as Dependências da Plataforma**
+
+   <Tabs syncKey="os">
+     <TabItem label="Windows" icon="seti:windows">
+       **WebView2 Runtime** (geralmente pré-instalado)
+
+       O Windows 10/11 inclui o WebView2 por padrão. Se estiver faltando:
+       - Baixe em [Microsoft](https://developer.microsoft.com/microsoft-edge/webview2/)
+       - Ou execute `wails3 doctor` mais tarde — ele irá guiá-lo
+
+       **Pronto!** Nenhuma outra dependência é necessária.
+
+       :::tip[Dica de Desempenho para Windows 11]
+       Considere usar o [Dev Drive](https://learn.microsoft.com/en-us/windows/dev-drive/) para armazenar seus projetos. Os Dev Drives são otimizados para cargas de trabalho de desenvolvedores e podem melhorar significativamente os tempos de compilação e a velocidade de acesso ao disco em até 30%.
+       :::
+     </TabItem>
+
+     <TabItem label="macOS" icon="apple">
+       **Ferramentas de Linha de Comando do Xcode** (obrigatório)
+
+       ```bash
+       xcode-select --install
+       ```
+
+       Clique em "Instalar" na caixa de diálogo que aparecer.
+
+       **Verifique:**
+       ```bash
+       xcode-select -p  # Deve mostrar /Library/Developer/CommandLineTools
+       ```
+
+       **Pronto!** O macOS inclui o WebKit por padrão.
+     </TabItem>
+
+     <TabItem label="Linux" icon="linux">
+       **Ferramentas de compilação e WebKit**
+
+       :::caution[Versões mínimas da distribuição]
+       O Wails v3 requer **WebKitGTK 4.1** (usa libsoup3). Lançamentos mais antigos que apenas disponibilizam a versão 4.0 — Ubuntu 20.04, Debian 11, RHEL 8/9 e suas derivações — não são suportados.
+       :::
+
+       <Tabs syncKey="distro">
+         <TabItem label="Ubuntu/Debian">
+           Requer Ubuntu 22.04+ ou Debian 12+.
+           ```bash
+           sudo apt update
+           sudo apt install build-essential pkg-config libgtk-3-dev libwebkit2gtk-4.1-dev
+           ```
+         </TabItem>
+
+         <TabItem label="Fedora">
+           ```bash
+           sudo dnf install gcc pkg-config gtk3-devel webkit2gtk4.1-devel
+           ```
+         </TabItem>
+
+         <TabItem label="Arch">
+           ```bash
+           sudo pacman -S base-devel gtk3 webkit2gtk-4.1
+           ```
+         </TabItem>
+
+         <TabItem label="openSUSE">
+           ```bash
+           sudo zypper install gcc pkg-config gtk3-devel webkit2gtk3-devel
+           ```
+         </TabItem>
+
+         <TabItem label="Gentoo">
+           ```bash
+           sudo emerge --ask net-libs/webkit-gtk:4.1
+           ```
+         </TabItem>
+
+         <TabItem label="NixOS">
+           Adicione ao seu `shell.nix` ou `devShell`:
+           ```nix
+           buildInputs = with pkgs; [ webkitgtk_4_1 gtk3 pkg-config gcc ];
+           ```
+         </TabItem>
+
+         <TabItem label="Outro">
+           Execute `wails3 doctor` após instalar o Wails — ele mostrará os pacotes exatos necessários para sua distribuição.
+         </TabItem>
+       </Tabs>
+
+       :::note[Opcional: Suporte ao GTK4]
+       O Wails também possui suporte experimental ao GTK4 / WebKitGTK 6.0. Se você quiser compilar com o GTK4, instale as dependências adicionais para sua distribuição e compile com `wails3 build -tags gtk4`. Consulte [Empacotamento no Linux - GTK4](/guides/build/linux#gtk4-support-experimental) para mais detalhes.
+       :::
+     </TabItem>
+   </Tabs>
+
+3. **Instale o Wails CLI**
+
+   ```bash
+   go install github.com/wailsapp/wails/v3/cmd/wails3@latest
+   ```
+
+   Isso instala o comando `wails3` em `~/go/bin` (ou `%USERPROFILE%\go\bin` no Windows).
+
+4. **Verifique a Instalação**
+
+   ```bash
+   wails3 doctor
+   ```
+
+   **Saída esperada (ou similar):**
+   ```
+   Wails (v3.0.0-dev)  Wails Doctor
+
+   # System
+
+   ┌──────────────────────────────────────────────────┐
+   | Name          | MacOS                            |
+   | Version       | 26.0                             |
+   | ID            | 25A354                           |
+   | Branding      | MacOS 26.0                       |
+   | Platform      | darwin                           |
+   | Architecture  | arm64                            |
+   | Apple Silicon | true                             |
+   | CPU           | Apple M2 Pro                     |
+   | CPU 1         | Apple M2 Pro                     |
+   | CPU 2         | Apple M2 Pro                     |
+   | GPU           | 16 cores, Metal Support: Metal 4 |
+   | Memory        | 16 GB                            |
+   └──────────────────────────────────────────────────┘
+
+   # Build Environment
+
+   ┌─────────────┬─────────────────┐
+   | Wails CLI   | v3.0.0-alpha.40 |
+   | Go Version  | go1.24.6        |
+   └─────────────┴─────────────────┘
+
+   # Dependencies
+
+   ┌─────────────────┬─────────────────────────────────────────────────┐
+   | npm             | 11.6.2                                          |
+   | *NSIS           | Not Installed. Install with `brew install...`.  |
+   | Xcode cli tools | 2412                                            |
+   └─────────────────┴─────────────────────────────────────────────────┘
+
+   # Checking for issues
+
+   SUCCESS No issues found
+
+   # Diagnosis
+
+   SUCCESS Your system is ready for Wails development!
+   ```
+
+   :::note[Se o comando `wails3` não for encontrado]
+   Seu `~/go/bin` não está no PATH. Veja o passo 1 acima para corrigir isso, depois reinicie seu terminal.
+   :::
+
+5. **Instale o npm (Opcional, mas Recomendado)**
+
+   A maioria dos modelos do Wails usa o npm para ferramentas de frontend.
+
+   <Tabs syncKey="os">
+     <TabItem label="Windows" icon="seti:windows">
+       Baixe em [nodejs.org](https://nodejs.org/) e execute o instalador.
+
+       **Verifique:**
+       ```powershell
+       npm --version
+       ```
+     </TabItem>#### Versão do Go muito antiga
+
+O Wails v3 requer Go 1.25+. Se você tiver uma versão mais antiga:
+
+<Tabs syncKey="os">
+  <TabItem label="Windows/macOS" icon="seti:windows">
+    Baixe a versão mais recente em [go.dev/dl](https://go.dev/dl/) e reinstale.
+  </TabItem>
+
+  <TabItem label="Linux" icon="linux">
+    Baixe o arquivo tarball mais recente em [go.dev/dl](https://go.dev/dl/), depois:
+    ```bash
+    sudo rm -rf /usr/local/go
+    sudo tar -C /usr/local -xzf go1.25.linux-amd64.tar.gz
+    ```
+  </TabItem>
+</Tabs>
+
+## Versão de Desenvolvimento (Bleeding Edge)
+
+Quer usar o código mais recente diretamente do branch principal de desenvolvimento? Isso dá acesso a novos recursos e correções antes que sejam lançados, mas vem com o risco de bugs e mudanças que quebram compatibilidade. Recomendado apenas para contribuidores ou para quem precisa testar recursos futuros.
+
+```bash
+git clone https://github.com/wailsapp/wails.git
+cd wails
+git checkout v3
+cd v3/cmd/wails3
+go install
+```
+
+:::caution[Versão de Desenvolvimento]
+- Pode ter bugs ou mudanças que quebram compatibilidade
+- Projetos criados usarão a diretiva `replace` para apontar para o Wails local
+- Recomendado apenas para contribuidores ou para testar novos recursos
+:::
+
+## Próximos Passos
+
+**Instalação Concluída!** Seu sistema está pronto para o desenvolvimento com Wails.
+
+<Card title="Crie seu Primeiro App" icon="rocket">
+  Crie um aplicativo funcional em 10 minutos.
+
+  [Tutorial Primeiro App →](/pt/quick-start/first-app)
+</Card>
+
+<Card title="Explore os Templates" icon="open-book">
+  Veja o que está disponível nativamente.
+
+  ```bash
+  wails3 init -l  # Listar templates
+  ```
+</Card>
+
+---
+
+**Tendo problemas?** Pergunte no [Discord](https://discord.gg/JDdSxwjhGf) ou [abra uma issue](https://github.com/wailsapp/wails/issues).


### PR DESCRIPTION
Automated translation batch 2 for Portuguese / Brazilian (Português).

## Changes

Adds 15 translated pages not yet in the repo:

- `quick-start/installation.mdx` — Installation guide (was showing English)
- `quick-start/first-app.mdx` — Your First App (was showing English)
- `getting-started/your-first-app.mdx`
- `concepts/architecture.mdx`
- `concepts/bridge.mdx`
- `concepts/build-system.mdx`
- `concepts/lifecycle.mdx`
- `concepts/manager-api.mdx`
- `contributing.mdx`
- `contributing/architecture/bindings.mdx`
- `credits.mdx`
- `faq.mdx`
- `feedback.mdx`
- `community/links.md`
- `community/templates.md`

## QA Scores

All locales scored ≥ 0.97 avg COMET score across batch runs. No pages flagged for human review.

## Notes

Translated by automated pipeline using qwen3:30b (self-hosted Ollama). No code blocks or technical syntax translated.

🤖 Wails Doc Translator

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive Portuguese-language documentation covering community resources, core concepts (architecture, bridge, build system, lifecycle, manager API), contribution guidelines, getting started tutorials, quick-start installation guide, FAQ, credits, feedback channels, and bindings system architecture.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->