### PR TITLE
i18n(de): add translations batch 2 2026-05-07

### DIFF
--- a/docs/src/content/docs/de/community/links.md
+++ b/docs/src/content/docs/de/community/links.md
@@ -1,0 +1,28 @@
+---
+title: Links
+description: Von der Community kuratierte Links und Ressourcen für Wails
+---
+
+Diese Seite dient als Liste für community-bezogene Links.
+
+:::tip[Wie man einen Link einreicht]
+
+Sie können auf `Seite bearbeiten` am Ende dieser Seite klicken, um einen PR einzureichen.
+
+:::
+
+## Awesome Wails
+
+Die [definitive Liste](https://github.com/wailsapp/awesome-wails) mit Links,
+die sich auf Wails beziehen.
+
+## Support-Kanäle
+
+- [Wails Discord Server](https://discord.gg/bdj28QNHmT)
+- [Github Issues](https://github.com/wailsapp/wails/issues)
+
+## Soziale Medien
+
+- [Twitter](https://x.com/wailsapp)
+- [Wails Chinese Community QQ Group](https://qm.qq.com/cgi-bin/qm/qr?k=PmIURne5hFGNd7QWzW5qd6FV-INEjNJv&jump_from=webapi) -
+  Gruppennummer: 1067173054

--- a/docs/src/content/docs/de/community/templates.md
+++ b/docs/src/content/docs/de/community/templates.md
@@ -1,0 +1,133 @@
+---
+title: Vorlagen
+description: Projektvorlagen und Starter-Kits für Wails
+---
+
+:::caution
+
+Diese Seite könnte für Wails v3 veraltet sein.
+
+:::
+
+<!-- TODO: Update this link -->
+
+Diese Seite dient als Liste von von der Community unterstützten Vorlagen. Um Ihre eigene
+Vorlage zu erstellen, sehen Sie bitte im Leitfaden [Vorlagen](https://wails.io/docs/guides/templates)
+nach.
+
+:::tip[Wie man eine Vorlage einreicht]
+
+Sie können unten auf `Edit this page` klicken, um Ihre Vorlagen einzufügen.
+
+:::
+
+Um diese Vorlagen zu verwenden, führen Sie
+`wails init -n "Ihr Projektname" -t [der Link unten[@version]]` aus.
+
+Wenn kein Versions-Suffix vorhanden ist, wird standardmäßig die Vorlage des main-Branches verwendet.
+Wenn ein Versions-Suffix vorhanden ist, wird die Vorlage verwendet, die dem Tag dieser
+Version entspricht.
+
+Beispiel:
+`wails init -n "Ihr Projektname" -t https://github.com/misitebao/wails-template-vue`
+
+:::danger[Achtung]
+
+**Das Wails-Projekt pflegt keine, ist nicht verantwortlich und haftet nicht für
+Vorlagen von Drittanbietern!**
+
+Wenn Sie sich bei einer Vorlage unsicher sind, prüfen Sie `package.json` und `wails.json`,
+welche Skripte ausgeführt werden und welche Pakete installiert sind.
+
+:::
+
+## Vue
+
+- [wails-template-vue](https://github.com/misitebao/wails-template-vue) - Wails
+  Vorlage basierend auf der Vue-Ökologie (Integriertes TypeScript, Dunkles Thema,
+  Internationalisierung, Single-Page-Routing, TailwindCSS)
+- [wails-template-quasar-js](https://github.com/sgosiaco/wails-template-quasar-js) -
+  Eine Vorlage, die JavaScript + Quasar V2 verwendet (Vue 3, Vite, Sass, Pinia, ESLint,
+  Prettier)
+- [wails-template-quasar-ts](https://github.com/sgosiaco/wails-template-quasar-ts) -
+  Eine Vorlage, die TypeScript + Quasar V2 verwendet (Vue 3, Vite, Sass, Pinia, ESLint,
+  Prettier, Composition API mit &lt;script setup&gt;)
+- [wails-template-naive](https://github.com/tk103331/wails-template-naive) -
+  Wails Vorlage basierend auf Naive UI (eine Vue 3 Komponentenbibliothek)
+- [wails-template-nuxt](https://github.com/gornius/wails-template-nuxt) - Wails
+  Vorlage, die sauberes Nuxt3 und TypeScript mit Auto-Imports für die Wails JS
+  Laufzeit verwendet
+- [Wails-Tool-Template](https://github.com/xisuo67/Wails-Tool-Template) - Wails
+  Vorlage, die Vue+TypeScript+Vite+Element-plus (im Stil von NetEase Cloud) verwendet
+
+## Angular
+
+- [wails-template-angular](https://github.com/mateothegreat/wails-template-angular) -
+  Angular 15+ actiongeladen & bereit für die Produktion.
+- [wails-angular-template](https://github.com/TAINCER/wails-angular-template) -
+  Angular mit TypeScript, Sass, Hot-Reload, Code-Splitting und i18n
+
+## React
+
+- [wails-react-template](https://github.com/AlienRecall/wails-react-template) -
+  Eine Vorlage, die reactjs verwendet
+- [wails-react-template](https://github.com/flin7/wails-react-template) - Eine
+  minimale Vorlage für React, die Live-Entwicklung unterstützt
+- [wails-template-nextjs](https://github.com/LGiki/wails-template-nextjs) - Eine
+  Vorlage, die Next.js und TypeScript verwendet
+- [wails-template-nextjs-app-router](https://github.com/thisisvk-in/wails-template-nextjs-app-router) -
+  Eine Vorlage, die Next.js und TypeScript mit App-Router verwendet
+- [wails-template-nextjs-app-router-src](https://github.com/edai-git/wails-template-nextjs-app-router) -
+  Eine Vorlage, die Next.js und TypeScript mit App-Router src + Beispiel verwendet
+- [wails-vite-react-ts-tailwind-template](https://github.com/hotafrika/wails-vite-react-ts-tailwind-template) -
+  Eine Vorlage für React + TypeScript + Vite + TailwindCSS
+- [wails-vite-react-ts-tailwind-shadcnui-template](https://github.com/Mahcks/wails-vite-react-tailwind-shadcnui-ts) -
+  Eine Vorlage mit Vite, React, TypeScript, TailwindCSS und shadcn/ui
+
+## Svelte
+
+- [wails-svelte-template](https://github.com/raitonoberu/wails-svelte-template) -
+  Eine Vorlage, die Svelte verwendet
+- [wails-vite-svelte-template](https://github.com/BillBuilt/wails-vite-svelte-template) -
+  Eine Vorlage, die Svelte und Vite verwendet
+- [wails-vite-svelte-tailwind-template](https://github.com/BillBuilt/wails-vite-svelte-tailwind-template) -
+  Eine Vorlage, die Svelte und Vite mit TailwindCSS v3 verwendet
+- [wails-svelte-tailwind-vite-template](https://github.com/PylotLight/wails-vite-svelte-tailwind-template/tree/master) -
+  Eine aktualisierte Vorlage, die Svelte v4.2.0 und Vite mit TailwindCSS v3.3.3 verwendet
+- [wails-sveltekit-template](https://github.com/h8gi/wails-sveltekit-template) -
+  Eine Vorlage, die SvelteKit verwendet
+- [wails-template-shadcn-svelte](https://github.com/xijaja/wails-template-shadcn-svelte) -
+  Eine Vorlage, die Sveltekit und Shadcn-Svelte verwendet
+
+## Solid
+
+- [wails-template-vite-solid-ts](https://github.com/xijaja/wails-template-solid-ts) -
+  Eine Vorlage, die Solid + Ts + Vite verwendet
+- [wails-template-vite-solid-js](https://github.com/xijaja/wails-template-solid-js) -
+  Eine Vorlage, die Solid + Js + Vite verwendet
+
+## Elm
+
+- [wails-elm-template](https://github.com/benjamin-thomas/wails-elm-template) -
+  Entwickeln Sie Ihre GUI-App mit funktionaler Programmierung und einem **schnellen**
+  Hot-Reload-Setup :tada: :rocket:
+- [wails-template-elm-tailwind](https://github.com/rnice01/wails-template-elm-tailwind) -
+  Kombinieren Sie die Kräfte :muscle: von Elm + Tailwind CSS + Wails! Hot-Reloading
+  unterstützt.
+
+## HTMX
+
+- [wails-htmx-templ-chi-tailwind](https://github.com/PylotLight/wails-hmtx-templ-template) -
+  Verwenden Sie eine einzigartige Kombination aus purem htmx für Interaktivität sowie templ zum
+  Erstellen von Komponenten und Formularen
+
+## Reines JavaScript (Vanilla)
+
+- [wails-pure-js-template](https://github.com/KiddoV/wails-pure-js-template) - Eine
+  Vorlage mit nichts als grundlegendem JavaScript, HTML und CSS
+
+## Lit (Web-Komponenten)
+
+- [wails-lit-shoelace-esbuild-template](https://github.com/Braincompiler/wails-lit-shoelace-esbuild-template) -
+  Wails-Vorlage, die dem Frontend lit, die Shoelace-Komponentenbibliothek +
+  vorkonfiguriertes Prettier und TypeScript bietet.

--- a/docs/src/content/docs/de/concepts/architecture.mdx
+++ b/docs/src/content/docs/de/concepts/architecture.mdx
@@ -1,0 +1,328 @@
+---
+title: Wie Wails funktioniert
+description: Verständnis der Wails-Architektur und wie sie native Leistung erreicht
+sidebar:
+  order: 1
+---
+
+import { Tabs, TabItem } from "@astrojs/starlight/components";
+
+Wails ist ein Framework zum Erstellen von Desktop-Anwendungen mit **Go für das Backend** und **Webtechnologien für das Frontend**. Im Gegensatz zu Electron bündelt Wails jedoch keinen Browser, sondern verwendet das **native WebView des Betriebssystems**.
+
+```d2
+direction: right
+
+User: "User" {
+  shape: person
+  style.fill: "#3B82F6"
+}
+
+Application: "Your Wails Application" {
+  Frontend: "Frontend\n(HTML/CSS/JS)" {
+    shape: rectangle
+    style.fill: "#8B5CF6"
+  }
+  
+  Runtime: "Wails Runtime" {
+    Bridge: "Message Bridge" {
+      shape: diamond
+      style.fill: "#10B981"
+    }
+    
+    Bindings: "Type-Safe Bindings" {
+      shape: rectangle
+      style.fill: "#10B981"
+    }
+  }
+  
+  Backend: "Go Backend" {
+    Services: "Your Services" {
+      shape: rectangle
+      style.fill: "#00ADD8"
+    }
+    
+    NativeAPIs: "OS APIs" {
+      shape: rectangle
+      style.fill: "#00ADD8"
+    }
+  }
+}
+
+OS: "Operating System" {
+  WebView: "Native WebView\n(WebKit/WebView2/WebKitGTK)" {
+    shape: rectangle
+    style.fill: "#6B7280"
+  }
+  
+  SystemAPIs: "System APIs\n(Windows/macOS/Linux)" {
+    shape: rectangle
+    style.fill: "#6B7280"
+  }
+}
+
+User -> Application.Frontend: "Interacts with UI"
+Application.Frontend <-> Application.Runtime.Bridge: "JSON messages"
+Application.Runtime.Bridge <-> Application.Backend.Services: "Direct function calls"
+Application.Runtime.Bindings -> Application.Frontend: "TypeScript definitions"
+Application.Frontend -> OS.WebView: "Renders in"
+Application.Backend.NativeAPIs -> OS.SystemAPIs: "Native calls"
+```
+
+**Hauptunterschiede zu Electron:**
+
+| Aspekt | Wails | Electron |
+|--------|-------|----------|
+| **Browser** | Vom Betriebssystem bereitgestelltes WebView | Gebündeltes Chromium (~100MB) |
+| **Backend** | Go (kompiliert) | Node.js (interpretiert) |
+| **Kommunikation** | In-Memory-Bridge | IPC (Inter-Prozess-Kommunikation) |
+| **Paketgröße** | ~15MB | ~150MB |
+| **Speicher** | ~10MB | ~100MB+ |
+| **Startzeit** | &lt;0,5s | 2-3s |
+
+## Kernkomponenten
+
+### 1. Native WebView
+
+Wails verwendet die im Betriebssystem integrierte Web-Rendering-Engine:
+
+<Tabs syncKey="platform">
+  <TabItem label="Windows" icon="seti:windows">
+    **WebView2** (Microsoft Edge WebView2)
+    - Basierend auf Chromium (selbe Engine wie der Edge-Browser)
+    - Vorinstalliert auf Windows 10/11
+    - Automatische Updates über Windows Update
+    - Vollständige Unterstützung moderner Webstandards
+  </TabItem>
+
+  <TabItem label="macOS" icon="apple">
+    **WebKit** (Rendering-Engine von Safari)
+    - In macOS integriert
+    - Gleiche Engine wie im Safari-Browser
+    - Hervorragende Leistung und Akkulaufzeit
+    - Vollständige Unterstützung moderner Webstandards
+  </TabItem>
+
+  <TabItem label="Linux" icon="linux">
+    **WebKitGTK** (GTK-Port von WebKit)
+    - Installation über Paketmanager
+    - Gleiche Engine wie GNOME Web (Epiphany)
+    - Gute Standards-Unterstützung
+    - Leichtgewichtig und leistungsstark
+  </TabItem>
+</Tabs>
+
+**Warum das wichtig ist:**
+- **Kein gebündelter Browser** → Kleinere App-Größe
+- **OS-nativ** → Bessere Integration und Leistung
+- **Automatische Updates** → Sicherheitspatches durch OS-Updates
+- **Vertrautes Rendering** → Gleich wie im Systembrowser
+
+### 2. Die Wails-Bridge
+
+Die Bridge ist das Herzstück von Wails – sie ermöglicht die **direkte Kommunikation** zwischen Go und JavaScript.
+
+```d2
+direction: down
+
+Frontend: "Frontend (JavaScript)" {
+  shape: rectangle
+  style.fill: "#8B5CF6"
+}
+
+Bridge: "Wails Bridge" {
+  Encoder: "JSON Encoder" {
+    shape: rectangle
+  }
+  
+  Router: "Method Router" {
+    shape: diamond
+    style.fill: "#10B981"
+  }
+  
+  Decoder: "JSON Decoder" {
+    shape: rectangle
+  }
+}
+
+Backend: "Backend (Go)" {
+  Services: "Registered Services" {
+    shape: rectangle
+    style.fill: "#00ADD8"
+  }
+}
+
+Frontend -> Bridge.Encoder: "1. Call Go method\nGreet('Alice')"
+Bridge.Encoder -> Bridge.Router: "2. Encode to JSON\n{method: 'Greet', args: ['Alice']}"
+Bridge.Router -> Backend.Services: "3. Route to service\nGreetService.Greet('Alice')"
+Backend.Services -> Bridge.Decoder: "4. Return result\n'Hello, Alice!'"
+Bridge.Decoder -> Frontend: "5. Decode to JS\nPromise resolves"
+```
+
+**So funktioniert es:**
+
+1. **Frontend ruft eine Go-Methode auf** (über automatisch generierte Bindings)
+2. **Bridge kodiert den Aufruf** in JSON (Methodenname + Argumente)
+3. **Router findet die Go-Methode** in den registrierten Diensten
+4. **Go-Methode wird ausgeführt** und gibt einen Wert zurück
+5. **Bridge decodiert das Ergebnis** und sendet es an das Frontend zurück
+6. **Promise wird aufgelöst** in JavaScript mit dem Ergebnis
+
+**Leistungseigenschaften:**
+- **In-Memory**: Keine Netzwerk-Overhead, kein HTTP
+- **Zero-Copy** wo möglich (für große Datenmengen)
+- **Standardmäßig asynchron**: Nicht-blockierend auf beiden Seiten
+- **Typsicher**: TypeScript-Definitionen werden automatisch generiert
+
+### 3. Dienstesystem
+
+Dienste sind der empfohlene Weg, um Go-Funktionalität für das Frontend verfügbar zu machen.
+
+```go
+// Define a service (just a regular Go struct)
+type GreetService struct {
+    prefix string
+}
+
+// Methods with exported names are automatically available
+func (g *GreetService) Greet(name string) string {
+    return g.prefix + name + "!"
+}
+
+func (g *GreetService) GetTime() time.Time {
+    return time.Now()
+}
+
+// Register the service
+app := application.New(application.Options{
+    Services: []application.Service{
+        application.NewService(&GreetService{prefix: "Hello, "}),
+    },
+})
+```
+
+**Dienstentdeckung:**
+- Wails **scant Ihre Struktur** beim Start
+- **Exportierte Methoden** werden vom Frontend aufrufbar
+- **Typinformationen** werden für TypeScript-Bindings extrahiert
+- **Fehlerbehandlung** ist automatisch (Go-Fehler → JS-Ausnahmen)
+
+**Generierte TypeScript-Bindung:**
+```typescript
+// Auto-generated in frontend/bindings/GreetService.ts
+export function Greet(name: string): Promise<string>
+export function GetTime(): Promise<Date>
+```
+
+**Warum Dienste?**
+- **Typsicher**: Vollständige TypeScript-Unterstützung
+- **Automatische Entdeckung**: Keine manuelle Registrierung von Methoden
+- **Organisiert**: Verwandte Funktionalität gruppieren
+- **Testbar**: Dienste sind einfache Go-Strukturen
+
+[Weitere Informationen zu Diensten →](/features/bindings/services)
+
+### 4. Ereignissystem
+
+Ereignisse ermöglichen **Pub/Sub-Kommunikation** zwischen Komponenten.
+
+```d2
+direction: right
+
+GoService: "Go Service" {
+  shape: rectangle
+  style.fill: "#00ADD8"
+}
+
+EventBus: "Event Bus" {
+  shape: cylinder
+  style.fill: "#10B981"
+}
+
+Frontend1: "Window 1" {
+  shape: rectangle
+  style.fill: "#8B5CF6"
+}
+
+Frontend2: "Window 2" {
+  shape: rectangle
+  style.fill: "#8B5CF6"
+}
+
+GoService -> EventBus: "Emit('data-updated', data)"
+EventBus -> Frontend1: "Notify subscribers"
+EventBus -> Frontend2: "Notify subscribers"
+Frontend1 -> EventBus: "On('data-updated', handler)"
+Frontend2 -> EventBus: "On('data-updated', handler)"
+```
+
+**Verwendungsfälle:**
+- **Fensterkommunikation**: Ein Fenster benachrichtigt andere
+- **Hintergrundaufgaben**: Go-Dienst benachrichtigt UI über Fortschritt
+- **Statussynchronisation**: Mehrere Fenster synchron halten
+- **Losere Kopplung**: Komponenten benötigen keine direkten Referenzen
+
+**Beispiel:**
+```go
+// Go: Emit an event
+app.Event.Emit("user-logged-in", user)
+```
+
+```javascript
+// JavaScript: Listen for event
+import { Events } from '@wailsio/runtime'
+
+Events.On('user-logged-in', (user) => {
+    console.log('User logged in:', user)
+})
+```
+
+[Weitere Informationen zu Ereignissen →](/features/events/system)
+
+## Anwendungslebenszyklus
+
+Das Verständnis des Lebenszyklus hilft Ihnen zu wissen, wann Sie Ressourcen initialisieren und bereinigen sollten.
+
+```d2
+direction: down
+
+Start: "Application Start" {
+  shape: oval
+  style.fill: "#10B981"
+}
+
+Init: "Initialisation" {
+  Create: "Create Application" {
+    shape: rectangle
+  }
+  
+  Register: "Register Services" {
+    shape: rectangle
+  }
+  
+  Setup: "Setup Windows/Menus" {
+    shape: rectangle
+  }
+}
+
+Run: "Event Loop" {
+  Events: "Process Events" {
+    shape: rectangle
+  }
+  
+  Messages: "Handle Messages" {
+    shape: rectangle
+  }
+  
+  Render: "Update UI" {
+    shape: rectangle
+  }
+}
+
+Shutdown: "Shutdown" {
+  Cleanup: "Cleanup Resources" {
+    shape: rectangle
+  }
+  
+  Save: "Save State" {---
+
+**Fragen zur Architektur?** Stellen Sie diese im [Discord](https://discord.gg/JDdSxwjhGf) oder schauen Sie in die [API-Referenz](/reference/overview).

--- a/docs/src/content/docs/de/concepts/bridge.mdx
+++ b/docs/src/content/docs/de/concepts/bridge.mdx
@@ -1,0 +1,391 @@
+---
+title: Go-Frontend-Bridge
+description: Tiefergehender Blick darauf, wie Wails die direkte Kommunikation zwischen Go und JavaScript ermöglicht
+sidebar:
+  order: 3
+---
+
+import { Tabs, TabItem } from "@astrojs/starlight/components";
+
+## Direkte Go-JavaScript-Kommunikation
+
+Wails bietet eine **direkte, im Speicher befindliche Brücke** zwischen Go und JavaScript, die eine nahtlose Kommunikation ohne HTTP-Overhead, Prozessgrenzen oder Serialisierungsengpässe ermöglicht.
+
+## Das große Bild
+
+```d2
+direction: right
+
+Frontend: "Frontend (JavaScript)" {
+  UI: "React/Vue/Vanilla" {
+    shape: rectangle
+    style.fill: "#8B5CF6"
+  }
+  
+  Bindings: "Auto-Generated Bindings" {
+    shape: rectangle
+    style.fill: "#A78BFA"
+  }
+}
+
+Bridge: "Wails Bridge" {
+  Encoder: "JSON Encoder" {
+    shape: rectangle
+    style.fill: "#10B981"
+  }
+  
+  Router: "Method Router" {
+    shape: diamond
+    style.fill: "#10B981"
+  }
+  
+  Decoder: "JSON Decoder" {
+    shape: rectangle
+    style.fill: "#10B981"
+  }
+  
+  TypeGen: "Type Generator" {
+    shape: rectangle
+    style.fill: "#10B981"
+  }
+}
+
+Backend: "Backend (Go)" {
+  Services: "Your Services" {
+    shape: rectangle
+    style.fill: "#00ADD8"
+  }
+  
+  Registry: "Service Registry" {
+    shape: rectangle
+    style.fill: "#00ADD8"
+  }
+}
+
+Frontend.UI -> Frontend.Bindings: "import { Method }"
+Frontend.Bindings -> Bridge.Encoder: "Call Method('arg')"
+Bridge.Encoder -> Bridge.Router: "Encode to JSON"
+Bridge.Router -> Backend.Registry: "Find service"
+Backend.Registry -> Backend.Services: "Invoke method"
+Backend.Services -> Bridge.Decoder: "Return result"
+Bridge.Decoder -> Frontend.Bindings: "Decode to JS"
+Frontend.Bindings -> Frontend.UI: "Promise resolves"
+Bridge.TypeGen -> Frontend.Bindings: "Generate types"
+```
+
+**Wichtige Erkenntnis:** Kein HTTP, kein IPC, keine Prozessgrenzen. Nur **direkte Funktionsaufrufe** mit **Typsicherheit**.
+
+## Funktionsweise: Schritt für Schritt
+
+### 1. Dienstreistrierung (Start)
+
+Wenn Ihre Anwendung startet, scannt Wails Ihre Dienste:
+
+```go
+type GreetService struct {
+    prefix string
+}
+
+func (g *GreetService) Greet(name string) string {
+    return g.prefix + name + "!"
+}
+
+func (g *GreetService) Add(a, b int) int {
+    return a + b
+}
+
+// Register service
+app := application.New(application.Options{
+    Services: []application.Service{
+        application.NewService(&GreetService{prefix: "Hello, "}),
+    },
+})
+```
+
+**Was Wails tut:**
+1. **Scannt die Struktur** nach exportierten Methoden
+2. **Extrahiert Typinformationen** (Parameter, Rückgabetypen)
+3. **Erstellt ein Verzeichnis**, das Methodennamen Funktionen zuordnet
+4. **Generiert TypeScript-Bindings** mit vollständigen Typdefinitionen
+
+### 2. Binding-Generierung (Build-Zeit)
+
+Wails generiert automatisch TypeScript-Bindings:
+
+```typescript
+// Auto-generated: frontend/bindings/GreetService.ts
+export function Greet(name: string): Promise<string>
+export function Add(a: number, b: number): Promise<number>
+```
+
+**Typzuordnung:**
+
+| Go-Typ | TypeScript-Typ |
+|---------|-----------------|
+| `string` | `string` |
+| `int`, `int32`, `int64` | `number` |
+| `float32`, `float64` | `number` |
+| `bool` | `boolean` |
+| `[]T` | `T[]` |
+| `map[string]T` | `Record<string, T>` |
+| `struct` | `interface` |
+| `time.Time` | `Date` |
+| `error` | Exception (geworfen) |
+
+### 3. Frontend-Aufruf (Laufzeit)
+
+Der Entwickler ruft die Go-Methode aus JavaScript heraus auf:
+
+```javascript
+import { Greet, Add } from './bindings/GreetService'
+
+// Call Go from JavaScript
+const greeting = await Greet("World")
+console.log(greeting)  // "Hello, World!"
+
+const sum = await Add(5, 3)
+console.log(sum)  // 8
+```
+
+**Was passiert:**
+1. **Binding-Funktion aufgerufen** - `Greet("World")`
+2. **Nachricht erstellt** - `{ service: "GreetService", method: "Greet", args: ["World"] }`
+3. **An die Brücke gesendet** - Über die JavaScript-Brücke von WebView
+4. **Promise zurückgegeben** - Wartet auf Antwort
+
+### 4. Bridge-Verarbeitung (Laufzeit)
+
+Die Brücke empfängt die Nachricht und verarbeitet sie:
+
+```d2
+direction: down
+
+Receive: "Receive Message" {
+  shape: rectangle
+  style.fill: "#10B981"
+}
+
+Parse: "Parse JSON" {
+  shape: rectangle
+}
+
+Validate: "Validate" {
+  Check: "Service exists?" {
+    shape: diamond
+  }
+  
+  CheckMethod: "Method exists?" {
+    shape: diamond
+  }
+  
+  CheckTypes: "Types correct?" {
+    shape: diamond
+  }
+}
+
+Invoke: "Invoke Go Method" {
+  shape: rectangle
+  style.fill: "#00ADD8"
+}
+
+Encode: "Encode Result" {
+  shape: rectangle
+}
+
+Send: "Send Response" {
+  shape: rectangle
+  style.fill: "#10B981"
+}
+
+Error: "Send Error" {
+  shape: rectangle
+  style.fill: "#EF4444"
+}
+
+Receive -> Parse
+Parse -> Validate.Check
+Validate.Check -> Validate.CheckMethod: "Yes"
+Validate.Check -> Error: "No"
+Validate.CheckMethod -> Validate.CheckTypes: "Yes"
+Validate.CheckMethod -> Error: "No"
+Validate.CheckTypes -> Invoke: "Yes"
+Validate.CheckTypes -> Error: "No"
+Invoke -> Encode: "Success"
+Invoke -> Error: "Error"
+Encode -> Send
+```
+
+**Sicherheit:** Nur registrierte Dienste und exportierte Methoden sind aufrufbar.
+
+### 5. Go-Ausführung (Laufzeit)
+
+Die Go-Methode wird ausgeführt:
+
+```go
+func (g *GreetService) Greet(name string) string {
+    // This runs in Go
+    return g.prefix + name + "!"
+}
+```
+
+**Ausführungskontext:**
+- Läuft in einer **Goroutine** (nicht-blockierend)
+- Hat Zugriff auf **alle Go-Funktionen** (Dateisystem, Netzwerk, Datenbanken)
+- Kann frei **anderen Go-Code** aufrufen
+- Gibt Ergebnis oder Fehler zurück
+
+### 6. Antwort (Laufzeit)
+
+Das Ergebnis wird an JavaScript zurückgesendet:
+
+```javascript
+// Promise resolves with result
+const greeting = await Greet("World")
+// greeting = "Hello, World!"
+```
+
+**Fehlerbehandlung:**
+
+```go
+func (g *GreetService) Divide(a, b float64) (float64, error) {
+    if b == 0 {
+        return 0, errors.New("division by zero")
+    }
+    return a / b, nil
+}
+```
+
+```javascript
+try {
+    const result = await Divide(10, 0)
+} catch (error) {
+    console.error("Go error:", error)  // "division by zero"
+}
+```
+
+## Leistungseigenschaften
+
+### Geschwindigkeit
+
+**Typische Aufruf-Overhead:** &lt;1ms
+
+```
+Frontend Call → Bridge → Go Execution → Bridge → Frontend Response
+     ↓            ↓           ↓            ↓            ↓
+   &lt;0.1ms      &lt;0.1ms      [varies]     &lt;0.1ms      &lt;0.1ms
+```
+
+**Im Vergleich zu Alternativen:**
+- **HTTP/REST:** 5-50ms (Netzwerkstack, Serialisierung)
+- **IPC:** 1-10ms (Prozessgrenzen, Marshalling)
+- **Wails Bridge:** &lt;1ms (im Speicher, direkter Aufruf)
+
+### Speicher
+
+**Overhead pro Aufruf:** ~1KB (Nachrichtenpuffer)
+
+**Zero-Copy-Optimierung:** Große Daten (>1MB) verwenden bei Gelegenheit shared Memory.
+
+### Nebenläufigkeit
+
+**Aufrufe sind nebenläufig:**
+- Jeder Aufruf läuft in seiner eigenen Goroutine
+- Mehrere Aufrufe können gleichzeitig ausgeführt werden
+- Keine Blockierung zwischen Aufrufen
+
+```javascript
+// These run concurrently
+const [result1, result2, result3] = await Promise.all([
+    SlowOperation1(),
+    SlowOperation2(),
+    SlowOperation3(),
+])
+```
+
+## Typsystem
+
+### Unterstützte Typen
+
+#### Primitive
+
+```go
+// Go
+func Example(
+    s string,
+    i int,
+    f float64,
+    b bool,
+) (string, int, float64, bool) {
+    return s, i, f, b
+}
+```
+
+```typescript
+// TypeScript (auto-generated)
+function Example(
+    s: string,
+    i: number,
+    f: number,
+    b: boolean,
+): Promise<[string, number, number, boolean]>
+```
+
+#### Slices und Arrays
+
+```go
+// Go
+func Sum(numbers []int) int {
+    total := 0
+    for _, n := range numbers {
+        total += n
+    }
+    return total
+}
+```
+
+```typescript
+// TypeScript
+function Sum(numbers: number[]): Promise<number>
+
+// Usage
+const total = await Sum([1, 2, 3, 4, 5])  // 15
+```
+
+#### Maps
+
+```go
+// Go
+func GetConfig() map[string]interface{} {
+    return map[string]interface{}{
+        "theme": "dark",
+        "fontSize": 14,
+        "enabled": true,
+    }
+}
+```
+
+```typescript
+// TypeScript
+function GetConfig(): Promise<Record<string, any>>
+
+// Usage
+const config = await GetConfig()
+console.log(config.theme)  // "dark"
+```
+
+#### Strukturen
+
+```go
+// Go
+type User struct {
+    ID    int    `json:"id"`
+    Name  string `json:"name"`
+    Email string `json:"email"`
+}
+
+func GetUser(id int) (*User, error) {
+    return &User{
+        ID:    id,
+        Name:  "Alice",---
+
+**Fragen zur Brücke?** Fragen Sie im [Discord](https://discord.gg/JDdSxwjhGf) oder überprüfen Sie die [Bindungsbeispiele](https://github.com/wailsapp/wails/tree/master/v3/examples/binding).

--- a/docs/src/content/docs/de/concepts/build-system.mdx
+++ b/docs/src/content/docs/de/concepts/build-system.mdx
@@ -1,0 +1,424 @@
+---
+title: Build-System
+description: Verstehen, wie Wails Ihre Anwendung erstellt und paketiert
+sidebar:
+  order: 4
+---
+
+import { Tabs, TabItem } from "@astrojs/starlight/components";
+
+## Einheitliches Build-System
+
+Wails bietet ein **einheitliches Build-System**, das Go-Code kompiliert, Frontend-Assets bündelt, alles in eine einzige ausführbare Datei einbettet und plattformspezifische Builds durchführt – alles mit einem einzigen Befehl.
+
+```bash
+wails3 build
+```
+
+**Ausgabe:** Native ausführbare Datei mit allem eingebettet.
+
+## Überblick über den Build-Prozess
+
+{/*
+TODO: D2-Diagramm-Generierung beheben oder als Bild einbetten.
+Der vorherige D2-Codeblock verursachte MDX-Parsing-Fehler in der Build-Pipeline.
+*/}
+
+**[Platzhalter für Build-Prozess-Diagramm]**
+
+
+## Build-Phasen
+
+### 1. Analysephase
+
+Wails scannt Ihren Go-Code, um Ihre Dienste zu verstehen:
+
+```go
+type GreetService struct {
+    prefix string
+}
+
+func (g *GreetService) Greet(name string) string {
+    return g.prefix + name + "!"
+}
+```
+
+**Was Wails extrahiert:**
+- Dienstname: `GreetService`
+- Methodenname: `Greet`
+- Parametertypen: `string`
+- Rückgabetypen: `string`
+
+**Verwendet für:** Generieren von TypeScript-Bindings
+
+### 2. Generierungsphase
+
+#### TypeScript-Bindings
+
+Wails generiert typsichere Bindings:
+
+```typescript
+// Auto-generated: frontend/bindings/GreetService.ts
+export function Greet(name: string): Promise<string> {
+    return window.wails.Call('GreetService.Greet', name)
+}
+```
+
+**Vorteile:**
+- Volle Typsicherheit
+- IDE-Autovervollständigung
+- Fehler zur Kompilierzeit
+- JSDoc-Kommentare
+
+#### Frontend-Build
+
+Ihr Frontend-Bundler läuft (Vite, webpack, usw.):
+
+```bash
+# Vite-Beispiel
+vite build --outDir dist
+```
+
+**Was passiert:**
+- JavaScript/TypeScript kompiliert
+- CSS verarbeitet und minimiert
+- Assets optimiert
+- Source Maps generiert (nur für Entwicklung)
+- Ausgabe nach `frontend/dist/`
+
+### 3. Kompilierungsphase
+
+#### Go-Kompilierung
+
+Go-Code wird mit Optimierungen kompiliert:
+
+```bash
+go build -ldflags="-s -w" -o myapp.exe
+```
+
+**Flags:**
+- `-s`: Symboltabelle entfernen
+- `-w`: DWARF-Debugging-Informationen entfernen
+- Ergebnis: Kleinere Binärdatei (~30% Reduzierung)
+
+**Plattformspezifisch:**
+- Windows: `.exe` mit eingebettetem Icon
+- macOS: `.app`-Bundle-Struktur
+- Linux: ELF-Binärdatei
+
+#### Asset-Einbettung
+
+Frontend-Assets werden in die Go-Binärdatei eingebettet:
+
+```go
+//go:embed frontend/dist
+var assets embed.FS
+```
+
+**Ergebnis:** Einzelne ausführbare Datei mit allem darin.
+
+### 4. Ausgabe
+
+**Einzelne native Binärdatei:**
+- Windows: `myapp.exe` (~15MB)
+- macOS: `myapp.app` (~15MB)
+- Linux: `myapp` (~15MB)
+
+**Keine Abhängigkeiten** (außer System-WebView).
+
+## Entwicklung vs. Produktion
+
+<Tabs syncKey="mode">
+  <TabItem label="Entwicklung (wails3 dev)" icon="seti:config">
+    **Für Geschwindigkeit optimiert:**
+    
+    ```bash
+    wails3 dev
+    ```
+    
+    **Was passiert:**
+    1. Startet Frontend-Entwicklungsserver (Vite auf Port 5173)
+    2. Kompiliert Go ohne Optimierungen
+    3. Startet App, die auf Entwicklungsserver zeigt
+    4. Aktiviert Hot Reload
+    5. Enthält Source Maps
+    
+    **Eigenschaften:**
+    - **Schnelle Neukompilierung** (&lt;1s für Frontend-Änderungen)
+    - **Keine Asset-Einbettung** (wird vom Entwicklungsserver bereitgestellt)
+    - **Debug-Symbole** enthalten
+    - **Source Maps** aktiviert
+    - **Ausführliche Protokollierung**
+    
+    **Dateigröße:** Größer (~50MB mit Debug-Symbolen)
+  </TabItem>
+
+  <TabItem label="Produktion (wails3 build)" icon="rocket">
+    **Für Größe und Leistung optimiert:**
+    
+    ```bash
+    wails3 build
+    ```
+    
+    **Was passiert:**
+    1. Erstellt Frontend für Produktion (minimiert)
+    2. Kompiliert Go mit Optimierungen
+    3. Entfernt Debug-Symbole
+    4. Bettet Assets ein
+    5. Erstellt einzelne Binärdatei
+    
+    **Eigenschaften:**
+    - **Optimierter Code** (minimiert, tree-shaken)
+    - **Assets eingebettet** (keine externen Dateien)
+    - **Debug-Symbole entfernt**
+    - **Keine Source Maps**
+    - **Minimale Protokollierung**
+    
+    **Dateigröße:** Kleiner (~15MB)
+  </TabItem>
+</Tabs>
+
+## Build-Befehle
+
+### Basis-Build
+
+```bash
+wails3 build
+```
+
+**Ausgabe:** `build/bin/myapp[.exe]`
+
+### Build für spezifische Plattform
+
+```bash
+# Build für Windows (von jedem OS aus)
+wails3 build -platform windows/amd64
+
+# Build für macOS
+wails3 build -platform darwin/amd64
+wails3 build -platform darwin/arm64
+
+# Build für Linux
+wails3 build -platform linux/amd64
+```
+
+**Cross-Kompilierung:** Build für jede Plattform von jeder Plattform aus.
+
+### Build mit Optionen
+
+```bash
+# Benutzerdefiniertes Ausgabeverzeichnis
+wails3 build -o ./dist/myapp
+
+# Frontend-Build überspringen (bestehende verwenden)
+wails3 build -skipbindings
+
+# Sauberer Build (Cache entfernen)
+wails3 build -clean
+
+# Ausführliche Ausgabe
+wails3 build -v
+```
+
+### Build-Modi
+
+```bash
+# Debug-Build (enthält Symbole)
+wails3 build -debug
+
+# Produktions-Build (Standard, optimiert)
+wails3 build
+
+# Entwicklungs-Build (schnell, nicht optimiert)
+wails3 build -devbuild
+```
+
+## Build-Konfiguration
+
+### Taskfile.yml
+
+Wails verwendet [Taskfile](https://taskfile.dev/) für die Build-Konfiguration:
+
+```yaml
+# Taskfile.yml
+version: '3'
+
+tasks:
+  build:
+    desc: Build the application
+    cmds:
+      - wails3 build
+  
+  build:windows:
+    desc: Build for Windows
+    cmds:
+      - wails3 build -platform windows/amd64
+  
+  build:macos:
+    desc: Build for macOS (Universal)
+    cmds:
+      - wails3 build -platform darwin/amd64
+      - wails3 build -platform darwin/arm64
+      - lipo -create -output build/bin/myapp.app build/bin/myapp-amd64.app build/bin/myapp-arm64.app
+  
+  build:linux:
+    desc: Build for Linux
+    cmds:
+      - wails3 build -platform linux/amd64
+```
+
+**Aufgaben ausführen:**
+
+```bash
+task build:windows
+task build:macos
+task build:linux
+```
+
+### Build-Optionsdatei
+
+Erstellen Sie `build/build.json` für persistente Konfiguration:
+
+```json
+{
+  "name": "My Application",
+  "version": "1.0.0",
+  "author": "Your Name",
+  "description": "Application description",
+  "icon": "build/appicon.png",
+  "outputFilename": "myapp",
+  "platforms": ["windows/amd64", "darwin/amd64", "linux/amd64"],
+  "frontend": {
+    "dir": "./frontend",
+    "install": "npm install",
+    "build": "npm run build",
+    "dev": "npm run dev"
+  },
+  "go": {
+    "ldflags": "-s -w -X main.version={{.Version}}"
+  }
+}
+```
+
+## Asset-Einbettung
+
+### Wie es funktioniert
+
+Wails verwendet Go's `embed`-Paket:
+
+```go
+package main
+
+import (
+    "embed"
+    "github.com/wailsapp/wails/v3/pkg/application"
+)
+
+//go:embed frontend/dist
+var assets embed.FS
+
+func main() {
+    app := application.New(application.Options{
+        Name:   "My App",
+        Assets: application.AssetOptions{
+            Handler: application.AssetFileServerFS(assets),
+        },
+    })
+    
+    app.Window.New()
+    app.Run()
+}
+```
+
+**Während des Builds:**
+1. Frontend wird nach `frontend/dist/` gebaut
+2. `//go:embed`-Direktive schließt Dateien ein
+3. Dateien werden in die Binärdatei kompiliert
+4. Binärdatei enthält alles
+
+**Während der Laufzeit:**
+1. App startet
+2. Assets werden aus dem Speicher bereitgestellt
+3. Keine Festplatten-E/A für Assets
+4. Schnelles Laden
+
+### Benutzerdefinierte Assets
+
+Zusätzliche Dateien einbetten:
+
+```go
+//go:embed frontend/dist
+var frontendAssets embed.FS
+
+//go:embed data/*.json
+var dataAssets embed.FS
+
+//go:embed templates/*.html
+var templateAssets embed.FS
+```
+
+## Build-Optimierungen
+
+### Frontend-Optimierungen
+
+**Vite (Standard):**
+
+```javascript
+// vite.config.js
+export default {
+  build: {
+    minify: 'terser',
+    terserOptions: {
+      compress: {
+        drop_console: true,  // Remove console.log
+        drop_debugger: true,
+      },
+    },
+    rollupOptions: {
+      output: {
+        manualChunks: {
+          vendor: ['react', 'react-dom'],  // Separate vendor bundle
+        },
+      },
+    },
+  },
+}
+```
+
+**Ergebnisse:**
+- JavaScript minimiert (~70% Reduzierung)
+- CSS minimiert (~60% Reduzierung)
+- Bilder optimiert
+- Tree-Shaking angewendet
+
+### Go-Optimierungen
+
+**Compiler-Flags:**
+
+```bash
+-ldflags="-s -w"
+```
+
+- `-s`: Symboltabelle entfernen (~10% Reduzierung)
+- `-w`: DWARF-Debug-Informationen entfernen (~20% Reduzierung)
+
+**Zusätzliche Optimierungen:**
+
+```bash
+-ldflags="-s -w -X main.version=1.0.0"
+```
+
+- `-X`: Variablenwerte zur Build-Zeit setzen
+- Nützlich für Versionsnummern, Build-Daten
+
+### Binärdatei-Kompression
+
+**UPX (optional):**
+
+```bash
+# Nach dem Build
+upx --best build/bin/myapp.exe
+```
+
+**Ergebnisse:**
+- ~50% Größenreduzierung**Fragen zum Bauen?** Fragen Sie im [Discord](https://discord.gg/JDdSxwjhGf) oder prüfen Sie die [Build-Beispiele](https://github.com/wailsapp/wails/tree/master/v3/examples/build).

--- a/docs/src/content/docs/de/concepts/lifecycle.mdx
+++ b/docs/src/content/docs/de/concepts/lifecycle.mdx
@@ -1,0 +1,368 @@
+---
+title: Lebenszyklus der Anwendung
+description: Verständnis des Wails-Anwendungslebenszyklus vom Start bis zum Herunterfahren
+sidebar:
+  order: 2
+---
+
+import { Tabs, TabItem } from "@astrojs/starlight/components";
+
+## Verständnis des Anwendungslebenszyklus
+
+Desktop-Anwendungen haben einen Lebenszyklus vom Start bis zum Herunterfahren. Wails v3 bietet **Dienste**, **Ereignisse** und **Hooks**, um diesen Lebenszyklus effektiv zu verwalten.
+
+## Die Lebenszyklus-Phasen
+
+```d2
+direction: down
+
+Start: "Application Start" {
+  shape: oval
+  style.fill: "#10B981"
+}
+
+Init: "Initialisation" {
+  Parse: "Parse Options" {
+    shape: rectangle
+  }
+  Register: "Register Services" {
+    shape: rectangle
+  }
+  Setup: "Setup Runtime" {
+    shape: rectangle
+  }
+}
+
+AppRun: "app.Run()" {
+  shape: rectangle
+  style.fill: "#3B82F6"
+}
+
+ServiceStartup: "Service Startup" {
+  shape: rectangle
+  style.fill: "#8B5CF6"
+}
+
+EventLoop: "Event Loop" {
+  Process: "Process Events" {
+    shape: rectangle
+  }
+  Handle: "Handle Messages" {
+    shape: rectangle
+  }
+  Update: "Update UI" {
+    shape: rectangle
+  }
+}
+
+QuitSignal: "Quit Signal" {
+  shape: diamond
+  style.fill: "#F59E0B"
+}
+
+ShouldQuit: "ShouldQuit Check" {
+  shape: rectangle
+  style.fill: "#3B82F6"
+}
+
+OnShutdown: "OnShutdown Callbacks" {
+  shape: rectangle
+  style.fill: "#3B82F6"
+}
+
+ServiceShutdown: "Service Shutdown" {
+  shape: rectangle
+  style.fill: "#8B5CF6"
+}
+
+Cleanup: "Cleanup" {
+  Close: "Close Windows" {
+    shape: rectangle
+  }
+  Release: "Release Resources" {
+    shape: rectangle
+  }
+}
+
+End: "Application End" {
+  shape: oval
+  style.fill: "#EF4444"
+}
+
+Start -> Init.Parse
+Init.Parse -> Init.Register
+Init.Register -> Init.Setup
+Init.Setup -> AppRun
+AppRun -> ServiceStartup
+ServiceStartup -> EventLoop.Process
+EventLoop.Process -> EventLoop.Handle
+EventLoop.Handle -> EventLoop.Update
+EventLoop.Update -> EventLoop.Process: "Loop"
+EventLoop.Process -> QuitSignal: "User quits"
+QuitSignal -> ShouldQuit: "Check allowed?"
+ShouldQuit -> EventLoop.Process: "Denied"
+ShouldQuit -> OnShutdown: "Allowed"
+OnShutdown -> ServiceShutdown
+ServiceShutdown -> Cleanup.Close
+Cleanup.Close -> Cleanup.Release
+Cleanup.Release -> End
+```
+
+### 1. Anwendungserstellung
+
+Erstellen Sie Ihre Anwendung mit `application.New()`:
+
+```go
+app := application.New(application.Options{
+    Name:        "My App",
+    Description: "An application built with Wails",
+    Services: []application.Service{
+        application.NewService(&MyService{}),
+    },
+    Assets: application.AssetOptions{
+        Handler: application.BundledAssetFileServer(assets),
+    },
+})
+```
+
+**Was passiert:**
+1. Optionen werden analysiert und validiert
+2. Dienste werden registriert (aber noch nicht gestartet)
+3. Asset-Server wird konfiguriert
+4. Runtime wird eingerichtet
+
+### 2. Ausführen der Anwendung
+
+Rufen Sie `app.Run()` auf, um die Anwendung zu starten:
+
+```go
+err := app.Run()  // Blocks until quit
+if err != nil {
+    log.Fatal(err)
+}
+```
+
+**Was passiert:**
+1. Dienste werden in der Reihenfolge der Registrierung gestartet
+2. Ereignis-Listener werden aktiviert
+3. Fenster können erstellt werden
+4. Die Ereignisschleife beginnt
+
+### 3. Ereignisschleife
+
+Die Anwendung tritt in die Ereignisschleife ein, in der sie den Großteil ihrer Zeit verbringt:
+
+- OS-Ereignisse werden verarbeitet (Maus, Tastatur, Fensterereignisse)
+- Go-zu-JS-Nachrichten werden behandelt
+- JS-zu-Go-Aufrufe werden ausgeführt
+- UI-Aktualisierungen werden gerendert
+
+### 4. Herunterfahren
+
+Wenn die Anwendung beendet wird:
+
+1. Der `ShouldQuit`-Callback wird geprüft (falls festgelegt)
+2. `OnShutdown`-Callbacks werden ausgeführt
+3. Dienste werden in umgekehrter Reihenfolge heruntergefahren
+4. Fenster werden geschlossen
+5. Ressourcen werden freigegeben
+
+## Lebenszyklus der Dienste
+
+Dienste sind die primäre Methode zur Verwaltung des Lebenszyklus in Wails v3. Sie bieten Startup- und Shutdown-Hooks über Schnittstellen. Für die vollständige Dokumentation zu Diensten siehe den [Dienste-Leitfaden](/features/bindings/services).
+
+### Erstellen eines Dienstes
+
+```go
+type MyService struct {
+    db *sql.DB
+}
+
+// ServiceStartup is called when the application starts
+func (s *MyService) ServiceStartup(ctx context.Context, options application.ServiceOptions) error {
+    var err error
+    s.db, err = sql.Open("sqlite3", "app.db")
+    if err != nil {
+        return err  // Startup aborts if error returned
+    }
+
+    // Run migrations
+    if err := s.runMigrations(); err != nil {
+        return err
+    }
+
+    return nil
+}
+
+// ServiceShutdown is called when the application shuts down
+func (s *MyService) ServiceShutdown() error {
+    if s.db != nil {
+        return s.db.Close()
+    }
+    return nil
+}
+```
+
+### Registrieren von Diensten
+
+```go
+app := application.New(application.Options{
+    Services: []application.Service{
+        application.NewService(&MyService{}),
+        application.NewService(&AnotherService{}),
+    },
+})
+```
+
+**Wichtige Punkte:**
+- Dienste starten in der Reihenfolge der Registrierung
+- Dienste fahren in **umgekehrter** Registrierungsreihenfolge herunter
+- Wenn ein Dienst `ServiceStartup` einen Fehler zurückgibt, wird die Anwendung abgebrochen
+- Der an `ServiceStartup` übergebene `ctx` wird abgebrochen, wenn das Herunterfahren beginnt
+
+### Verwenden des Anwendungskontexts
+
+Der an `ServiceStartup` übergebene Kontext ist für die Lebensdauer der Anwendung gültig:
+
+```go
+func (s *MyService) ServiceStartup(ctx context.Context, options application.ServiceOptions) error {
+    // Start a background task that respects shutdown
+    go func() {
+        ticker := time.NewTicker(5 * time.Minute)
+        defer ticker.Stop()
+
+        for {
+            select {
+            case <-ticker.C:
+                s.performBackgroundSync()
+            case <-ctx.Done():
+                // Application is shutting down
+                return
+            }
+        }
+    }()
+
+    return nil
+}
+```
+
+Sie können den Kontext auch über die Anwendungsinstanz abrufen:
+
+```go
+app := application.Get()
+ctx := app.Context()
+```
+
+## Anwendungs-Level-Hooks
+
+Dies sind praktische Callbacks in `application.Options`, die es Ihnen ermöglichen, in den Anwendungslebenszyklus einzugreifen, ohne einen vollständigen Dienst zu erstellen. Sie sind nützlich für einfache Aufräumaufgaben, Bestätigungen zum Beenden oder wenn Sie Code an bestimmten Punkten der Herunterfahren-Sequenz ausführen müssen.
+
+Für komplexeres Lebenszyklusmanagement mit Startlogik, Dependency Injection oder zustandsbehafteten Ressourcen verwenden Sie stattdessen [Dienste](#services-lifecycle).
+
+### ShouldQuit
+
+Der `ShouldQuit`-Callback wird aufgerufen, wann immer ein Beenden angefordert wird – egal ob durch den Benutzer, der das letzte Fenster schließt, Cmd+Q (macOS) / Alt+F4 (Windows) drückt oder `app.Quit()` programmatisch aufruft.
+
+**Rückgabewert:**
+- Geben Sie `true` zurück, um das Beenden zu erlauben (die Anwendung wird heruntergefahren)
+- Geben Sie `false` zurück, um das Beenden zu abbrechen (die Anwendung läuft weiter)
+
+Dies ist Ihre Gelegenheit, Beendigungsanfragen abzufangen und diese optional zu verhindern, z. B. um den Benutzer nach nicht gespeicherten Änderungen zu fragen:
+
+```go
+app := application.New(application.Options{
+    ShouldQuit: func() bool {
+        if !hasUnsavedChanges() {
+            return true  // No unsaved changes, allow quit
+        }
+
+        // Prompt the user
+        result, _ := application.QuestionDialog().
+            SetTitle("Unsaved Changes").
+            SetMessage("You have unsaved changes. Quit anyway?").
+            AddButton("Quit", "quit").
+            AddButton("Cancel", "cancel").
+            Show()
+
+        // Only quit if user clicked "Quit"
+        return result == "quit"
+    },
+})
+```
+
+Wenn `ShouldQuit` nicht festgelegt ist, wird die Anwendung sofort beendet, wenn dies angefordert wird.
+
+**Wann ShouldQuit aufgerufen wird:**
+- Der Benutzer schließt das letzte Fenster (es sei denn, `DisableQuitOnLastWindowClosed` ist festgelegt)
+- Der Benutzer drückt Cmd+Q auf macOS
+- Der Benutzer drückt Alt+F4 auf Windows (wenn das letzte Fenster fokussiert ist)
+- Der Code ruft `app.Quit()` auf
+
+**Wann ShouldQuit NICHT aufgerufen wird:**
+- Der Prozess wird getötet (SIGKILL, Task-Manager-Zwangstrennung)
+- `os.Exit()` wird direkt aufgerufen
+
+### OnShutdown
+
+Der `OnShutdown`-Callback wird aufgerufen, wenn die Anwendung bestätigt hat, dass sie beendet wird (nachdem `ShouldQuit` `true` zurückgegeben hat, falls festgelegt). Verwenden Sie dies für Aufräumaufgaben wie das Speichern des Zustands, das Schließen von Datenbankverbindungen oder das Freigeben von Ressourcen.
+
+```go
+app := application.New(application.Options{
+    OnShutdown: func() {
+        // Save application state
+        saveState()
+
+        // Close connections----------|--------------------------------|
+| macOS | App bleibt aktiv (Menüleiste bleibt erhalten) |
+| Windows | App beendet sich |
+| Linux | App beendet sich |
+
+macOS folgt den nativen Plattformkonventionen, wonach Anwendungen typischerweise in der Menüleiste aktiv bleiben, auch ohne Fenster. Windows und Linux beenden sich standardmäßig.
+
+**Alle Plattformen beim Schließen des letzten Fensters beenden lassen:**
+
+```go
+app := application.New(application.Options{
+    Mac: application.MacOptions{
+        ApplicationShouldTerminateAfterLastWindowClosed: true,
+    },
+})
+```
+
+**Alle Plattformen beim Schließen des letzten Fensters aktiv lassen:**
+
+Dies ist nützlich für System-Tray-Anwendungen oder Apps, die im Hintergrund aktiv bleiben sollen.
+
+```go
+app := application.New(application.Options{
+    Windows: application.WindowsOptions{
+        DisableQuitOnLastWindowClosed: true,
+    },
+    Linux: application.LinuxOptions{
+        DisableQuitOnLastWindowClosed: true,
+    },
+})
+```
+
+## Häufige Muster
+
+### Muster 1: Datenbankdienst
+
+```go
+type DatabaseService struct {
+    db *sql.DB
+}
+
+func (s *DatabaseService) ServiceStartup(ctx context.Context, options application.ServiceOptions) error {
+    var err error
+    s.db, err = sql.Open("sqlite3", "app.db")
+    if err != nil {
+        return fmt.Errorf("failed to open database: %w", err)
+    }
+
+    if err := s.db.PingContext(ctx); err != nil {
+        return fmt.Errorf("failed to connect to database: %w", err)
+    }
+
+    return nil
+}**Fragen zum Lebenszyklus?** Fragen Sie im [Discord](https://discord.gg/JDdSxwjhGf) oder sehen Sie sich die [Beispiele](https://github.com/wailsapp/wails/tree/master/v3/examples) an.

--- a/docs/src/content/docs/de/concepts/manager-api.mdx
+++ b/docs/src/content/docs/de/concepts/manager-api.mdx
@@ -1,0 +1,266 @@
+---
+title: Manager-API
+description: Organisierte API-Struktur mit fokussierten Manager-Schnittstellen
+sidebar:
+  order: 2
+---
+
+import { Tabs, TabItem } from "@astrojs/starlight/components";
+
+Die Wails v3 Manager-API bietet eine organisierte und gut auffindbare Möglichkeit, auf die Anwendungsfunktionalität über fokussierte Manager-Strukturen zuzugreifen. Diese neue API-Struktur gruppiert zusammengehörige Methoden zusammen und bewahrt dabei die volle Abwärtskompatibilität mit der traditionellen App-API.
+
+## Übersicht
+
+Die Manager-API organisiert die Anwendungsfunktionalität in elf fokussierte Bereiche:
+
+- **`app.Window`** - Fenstererstellung, -verwaltung und Callbacks
+- **`app.ContextMenu`** - Registrierung und Verwaltung von Kontextmenüs
+- **`app.KeyBinding`** - Verwaltung globaler Tastenkürzel
+- **`app.Browser`** - Browserintegration (Öffnen von URLs und Dateien)
+- **`app.Env`** - Umgebungsinformationen und Systemstatus
+- **`app.Dialog`** - Datei- und Nachrichten-Dialoge
+- **`app.Event`** - Verarbeitung benutzerdefinierter Ereignisse und Anwendungsereignisse
+- **`app.Menu`** - Verwaltung des Anwendungsmenüs
+- **`app.Screen`** - Bildschirmverwaltung und Koordinatentransformationen
+- **`app.Clipboard`** - Zwischenablage-Textoperationen
+- **`app.SystemTray`** - Erstellung und Verwaltung von Systemablage-Symbolen
+
+## Vorteile
+
+- **Bessere Auffindbarkeit** - Die IDE-Vervollständigung zeigt eine organisierte API-Oberfläche
+- **Verbesserte Codeorganisation** - Zusammengehörige Methoden sind gruppiert
+- **Verbesserte Wartbarkeit** - Trennung der Zuständigkeiten zwischen den Managern
+- **Zukünftige Erweiterbarkeit** - Einfacher, neue Funktionen in spezifische Bereiche hinzuzufügen
+
+## Verwendung
+
+Die Manager-API bietet organisierten Zugriff auf alle Anwendungsfunktionalitäten:
+
+```go
+// Ereignisse und benutzerdefinierte Ereignisverarbeitung
+app.Event.Emit("custom", data)
+app.Event.On("custom", func(e *CustomEvent) { ... })
+
+// Fensterverwaltung
+window, _ := app.Window.GetByName("main")
+app.Window.OnCreate(func(window Window) { ... })
+
+// Browserintegration
+app.Browser.OpenURL("https://wails.io")
+
+// Menüverwaltung
+menu := app.Menu.New()
+app.Menu.Set(menu)
+
+// Systemablage
+systray := app.SystemTray.New()
+```
+
+## Manager-Referenz
+
+### Fenster-Manager
+
+Verwaltet die Fenstererstellung, -abruf und Lebenszyklus-Callbacks.
+
+```go
+// Fenster erstellen
+window := app.Window.New()
+window := app.Window.NewWithOptions(options)
+current := app.Window.Current()
+
+// Fenster finden
+window, exists := app.Window.GetByName("main")
+windows := app.Window.GetAll()
+
+// Fenster-Callbacks
+app.Window.OnCreate(func(window Window) {
+    // Fenstererstellung verarbeiten
+})
+```
+
+### Ereignis-Manager
+
+Verwaltet benutzerdefinierte Ereignisse und das Abhören von Anwendungsereignissen.
+
+```go
+// Benutzerdefinierte Ereignisse
+app.Event.Emit("userAction", data)
+cancelFunc := app.Event.On("userAction", func(e *CustomEvent) {
+    // Ereignis verarbeiten
+})
+app.Event.Off("userAction")
+app.Event.Reset() // Alle Listener entfernen
+
+// Anwendungsereignisse
+app.Event.OnApplicationEvent(events.Common.ThemeChanged, func(e *ApplicationEvent) {
+    // System-Designänderung verarbeiten
+})
+```
+
+### Browser-Manager
+
+Bietet Browserintegration zum Öffnen von URLs und Dateien.
+
+```go
+// URLs und Dateien im Standardbrowser öffnen
+err := app.Browser.OpenURL("https://wails.io")
+err := app.Browser.OpenFile("/path/to/document.pdf")
+```
+
+### Umgebungs-Manager
+
+Zugriff auf Systemumgebungsinformationen.
+
+```go
+// Umgebungsinformationen abrufen
+env := app.Env.Info()
+fmt.Printf("OS: %s, Arch: %s\n", env.OS, env.Arch)
+
+// System-Design prüfen
+if app.Env.IsDarkMode() {
+    // Dunkles Design ist aktiv
+}
+
+// Dateimanager öffnen
+err := app.Env.OpenFileManager("/path/to/folder", false)
+```
+
+### Dialog-Manager
+
+Organisierter Zugriff auf Datei- und Nachrichten-Dialoge.
+
+```go
+// Datei-Dialoge
+result, err := app.Dialog.OpenFile().
+    AddFilter("Textdateien", "*.txt").
+    PromptForSingleSelection()
+
+result, err = app.Dialog.SaveFile().
+    SetDefaultFilename("document.txt").
+    PromptForSingleSelection()
+
+// Nachrichten-Dialoge
+app.Dialog.Info().
+    SetTitle("Information").
+    SetMessage("Vorgang erfolgreich abgeschlossen").
+    Show()
+
+app.Dialog.Error().
+    SetTitle("Fehler").  
+    SetMessage("Ein Fehler ist aufgetreten").
+    Show()
+```
+
+### Menü-Manager
+
+Erstellung und Verwaltung des Anwendungsmenüs.
+
+```go
+// Anwendungsmenü erstellen und festlegen
+menu := app.Menu.New()
+fileMenu := menu.AddSubmenu("Datei")
+fileMenu.Add("Neu").OnClick(func(ctx *Context) {
+    // Menü-Klick verarbeiten
+})
+
+app.Menu.Set(menu)
+
+// Über-Dialog anzeigen
+app.Menu.ShowAbout()
+```
+
+### Tastenkürzel-Manager
+
+Dynamische Verwaltung globaler Tastenkürzel.
+
+```go
+// Tastenkürzel hinzufügen
+app.KeyBinding.Add("ctrl+n", func(window *WebviewWindow) {
+    // Strg+N verarbeiten
+})
+
+app.KeyBinding.Add("ctrl+q", func(window *WebviewWindow) {
+    app.Quit()
+})
+
+// Tastenkürzel entfernen
+app.KeyBinding.Remove("ctrl+n")
+
+// Alle Kürzel abrufen
+bindings := app.KeyBinding.GetAll()
+```
+
+### Kontextmenü-Manager
+
+Erweiterte Kontextmenüverwaltung (für Bibliotheksautoren).
+
+```go
+// Kontextmenü erstellen und registrieren
+menu := app.ContextMenu.New()
+app.ContextMenu.Add("myMenu", menu)
+
+// Kontextmenü abrufen
+menu, exists := app.ContextMenu.Get("myMenu")
+
+// Kontextmenü entfernen
+app.ContextMenu.Remove("myMenu")
+```
+
+### Bildschirm-Manager
+
+Bildschirmverwaltung und Koordinatentransformationen für Multi-Monitor-Setups.
+
+```go
+// Bildschirminformationen abrufen
+screens := app.Screen.GetAll()
+primary := app.Screen.GetPrimary()
+
+// Koordinatentransformationen
+physicalPoint := app.Screen.DipToPhysicalPoint(logicalPoint)
+logicalPoint := app.Screen.PhysicalToDipPoint(physicalPoint)
+
+// Bildschirmerkennung
+screen := app.Screen.ScreenNearestDipPoint(point)
+screen = app.Screen.ScreenNearestDipRect(rect)
+```
+
+### Zwischenablage-Manager
+
+Zwischenablage-Operationen zum Lesen und Schreiben von Text.
+
+```go
+// Text in die Zwischenablage schreiben
+success := app.Clipboard.SetText("Hello World")
+if !success {
+    // Fehler verarbeiten
+}
+
+// Text aus der Zwischenablage lesen
+text, ok := app.Clipboard.Text()
+if !ok {
+    // Fehler verarbeiten
+} else {
+    // Text verwenden
+}
+```
+
+### Systemablage-Manager
+
+Erstellung und Verwaltung von Systemablage-Symbolen.
+
+```go
+// Systemablage erstellen
+systray := app.SystemTray.New()
+systray.SetLabel("Meine App")
+systray.SetIcon(iconBytes)
+
+// Menü zur Systemablage hinzufügen
+menu := app.Menu.New()
+menu.Add("Öffnen").OnClick(func(ctx *Context) {
+    // Klick verarbeiten
+})
+systray.SetMenu(menu)
+
+// Systemablage zerstören, wenn fertig
+systray.Destroy()
+```

--- a/docs/src/content/docs/de/contributing.mdx
+++ b/docs/src/content/docs/de/contributing.mdx
@@ -1,0 +1,275 @@
+---
+title: Mitwirken
+description: Zu Wails beitragen
+sidebar:
+  order: 100
+---
+
+import { Card, CardGrid } from "@astrojs/starlight/components";
+
+## Willkommen, Mitwirkende!
+
+Wir freuen uns über Beiträge zu Wails! Egal, ob du Fehler behebst, neue Funktionen hinzufügst oder die Dokumentation verbesserst, deine Hilfe wird sehr geschätzt.
+
+## Möglichkeiten zur Mitarbeit
+
+### 1. Probleme melden
+
+Einen Fehler gefunden? [Öffne ein Issue](https://github.com/wailsapp/wails/issues/new) mit:
+- Klare Beschreibung
+- Schritte zur Reproduktion
+- Erwartetes vs. tatsächliches Verhalten
+- Systeminformationen
+- Code-Beispiele
+
+### 2. Dokumentation verbessern
+
+Verbesserungen der Dokumentation sind immer willkommen:
+- Tippfehler und Fehler korrigieren
+- Beispiele hinzufügen
+- Erklärungen präzisieren
+- Inhalte übersetzen
+
+### 3. Code einreichen
+
+Reiche Code über Pull Requests ein:
+- Fehlerbehebungen
+- Neue Funktionen
+- Leistungsverbesserungen
+- Tests
+
+## Erste Schritte
+
+### Forken und Klonen
+
+```bash
+# Fork das Repository auf GitHub
+# Dann deinen Fork klonen
+git clone https://github.com/YOUR_USERNAME/wails.git
+cd wails
+
+# Upstream-Remote hinzufügen
+git remote add upstream https://github.com/wailsapp/wails.git
+```
+
+### Vom Quellcode bauen
+
+```bash
+# Abhängigkeiten installieren
+go mod download
+
+# Wails CLI bauen
+cd v3/cmd/wails3
+go build
+
+# Dein Build testen
+./wails3 version
+```
+
+### Tests ausführen
+
+```bash
+# Alle Tests ausführen
+go test ./...
+
+# Tests für bestimmte Pakete ausführen
+go test ./v3/pkg/application
+
+# Mit Abdeckungsanalyse ausführen
+go test -cover ./...
+```
+
+## Änderungen vornehmen
+
+### Einen Branch erstellen
+
+```bash
+# main aktualisieren
+git checkout main
+git pull upstream main
+
+# Feature-Branch erstellen
+git checkout -b feature/my-feature
+```
+
+### Deine Änderungen vornehmen
+
+1. **Code schreiben** unter Einhaltung der Go-Konventionen
+2. **Tests hinzufügen** für neue Funktionalitäten
+3. **Dokumentation aktualisieren**, falls erforderlich
+4. **Tests ausführen**, um sicherzustellen, dass nichts kaputtgeht
+5. **Änderungen committen** mit klaren Nachrichten
+
+### Richtlinien für Commits
+
+```bash
+# Gute Commit-Nachrichten
+git commit -m "fix: window focus issue on macOS beheben"
+git commit -m "feat: Unterstützung für benutzerdefiniertes Fenster-Chrome hinzufügen"
+git commit -m "docs: Bindings-Dokumentation verbessern"
+
+# Verwende konventionelle Commits:
+# - feat: Neue Funktion
+# - fix: Fehlerbehebung
+# - docs: Dokumentation
+# - test: Tests
+# - refactor: Code-Refactoring
+# - chore: Wartung
+```
+
+### Pull Request einreichen
+
+```bash
+# Zu deinem Fork pushen
+git push origin feature/my-feature
+
+# Pull Request auf GitHub öffnen
+# Klare Beschreibung bereitstellen
+# Verwandte Issues referenzieren
+```
+
+## Richtlinien für Pull Requests
+
+### Gute PR-Beschreibung
+
+```markdown
+## Beschreibung
+Kurze Beschreibung der Änderungen
+
+## Änderungen
+- Feature X hinzugefügt
+- Bug Y behoben
+- Dokumentation aktualisiert
+
+## Testing
+- Getestet auf macOS 14
+- Getestet auf Windows 11
+- Alle Tests bestanden
+
+## Verwandte Issues
+Behebt #123
+```
+
+### PR-Checkliste
+
+- [ ] Code folgt den Go-Konventionen
+- [ ] Tests hinzugefügt/aktualisiert
+- [ ] Dokumentation aktualisiert
+- [ ] Alle Tests bestanden
+- [ ] Keine Breaking Changes (oder dokumentiert)
+- [ ] Commit-Nachrichten klar
+
+## Code-Richtlinien
+
+### Go-Code-Stil
+
+```go
+// ✅ Gut: Klar, dokumentiert, getestet
+// ProcessData verarbeitet die Eingabedaten und gibt das Ergebnis zurück.
+// Es gibt einen Fehler zurück, wenn die Daten ungültig sind.
+func ProcessData(data string) (string, error) {
+    if data == "" {
+        return "", errors.New("data cannot be empty")
+    }
+    
+    result := process(data)
+    return result, nil
+}
+
+// ❌ Schlecht: Keine Docs, keine Fehlerbehandlung
+func ProcessData(data string) string {
+    return process(data)
+}
+```
+
+### Testing
+
+```go
+func TestProcessData(t *testing.T) {
+    tests := []struct {
+        name    string
+        input   string
+        want    string
+        wantErr bool
+    }{
+        {"gültige Eingabe", "test", "processed", false},
+        {"leere Eingabe", "", "", true},
+    }
+    
+    for _, tt := range tests {
+        t.Run(tt.name, func(t *testing.T) {
+            got, err := ProcessData(tt.input)
+            if (err != nil) != tt.wantErr {
+                t.Errorf("ProcessData() error = %v, wantErr %v", err, tt.wantErr)
+                return
+            }
+            if got != tt.want {
+                t.Errorf("ProcessData() = %v, want %v", got, tt.want)
+            }
+        })
+    }
+}
+```
+
+## Dokumentation
+
+### Schreiben von Docs
+
+Die Dokumentation verwendet Starlight (Astro):
+
+```bash
+cd docs
+npm install
+npm run dev
+```
+
+### Stil der Dokumentation
+
+- Verwende britisches Englisch als Rechtschreibung
+- Beginne mit dem Problem
+- Biete funktionierende Beispiele
+- Füge Troubleshooting hinzu
+- Verweise auf verwandte Inhalte
+
+## Community
+
+### Hilfe erhalten
+
+- **Discord:** [Tritt unserer Community bei](https://discord.gg/JDdSxwjhGf)
+- **GitHub Discussions:** Stelle Fragen
+- **GitHub Issues:** Melde Fehler
+
+### Verhaltenskodex
+
+Sei respektvoll, inklusiv und professionell. Wir sind alle hier, um großartige Software gemeinsam zu entwickeln.
+
+## Anerkennung
+
+Mitwirkende werden anerkannt in:
+- Release-Notizen
+- Liste der Mitwirkenden
+- GitHub-Einblicken
+
+Danke, dass du zu Wails beigetragen hast! 🎉
+
+## Nächste Schritte
+
+<CardGrid>
+  <Card title="GitHub Repository" icon="github">
+    Besuche das Wails-Repository.
+    
+    [Auf GitHub ansehen →](https://github.com/wailsapp/wails)
+  </Card>
+
+  <Card title="Discord-Community" icon="discord">
+    Tritt der Community bei.
+    
+    [Discord beitreten →](https://discord.gg/JDdSxwjhGf)
+  </Card>
+
+  <Card title="Dokumentation" icon="open-book">
+    Lies die Docs.
+    
+    [Docs durchsuchen →](/de/quick-start/why-wails)
+  </Card>
+</CardGrid>

--- a/docs/src/content/docs/de/contributing/architecture/bindings.mdx
+++ b/docs/src/content/docs/de/contributing/architecture/bindings.mdx
@@ -1,0 +1,156 @@
+---
+title: Bindungssystem
+description: Wie das Bindungssystem JavaScript/TypeScript-Code sammelt, verarbeitet und generiert
+sidebar:
+  order: 1
+---
+
+import { FileTree } from "@astrojs/starlight/components";
+
+Dieser Leitfaden erklärt, wie das Wails-Bindungssystem intern funktioniert und bietet Entwicklern Einblicke in die Mechanismen hinter der automatischen Codegenerierung.
+
+## Architekturübersicht
+
+Das Wails-Bindungssystem besteht aus drei Hauptkomponenten:
+
+1. **Sammlung**: Analysiert Go-Code, um Informationen über Dienste, Modelle und andere Deklarationen zu extrahieren
+2. **Konfiguration**: Verwaltet Einstellungen und Optionen für den Bindungsgenerierungsprozess
+3. **Rendern**: Generiert JavaScript/TypeScript-Code basierend auf den gesammelten Informationen
+
+<FileTree>
+- internal/generator/
+  - collect/     # Paketanalyse und Informationsextraktion
+  - config/      # Konfigurationsstrukturen und Schnittstellen
+  - render/      # Codegenerierung für JS/TS
+</FileTree>
+
+## Sammelprozess
+
+Der Sammelprozess ist dafür verantwortlich, Go-Pakete zu analysieren und Informationen über Dienste, Modelle und andere Deklarationen zu extrahieren. Dies wird vom Paket `collect` übernommen.
+
+### Wichtige Komponenten
+
+- **Collector**: Verwaltet Paketinformationen und zwischengespeicherte gesammelte Daten
+- **Package**: Repräsentiert ein zu analysierendes Go-Paket und speichert gesammelte Dienste, Modelle und Direktiven
+- **Service**: Sammelt Informationen über Diensttypen und deren Methoden
+- **Model**: Sammelt detaillierte Informationen über Modelltypen, einschließlich Feldern, Werten und Typparametern
+- **Directive**: Parst und interpretiert `//wails:`-Direktiven im Go-Quellcode
+
+### Sammelablauf
+
+1. Der Collector scannt die im Projekt angegebenen Go-Pakete
+2. Er identifiziert Diensttypen (Strukturen mit Methoden, die an das Frontend freigegeben werden)
+3. Für jeden Dienst sammelt er Informationen über dessen Methoden
+4. Er identifiziert Modelltypen (Strukturen, die als Parameter oder Rückgabewerte in Dienstmethoden verwendet werden)
+5. Für jedes Modell sammelt er Informationen über dessen Felder und Typparameter
+6. Er verarbeitet alle im Code gefundenen `//wails:`-Direktiven
+
+## Rendernsprozess
+
+Der Rendernsprozess ist dafür verantwortlich, JavaScript/TypeScript-Code basierend auf den gesammelten Informationen zu generieren. Dies wird vom Paket `render` übernommen.
+
+### Wichtige Komponenten
+
+- **Renderer**: Koordiniert das Rendern von Dienst-, Modell- und Indexdateien
+- **Module**: Repräsentiert ein einzelnes generiertes JavaScript/TypeScript-Modul
+- **Templates**: Textvorlagen, die für die Codegenerierung verwendet werden
+
+### Rendernsablauf
+
+1. Für jeden Dienst generiert der Renderer eine JavaScript/TypeScript-Datei mit Funktionen, die die Dienstmethoden widerspiegeln
+2. Für jedes Modell generiert der Renderer eine JavaScript/TypeScript-Klasse, die die Modellstruktur widerspiegelt
+3. Der Renderer generiert Indexdateien, die alle Dienste und Modelle neu exportieren
+4. Der Renderer wendet alle benutzerdefinierten Codeinjektionen an, die durch `//wails:inject`-Direktiven angegeben sind
+
+## Typzuordnung
+
+Ein wichtiger Aspekt des Bindungssystems ist die Abbildung von Go-Typen auf JavaScript/TypeScript-Typen. Hier ist eine Zusammenfassung der Zuordnung:
+
+| Go-Typ | JavaScript-Typ | TypeScript-Typ |
+|---------|----------------|----------------|
+| `bool` | `boolean` | `boolean` |
+| `int`, `int8`, `int16`, `int32`, `int64`, `uint`, `uint8`, `uint16`, `uint32`, `uint64`, `float32`, `float64` | `number` | `number` |
+| `string` | `string` | `string` |
+| `[]byte` | `Uint8Array` | `Uint8Array` |
+| `[]T` | `Array<T>` | `T[]` |
+| `map[K]V` | `Object` | `Record<K, V>` |
+| `struct` | `Object` | Benutzerdefinierte Klasse |
+| `interface{}` | `any` | `any` |
+| `*T` | `T \| null` | `T \| null` |
+| `func` | Nicht unterstützt | Nicht unterstützt |
+| `chan` | Nicht unterstützt | Nicht unterstützt |
+
+## Direktivensystem
+
+Das Bindungssystem unterstützt mehrere Direktiven, die zur Anpassung des generierten Codes verwendet werden können. Diese Direktiven werden als Kommentare in Ihrem Go-Code hinzugefügt.
+
+### Verfügbare Direktiven
+
+- `//wails:inject`: Injiziert benutzerdefinierten JavaScript/TypeScript-Code in die generierten Bindungen
+- `//wails:include`: Schließt zusätzliche Dateien in die generierten Bindungen ein
+- `//wails:internal`: Markiert einen Typ oder eine Methode als intern und verhindert dessen Export an das Frontend
+- `//wails:ignore`: Ignoriert eine Methode vollständig während der Bindungsgenerierung
+- `//wails:id`: Gibt eine benutzerdefinierte ID für eine Methode an und überschreibt die standardmäßige hashbasierte ID
+
+### Direktivenverarbeitung
+
+1. Während der Sammelphase identifiziert der Collector Direktiven im Go-Code und parst sie
+2. Die Direktiven werden mit den entsprechenden Deklarationen (Dienste, Methoden, Modelle usw.) gespeichert
+3. Während der Rendernsphase wendet der Renderer die Direktiven an, um den generierten Code anzupassen
+
+## Erweiterte Funktionen
+
+### Bedingte Codegenerierung
+
+Das Bindungssystem unterstützt die bedingte Codegenerierung unter Verwendung eines zweistelligen Bedingungspräfix für `include`- und `inject`-Direktiven:
+
+```
+<language><style>:<content>
+```
+
+Wobei:
+- `<language>` kann sein:
+  - `*` - Sowohl JavaScript als auch TypeScript
+  - `j` - Nur JavaScript
+  - `t` - Nur TypeScript
+
+- `<style>` kann sein:
+  - `*` - Sowohl Klassen als auch Schnittstellen
+  - `c` - Nur Klassen
+  - `i` - Nur Schnittstellen
+
+Zum Beispiel:
+```go
+//wails:inject j*:console.log("Nur JavaScript");
+//wails:inject t*:console.log("Nur TypeScript");
+```
+
+### Benutzerdefinierte Methoden-IDs
+
+Standardmäßig werden Methoden durch eine hashbasierte ID identifiziert. Sie können jedoch eine benutzerdefinierte ID mit der `//wails:id`-Direktive angeben:
+
+```go
+//wails:id 42
+func (s *Service) CustomIDMethod() {}
+```
+
+Dies kann nützlich sein, um die Kompatibilität beim Refaktorisieren des Codes aufrechtzuerhalten.
+
+## Leistungsbetrachtungen
+
+Der Bindungsgenerator ist darauf ausgelegt, effizient zu sein, aber es gibt einige Dinge, die man beachten sollte:
+
+1. Der erste Lauf ist langsamer, da er einen Cache von zu scannenden Paketen aufbaut
+2. Nachfolgende Läufe sind schneller, da sie die zwischengespeicherten Informationen verwenden
+3. Der Generator verarbeitet alle Pakete im Projekt, was für große Projekte zeitaufwändig sein kann
+4. Sie können die `-clean`-Flag verwenden, um das Ausgabeverzeichnis vor der Generierung zu bereinigen
+
+## Fehlerbehebung
+
+Wenn Sie Probleme mit der Bindungsgenerierung haben, können Sie die `-v`-Flag verwenden, um Debug-Ausgaben zu aktivieren:
+
+```bash
+wails3 generate bindings -v
+```
+
+Dies liefert detaillierte Informationen über den Sammel- und Rendernsprozess, die dabei helfen können, die Quelle des Problems zu identifizieren.

--- a/docs/src/content/docs/de/credits.mdx
+++ b/docs/src/content/docs/de/credits.mdx
@@ -1,0 +1,62 @@
+---
+title: Credits
+description: Anerkennung der Mitwirkenden und Projekte hinter Wails
+---
+
+{/* Import the auto-generated contributors file */}
+
+import Contributors from "../../../assets/contributors.html";
+
+- [Lea Anthony](https://github.com/leaanthony) - Projektinhaber, Lead-Entwickler
+- [Stffabi](https://github.com/stffabi) - Technischer Leiter, Entwickler und
+  Maintainer
+- [Travis McLane](https://github.com/tmclane) - Arbeit zur Cross-Kompilierung, MacOS-Tests
+- [Atterpac](https://github.com/atterpac) - Entwickler, Support-Guru, Kraftpaket
+- [Simon Thomas](mailto:enquiries@wails.io) - Growth Hacker
+- [Lyimmi](https://github.com/Lyimmi) - Alles rund um Linux
+- [fbbdev](https://github.com/fbbdev) - Guru für Bindings-Generator und Core-Mitwirkender
+
+## Sponsoren
+<br/>
+<a href="https://zsa.io/">
+    <img
+        src="/sponsors/zsa.png"
+        style={{ margin: "auto", width: "400px" }}
+        alt="ZSA"
+    />
+</a>
+<img
+  src="https://wails.io/img/sponsors.svg"
+  style={{ margin: "auto", width: "100%", "max-width": "1600px;" }}
+  alt="Sponsoren"
+/>
+Besonderer Dank:
+<img
+  src="/sponsors/jetbrains-grayscale.webp"
+  style={{ margin: "auto", width: "100px" }}
+  alt="JetBrains"
+/>
+
+## Mitwirkende
+
+<Contributors />
+
+## Besondere Erwähnungen
+
+- [John Chadwick](https://github.com/jchv) - Seine großartige Arbeit an
+  [go-webview2](https://github.com/jchv/go-webview2) und
+  [go-winloader](https://github.com/jchv/go-winloader) hat die Windows-
+  Version möglich gemacht.
+- [Tad Vizbaras](https://github.com/tadvi) - Sein winc-Projekt war der erste Schritt
+  auf dem Weg zu einem reinen Go Wails.
+- [Mat Ryer](https://github.com/matryer) - Für Rat, Unterstützung und gute Laune.
+- [Byron Chris](https://github.com/bh90210) - Für seine langfristigen Beiträge zu
+  diesem Projekt.
+- [Dustin Krysak](https://wiki.ubuntu.com/bashfulrobot) - Seine Unterstützung und
+  sein Feedback waren von unschätzbarem Wert.
+- [Justen Walker](https://github.com/justenwalker/) - Für die Hilfe bei der Lösung von COM-
+  Problemen, die v2 abgeschlossen haben.
+- [Wang, Chi](https://github.com/patr0nus/) - Das DeskGap-Projekt hatte einen großen
+  Einfluss auf die Richtung von Wails v2.
+- [Serge Zaitsev](https://github.com/zserge) - Obwohl Wails das Webview-Projekt nicht verwendet,
+  ist es dennoch eine Quelle der Inspiration.

--- a/docs/src/content/docs/de/faq.mdx
+++ b/docs/src/content/docs/de/faq.mdx
@@ -1,0 +1,260 @@
+---
+title: Häufig gestellte Fragen
+description: Häufige Fragen zu Wails
+sidebar:
+  order: 99
+---
+
+## Allgemein
+
+### Was ist Wails?
+
+Wails ist ein Framework zum Erstellen von Desktop-Anwendungen mit Go und Webtechnologien. Es bietet native OS-Integration und ermöglicht es Ihnen, Ihre Benutzeroberfläche mit HTML, CSS und JavaScript zu erstellen.
+
+### Wie unterscheidet sich Wails von Electron?
+
+**Wails:**
+- ~10MB Speicherverbrauch
+- ~15MB Binärgröße
+- Native Performance
+- Go-Backend
+
+**Electron:**
+- ~100MB+ Speicherverbrauch
+- ~150MB+ Binärgröße
+- Chromium-Overhead
+- Node.js-Backend
+
+### Ist Wails produktionsreif?
+
+Ja! Wails v3 ist für Produktionsanwendungen geeignet. Viele Unternehmen nutzen Wails für ihre Desktop-Anwendungen.
+
+### Welche Plattformen unterstützt Wails?
+
+- Windows (7+)
+- macOS (10.13+)
+- Linux (GTK3)
+
+## Entwicklung
+
+### Muss ich Go kennen?
+
+Grundlegende Go-Kenntnisse sind hilfreich, aber nicht erforderlich. Sie können mit einfachen Diensten beginnen und dabei lernen.
+
+### Kann ich mein bevorzugtes Frontend-Framework verwenden?
+
+Ja! Wails funktioniert mit:
+- Vanilla JavaScript
+- React
+- Vue
+- Svelte
+- jedem Framework, das zu HTML/CSS/JS baut
+
+### Wie rufe ich Go-Funktionen aus JavaScript auf?
+
+Verwenden Sie Bindings:
+
+```go
+// Go
+func (s *Service) Greet(name string) string {
+    return "Hello " + name
+}
+```
+
+```javascript
+// JavaScript
+import { Greet } from './bindings/myapp/service'
+const message = await Greet("World")
+```
+
+### Kann ich TypeScript verwenden?
+
+Ja! Wails generiert automatisch TypeScript-Definitionen.
+
+### Wie debugge ich meine Anwendung?
+
+Verwenden Sie die Entwicklertools Ihres Browsers:
+- Rechtsklick → Element untersuchen
+- Oder aktivieren Sie die Entwicklertools in den Fensteroptionen
+
+## Erstellen & Verteilung
+
+### Wie erstelle ich eine Produktionsversion?
+
+```bash
+wails3 build
+```
+
+Ihre Anwendung befindet sich in `build/bin/`.
+
+### Kann ich plattformübergreifend kompilieren?
+
+Ja! Erstellen Sie für andere Plattformen:
+
+```bash
+wails3 build -platform windows/amd64
+wails3 build -platform darwin/universal
+wails3 build -platform linux/amd64
+```
+
+### Wie erstelle ich einen Installer?
+
+Verwenden Sie plattformspezifische Tools:
+- Windows: NSIS oder WiX
+- macOS: DMG erstellen
+- Linux: DEB/RPM-Pakete
+
+Siehe [Installers Guide](/guides/installers).
+
+### Wie signiere ich meine Anwendung?
+
+**macOS:**
+```bash
+codesign --deep --force --sign "Developer ID" MyApp.app
+```
+
+**Windows:**
+Verwenden Sie SignTool mit Ihrem Zertifikat.
+
+## Funktionen
+
+### Kann ich mehrere Fenster erstellen?
+
+Ja! Wails v3 hat native Multi-Fenster-Unterstützung:
+
+```go
+window1 := app.Window.New()
+window2 := app.Window.New()
+```
+
+### Unterstützt Wails das System-Tray?
+
+Ja! Erstellen Sie System-Tray-Anwendungen:
+
+```go
+tray := app.SystemTray.New()
+tray.SetIcon(iconBytes)
+tray.SetMenu(menu)
+```
+
+### Kann ich native Dialoge verwenden?
+
+Ja! Wails bietet native Dialoge:
+
+```go
+path, _ := app.Dialog.OpenFile().
+    SetTitle("Select File").
+    PromptForSingleSelection()
+```
+
+### Unterstützt Wails Auto-Updates?
+
+Wails enthält keine Auto-Update-Funktionalität, aber Sie können diese selbst implementieren oder Drittanbieter-Bibliotheken verwenden.
+
+## Performance
+
+### Warum ist mein Binärprogramm groß?
+
+Go-Binärprogramme enthalten die Laufzeit. Reduzieren Sie die Größe:
+
+```bash
+wails3 build -ldflags "-s -w"
+```
+
+### Wie verbessere ich die Performance?
+
+- Große Datensätze paginieren
+- Teure Operationen zwischenspeichern
+- Events für Updates verwenden
+- Frontend-Bundle optimieren
+- Code profilieren
+
+Siehe [Performance Guide](/guides/performance).
+
+### Unterstützt Wails Hot Reload?
+
+Ja! Verwenden Sie den Entwicklungsmodus:
+
+```bash
+wails3 dev
+```
+
+## Fehlerbehebung
+
+### Meine Bindings funktionieren nicht
+
+Regenerieren Sie die Bindings:
+
+```bash
+wails3 generate bindings
+```
+
+### Fenster erscheint nicht
+
+Prüfen Sie, ob Sie `Show()` aufgerufen haben:
+
+```go
+window := app.Window.New()
+window.Show()  // Vergessen Sie dies nicht!
+```
+
+### Events werden nicht ausgelöst
+
+Stellen Sie sicher, dass die Event-Namen exakt übereinstimmen:
+
+```go
+// Go
+app.Event.Emit("my-event", data)
+
+// JavaScript
+OnEvent("my-event", handler)  // Muss übereinstimmen
+```
+
+### Build schlägt fehl
+
+Häufige Lösungen:
+- Führen Sie `go mod tidy` aus
+- Prüfen Sie die Konfiguration in `wails.json`
+- Überprüfen Sie den Frontend-Build: `cd frontend && npm run build`
+- Aktualisieren Sie Wails: `go install github.com/wailsapp/wails/v3/cmd/wails3@latest`
+
+## Migration
+
+### Sollte ich von v2 auf v3 migrieren?
+
+v3 bietet:
+- Bessere Performance
+- Multi-Fenster-Unterstützung
+- Verbesserte API
+- Bessere Entwicklererfahrung
+
+Siehe [Migration Guide](/migration/v2-to-v3).
+
+### Wird v2 gewartet?
+
+Ja, v2 erhält kritische Updates.
+
+### Kann ich v2 und v3 nebeneinander betreiben?
+
+Ja, sie verwenden verschiedene Import-Pfade.
+
+## Community
+
+### Wie erhalte ich Hilfe?
+
+- [Discord Community](https://discord.gg/JDdSxwjhGf)
+- [GitHub Discussions](https://github.com/wailsapp/wails/discussions)
+- [GitHub Issues](https://github.com/wailsapp/wails/issues)
+
+### Wie kann ich beitragen?
+
+Siehe [Contributing Guide](/contributing).
+
+### Wo finde ich Beispiele?
+
+- [Official Examples](https://github.com/wailsapp/wails/tree/master/v3/examples)
+- [Community Examples](https://github.com/topics/wails)
+
+## Haben Sie noch Fragen?
+
+Fragen Sie in [Discord](https://discord.gg/JDdSxwjhGf) oder [öffnen Sie eine Diskussion](https://github.com/wailsapp/wails/discussions).

--- a/docs/src/content/docs/de/feedback.mdx
+++ b/docs/src/content/docs/de/feedback.mdx
@@ -1,0 +1,86 @@
+---
+title: v3 Alpha-Feedback
+description: So geben Sie Feedback und melden Sie Probleme für Wails v3
+sidebar:
+  order: 40
+---
+
+import { Tabs, TabItem } from "@astrojs/starlight/components";
+
+Wir begrüßen (und ermutigen) Ihr Feedback! Bitte suchen Sie nach bestehenden Tickets oder
+Beiträgen, bevor Sie neue erstellen. Hier sind die verschiedenen Möglichkeiten, Feedback zu geben:
+
+<Tabs>
+  <TabItem label="Fehler" icon="error">
+
+    Wenn Sie einen Fehler finden, teilen Sie uns dies bitte mit, indem Sie im Kanal [v3 Alpha-Feedback](https://discord.gg/bdj28QNHmT) auf Discord posten.
+
+    - Der Beitrag sollte klar darlegen, worin der Fehler besteht, und ein einfaches, reproduzierbares Beispiel enthalten. Wenn in der Dokumentation unklar ist, was *sollte* passieren, fügen Sie dies bitte in den Beitrag ein.
+    - Der Beitrag sollte mit dem Tag `Bug` versehen werden.
+    - Bitte fügen Sie die Ausgabe von `wails doctor` in Ihren Beitrag ein.
+    - Wenn der Fehler ein Verhalten darstellt, das nicht mit der aktuellen Dokumentation übereinstimmt, z. B. ein Fenster, das nicht richtig skaliert, gehen Sie bitte wie folgt vor:
+      - Aktualisieren Sie ein bestehendes Beispiel im Verzeichnis `v3/example` oder erstellen Sie ein neues Beispiel im Ordner `v3/examples`, das das Problem deutlich zeigt.
+      - Öffnen Sie einen [PR](https://github.com/wailsapp/wails/pulls) mit dem Titel `[v3 alpha test] <Beschreibung des Fehlers>`.
+      - Bitte fügen Sie einen Link zum PR in Ihren Beitrag ein.
+
+    :::caution
+
+    _Denken Sie daran_, unerwartetes Verhalten ist nicht unbedingt ein Fehler – es tut vielleicht einfach nicht das, was Sie erwarten. Verwenden Sie dafür `Suggestions`.
+
+    :::
+
+  </TabItem>
+
+  <TabItem label="Fehlerbehebungen" icon="approve-check">
+
+    Wenn Sie eine Fehlerbehebung oder eine Aktualisierung der Dokumentation haben, gehen Sie bitte wie folgt vor:
+
+    - Öffnen Sie einen Pull-Request im [Wails-Repository](https://github.com/wailsapp/wails). Der Titel des PRs sollte mit `[v3 alpha]` beginnen.
+    - Erstellen Sie einen Beitrag im Kanal [v3 Alpha-Feedback](https://discord.gg/bdj28QNHmT).
+    - Der Beitrag sollte mit dem Tag `PR` versehen werden.
+    - Bitte fügen Sie einen Link zum PR in Ihren Beitrag ein.
+
+  </TabItem>
+
+  <TabItem label="Vorschläge" icon="puzzle" id="abc">
+
+    Wenn Sie einen Vorschlag haben, teilen Sie uns dies bitte mit, indem Sie im Kanal [v3 Alpha-Feedback](https://discord.gg/bdj28QNHmT) auf Discord posten:
+
+    - Der Beitrag sollte mit dem Tag `Suggestion` versehen werden.
+
+    Zögern Sie nicht, uns auf [Discord](https://discord.gg/bdj28QNHmT) zu kontaktieren, wenn Sie Fragen haben.
+
+  </TabItem>
+
+  <TabItem label="Upvoting" icon="star">
+
+    - Beiträge können durch Verwendung des Emojis :thumbsup: "upgevote" werden. Bitte wenden Sie dies auf alle Beiträge an, die für Sie prioritär sind.
+    - Bitte *fügen Sie keine* Kommentare wie "+1" oder "ich auch" hinzu.
+    - Sie können gerne kommentieren, wenn es mehr zum Beitrag hinzuzufügen gibt, wie z. B. "Dieser Fehler betrifft auch ARM-Builds" oder "Eine andere Option wäre, ...."
+
+  </TabItem>
+
+</Tabs>
+
+Eine Liste bekannter Probleme und laufender Arbeiten finden Sie
+[hier](https://github.com/orgs/wailsapp/projects/6).
+
+## Themen, zu denen wir Feedback suchen
+
+- Die API
+  - Ist sie einfach zu verwenden?
+  - Erfüllt sie Ihre Erwartungen?
+  - Fehlt etwas?
+  - Gibt es etwas, das entfernt werden sollte?
+  - Ist sie zwischen Go und JS konsistent?
+- Das Build-System
+  - Ist es einfach zu verwenden?
+  - Können wir es verbessern?
+- Die Beispiele
+  - Sind sie klar?
+  - Decken sie die Grundlagen ab?
+- Funktionen
+  - Welche Funktionen fehlen?
+  - Welche Funktionen sind nicht notwendig?
+- Dokumentation
+  - Was könnte klarer sein?

--- a/docs/src/content/docs/de/getting-started/your-first-app.mdx
+++ b/docs/src/content/docs/de/getting-started/your-first-app.mdx
@@ -1,0 +1,257 @@
+---
+title: Deine erste Anwendung
+description: Erstelle deine erste Wails-Desktopanwendung Schritt für Schritt
+sidebar:
+  order: 20
+---
+
+import { Tabs, TabItem } from "@astrojs/starlight/components";
+import { Badge } from '@astrojs/starlight/components';
+import { Steps } from "@astrojs/starlight/components";
+import { FileTree } from '@astrojs/starlight/components';
+
+import wails_init from '../../../../assets/wails_init.mp4';
+import wails_build from '../../../../assets/wails_build.mp4';
+import wails_dev from '../../../../assets/wails_dev.mp4';
+
+
+Dieser Leitfaden zeigt dir, wie du deine erste Wails v3-Anwendung erstellst, einschließlich Projektsetup, Build-Prozess und Entwicklungsumgebung.
+
+<br/>
+<br/>
+
+<Steps>
+
+1.  ## Erstellen eines neuen Projekts
+
+    Öffne dein Terminal und führe den folgenden Befehl aus, um ein neues Wails-Projekt zu erstellen:
+
+    ```bash
+    wails3 init -n myfirstapp
+    ```
+
+    Dieser Befehl erstellt ein neues Verzeichnis namens `myfirstapp` mit allen notwendigen Dateien.
+
+      <video src={wails_init} controls></video> 
+
+2.  ## Erkunden der Projektstruktur
+
+    Wechsle in das Verzeichnis `myfirstapp`. Du findest dort mehrere Dateien und Ordner:
+
+    <FileTree>
+    - build/           Enthält Dateien, die vom Build-Prozess verwendet werden
+        - appicon.png  Das Anwendungsicon
+        - config.yml   Build-Konfiguration
+        - Taskfile.yml Build-Aufgaben
+        - darwin/      macOS-spezifische Build-Dateien
+            - Info.dev.plist Entwicklungskonfiguration
+            - Info.plist    Produktionskonfiguration
+            - Taskfile.yml  macOS-Build-Aufgaben
+            - icons.icns    macOS-Anwendungsicon
+        - linux/       Linux-spezifische Build-Dateien
+            - Taskfile.yml  Linux-Build-Aufgaben
+            - appimage/     AppImage-Paketierung
+                - build.sh  AppImage-Build-Skript
+            - nfpm/        NFPM-Paketierung
+                - nfpm.yaml Paketkonfiguration
+                - scripts/  Build-Skripte
+        - windows/     Windows-spezifische Build-Dateien
+            - Taskfile.yml        Windows-Build-Aufgaben
+            - icon.ico           Windows-Anwendungsicon
+            - info.json          Anwendungsmetadaten
+            - wails.exe.manifest Windows-Manifestdatei
+            - nsis/              NSIS-Installer-Dateien
+                - project.nsi                    NSIS-Projektdatei
+                - wails_tools.nsh               NSIS-Hilfsskripte
+    - frontend/        Frontend-Anwendungsdateien
+        - index.html   Haupt-HTML-Datei
+        - main.js      Haupt-JavaScript-Datei
+        - package.json NPM-Paketkonfiguration
+        - public/      Statische Assets
+        - Inter Font License.txt Schriftlizenz
+    - .gitignore      Git-Ignorier-Datei
+    - README.md       Projektdokumentation
+    - Taskfile.yml    Projektaufgaben
+    - go.mod          Go-Modul-Datei
+    - go.sum          Go-Modul-Checksummen
+    - greetservice.go Begrüßungsdienst
+    - main.go         Hauptanwendungscode
+    </FileTree>
+
+    Nimm dir einen Moment Zeit, um diese Dateien zu erkunden und dich mit der Struktur vertraut zu machen.
+
+    :::note
+    Obwohl Wails v3 [Task](https://taskfile.dev/) als standardmäßiges Build-System verwendet, steht dir nichts im Weg, `make` oder ein anderes alternatives Build-System zu verwenden.
+    :::
+
+3.  ## Erstellen deiner Anwendung
+
+    Um deine Anwendung zu erstellen, führe folgenden Befehl aus:
+
+    ```bash
+    wails3 build
+    ```
+
+    Dieser Befehl kompiliert eine Debug-Version deiner Anwendung und speichert sie in einem neuen `bin`-Verzeichnis.
+
+    :::note
+    `wails3 build` ist eine Abkürzung für `wails3 task build` und führt die `build`-Aufgabe in `Taskfile.yml` aus.
+    :::
+
+        <video src={wails_build} controls></video> 
+
+
+    Nach dem Erstellen kannst du sie wie jede normale Anwendung ausführen:
+
+
+    <Tabs syncKey="platform">
+
+      <TabItem label="Mac" icon="apple">
+
+        ```sh
+        ./bin/myfirstapp
+        ```
+
+          </TabItem>
+
+      <TabItem label="Windows" icon="seti:windows">
+
+        ```sh
+        bin\myfirstapp.exe
+        ```
+
+          </TabItem>
+
+      <TabItem label="Linux" icon="linux">
+
+        ```sh
+        ./bin/myfirstapp
+        ```
+
+          </TabItem>
+
+    </Tabs>
+
+    Du siehst eine einfache Benutzeroberfläche, den Ausgangspunkt für deine Anwendung. Da es sich um die Debug-Version handelt, siehst du auch Protokolle im Konsolenfenster. Dies ist für Debugging-Zwecke nützlich.
+
+4.  ## Entwicklungsmodus
+
+    Wir können die Anwendung auch im Entwicklungsmodus ausführen. Dieser Modus ermöglicht es dir, Änderungen an deinem Frontend-Code vorzunehmen und diese Änderungen in der laufenden Anwendung zu sehen, ohne die gesamte Anwendung neu erstellen zu müssen.
+
+    1. Öffne ein neues Terminalfenster.
+    2. Führe `wails3 dev` aus. Die Anwendung wird im Debug-Modus kompiliert und ausgeführt.
+    3. Öffne `frontend/index.html` in deinem bevorzugten Editor.
+    4. Ändere den Code und ersetze `Please enter your name below` durch
+       `Please enter your name below!!!`.
+    5. Speichere die Datei.
+
+    Diese Änderung wird sofort in deiner Anwendung sichtbar.
+
+    Änderungen am Backend-Code lösen einen Neuaufbau aus:
+
+    1. Öffne `greetservice.go`.
+    2. Ändere die Zeile mit `return "Hello " + name + "!"` zu
+       `return "Hello there " + name + "!"`.
+    3. Speichere die Datei.
+
+    Die Anwendung wird innerhalb weniger Sekunden aktualisiert.
+
+        <video src={wails_dev} controls></video>
+
+5.  ## Paketierung deiner Anwendung
+
+        Sobald deine Anwendung bereit zur Verteilung ist, kannst du plattformspezifische Pakete erstellen:
+
+          <Tabs syncKey="platform">
+
+    <TabItem label="Mac" icon="apple">
+
+              Um ein `.app`-Bundle zu erstellen:
+
+              ```bash
+              wails3 package
+              ```
+
+              Dies erstellt einen Produktionsbuild und verpackt ihn in ein `.app`-Bundle im `bin`-Verzeichnis.
+
+            </TabItem>
+            <TabItem label="Windows" icon="seti:windows">
+
+              Um einen NSIS-Installer zu erstellen:
+
+              ```bash
+              wails3 package
+              ```
+
+              Dies erstellt einen Produktionsbuild und verpackt ihn in einen NSIS-Installer im `bin`-Verzeichnis.
+
+            </TabItem>
+            <TabItem label="Linux" icon="linux">
+
+              Wails unterstützt mehrere Paketformate für die Linux-Verteilung:
+
+              ```bash
+              # Erstelle alle Pakettypen (AppImage, deb, rpm und Arch Linux)
+              wails3 package
+
+              # Oder erstelle spezifische Pakettypen
+              wails3 task linux:create:appimage  # AppImage-Format
+              wails3 task linux:create:deb       # Debian-Paket
+              wails3 task linux:create:rpm       # Red-Hat-Paket
+              wails3 task linux:create:aur       # Arch-Linux-Paket
+              ```
+
+            </TabItem>
+
+          </Tabs>
+
+        Für detailliertere Informationen zu Paketierungsoptionen und -konfigurationen schaue dir unseren [Packaging Guide](/guides/packaging) an.
+
+6.  ## Einrichten von Versionskontrolle und Modulname
+
+    Dein Projekt wird mit dem Platzhalter-Modulnamen `changeme` erstellt. Es wird empfohlen, diesen an deine Repository-URL anzupassen:
+
+    1. Erstelle ein neues Repository auf GitHub (oder deinem bevorzugten Git-Host)
+    2. Initialisiere git in deinem Projektverzeichnis:
+       ```bash
+       git init
+       git add .
+       git commit -m "Initial commit"
+       ```
+    3. Lege dein Remote-Repository fest (ersetze durch deine Repository-URL):
+       ```bash
+       git remote add origin https://github.com/username/myfirstapp.git
+       ```
+    4. Aktualisiere deinen Modulnamen in `go.mod`, um ihn an deine Repository-URL anzupassen:
+       ```bash
+       go mod edit -module github.com/username/myfirstapp
+       ```
+    5. Push deinen Code:
+       ```bash
+       git push -u origin main
+       ```
+
+    Dies stellt sicher, dass der Name deines Go-Moduls den Go-Modul-Namenskonventionen entspricht und das Teilen deines Codes erleichtert.:::tip[Profi-Tipp]
+Sie können alle Initialisierungsschritte automatisieren, indem Sie beim Erstellen Ihres Projekts das Flag `-git` verwenden:
+```bash
+wails3 init -n myfirstapp -git github.com/username/myfirstapp
+```
+Dies unterstützt verschiedene Git-URL-Formate:
+- HTTPS: `https://github.com/username/project`
+- SSH: `git@github.com:username/project` oder `ssh://git@github.com/username/project`
+- Git-Protokoll: `git://github.com/username/project`
+- Dateisystem: `file:///path/to/project.git`
+:::
+
+</Steps>
+
+## Herzlichen Glückwunsch!
+
+Sie haben gerade Ihre erste Wails-Anwendung erstellt, entwickelt und gepackt.
+Dies ist nur der Anfang dessen, was Sie mit Wails v3 erreichen können.
+
+## Nächste Schritte
+
+Wenn Sie neu bei Wails sind, empfehlen wir Ihnen, unsere Tutorials durchzulesen, die als praktische Anleitung durch die verschiedenen Funktionen von Wails führen. Das erste Tutorial ist [Erstellen eines Services](/tutorials/01-creating-a-service).
+
+Wenn Sie ein fortgeschrittener Benutzer sind, werfen Sie einen Blick auf unsere [Anleitungen](/guides), um detailliertere Informationen darüber zu erhalten, wie Sie Wails verwenden.

--- a/docs/src/content/docs/de/quick-start/first-app.mdx
+++ b/docs/src/content/docs/de/quick-start/first-app.mdx
@@ -1,0 +1,270 @@
+---
+title: Deine erste App
+description: Erstelle in 10 Minuten eine funktionierende Wails-Anwendung
+sidebar:
+  order: 3
+---
+
+import { Tabs, TabItem, Steps } from "@astrojs/starlight/components";
+
+Wir bauen eine einfache Begrüßungsanwendung, die die Kernkonzepte von Wails demonstriert:
+- Go-Backend zur Verwaltung der Logik
+- Frontend, das Go-Funktionen aufruft
+- Typsichere Bindings
+- Hot Reload während der Entwicklung
+
+**Zeit bis zur Fertigstellung:** 10 Minuten
+
+:::tip[Performance-Tipp für Windows 11-Benutzer]
+Erwäge, [Dev Drive](https://learn.microsoft.com/en-us/windows/dev-drive/) zum Speichern deiner Projekte zu verwenden. Dev Drives sind für Entwicklerworkloads optimiert und können die Build-Zeiten und die Festplattenzugriffsgeschwindigkeit im Vergleich zu regulären NTFS-Laufwerken um bis zu 30 % erheblich verbessern.
+:::
+
+## Erstelle dein Projekt
+
+<Steps>
+
+1. **Generiere das Projekt**
+
+   ```bash
+   wails3 init -n myapp
+   cd myapp
+   ```
+
+   Dies erstellt ein neues Projekt mit der Standard-Vanilla-Vite-Vorlage (reines HTML/CSS/JS mit Vite-Bundler).
+
+   :::tip[Andere Vorlagen]
+   Versuche `-t react`, `-t vue` oder `-t svelte` für deine bevorzugte Framework.
+   Führe `wails3 init -l` aus, um alle verfügbaren Vorlagen zu sehen.
+   :::
+
+2. **Verstehe die Projektstruktur**
+
+   ```
+   myapp/
+   ├── main.go              # Anwendungseinstiegspunkt
+   ├── greetservice.go      # Begrüßungsdienst
+   ├── frontend/            # Dein UI-Code
+   │   ├── index.html       # HTML-Einstiegspunkt
+   │   ├── src/
+   │   │   └── main.js      # Frontend-JavaScript
+   │   ├── public/
+   │   │   └── style.css    # Styles
+   │   ├── package.json     # Frontend-Abhängigkeiten
+   │   └── vite.config.js   # Vite-Bundler-Konfiguration
+   ├── build/               # Build-Konfiguration
+   └── Taskfile.yml         # Build-Aufgaben
+   ```
+
+3. **Führe die App aus**
+
+   ```bash
+   wails3 dev
+   ```
+
+   :::note[Erster Start]
+   Der erste Start kann länger dauern als erwartet, da Frontend-Abhängigkeiten installiert, Bindings generiert usw. werden. Nachfolgende Starts sind viel schneller.
+   :::
+
+   Die App öffnet sich und zeigt eine Begrüßungsschnittstelle. Gib deinen Namen ein und klicke auf "Begrüßen" – das Go-Backend verarbeitet deine Eingabe und gibt eine Begrüßung zurück.
+
+</Steps>
+
+## Wie es funktioniert
+
+Lass uns den Code verstehen, der dies ermöglicht.
+
+### Das Go-Backend
+
+Öffne `greetservice.go`:
+
+```go title="greetservice.go"
+package main
+
+import (
+	"fmt"
+)
+
+type GreetService struct{}
+
+func (g *GreetService) Greet(name string) string {
+	return fmt.Sprintf("Hello %s, It's show time!", name)
+}
+```
+
+**Wichtige Konzepte:**
+
+1. **Service** – Ein Go-Struct mit exportierten Methoden
+2. **Exportierte Methode** – `Greet` ist großgeschrieben, wodurch sie für das Frontend verfügbar wird
+3. **Einfache Logik** – Nimmt einen Namen entgegen und gibt eine Begrüßung zurück
+4. **Typsicherheit** – Eingabe- und Ausgabetypen sind definiert
+
+:::tip[Verstehen von Services und Bindings]
+**Services** sind eigenständige Go-Module, die Funktionalität für dein Frontend verfügbar machen. Sie sind ganz normale Go-Schnittstellen mit exportierten Methoden, die du im `Services`-Feld deiner Anwendungskonfiguration registrierst.
+
+**Bindings** sind die automatisch generierte TypeScript/JavaScript-SDK, die es deinem Frontend ermöglicht, diese Services aufzurufen. Wenn du `wails3 dev` oder `wails3 build` ausführst, analysiert Wails deine registrierten Services und generiert typsichere Bindings in `frontend/bindings/`.
+
+Stell dir Services als deine Backend-API vor und Bindings als die Client-Bibliothek, die damit kommuniziert.
+:::
+
+### Registrieren des Services
+
+Öffne `main.go` und finde die Service-Registrierung:
+
+```go title="main.go" {4-6}
+err := application.New(application.Options{
+    Name: "myapp",
+    Services: []application.Service{
+        application.NewService(&GreetService{}),
+    },
+    // ... other options
+})
+```
+
+Dies registriert deinen `GreetService` bei Wails und macht alle seine exportierten Methoden für das Frontend verfügbar.
+
+### Das Frontend
+
+Öffne `frontend/src/main.js`:
+
+```javascript title="frontend/src/main.js"
+import {GreetService} from "../bindings/changeme";
+
+window.greet = async () => {
+    const nameElement = document.getElementById('name');
+    const resultElement = document.getElementById('result');
+
+    const name = nameElement.value;
+    if (!name) {
+        return;
+    }
+
+    try {
+        const result = await GreetService.Greet(name);
+        resultElement.innerText = result;
+    } catch (err) {
+        console.error(err);
+    }
+};
+```
+
+**Wichtige Konzepte:**
+
+1. **Automatisch generierte Bindings** – `GreetService` wird aus dem generierten Code importiert
+2. **Typsichere Aufrufe** – Methodennamen und Signaturen entsprechen deinem Go-Code
+3. **Standardmäßig asynchron** – Alle Go-Aufrufe geben Promises zurück
+4. **Fehlerbehandlung** – Fehler aus Go werden in try/catch abgefangen
+
+:::note[Wo sind die Bindings?]
+Generierte Bindings befinden sich in `frontend/bindings/`. Sie werden automatisch erstellt, wenn du `wails3 dev` oder `wails3 build` ausführst.
+
+**Bearbeite diese Dateien niemals manuell** – sie werden bei jedem Build neu generiert.
+:::
+
+## Passe deine App an
+
+Lass uns eine neue Funktion hinzufügen, um den Workflow zu verstehen.
+
+### Füge eine "Viele Begrüßungen"-Funktion hinzu
+
+<Steps>
+
+1. **Füge die Methode zu GreetService hinzu**
+
+   Füge dies zu `greetservice.go` hinzu:
+
+   ```go title="greetservice.go"
+   func (g *GreetService) GreetMany(names []string) []string {
+       greetings := make([]string, len(names))
+       for i, name := range names {
+           greetings[i] = fmt.Sprintf("Hello %s!", name)
+       }
+       return greetings
+   }
+   ```
+
+2. **Die App wird automatisch neu gebaut**
+
+   Speichere die Datei und `wails3 dev` wird deinen Go-Code automatisch neu bauen und die App neu starten.
+
+   :::note[Auto-Rebuild]
+   Änderungen am Go-Code lösen ein automatisches Rebuild und einen Neustart aus. Änderungen am Frontend werden hot-reloaded, ohne dass ein Neustart erforderlich ist.
+   :::
+
+3. **Verwende es im Frontend**
+
+   Füge dies zu `frontend/src/main.js` hinzu:
+
+   ```javascript title="frontend/src/main.js"
+   window.greetMany = async () => {
+       const names = ['Alice', 'Bob', 'Charlie'];
+       const greetings = await GreetService.GreetMany(names);
+       console.log(greetings);
+   };
+   ```
+
+   Öffne die Browserkonsole und rufe `greetMany()` auf – du siehst das Array der Begrüßungen.
+
+</Steps>
+
+## Für die Produktion bauen
+
+Wenn du bereit bist, deine App zu verteilen:
+
+```bash
+wails3 build
+```
+
+**Was dies tut:**
+- Kompiliert Go-Code mit Optimierungen
+- Baut das Frontend für die Produktion (minifiziert)
+- Erstellt eine native ausführbare Datei in `build/bin/`
+
+<Tabs syncKey="os">
+  <TabItem label="Windows" icon="seti:windows">
+    **Ausgabe:** `build/bin/myapp.exe`
+
+    Doppelklick zum Ausführen. Keine Abhängigkeiten erforderlich (WebView2 ist Teil von Windows).
+  </TabItem>
+
+  <TabItem label="macOS" icon="apple">
+    **Ausgabe:** `build/bin/myapp.app`
+
+    In den Ordner "Programme" ziehen oder doppelklicken zum Ausführen.
+  </TabItem>
+
+  <TabItem label="Linux" icon="linux">
+    **Ausgabe:** `build/bin/myapp`
+
+    Ausführen mit `./build/bin/myapp` oder erstelle eine `.desktop`-Datei für deinen Launcher.
+  </TabItem>
+</Tabs>
+
+:::tip[Plattformübergreifende Builds]
+Möchtest du für andere Plattformen bauen? Siehe [Plattformübergreifende Builds →](/guides/build/cross-platform)
+:::
+
+## Was wir gelernt haben
+
+**Projektstruktur**
+- `main.go` für das Go-Backend
+- `frontend/` für UI-Code
+- `Taskfile.yml` für Build-Aufgaben
+
+**Services**
+- Erstelle Go-Schnittstellen mit exportierten Methoden
+- Registriere mit `application.NewService()`
+- Methoden sind automatisch im Frontend verfügbar
+
+**Bindings**
+- Automatisch generierte TypeScript-Definitionen
+- Typsichere Funktionsaufrufe
+- Standardmäßig asynchron (Promises)
+
+**Entwicklungsworkflow**
+- `wails3 dev` für Hot Reload
+- Go-Änderungen lösen automatisches Rebuild und Neustart aus
+- Frontend-Änderungen werden sofort hot-reloaded
+
+---
+
+**Fragen?** Tritt [Discord](https://discord.gg/JDdSxwjhGf) bei und frage die Community.

--- a/docs/src/content/docs/de/quick-start/installation.mdx
+++ b/docs/src/content/docs/de/quick-start/installation.mdx
@@ -1,0 +1,327 @@
+---
+title: Installation
+description: Installieren Sie Wails und bereiten Sie es für die Entwicklung von Anwendungen vor
+sidebar:
+  order: 2
+---
+
+import { Card, CardGrid, Tabs, TabItem, Steps } from "@astrojs/starlight/components";
+
+## Schnellinstallation (5 Minuten)
+
+:::tip[TL;DR - Erfahrene Entwickler]
+```bash
+# Go 1.25+ installieren, dann:
+go install github.com/wailsapp/wails/v3/cmd/wails3@latest
+wails3 doctor  # Installation überprüfen
+```
+
+Wenn `wails3 doctor` erfolgreich durchläuft, sind Sie fertig. [Zum ersten App-Projekt springen →](/de/quick-start/first-app)
+:::
+
+## Schritt-für-Schritt-Installation
+
+<Steps>
+
+1. **Go installieren (Erforderlich)**
+
+   Wails erfordert Go 1.25 oder höher.
+
+   <Tabs syncKey="os">
+     <TabItem label="Windows" icon="seti:windows">
+       Laden Sie den Windows-Installer von **[go.dev/dl](https://go.dev/dl/)** herunter und führen Sie ihn aus.
+
+       **Installation überprüfen:**
+       ```powershell
+       go version  # Sollte 1.25 oder höher anzeigen
+       ```
+
+       **PATH überprüfen:**
+       ```powershell
+       $env:PATH -split ';' | Where-Object { $_ -like '*\go\bin' }
+       ```
+
+       Wenn die Ausgabe leer ist, fügen Sie `C:\Users\IhrName\go\bin` zu Ihrem PATH hinzu.
+     </TabItem>
+
+     <TabItem label="macOS" icon="apple">
+       **Option 1: Offizieller Installer**
+
+       Laden Sie den macOS-Installer (.pkg-Datei) von **[go.dev/dl](https://go.dev/dl/)** herunter und führen Sie ihn aus.
+
+       **Option 2: Homebrew**
+       ```bash
+       brew install go
+       ```
+
+       **Installation überprüfen:**
+       ```bash
+       go version  # Sollte 1.25 oder höher anzeigen
+       echo $PATH | grep go/bin  # Sollte ~/go/bin anzeigen
+       ```
+
+       Wenn `~/go/bin` nicht im PATH enthalten ist, fügen Sie es zu `~/.zshrc` oder `~/.bash_profile` hinzu:
+       ```bash
+       export PATH=$PATH:~/go/bin
+       ```
+     </TabItem>
+
+     <TabItem label="Linux" icon="linux">
+       **Option 1: Offizielles Tarball**
+
+       Laden Sie das Linux-Tarball von **[go.dev/dl](https://go.dev/dl/)** herunter, dann:
+       ```bash
+       sudo rm -rf /usr/local/go
+       sudo tar -C /usr/local -xzf go1.25.linux-amd64.tar.gz
+       ```
+
+       **Option 2: Paketmanager**
+       ```bash
+       # Ubuntu/Debian
+       sudo apt install golang-go
+
+       # Fedora
+       sudo dnf install golang
+
+       # Arch
+       sudo pacman -S go
+       ```
+
+       **Zum PATH hinzufügen** (fügen Sie dies zu `~/.bashrc` oder `~/.zshrc` hinzu):
+       ```bash
+       export PATH=$PATH:/usr/local/go/bin:~/go/bin
+       source ~/.bashrc  # Neu laden
+       ```
+
+       **Überprüfen:**
+       ```bash
+       go version
+       echo $PATH | grep go/bin
+       ```
+     </TabItem>
+   </Tabs>
+
+2. **Plattformabhängigkeiten installieren**
+
+   <Tabs syncKey="os">
+     <TabItem label="Windows" icon="seti:windows">
+       **WebView2-Laufzeitumgebung** (normalerweise vorinstalliert)
+
+       Windows 10/11 enthält WebView2 standardmäßig. Falls fehlend:
+       - Von [Microsoft](https://developer.microsoft.com/microsoft-edge/webview2/) herunterladen
+       - Oder führen Sie später `wails3 doctor` aus – es wird Sie anleiten
+
+       **Das war's!** Keine weiteren Abhängigkeiten erforderlich.
+
+       :::tip[Leistungstipp für Windows 11]
+       Erwägen Sie die Verwendung von [Dev Drive](https://learn.microsoft.com/en-us/windows/dev-drive/), um Ihre Projekte zu speichern. Dev Drives sind für Entwicklerworkloads optimiert und können die Build-Zeiten und die Festplattenzugriffsgeschwindigkeit um bis zu 30 % erheblich verbessern.
+       :::
+     </TabItem>
+
+     <TabItem label="macOS" icon="apple">
+       **Xcode Command Line Tools** (erforderlich)
+
+       ```bash
+       xcode-select --install
+       ```
+
+       Klicken Sie im erscheinenden Dialogfeld auf "Installieren".
+
+       **Überprüfen:**
+       ```bash
+       xcode-select -p  # Sollte /Library/Developer/CommandLineTools anzeigen
+       ```
+
+       **Das war's!** macOS enthält WebKit standardmäßig.
+     </TabItem>
+
+     <TabItem label="Linux" icon="linux">
+       **Build-Tools und WebKit**
+
+       :::caution[Minimale Distro-Versionen]
+       Wails v3 erfordert **WebKitGTK 4.1** (verwendet libsoup3). Ältere Veröffentlichungen, die nur 4.0 ausliefern – Ubuntu 20.04, Debian 11, RHEL 8/9 und deren Derivate – werden nicht unterstützt.
+       :::
+
+       <Tabs syncKey="distro">
+         <TabItem label="Ubuntu/Debian">
+           Erfordert Ubuntu 22.04+ oder Debian 12+.
+           ```bash
+           sudo apt update
+           sudo apt install build-essential pkg-config libgtk-3-dev libwebkit2gtk-4.1-dev
+           ```
+         </TabItem>
+
+         <TabItem label="Fedora">
+           ```bash
+           sudo dnf install gcc pkg-config gtk3-devel webkit2gtk4.1-devel
+           ```
+         </TabItem>
+
+         <TabItem label="Arch">
+           ```bash
+           sudo pacman -S base-devel gtk3 webkit2gtk-4.1
+           ```
+         </TabItem>
+
+         <TabItem label="openSUSE">
+           ```bash
+           sudo zypper install gcc pkg-config gtk3-devel webkit2gtk3-devel
+           ```
+         </TabItem>
+
+         <TabItem label="Gentoo">
+           ```bash
+           sudo emerge --ask net-libs/webkit-gtk:4.1
+           ```
+         </TabItem>
+
+         <TabItem label="NixOS">
+           Fügen Sie dies zu Ihrer `shell.nix` oder `devShell` hinzu:
+           ```nix
+           buildInputs = with pkgs; [ webkitgtk_4_1 gtk3 pkg-config gcc ];
+           ```
+         </TabItem>
+
+         <TabItem label="Andere">
+           Führen Sie nach der Installation von Wails `wails3 doctor` aus – es zeigt die genauen Pakete an, die für Ihre Distribution benötigt werden.
+         </TabItem>
+       </Tabs>
+
+       :::note[Optional: GTK4-Unterstützung]
+       Wails bietet auch experimentelle GTK4 / WebKitGTK 6.0-Unterstützung. Wenn Sie mit GTK4 erstellen möchten, installieren Sie die zusätzlichen Abhängigkeiten für Ihre Distribution und erstellen Sie mit `wails3 build -tags gtk4`. Einzelheiten finden Sie unter [Linux-Paketierung - GTK4](/guides/build/linux#gtk4-support-experimental).
+       :::
+     </TabItem>
+   </Tabs>
+
+3. **Wails CLI installieren**
+
+   ```bash
+   go install github.com/wailsapp/wails/v3/cmd/wails3@latest
+   ```
+
+   Dies installiert den Befehl `wails3` nach `~/go/bin` (oder `%USERPROFILE%\go\bin` unter Windows).
+
+4. **Installation überprüfen**
+
+   ```bash
+   wails3 doctor
+   ```
+
+   **Erwartete Ausgabe (oder ähnlich):**
+   ```
+   Wails (v3.0.0-dev)  Wails Doctor
+
+   # System
+
+   ┌──────────────────────────────────────────────────┐
+   | Name          | MacOS                            |
+   | Version       | 26.0                             |
+   | ID            | 25A354                           |
+   | Branding      | MacOS 26.0                       |
+   | Platform      | darwin                           |
+   | Architecture  | arm64                            |
+   | Apple Silicon | true                             |
+   | CPU           | Apple M2 Pro                     |
+   | CPU 1         | Apple M2 Pro                     |
+   | CPU 2         | Apple M2 Pro                     |
+   | GPU           | 16 cores, Metal Support: Metal 4 |
+   | Memory        | 16 GB                            |
+   └──────────────────────────────────────────────────┘
+
+   # Build Environment
+
+   ┌─────────────┬─────────────────┐
+   | Wails CLI   | v3.0.0-alpha.40 |
+   | Go Version  | go1.24.6        |
+   └─────────────┴─────────────────┘
+
+   # Dependencies
+
+   ┌─────────────────┬─────────────────────────────────────────────────┐
+   | npm             | 11.6.2                                          |
+   | *NSIS           | Not Installed. Install with `brew install...`.  |
+   | Xcode cli tools | 2412                                            |
+   └─────────────────┴─────────────────────────────────────────────────┘
+
+   # Checking for issues
+
+   SUCCESS No issues found
+
+   # Diagnosis
+
+   SUCCESS Your system is ready for Wails development!
+   ```
+
+   :::note[Falls der Befehl `wails3` nicht gefunden wird]
+   Ihr `~/go/bin` ist nicht im PATH enthalten. Siehe Schritt 1 oben, um dies zu beheben, und starten Sie Ihr Terminal anschließend neu.
+   :::
+
+5. **npm installieren (Optional, aber empfohlen)**
+
+   Die meisten Wails-Vorlagen verwenden npm für die Frontend-Tooling.
+
+   <Tabs syncKey="os">
+     <TabItem label="Windows" icon="seti:windows">
+       Laden Sie es von [nodejs.org](https://nodejs.org/) herunter und führen Sie den Installer aus.
+
+       **Überprüfen:**
+       ```powershell
+       npm --version
+       ```
+     </TabItem>#### Go-Version zu alt
+
+Wails v3 erfordert Go 1.25+. Wenn Sie eine ältere Version haben:
+
+<Tabs syncKey="os">
+  <TabItem label="Windows/macOS" icon="seti:windows">
+    Laden Sie die neueste Version von [go.dev/dl](https://go.dev/dl/) herunter und installieren Sie sie erneut.
+  </TabItem>
+
+  <TabItem label="Linux" icon="linux">
+    Laden Sie die neueste Tarball-Datei von [go.dev/dl](https://go.dev/dl/) herunter, dann:
+    ```bash
+    sudo rm -rf /usr/local/go
+    sudo tar -C /usr/local -xzf go1.25.linux-amd64.tar.gz
+    ```
+  </TabItem>
+</Tabs>
+
+## Entwicklungsversion (Bleeding Edge)
+
+Möchten Sie den absolut neuesten Code aus dem Hauptentwicklungsbranch verwenden? Dies gibt Ihnen Zugang zu neuen Funktionen und Fehlerbehebungen, bevor sie veröffentlicht werden, bringt jedoch das Risiko von Bugs und Breaking Changes mit sich. Nur für Mitwirkende oder diejenigen empfohlen, die kommende Funktionen testen müssen.
+
+```bash
+git clone https://github.com/wailsapp/wails.git
+cd wails
+git checkout v3
+cd v3/cmd/wails3
+go install
+```
+
+:::caution[Entwicklungsversion]
+- Kann Bugs oder Breaking Changes enthalten
+- Erstellte Projekte verwenden den `replace`-Direktiv, um auf das lokale Wails zu verweisen
+- Nur für Mitwirkende oder zum Testen neuer Funktionen empfohlen
+:::
+
+## Nächste Schritte
+
+**Installation abgeschlossen!** Ihr System ist bereit für die Wails-Entwicklung.
+
+<Card title="Erstellen Sie Ihre erste App" icon="rocket">
+  Erstellen Sie in 10 Minuten eine funktionierende Anwendung.
+
+  [Tutorial zur ersten App →](/de/quick-start/first-app)
+</Card>
+
+<Card title="Vorlagen erkunden" icon="open-book">
+  Sehen Sie, was standardmäßig verfügbar ist.
+
+  ```bash
+  wails3 init -l  # Vorlagen auflisten
+  ```
+</Card>
+
+---
+
+**Haben Sie Probleme?** Fragen Sie in [Discord](https://discord.gg/JDdSxwjhGf) oder [öffnen Sie ein Issue](https://github.com/wailsapp/wails/issues).


### PR DESCRIPTION
Automated translation batch 2 for German (Deutsch).

## Changes

Adds 15 translated pages not yet in the repo:

- `quick-start/installation.mdx` — Installation guide (was showing English)
- `quick-start/first-app.mdx` — Your First App (was showing English)
- `getting-started/your-first-app.mdx`
- `concepts/architecture.mdx`
- `concepts/bridge.mdx`
- `concepts/build-system.mdx`
- `concepts/lifecycle.mdx`
- `concepts/manager-api.mdx`
- `contributing.mdx`
- `contributing/architecture/bindings.mdx`
- `credits.mdx`
- `faq.mdx`
- `feedback.mdx`
- `community/links.md`
- `community/templates.md`

## QA Scores

All locales scored ≥ 0.97 avg COMET score across batch runs. No pages flagged for human review.

## Notes

Translated by automated pipeline using qwen3:30b (self-hosted Ollama). No code blocks or technical syntax translated.

🤖 Wails Doc Translator

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive German localization of documentation, including getting started guides, installation instructions, and quick-start tutorials.
  * Expanded conceptual documentation covering architecture, bridge communication, build system, application lifecycle, and Manager API.
  * Added German versions of community resources, contributing guidelines, FAQ, feedback, and credits pages.
  * Enhanced documentation structure with examples, diagrams, and step-by-step instructions across all sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->