### PR TITLE
fix(v3): configure Vite port via env var so pnpm (and other package managers) work in dev mode

### DIFF
--- a/v3/examples/android/build/Taskfile.yml
+++ b/v3/examples/android/build/Taskfile.yml
@@ -105,7 +105,7 @@ tasks:
     deps:
       - task: install:frontend:deps
     cmds:
-      - npm run dev -- --port {{.VITE_PORT}} --strictPort
+      - npm run dev
 
   update:build-assets:
     summary: Updates the build assets

--- a/v3/examples/android/frontend/vite.config.js
+++ b/v3/examples/android/frontend/vite.config.js
@@ -8,4 +8,8 @@ export default defineConfig({
       '@wailsio/runtime': path.resolve(__dirname, '../../../internal/runtime/desktop/@wailsio/runtime/src/index.ts'),
     },
   },
+  server: {
+    port: parseInt(process.env.WAILS_VITE_PORT || "9245"),
+    strictPort: true,
+  },
 });

--- a/v3/examples/android/frontend/vite.config.js
+++ b/v3/examples/android/frontend/vite.config.js
@@ -9,7 +9,7 @@ export default defineConfig({
     },
   },
   server: {
-    port: parseInt(process.env.WAILS_VITE_PORT || "9245"),
+    port: Number(process.env.WAILS_VITE_PORT) || 9245,
     strictPort: true,
   },
 });

--- a/v3/examples/badge-custom/build/Taskfile.yml
+++ b/v3/examples/badge-custom/build/Taskfile.yml
@@ -78,7 +78,7 @@ tasks:
     deps:
       - task: install:frontend:deps
     cmds:
-      - npm run dev -- --port {{.VITE_PORT}} --strictPort
+      - npm run dev
 
   update:build-assets:
     summary: Updates the build assets

--- a/v3/examples/badge-custom/frontend/vite.config.js
+++ b/v3/examples/badge-custom/frontend/vite.config.js
@@ -1,12 +1,6 @@
 import { defineConfig } from "vite";
-import wails from "@wailsio/runtime/plugins/vite";
 
-// https://vitejs.dev/config/
 export default defineConfig({
-  server: {
-    host: "127.0.0.1",
-  },
-  plugins: [wails("./bindings")],
   server: {
     port: parseInt(process.env.WAILS_VITE_PORT || "9245"),
     strictPort: true,

--- a/v3/examples/badge-custom/frontend/vite.config.js
+++ b/v3/examples/badge-custom/frontend/vite.config.js
@@ -2,7 +2,7 @@ import { defineConfig } from "vite";
 
 export default defineConfig({
   server: {
-    port: parseInt(process.env.WAILS_VITE_PORT || "9245"),
+    port: Number(process.env.WAILS_VITE_PORT) || 9245,
     strictPort: true,
   },
 });

--- a/v3/examples/badge/build/Taskfile.yml
+++ b/v3/examples/badge/build/Taskfile.yml
@@ -78,7 +78,7 @@ tasks:
     deps:
       - task: install:frontend:deps
     cmds:
-      - npm run dev -- --port {{.VITE_PORT}} --strictPort
+      - npm run dev
 
   update:build-assets:
     summary: Updates the build assets

--- a/v3/examples/badge/frontend/vite.config.js
+++ b/v3/examples/badge/frontend/vite.config.js
@@ -1,12 +1,6 @@
 import { defineConfig } from "vite";
-import wails from "@wailsio/runtime/plugins/vite";
 
-// https://vitejs.dev/config/
 export default defineConfig({
-  server: {
-    host: "127.0.0.1",
-  },
-  plugins: [wails("./bindings")],
   server: {
     port: parseInt(process.env.WAILS_VITE_PORT || "9245"),
     strictPort: true,

--- a/v3/examples/badge/frontend/vite.config.js
+++ b/v3/examples/badge/frontend/vite.config.js
@@ -2,7 +2,7 @@ import { defineConfig } from "vite";
 
 export default defineConfig({
   server: {
-    port: parseInt(process.env.WAILS_VITE_PORT || "9245"),
+    port: Number(process.env.WAILS_VITE_PORT) || 9245,
     strictPort: true,
   },
 });

--- a/v3/examples/dev/frontend/vite.config.js
+++ b/v3/examples/dev/frontend/vite.config.js
@@ -4,4 +4,8 @@ import { svelte } from '@sveltejs/vite-plugin-svelte'
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [svelte()],
+  server: {
+    port: parseInt(process.env.WAILS_VITE_PORT || "9245"),
+    strictPort: true,
+  },
 })

--- a/v3/examples/dev/frontend/vite.config.js
+++ b/v3/examples/dev/frontend/vite.config.js
@@ -5,7 +5,7 @@ import { svelte } from '@sveltejs/vite-plugin-svelte'
 export default defineConfig({
   plugins: [svelte()],
   server: {
-    port: parseInt(process.env.WAILS_VITE_PORT || "9245"),
+    port: Number(process.env.WAILS_VITE_PORT) || 9245,
     strictPort: true,
   },
 })

--- a/v3/examples/dock/build/Taskfile.yml
+++ b/v3/examples/dock/build/Taskfile.yml
@@ -78,7 +78,7 @@ tasks:
     deps:
       - task: install:frontend:deps
     cmds:
-      - npm run dev -- --port {{.VITE_PORT}} --strictPort
+      - npm run dev
 
   update:build-assets:
     summary: Updates the build assets

--- a/v3/examples/dock/frontend/vite.config.js
+++ b/v3/examples/dock/frontend/vite.config.js
@@ -1,12 +1,6 @@
 import { defineConfig } from "vite";
-import wails from "@wailsio/runtime/plugins/vite";
 
-// https://vitejs.dev/config/
 export default defineConfig({
-  server: {
-    host: "127.0.0.1",
-  },
-  plugins: [wails("./bindings")],
   server: {
     port: parseInt(process.env.WAILS_VITE_PORT || "9245"),
     strictPort: true,

--- a/v3/examples/dock/frontend/vite.config.js
+++ b/v3/examples/dock/frontend/vite.config.js
@@ -2,7 +2,7 @@ import { defineConfig } from "vite";
 
 export default defineConfig({
   server: {
-    port: parseInt(process.env.WAILS_VITE_PORT || "9245"),
+    port: Number(process.env.WAILS_VITE_PORT) || 9245,
     strictPort: true,
   },
 });

--- a/v3/examples/file-association/build/Taskfile.common.yml
+++ b/v3/examples/file-association/build/Taskfile.common.yml
@@ -67,7 +67,7 @@ tasks:
     deps:
       - task: install:frontend:deps
     cmds:
-      - npm run dev -- --port {{.VITE_PORT}} --strictPort
+      - npm run dev
 
   update:build-assets:
     summary: Updates the build assets

--- a/v3/examples/file-association/frontend/vite.config.js
+++ b/v3/examples/file-association/frontend/vite.config.js
@@ -1,12 +1,6 @@
 import { defineConfig } from "vite";
-import wails from "@wailsio/runtime/plugins/vite";
 
-// https://vitejs.dev/config/
 export default defineConfig({
-  server: {
-    host: "127.0.0.1",
-  },
-  plugins: [wails("./bindings")],
   server: {
     port: parseInt(process.env.WAILS_VITE_PORT || "9245"),
     strictPort: true,

--- a/v3/examples/file-association/frontend/vite.config.js
+++ b/v3/examples/file-association/frontend/vite.config.js
@@ -2,7 +2,7 @@ import { defineConfig } from "vite";
 
 export default defineConfig({
   server: {
-    port: parseInt(process.env.WAILS_VITE_PORT || "9245"),
+    port: Number(process.env.WAILS_VITE_PORT) || 9245,
     strictPort: true,
   },
 });

--- a/v3/examples/ios/build/Taskfile.yml
+++ b/v3/examples/ios/build/Taskfile.yml
@@ -105,7 +105,7 @@ tasks:
     deps:
       - task: install:frontend:deps
     cmds:
-      - npm run dev -- --port {{.VITE_PORT}} --strictPort
+      - npm run dev
 
   update:build-assets:
     summary: Updates the build assets

--- a/v3/examples/ios/frontend/vite.config.js
+++ b/v3/examples/ios/frontend/vite.config.js
@@ -8,4 +8,8 @@ export default defineConfig({
       '@wailsio/runtime': path.resolve(__dirname, '../../../internal/runtime/desktop/@wailsio/runtime/src/index.ts'),
     },
   },
+  server: {
+    port: parseInt(process.env.WAILS_VITE_PORT || "9245"),
+    strictPort: true,
+  },
 });

--- a/v3/examples/ios/frontend/vite.config.js
+++ b/v3/examples/ios/frontend/vite.config.js
@@ -9,7 +9,7 @@ export default defineConfig({
     },
   },
   server: {
-    port: parseInt(process.env.WAILS_VITE_PORT || "9245"),
+    port: Number(process.env.WAILS_VITE_PORT) || 9245,
     strictPort: true,
   },
 });

--- a/v3/examples/notifications/build/Taskfile.yml
+++ b/v3/examples/notifications/build/Taskfile.yml
@@ -78,7 +78,7 @@ tasks:
     deps:
       - task: install:frontend:deps
     cmds:
-      - npm run dev -- --port {{.VITE_PORT}} --strictPort
+      - npm run dev
 
   update:build-assets:
     summary: Updates the build assets

--- a/v3/examples/notifications/frontend/vite.config.js
+++ b/v3/examples/notifications/frontend/vite.config.js
@@ -1,12 +1,6 @@
 import { defineConfig } from "vite";
-import wails from "@wailsio/runtime/plugins/vite";
 
-// https://vitejs.dev/config/
 export default defineConfig({
-  server: {
-    host: "127.0.0.1",
-  },
-  plugins: [wails("./bindings")],
   server: {
     port: parseInt(process.env.WAILS_VITE_PORT || "9245"),
     strictPort: true,

--- a/v3/examples/notifications/frontend/vite.config.js
+++ b/v3/examples/notifications/frontend/vite.config.js
@@ -2,7 +2,7 @@ import { defineConfig } from "vite";
 
 export default defineConfig({
   server: {
-    port: parseInt(process.env.WAILS_VITE_PORT || "9245"),
+    port: Number(process.env.WAILS_VITE_PORT) || 9245,
     strictPort: true,
   },
 });

--- a/v3/internal/commands/build_assets/Taskfile.tmpl.yml
+++ b/v3/internal/commands/build_assets/Taskfile.tmpl.yml
@@ -115,7 +115,7 @@ tasks:
     deps:
       - task: install:frontend:deps
     cmds:
-      - npm run dev -- --port {{ "{{.VITE_PORT}}" }} --strictPort
+      - npm run dev
 
   update:build-assets:
     summary: Updates the build assets

--- a/v3/internal/templates/lit-ts/frontend/vite.config.ts
+++ b/v3/internal/templates/lit-ts/frontend/vite.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
   },
   plugins: [wails("./bindings")],
   server: {
-    port: parseInt(process.env.WAILS_VITE_PORT || "9245"),
+    port: Number(process.env.WAILS_VITE_PORT) || 9245,
     strictPort: true,
   },
 });

--- a/v3/internal/templates/lit-ts/frontend/vite.config.ts
+++ b/v3/internal/templates/lit-ts/frontend/vite.config.ts
@@ -5,10 +5,8 @@ import wails from "@wailsio/runtime/plugins/vite";
 export default defineConfig({
   server: {
     host: "127.0.0.1",
-  },
-  plugins: [wails("./bindings")],
-  server: {
     port: Number(process.env.WAILS_VITE_PORT) || 9245,
     strictPort: true,
   },
+  plugins: [wails("./bindings")],
 });

--- a/v3/internal/templates/lit/frontend/vite.config.js
+++ b/v3/internal/templates/lit/frontend/vite.config.js
@@ -8,7 +8,7 @@ export default defineConfig({
   },
   plugins: [wails("./bindings")],
   server: {
-    port: parseInt(process.env.WAILS_VITE_PORT || "9245"),
+    port: Number(process.env.WAILS_VITE_PORT) || 9245,
     strictPort: true,
   },
 });

--- a/v3/internal/templates/lit/frontend/vite.config.js
+++ b/v3/internal/templates/lit/frontend/vite.config.js
@@ -5,10 +5,8 @@ import wails from "@wailsio/runtime/plugins/vite";
 export default defineConfig({
   server: {
     host: "127.0.0.1",
-  },
-  plugins: [wails("./bindings")],
-  server: {
     port: Number(process.env.WAILS_VITE_PORT) || 9245,
     strictPort: true,
   },
+  plugins: [wails("./bindings")],
 });

--- a/v3/internal/templates/lit/frontend/vite.config.js
+++ b/v3/internal/templates/lit/frontend/vite.config.js
@@ -7,4 +7,8 @@ export default defineConfig({
     host: "127.0.0.1",
   },
   plugins: [wails("./bindings")],
+  server: {
+    port: parseInt(process.env.WAILS_VITE_PORT || "9245"),
+    strictPort: true,
+  },
 });

--- a/v3/internal/templates/preact-ts/frontend/vite.config.ts
+++ b/v3/internal/templates/preact-ts/frontend/vite.config.ts
@@ -8,4 +8,8 @@ export default defineConfig({
     host: "127.0.0.1",
   },
   plugins: [preact(), wails("./bindings")],
+  server: {
+    port: parseInt(process.env.WAILS_VITE_PORT || "9245"),
+    strictPort: true,
+  },
 });

--- a/v3/internal/templates/preact-ts/frontend/vite.config.ts
+++ b/v3/internal/templates/preact-ts/frontend/vite.config.ts
@@ -6,10 +6,8 @@ import wails from "@wailsio/runtime/plugins/vite";
 export default defineConfig({
   server: {
     host: "127.0.0.1",
-  },
-  plugins: [preact(), wails("./bindings")],
-  server: {
     port: Number(process.env.WAILS_VITE_PORT) || 9245,
     strictPort: true,
   },
+  plugins: [preact(), wails("./bindings")],
 });

--- a/v3/internal/templates/preact-ts/frontend/vite.config.ts
+++ b/v3/internal/templates/preact-ts/frontend/vite.config.ts
@@ -9,7 +9,7 @@ export default defineConfig({
   },
   plugins: [preact(), wails("./bindings")],
   server: {
-    port: parseInt(process.env.WAILS_VITE_PORT || "9245"),
+    port: Number(process.env.WAILS_VITE_PORT) || 9245,
     strictPort: true,
   },
 });

--- a/v3/internal/templates/preact/frontend/vite.config.js
+++ b/v3/internal/templates/preact/frontend/vite.config.js
@@ -8,4 +8,8 @@ export default defineConfig({
     host: "127.0.0.1",
   },
   plugins: [preact(), wails("./bindings")],
+  server: {
+    port: parseInt(process.env.WAILS_VITE_PORT || "9245"),
+    strictPort: true,
+  },
 });

--- a/v3/internal/templates/preact/frontend/vite.config.js
+++ b/v3/internal/templates/preact/frontend/vite.config.js
@@ -6,10 +6,8 @@ import wails from "@wailsio/runtime/plugins/vite";
 export default defineConfig({
   server: {
     host: "127.0.0.1",
-  },
-  plugins: [preact(), wails("./bindings")],
-  server: {
     port: Number(process.env.WAILS_VITE_PORT) || 9245,
     strictPort: true,
   },
+  plugins: [preact(), wails("./bindings")],
 });

--- a/v3/internal/templates/preact/frontend/vite.config.js
+++ b/v3/internal/templates/preact/frontend/vite.config.js
@@ -9,7 +9,7 @@ export default defineConfig({
   },
   plugins: [preact(), wails("./bindings")],
   server: {
-    port: parseInt(process.env.WAILS_VITE_PORT || "9245"),
+    port: Number(process.env.WAILS_VITE_PORT) || 9245,
     strictPort: true,
   },
 });

--- a/v3/internal/templates/qwik-ts/frontend/vite.config.ts
+++ b/v3/internal/templates/qwik-ts/frontend/vite.config.ts
@@ -13,4 +13,8 @@ export default defineConfig({
     }),
     wails("./bindings"),
   ],
+  server: {
+    port: parseInt(process.env.WAILS_VITE_PORT || "9245"),
+    strictPort: true,
+  },
 });

--- a/v3/internal/templates/qwik-ts/frontend/vite.config.ts
+++ b/v3/internal/templates/qwik-ts/frontend/vite.config.ts
@@ -14,7 +14,7 @@ export default defineConfig({
     wails("./bindings"),
   ],
   server: {
-    port: parseInt(process.env.WAILS_VITE_PORT || "9245"),
+    port: Number(process.env.WAILS_VITE_PORT) || 9245,
     strictPort: true,
   },
 });

--- a/v3/internal/templates/qwik-ts/frontend/vite.config.ts
+++ b/v3/internal/templates/qwik-ts/frontend/vite.config.ts
@@ -6,6 +6,8 @@ import wails from "@wailsio/runtime/plugins/vite";
 export default defineConfig({
   server: {
     host: "127.0.0.1",
+    port: Number(process.env.WAILS_VITE_PORT) || 9245,
+    strictPort: true,
   },
   plugins: [
     qwikVite({
@@ -13,8 +15,4 @@ export default defineConfig({
     }),
     wails("./bindings"),
   ],
-  server: {
-    port: Number(process.env.WAILS_VITE_PORT) || 9245,
-    strictPort: true,
-  },
 });

--- a/v3/internal/templates/qwik/frontend/vite.config.js
+++ b/v3/internal/templates/qwik/frontend/vite.config.js
@@ -13,4 +13,8 @@ export default defineConfig({
     }),
     wails("./bindings"),
   ],
+  server: {
+    port: parseInt(process.env.WAILS_VITE_PORT || "9245"),
+    strictPort: true,
+  },
 });

--- a/v3/internal/templates/qwik/frontend/vite.config.js
+++ b/v3/internal/templates/qwik/frontend/vite.config.js
@@ -14,7 +14,7 @@ export default defineConfig({
     wails("./bindings"),
   ],
   server: {
-    port: parseInt(process.env.WAILS_VITE_PORT || "9245"),
+    port: Number(process.env.WAILS_VITE_PORT) || 9245,
     strictPort: true,
   },
 });

--- a/v3/internal/templates/qwik/frontend/vite.config.js
+++ b/v3/internal/templates/qwik/frontend/vite.config.js
@@ -6,6 +6,8 @@ import wails from "@wailsio/runtime/plugins/vite";
 export default defineConfig({
   server: {
     host: "127.0.0.1",
+    port: Number(process.env.WAILS_VITE_PORT) || 9245,
+    strictPort: true,
   },
   plugins: [
     qwikVite({
@@ -13,8 +15,4 @@ export default defineConfig({
     }),
     wails("./bindings"),
   ],
-  server: {
-    port: Number(process.env.WAILS_VITE_PORT) || 9245,
-    strictPort: true,
-  },
 });

--- a/v3/internal/templates/react-swc-ts/frontend/vite.config.ts
+++ b/v3/internal/templates/react-swc-ts/frontend/vite.config.ts
@@ -9,7 +9,7 @@ export default defineConfig({
   },
   plugins: [react(), wails("./bindings")],
   server: {
-    port: parseInt(process.env.WAILS_VITE_PORT || "9245"),
+    port: Number(process.env.WAILS_VITE_PORT) || 9245,
     strictPort: true,
   },
 });

--- a/v3/internal/templates/react-swc-ts/frontend/vite.config.ts
+++ b/v3/internal/templates/react-swc-ts/frontend/vite.config.ts
@@ -6,10 +6,8 @@ import wails from "@wailsio/runtime/plugins/vite";
 export default defineConfig({
   server: {
     host: "127.0.0.1",
-  },
-  plugins: [react(), wails("./bindings")],
-  server: {
     port: Number(process.env.WAILS_VITE_PORT) || 9245,
     strictPort: true,
   },
+  plugins: [react(), wails("./bindings")],
 });

--- a/v3/internal/templates/react-swc-ts/frontend/vite.config.ts
+++ b/v3/internal/templates/react-swc-ts/frontend/vite.config.ts
@@ -8,4 +8,8 @@ export default defineConfig({
     host: "127.0.0.1",
   },
   plugins: [react(), wails("./bindings")],
+  server: {
+    port: parseInt(process.env.WAILS_VITE_PORT || "9245"),
+    strictPort: true,
+  },
 });

--- a/v3/internal/templates/react-swc/frontend/vite.config.js
+++ b/v3/internal/templates/react-swc/frontend/vite.config.js
@@ -9,7 +9,7 @@ export default defineConfig({
   },
   plugins: [react(), wails("./bindings")],
   server: {
-    port: parseInt(process.env.WAILS_VITE_PORT || "9245"),
+    port: Number(process.env.WAILS_VITE_PORT) || 9245,
     strictPort: true,
   },
 });

--- a/v3/internal/templates/react-swc/frontend/vite.config.js
+++ b/v3/internal/templates/react-swc/frontend/vite.config.js
@@ -6,10 +6,8 @@ import wails from "@wailsio/runtime/plugins/vite";
 export default defineConfig({
   server: {
     host: "127.0.0.1",
-  },
-  plugins: [react(), wails("./bindings")],
-  server: {
     port: Number(process.env.WAILS_VITE_PORT) || 9245,
     strictPort: true,
   },
+  plugins: [react(), wails("./bindings")],
 });

--- a/v3/internal/templates/react-swc/frontend/vite.config.js
+++ b/v3/internal/templates/react-swc/frontend/vite.config.js
@@ -8,4 +8,8 @@ export default defineConfig({
     host: "127.0.0.1",
   },
   plugins: [react(), wails("./bindings")],
+  server: {
+    port: parseInt(process.env.WAILS_VITE_PORT || "9245"),
+    strictPort: true,
+  },
 });

--- a/v3/internal/templates/react-ts/frontend/vite.config.ts
+++ b/v3/internal/templates/react-ts/frontend/vite.config.ts
@@ -9,7 +9,7 @@ export default defineConfig({
   },
   plugins: [react(), wails("./bindings")],
   server: {
-    port: parseInt(process.env.WAILS_VITE_PORT || "9245"),
+    port: Number(process.env.WAILS_VITE_PORT) || 9245,
     strictPort: true,
   },
 });

--- a/v3/internal/templates/react-ts/frontend/vite.config.ts
+++ b/v3/internal/templates/react-ts/frontend/vite.config.ts
@@ -6,10 +6,8 @@ import wails from "@wailsio/runtime/plugins/vite";
 export default defineConfig({
   server: {
     host: "127.0.0.1",
-  },
-  plugins: [react(), wails("./bindings")],
-  server: {
     port: Number(process.env.WAILS_VITE_PORT) || 9245,
     strictPort: true,
   },
+  plugins: [react(), wails("./bindings")],
 });

--- a/v3/internal/templates/react-ts/frontend/vite.config.ts
+++ b/v3/internal/templates/react-ts/frontend/vite.config.ts
@@ -8,4 +8,8 @@ export default defineConfig({
     host: "127.0.0.1",
   },
   plugins: [react(), wails("./bindings")],
+  server: {
+    port: parseInt(process.env.WAILS_VITE_PORT || "9245"),
+    strictPort: true,
+  },
 });

--- a/v3/internal/templates/react/frontend/vite.config.js
+++ b/v3/internal/templates/react/frontend/vite.config.js
@@ -9,7 +9,7 @@ export default defineConfig({
   },
   plugins: [react(), wails("./bindings")],
   server: {
-    port: parseInt(process.env.WAILS_VITE_PORT || "9245"),
+    port: Number(process.env.WAILS_VITE_PORT) || 9245,
     strictPort: true,
   },
 });

--- a/v3/internal/templates/react/frontend/vite.config.js
+++ b/v3/internal/templates/react/frontend/vite.config.js
@@ -6,10 +6,8 @@ import wails from "@wailsio/runtime/plugins/vite";
 export default defineConfig({
   server: {
     host: "127.0.0.1",
-  },
-  plugins: [react(), wails("./bindings")],
-  server: {
     port: Number(process.env.WAILS_VITE_PORT) || 9245,
     strictPort: true,
   },
+  plugins: [react(), wails("./bindings")],
 });

--- a/v3/internal/templates/react/frontend/vite.config.js
+++ b/v3/internal/templates/react/frontend/vite.config.js
@@ -8,4 +8,8 @@ export default defineConfig({
     host: "127.0.0.1",
   },
   plugins: [react(), wails("./bindings")],
+  server: {
+    port: parseInt(process.env.WAILS_VITE_PORT || "9245"),
+    strictPort: true,
+  },
 });

--- a/v3/internal/templates/solid-ts/frontend/vite.config.ts
+++ b/v3/internal/templates/solid-ts/frontend/vite.config.ts
@@ -7,4 +7,8 @@ export default defineConfig({
     host: "127.0.0.1",
   },
   plugins: [solid(), wails("./bindings")],
+  server: {
+    port: parseInt(process.env.WAILS_VITE_PORT || "9245"),
+    strictPort: true,
+  },
 });

--- a/v3/internal/templates/solid-ts/frontend/vite.config.ts
+++ b/v3/internal/templates/solid-ts/frontend/vite.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
   },
   plugins: [solid(), wails("./bindings")],
   server: {
-    port: parseInt(process.env.WAILS_VITE_PORT || "9245"),
+    port: Number(process.env.WAILS_VITE_PORT) || 9245,
     strictPort: true,
   },
 });

--- a/v3/internal/templates/solid-ts/frontend/vite.config.ts
+++ b/v3/internal/templates/solid-ts/frontend/vite.config.ts
@@ -5,10 +5,8 @@ import wails from "@wailsio/runtime/plugins/vite";
 export default defineConfig({
   server: {
     host: "127.0.0.1",
-  },
-  plugins: [solid(), wails("./bindings")],
-  server: {
     port: Number(process.env.WAILS_VITE_PORT) || 9245,
     strictPort: true,
   },
+  plugins: [solid(), wails("./bindings")],
 });

--- a/v3/internal/templates/solid/frontend/vite.config.js
+++ b/v3/internal/templates/solid/frontend/vite.config.js
@@ -8,4 +8,8 @@ export default defineConfig({
     host: "127.0.0.1",
   },
   plugins: [solid(), wails("./bindings")],
+  server: {
+    port: parseInt(process.env.WAILS_VITE_PORT || "9245"),
+    strictPort: true,
+  },
 });

--- a/v3/internal/templates/solid/frontend/vite.config.js
+++ b/v3/internal/templates/solid/frontend/vite.config.js
@@ -9,7 +9,7 @@ export default defineConfig({
   },
   plugins: [solid(), wails("./bindings")],
   server: {
-    port: parseInt(process.env.WAILS_VITE_PORT || "9245"),
+    port: Number(process.env.WAILS_VITE_PORT) || 9245,
     strictPort: true,
   },
 });

--- a/v3/internal/templates/solid/frontend/vite.config.js
+++ b/v3/internal/templates/solid/frontend/vite.config.js
@@ -6,10 +6,8 @@ import wails from "@wailsio/runtime/plugins/vite";
 export default defineConfig({
   server: {
     host: "127.0.0.1",
-  },
-  plugins: [solid(), wails("./bindings")],
-  server: {
     port: Number(process.env.WAILS_VITE_PORT) || 9245,
     strictPort: true,
   },
+  plugins: [solid(), wails("./bindings")],
 });

--- a/v3/internal/templates/svelte-ts/frontend/vite.config.ts
+++ b/v3/internal/templates/svelte-ts/frontend/vite.config.ts
@@ -8,4 +8,8 @@ export default defineConfig({
     host: "127.0.0.1",
   },
   plugins: [svelte(), wails("./bindings")],
+  server: {
+    port: parseInt(process.env.WAILS_VITE_PORT || "9245"),
+    strictPort: true,
+  },
 });

--- a/v3/internal/templates/svelte-ts/frontend/vite.config.ts
+++ b/v3/internal/templates/svelte-ts/frontend/vite.config.ts
@@ -9,7 +9,7 @@ export default defineConfig({
   },
   plugins: [svelte(), wails("./bindings")],
   server: {
-    port: parseInt(process.env.WAILS_VITE_PORT || "9245"),
+    port: Number(process.env.WAILS_VITE_PORT) || 9245,
     strictPort: true,
   },
 });

--- a/v3/internal/templates/svelte-ts/frontend/vite.config.ts
+++ b/v3/internal/templates/svelte-ts/frontend/vite.config.ts
@@ -6,10 +6,8 @@ import wails from "@wailsio/runtime/plugins/vite";
 export default defineConfig({
   server: {
     host: "127.0.0.1",
-  },
-  plugins: [svelte(), wails("./bindings")],
-  server: {
     port: Number(process.env.WAILS_VITE_PORT) || 9245,
     strictPort: true,
   },
+  plugins: [svelte(), wails("./bindings")],
 });

--- a/v3/internal/templates/svelte/frontend/vite.config.js
+++ b/v3/internal/templates/svelte/frontend/vite.config.js
@@ -8,4 +8,8 @@ export default defineConfig({
     host: "127.0.0.1",
   },
   plugins: [svelte(), wails("./bindings")],
+  server: {
+    port: parseInt(process.env.WAILS_VITE_PORT || "9245"),
+    strictPort: true,
+  },
 });

--- a/v3/internal/templates/svelte/frontend/vite.config.js
+++ b/v3/internal/templates/svelte/frontend/vite.config.js
@@ -9,7 +9,7 @@ export default defineConfig({
   },
   plugins: [svelte(), wails("./bindings")],
   server: {
-    port: parseInt(process.env.WAILS_VITE_PORT || "9245"),
+    port: Number(process.env.WAILS_VITE_PORT) || 9245,
     strictPort: true,
   },
 });

--- a/v3/internal/templates/svelte/frontend/vite.config.js
+++ b/v3/internal/templates/svelte/frontend/vite.config.js
@@ -6,10 +6,8 @@ import wails from "@wailsio/runtime/plugins/vite";
 export default defineConfig({
   server: {
     host: "127.0.0.1",
-  },
-  plugins: [svelte(), wails("./bindings")],
-  server: {
     port: Number(process.env.WAILS_VITE_PORT) || 9245,
     strictPort: true,
   },
+  plugins: [svelte(), wails("./bindings")],
 });

--- a/v3/internal/templates/sveltekit-ts/frontend/vite.config.ts
+++ b/v3/internal/templates/sveltekit-ts/frontend/vite.config.ts
@@ -5,7 +5,7 @@ import wails from "@wailsio/runtime/plugins/vite";
 export default defineConfig({
   server: {
     host: "127.0.0.1",
-    port: parseInt(process.env.WAILS_VITE_PORT || "9245"),
+    port: Number(process.env.WAILS_VITE_PORT) || 9245,
     strictPort: true,
     fs: {
       allow: [

--- a/v3/internal/templates/sveltekit-ts/frontend/vite.config.ts
+++ b/v3/internal/templates/sveltekit-ts/frontend/vite.config.ts
@@ -5,6 +5,8 @@ import wails from "@wailsio/runtime/plugins/vite";
 export default defineConfig({
   server: {
     host: "127.0.0.1",
+    port: parseInt(process.env.WAILS_VITE_PORT || "9245"),
+    strictPort: true,
     fs: {
       allow: [
         // search up for workspace root

--- a/v3/internal/templates/sveltekit/frontend/vite.config.js
+++ b/v3/internal/templates/sveltekit/frontend/vite.config.js
@@ -7,6 +7,8 @@ export default defineConfig({
   plugins: [sveltekit(), wails("./bindings")],
   server: {
     host: "127.0.0.1",
+    port: parseInt(process.env.WAILS_VITE_PORT || "9245"),
+    strictPort: true,
     fs: {
       allow: [
         // search up for workspace root

--- a/v3/internal/templates/sveltekit/frontend/vite.config.js
+++ b/v3/internal/templates/sveltekit/frontend/vite.config.js
@@ -7,7 +7,7 @@ export default defineConfig({
   plugins: [sveltekit(), wails("./bindings")],
   server: {
     host: "127.0.0.1",
-    port: parseInt(process.env.WAILS_VITE_PORT || "9245"),
+    port: Number(process.env.WAILS_VITE_PORT) || 9245,
     strictPort: true,
     fs: {
       allow: [

--- a/v3/internal/templates/vanilla-ts/frontend/vite.config.ts
+++ b/v3/internal/templates/vanilla-ts/frontend/vite.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
   },
   plugins: [wails("./bindings")],
   server: {
-    port: parseInt(process.env.WAILS_VITE_PORT || "9245"),
+    port: Number(process.env.WAILS_VITE_PORT) || 9245,
     strictPort: true,
   },
 });

--- a/v3/internal/templates/vanilla-ts/frontend/vite.config.ts
+++ b/v3/internal/templates/vanilla-ts/frontend/vite.config.ts
@@ -5,10 +5,8 @@ import wails from "@wailsio/runtime/plugins/vite";
 export default defineConfig({
   server: {
     host: "127.0.0.1",
-  },
-  plugins: [wails("./bindings")],
-  server: {
     port: Number(process.env.WAILS_VITE_PORT) || 9245,
     strictPort: true,
   },
+  plugins: [wails("./bindings")],
 });

--- a/v3/internal/templates/vanilla-ts/frontend/vite.config.ts
+++ b/v3/internal/templates/vanilla-ts/frontend/vite.config.ts
@@ -7,4 +7,8 @@ export default defineConfig({
     host: "127.0.0.1",
   },
   plugins: [wails("./bindings")],
+  server: {
+    port: parseInt(process.env.WAILS_VITE_PORT || "9245"),
+    strictPort: true,
+  },
 });

--- a/v3/internal/templates/vanilla/frontend/vite.config.js
+++ b/v3/internal/templates/vanilla/frontend/vite.config.js
@@ -8,7 +8,7 @@ export default defineConfig({
   },
   plugins: [wails("./bindings")],
   server: {
-    port: parseInt(process.env.WAILS_VITE_PORT || "9245"),
+    port: Number(process.env.WAILS_VITE_PORT) || 9245,
     strictPort: true,
   },
 });

--- a/v3/internal/templates/vanilla/frontend/vite.config.js
+++ b/v3/internal/templates/vanilla/frontend/vite.config.js
@@ -5,10 +5,8 @@ import wails from "@wailsio/runtime/plugins/vite";
 export default defineConfig({
   server: {
     host: "127.0.0.1",
-  },
-  plugins: [wails("./bindings")],
-  server: {
     port: Number(process.env.WAILS_VITE_PORT) || 9245,
     strictPort: true,
   },
+  plugins: [wails("./bindings")],
 });

--- a/v3/internal/templates/vanilla/frontend/vite.config.js
+++ b/v3/internal/templates/vanilla/frontend/vite.config.js
@@ -7,4 +7,8 @@ export default defineConfig({
     host: "127.0.0.1",
   },
   plugins: [wails("./bindings")],
+  server: {
+    port: parseInt(process.env.WAILS_VITE_PORT || "9245"),
+    strictPort: true,
+  },
 });

--- a/v3/internal/templates/vue-ts/frontend/vite.config.ts
+++ b/v3/internal/templates/vue-ts/frontend/vite.config.ts
@@ -9,7 +9,7 @@ export default defineConfig({
   },
   plugins: [vue(), wails("./bindings")],
   server: {
-    port: parseInt(process.env.WAILS_VITE_PORT || "9245"),
+    port: Number(process.env.WAILS_VITE_PORT) || 9245,
     strictPort: true,
   },
 });

--- a/v3/internal/templates/vue-ts/frontend/vite.config.ts
+++ b/v3/internal/templates/vue-ts/frontend/vite.config.ts
@@ -8,4 +8,8 @@ export default defineConfig({
     host: "127.0.0.1",
   },
   plugins: [vue(), wails("./bindings")],
+  server: {
+    port: parseInt(process.env.WAILS_VITE_PORT || "9245"),
+    strictPort: true,
+  },
 });

--- a/v3/internal/templates/vue-ts/frontend/vite.config.ts
+++ b/v3/internal/templates/vue-ts/frontend/vite.config.ts
@@ -6,10 +6,8 @@ import wails from "@wailsio/runtime/plugins/vite";
 export default defineConfig({
   server: {
     host: "127.0.0.1",
-  },
-  plugins: [vue(), wails("./bindings")],
-  server: {
     port: Number(process.env.WAILS_VITE_PORT) || 9245,
     strictPort: true,
   },
+  plugins: [vue(), wails("./bindings")],
 });

--- a/v3/internal/templates/vue/frontend/vite.config.js
+++ b/v3/internal/templates/vue/frontend/vite.config.js
@@ -9,7 +9,7 @@ export default defineConfig({
   },
   plugins: [vue(), wails("./bindings")],
   server: {
-    port: parseInt(process.env.WAILS_VITE_PORT || "9245"),
+    port: Number(process.env.WAILS_VITE_PORT) || 9245,
     strictPort: true,
   },
 });

--- a/v3/internal/templates/vue/frontend/vite.config.js
+++ b/v3/internal/templates/vue/frontend/vite.config.js
@@ -8,4 +8,8 @@ export default defineConfig({
     host: "127.0.0.1",
   },
   plugins: [vue(), wails("./bindings")],
+  server: {
+    port: parseInt(process.env.WAILS_VITE_PORT || "9245"),
+    strictPort: true,
+  },
 });

--- a/v3/internal/templates/vue/frontend/vite.config.js
+++ b/v3/internal/templates/vue/frontend/vite.config.js
@@ -6,10 +6,8 @@ import wails from "@wailsio/runtime/plugins/vite";
 export default defineConfig({
   server: {
     host: "127.0.0.1",
-  },
-  plugins: [vue(), wails("./bindings")],
-  server: {
     port: Number(process.env.WAILS_VITE_PORT) || 9245,
     strictPort: true,
   },
+  plugins: [vue(), wails("./bindings")],
 });


### PR DESCRIPTION
## Root cause

When users replace `npm` with `pnpm` in `build/Taskfile.yml`, the `dev:frontend` task runs:

```
pnpm run dev -- --port 9245 --strictPort
```

Unlike `npm`, `pnpm`'s `--` separator does not reliably forward CLI args to the underlying Vite script (the behaviour varies by pnpm version and config). Vite falls back to its default port **5173** instead of the Wails-managed port **9245**. The Wails backend polls `FRONTEND_DEVSERVER_URL` (`http://localhost:9245`) for up to 5 s, fails to connect, and aborts.

## Fix

`wails3 dev` already sets the `WAILS_VITE_PORT` environment variable before launching the watcher. This PR makes every project template `vite.config` read from that env var:

```ts
server: {
  port: parseInt(process.env.WAILS_VITE_PORT || "9245"),
  strictPort: true,
},
```

Because Vite merges config-file settings with CLI args (CLI wins when both are present), this is fully backward-compatible: existing `npm` users are unaffected (the CLI `--port` arg still overrides), while `pnpm`, `yarn`, and `bun` users get the correct port through the env var.

The `dev:frontend` Taskfile task is simplified to `npm run dev` — the port is no longer passed via CLI args since vite.config handles it. Users can swap `npm` for any other package manager in their Taskfile and dev mode works correctly.

## Changes

- All 20 `vite.config.{ts,js}` templates updated with `server.port`/`server.strictPort`
- `v3/internal/commands/build_assets/Taskfile.tmpl.yml` — `dev:frontend` simplified to `npm run dev`
- 7 example `build/Taskfile.yml` files updated to match
- 3 example `vite.config.js` files updated (android, ios, dev)
- 5 minimal `vite.config.js` files added to examples that were missing them (notifications, dock, badge, badge-custom, file-association)

## Testing

- Reproduce: create a new Wails v3 project with any template, replace `npm` with `pnpm` in `build/Taskfile.yml`, run `wails3 dev` → previously hangs with "unable to connect to frontend server"
- After: `WAILS_VITE_PORT` is read by vite.config, Vite starts on port 9245, `wails3 dev` connects successfully
- Existing `npm` users: unaffected — `npm run dev` reads port from vite.config as before

Closes #4652

CC @leaanthony

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized dev-server behavior: frontends now read a common env var (fallback 9245) and enforce the requested port to avoid automatic port fallback.
* **Chores**
  * Simplified local dev commands by removing explicit CLI port forwarding, reducing duplicated configuration and streamlining startup.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wailsapp/wails/pull/5365)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->