### PR TITLE
fix(v2/windows): batch WebView2 callbacks to prevent promise loss under heavy load

### DIFF
--- a/v2/internal/frontend/desktop/windows/frontend.go
+++ b/v2/internal/frontend/desktop/windows/frontend.go
@@ -70,6 +70,11 @@ type Frontend struct {
 	// Windows build number
 	versionInfo     *operatingsystem.WindowsVersionInfo
 	resizeDebouncer func(f func())
+
+	// Pending JS callbacks are batched to avoid saturating WebView2's
+	// ExecuteScript queue under heavy concurrent Go→JS call load.
+	callbackMu      sync.Mutex
+	pendingCallbacks []string
 }
 
 func NewFrontend(ctx context.Context, appoptions *options.App, myLogger *logger.Logger, appBindings *binding.Bindings, dispatcher frontend.Dispatcher) *Frontend {
@@ -871,9 +876,37 @@ func (f *Frontend) Callback(message string) {
 	if err != nil {
 		panic(err)
 	}
-	f.mainWindow.Invoke(func() {
-		f.chromium.Eval(`window.wails.Callback(` + string(escaped) + `);`)
-	})
+	script := `window.wails.Callback(` + string(escaped) + `);`
+
+	f.callbackMu.Lock()
+	wasEmpty := len(f.pendingCallbacks) == 0
+	f.pendingCallbacks = append(f.pendingCallbacks, script)
+	f.callbackMu.Unlock()
+
+	// Only the first waiter needs to queue a drain; subsequent callers piggyback on it.
+	if wasEmpty {
+		f.mainWindow.Invoke(f.drainCallbacks)
+	}
+}
+
+// drainCallbacks is called on the UI thread by the Invoke mechanism.
+// It flushes all accumulated callbacks in a single ExecuteScript call,
+// preventing WebView2 queue saturation under high concurrent load.
+func (f *Frontend) drainCallbacks() {
+	f.callbackMu.Lock()
+	scripts := f.pendingCallbacks
+	f.pendingCallbacks = nil
+	f.callbackMu.Unlock()
+
+	if len(scripts) == 0 {
+		return
+	}
+
+	var sb strings.Builder
+	for _, s := range scripts {
+		sb.WriteString(s)
+	}
+	f.chromium.Eval(sb.String())
 }
 
 func (f *Frontend) startDrag() error {

--- a/v2/internal/frontend/desktop/windows/frontend.go
+++ b/v2/internal/frontend/desktop/windows/frontend.go
@@ -75,6 +75,7 @@ type Frontend struct {
 	// ExecuteScript queue under heavy concurrent Go→JS call load.
 	callbackMu      sync.Mutex
 	pendingCallbacks []string
+	drainScheduled  bool
 }
 
 func NewFrontend(ctx context.Context, appoptions *options.App, myLogger *logger.Logger, appBindings *binding.Bindings, dispatcher frontend.Dispatcher) *Frontend {
@@ -879,13 +880,22 @@ func (f *Frontend) Callback(message string) {
 	script := `window.wails.Callback(` + string(escaped) + `);`
 
 	f.callbackMu.Lock()
-	wasEmpty := len(f.pendingCallbacks) == 0
 	f.pendingCallbacks = append(f.pendingCallbacks, script)
+	shouldSchedule := !f.drainScheduled
+	if shouldSchedule {
+		f.drainScheduled = true
+	}
 	f.callbackMu.Unlock()
 
-	// Only the first waiter needs to queue a drain; subsequent callers piggyback on it.
-	if wasEmpty {
-		f.mainWindow.Invoke(f.drainCallbacks)
+	if shouldSchedule {
+		if !f.mainWindow.Invoke(f.drainCallbacks) {
+			// PostMessage failed (queue full or HWND invalid). Reset the flag so the
+			// next incoming callback can try to schedule a fresh drain.
+			f.callbackMu.Lock()
+			f.drainScheduled = false
+			f.callbackMu.Unlock()
+			f.logger.Warning("Invoke: PostMessage failed — pending WebView2 callbacks may be delayed")
+		}
 	}
 }
 
@@ -896,13 +906,19 @@ func (f *Frontend) drainCallbacks() {
 	f.callbackMu.Lock()
 	scripts := f.pendingCallbacks
 	f.pendingCallbacks = nil
+	f.drainScheduled = false // allow re-scheduling before we release the lock
 	f.callbackMu.Unlock()
 
 	if len(scripts) == 0 {
 		return
 	}
 
+	totalLen := 0
+	for _, s := range scripts {
+		totalLen += len(s)
+	}
 	var sb strings.Builder
+	sb.Grow(totalLen)
 	for _, s := range scripts {
 		sb.WriteString(s)
 	}

--- a/v2/internal/frontend/desktop/windows/winc/controlbase.go
+++ b/v2/internal/frontend/desktop/windows/winc/controlbase.go
@@ -428,7 +428,12 @@ func (cba *ControlBase) Invoke(f func()) {
 	cba.m.Lock()
 	cba.dispatchq = append(cba.dispatchq, f)
 	cba.m.Unlock()
-	w32.PostMessage(cba.hwnd, wmInvokeCallback, 0, 0)
+	if !w32.PostMessage(cba.hwnd, wmInvokeCallback, 0, 0) {
+		// PostMessage fails when the Windows message queue is full (>10 000 msgs) or the
+		// HWND is no longer valid. The function is already in dispatchq so it will run the
+		// next time any wmInvokeCallback is processed, but log so the failure is visible.
+		fmt.Printf("[wails] Invoke: PostMessage failed – callbacks may be delayed\n")
+	}
 }
 
 func (cba *ControlBase) PreTranslateMessage(msg *w32.MSG) bool {

--- a/v2/internal/frontend/desktop/windows/winc/controlbase.go
+++ b/v2/internal/frontend/desktop/windows/winc/controlbase.go
@@ -420,20 +420,19 @@ func (cba *ControlBase) InvokeRequired() bool {
 	return windowThreadId != currentThreadId
 }
 
-func (cba *ControlBase) Invoke(f func()) {
+// Invoke schedules f to run on the window's UI thread. It returns true when
+// PostMessage succeeded (or f was executed synchronously on the current thread),
+// and false when PostMessage failed — the caller is responsible for logging and
+// retrying when a false return matters.
+func (cba *ControlBase) Invoke(f func()) bool {
 	if cba.tryInvokeOnCurrentGoRoutine(f) {
-		return
+		return true
 	}
 
 	cba.m.Lock()
 	cba.dispatchq = append(cba.dispatchq, f)
 	cba.m.Unlock()
-	if !w32.PostMessage(cba.hwnd, wmInvokeCallback, 0, 0) {
-		// PostMessage fails when the Windows message queue is full (>10 000 msgs) or the
-		// HWND is no longer valid. The function is already in dispatchq so it will run the
-		// next time any wmInvokeCallback is processed, but log so the failure is visible.
-		fmt.Printf("[wails] Invoke: PostMessage failed – callbacks may be delayed\n")
-	}
+	return w32.PostMessage(cba.hwnd, wmInvokeCallback, 0, 0)
 }
 
 func (cba *ControlBase) PreTranslateMessage(msg *w32.MSG) bool {

--- a/v2/internal/frontend/desktop/windows/winc/controller.go
+++ b/v2/internal/frontend/desktop/windows/winc/controller.go
@@ -43,7 +43,7 @@ type Controller interface {
 	Font() *Font
 	SetFont(font *Font)
 	InvokeRequired() bool
-	Invoke(func())
+	Invoke(func()) bool
 	PreTranslateMessage(msg *w32.MSG) bool
 	WndProc(msg uint32, wparam, lparam uintptr) uintptr
 


### PR DESCRIPTION
## Summary

Fixes #4418: JavaScript promises made to Go backend methods stop resolving under heavy concurrent load in production builds on Windows.

**Root cause**: `Frontend.Callback()` previously called `mainWindow.Invoke()` once per callback. Each `Invoke()` call (a) appended to `dispatchq` and (b) called `PostMessage(wmInvokeCallback)`. When `invokeCallbacks()` drained the queue it called `chromium.Eval()` → `ExecuteScript` once *per callback*. Under heavy concurrent load WebView2 returns `ERROR_IO_PENDING` from rapid-fire `ExecuteScript` calls; `chromium.Eval()` swallows this silently — the corresponding `window.wails.Callback(...)` is never executed and the JS promise stalls forever. Dev mode is unaffected because it routes callbacks through a WebSocket, bypassing `ExecuteScript` entirely.

**Fix**:

1. **`frontend.go`** — Introduce a `pendingCallbacks []string` buffer protected by a `sync.Mutex`. The first goroutine to call `Callback()` after a drain queues a single `drainCallbacks` via `Invoke()`; subsequent concurrent callers append to the buffer without posting additional messages. `drainCallbacks` runs on the UI thread and dispatches **all** accumulated `window.wails.Callback(…)` invocations as one `ExecuteScript` call — reducing both PostMessage pressure and ExecuteScript saturation from O(N) to O(1) per batch.

2. **`controlbase.go`** — Check `PostMessage`'s return value in `Invoke()` and log a warning on failure so the condition is visible rather than silent.

## Test plan

- [ ] Build a production Wails v2 app with a Go binding that performs no-op work
- [ ] Rapidly fire 500+ concurrent calls from JavaScript (e.g. `Promise.all(Array.from({length:500}, () => window.go.App.Noop()))`)
- [ ] Verify all promises resolve (previously many would stall)
- [ ] Confirm dev mode is unaffected
- [ ] Test on Windows x64 and ARM64

CC @leaanthony

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows desktop stability and responsiveness under heavy concurrent load by batching and reducing script execution pressure for JS callbacks.
* **Breaking Changes**
  * The desktop invoke API now returns a boolean indicating whether a UI-thread dispatch was successfully scheduled; callers should handle the new return value.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wailsapp/wails/pull/5364)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->