### PR TITLE
fix: repaint dark-mode menubar after snap-to-side on Windows 11

### DIFF
--- a/v3/pkg/application/webview_window_windows.go
+++ b/v3/pkg/application/webview_window_windows.go
@@ -76,6 +76,10 @@ type windowsWebviewWindow struct {
 	// Used to prevent unnecessary redraws during minimize/restore operations
 	isMinimizing bool
 
+	// inSizeMove is true between WM_ENTERSIZEMOVE and WM_EXITSIZEMOVE.
+	// Used to suppress menubar redraws during live-resize drag.
+	inSizeMove bool
+
 	// menubarTheme is the theme for the menubar
 	menubarTheme *w32.MenuBarTheme
 
@@ -1513,6 +1517,7 @@ func (w *windowsWebviewWindow) WndProc(msg uint32, wparam, lparam uintptr) uintp
 		}
 		w.parent.emit(events.Windows.WindowKillFocus)
 	case w32.WM_ENTERSIZEMOVE:
+		w.inSizeMove = true
 		// This is needed to close open dropdowns when moving the window https://github.com/MicrosoftEdge/WebView2Feedback/issues/2290
 		w32.SetFocus(w.hwnd)
 		if int(w32.GetKeyState(w32.VK_LBUTTON))&(0x8000) != 0 {
@@ -1523,6 +1528,7 @@ func (w *windowsWebviewWindow) WndProc(msg uint32, wparam, lparam uintptr) uintp
 			w.parent.emit(events.Windows.WindowStartResize)
 		}
 	case w32.WM_EXITSIZEMOVE:
+		w.inSizeMove = false
 		if int(w32.GetKeyState(w32.VK_LBUTTON))&0x8000 != 0 {
 			w.parent.emit(events.Windows.WindowEndMove)
 		} else {
@@ -1606,10 +1612,10 @@ func (w *windowsWebviewWindow) WndProc(msg uint32, wparam, lparam uintptr) uintp
 			}
 			w.isMinimizing = false
 			w.parent.emit(events.Windows.WindowRestore)
-			// Snap-to-side sends SIZE_RESTORED; repaint the frame so the dark menubar
-			// is not left invisible after a snap operation.
-			if w.menu != nil && w.menubarTheme != nil {
-				w32.RedrawWindow(w.hwnd, nil, 0, w32.RDW_FRAME|w32.RDW_INVALIDATE|w32.RDW_UPDATENOW)
+			// Snap-to-side sends SIZE_RESTORED; queue an async frame redraw so the dark
+			// menubar is not left invisible. Skip during live-resize drag to avoid flicker.
+			if !w.inSizeMove && w.menu != nil && w.menubarTheme != nil {
+				w32.RedrawWindow(w.hwnd, nil, 0, w32.RDW_FRAME|w32.RDW_INVALIDATE)
 			}
 		case w32.SIZE_MINIMIZED:
 			w.isMinimizing = true

--- a/v3/pkg/application/webview_window_windows.go
+++ b/v3/pkg/application/webview_window_windows.go
@@ -1606,6 +1606,11 @@ func (w *windowsWebviewWindow) WndProc(msg uint32, wparam, lparam uintptr) uintp
 			}
 			w.isMinimizing = false
 			w.parent.emit(events.Windows.WindowRestore)
+			// Snap-to-side sends SIZE_RESTORED; repaint the frame so the dark menubar
+			// is not left invisible after a snap operation.
+			if w.menu != nil && w.menubarTheme != nil {
+				w32.RedrawWindow(w.hwnd, nil, 0, w32.RDW_FRAME|w32.RDW_INVALIDATE|w32.RDW_UPDATENOW)
+			}
 		case w32.SIZE_MINIMIZED:
 			w.isMinimizing = true
 			w.parent.emit(events.Windows.WindowMinimise)

--- a/v3/pkg/w32/menubar.go
+++ b/v3/pkg/w32/menubar.go
@@ -561,8 +561,9 @@ func MenuBarWndProc(hwnd HWND, msg uint32, wParam WPARAM, lParam LPARAM, theme *
 		// Repaint menubar after size change
 		paintDarkMenuBar(hwnd, theme)
 
-		// CRITICAL: Force complete menubar redraw when maximized
-		if msg == WM_SIZE && wParam == SIZE_MAXIMIZED {
+		// Snap-to-side produces SIZE_RESTORED, not SIZE_MAXIMIZED; include both so the
+		// dark menubar is repainted after every snap or maximize operation.
+		if msg == WM_SIZE && (wParam == SIZE_MAXIMIZED || wParam == SIZE_RESTORED) {
 			// Invalidate the entire menubar area to force redraw
 			var mbi MENUBARINFO
 			mbi.CbSize = uint32(unsafe.Sizeof(mbi))

--- a/v3/pkg/w32/menubar.go
+++ b/v3/pkg/w32/menubar.go
@@ -4,8 +4,13 @@ package w32
 
 import (
 	"os"
+	"sync"
 	"unsafe"
 )
+
+// sizeMovingWindows tracks which HWNDs are currently inside a WM_ENTERSIZEMOVE/WM_EXITSIZEMOVE session.
+// This prevents spurious DrawMenuBar calls during live-resize drag.
+var sizeMovingWindows sync.Map
 
 const (
 	OBJID_MENU = -3
@@ -268,6 +273,12 @@ func MenuBarWndProc(hwnd HWND, msg uint32, wParam WPARAM, lParam LPARAM, theme *
 		return false, 0
 	}
 	switch msg {
+	case WM_ENTERSIZEMOVE:
+		sizeMovingWindows.Store(hwnd, struct{}{})
+		return false, 0
+	case WM_EXITSIZEMOVE:
+		sizeMovingWindows.Delete(hwnd)
+		return false, 0
 	case WM_UAHDRAWMENU:
 		udm := (*UAHMENU)(unsafe.Pointer(lParam))
 
@@ -563,7 +574,9 @@ func MenuBarWndProc(hwnd HWND, msg uint32, wParam WPARAM, lParam LPARAM, theme *
 
 		// Snap-to-side produces SIZE_RESTORED, not SIZE_MAXIMIZED; include both so the
 		// dark menubar is repainted after every snap or maximize operation.
-		if msg == WM_SIZE && (wParam == SIZE_MAXIMIZED || wParam == SIZE_RESTORED) {
+		// Skip during live resize drag (WM_ENTERSIZEMOVE active) to avoid redundant redraws.
+		_, inSizeMove := sizeMovingWindows.Load(hwnd)
+		if msg == WM_SIZE && !inSizeMove && (wParam == SIZE_MAXIMIZED || wParam == SIZE_RESTORED) {
 			// Invalidate the entire menubar area to force redraw
 			var mbi MENUBARINFO
 			mbi.CbSize = uint32(unsafe.Sizeof(mbi))


### PR DESCRIPTION
## Summary

- Windows snap-to-side (`Win+Left` / drag to edge) sends `WM_SIZE` with `wParam = SIZE_RESTORED`, **not** `SIZE_MAXIMIZED`
- The force-redraw path in `MenuBarWndProc` (`InvalidateRect` + `DrawMenuBar`) and in `WndProc` (`RedrawWindow RDW_FRAME`) was gated on `SIZE_MAXIMIZED` only
- Result: dark-mode menubar was not repainted after a side snap, leaving it invisible

**Fix:** extend both conditions to include `SIZE_RESTORED` so the menubar is force-redrawn after every snap or restore operation, not just after a full maximize.

Files changed:
- `v3/pkg/w32/menubar.go` — `MenuBarWndProc` WM_SIZE condition
- `v3/pkg/application/webview_window_windows.go` — `WndProc` SIZE_RESTORED case

Fixes #4462

## Test plan

- [ ] Run the Window example with a menu and dark mode enabled
- [ ] Snap the window to the left/right half of the screen (drag to edge or `Win+Left`/`Win+Right`)
- [ ] Verify the menu bar remains visible and correctly dark-themed after snapping
- [ ] Verify menu bar is still correct after un-snapping (restore from snap)
- [ ] Verify maximize (`Win+Up`) still works correctly (no regression)
- [ ] Test on Windows 11 x64 and ARM64

CC @leaanthony

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue on Windows where the dark menubar could disappear or not repaint correctly after snap-to-side, maximize, or window restore—menubar now reliably refreshes in these transitions.
  * Reduced visual flicker during live window resizing by suppressing redundant menubar redraws while the user is actively dragging/resizing the window.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wailsapp/wails/pull/5362)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->