### PR TITLE
chore(templates): bump Vite to ^8.0.11 with coordinated plugin co-bumps

### DIFF
--- a/v3/internal/templates/base/frontend/package.json
+++ b/v3/internal/templates/base/frontend/package.json
@@ -10,7 +10,7 @@
     "preview": "vite preview"
   },
   "devDependencies": {
-    "vite": "^5.0.0",
+    "vite": "^8.0.11",
     "@wailsio/runtime": "latest"
   }
 }

--- a/v3/internal/templates/ios/frontend/package.json
+++ b/v3/internal/templates/ios/frontend/package.json
@@ -13,6 +13,6 @@
     "@wailsio/runtime": "latest"
   },
   "devDependencies": {
-    "vite": "^5.0.0"
+    "vite": "^8.0.11"
   }
 }

--- a/v3/internal/templates/lit-ts/frontend/package.json
+++ b/v3/internal/templates/lit-ts/frontend/package.json
@@ -15,6 +15,6 @@
   },
   "devDependencies": {
     "typescript": "^5.2.2",
-    "vite": "^5.0.0"
+    "vite": "^8.0.11"
   }
 }

--- a/v3/internal/templates/lit/frontend/package.json
+++ b/v3/internal/templates/lit/frontend/package.json
@@ -14,6 +14,6 @@
     "lit": "^3.1.0"
   },
   "devDependencies": {
-    "vite": "^5.0.0"
+    "vite": "^8.0.11"
   }
 }

--- a/v3/internal/templates/preact-ts/frontend/package.json
+++ b/v3/internal/templates/preact-ts/frontend/package.json
@@ -16,6 +16,6 @@
   "devDependencies": {
     "@preact/preset-vite": "^2.7.0",
     "typescript": "^5.2.2",
-    "vite": "^5.0.8"
+    "vite": "^8.0.11"
   }
 }

--- a/v3/internal/templates/preact/frontend/package.json
+++ b/v3/internal/templates/preact/frontend/package.json
@@ -15,6 +15,6 @@
   },
   "devDependencies": {
     "@preact/preset-vite": "^2.7.0",
-    "vite": "^5.0.8"
+    "vite": "^8.0.11"
   }
 }

--- a/v3/internal/templates/qwik-ts/frontend/package.json
+++ b/v3/internal/templates/qwik-ts/frontend/package.json
@@ -15,6 +15,6 @@
   },
   "devDependencies": {
     "typescript": "^5.2.2",
-    "vite": "^5.0.8"
+    "vite": "^8.0.11"
   }
 }

--- a/v3/internal/templates/qwik/frontend/package.json
+++ b/v3/internal/templates/qwik/frontend/package.json
@@ -15,6 +15,6 @@
   },
   "devDependencies": {
     "typescript": "^5.2.2",
-    "vite": "^5.0.8"
+    "vite": "^8.0.11"
   }
 }

--- a/v3/internal/templates/react-swc-ts/frontend/package.json
+++ b/v3/internal/templates/react-swc-ts/frontend/package.json
@@ -17,8 +17,8 @@
   "devDependencies": {
     "@types/react": "^18.2.43",
     "@types/react-dom": "^18.2.17",
-    "@vitejs/plugin-react-swc": "^3.5.0",
+    "@vitejs/plugin-react-swc": "^4.0.0",
     "typescript": "^5.2.2",
-    "vite": "^5.0.8"
+    "vite": "^8.0.11"
   }
 }

--- a/v3/internal/templates/react-swc/frontend/package.json
+++ b/v3/internal/templates/react-swc/frontend/package.json
@@ -17,7 +17,7 @@
   "devDependencies": {
     "@types/react": "^18.2.43",
     "@types/react-dom": "^18.2.17",
-    "@vitejs/plugin-react-swc": "^3.5.0",
-    "vite": "^5.0.8"
+    "@vitejs/plugin-react-swc": "^4.0.0",
+    "vite": "^8.0.11"
   }
 }

--- a/v3/internal/templates/react-ts/frontend/package.json
+++ b/v3/internal/templates/react-ts/frontend/package.json
@@ -17,8 +17,8 @@
   "devDependencies": {
     "@types/react": "^18.2.43",
     "@types/react-dom": "^18.2.17",
-    "@vitejs/plugin-react": "^4.2.1",
+    "@vitejs/plugin-react": "^5.2.0",
     "typescript": "^5.2.2",
-    "vite": "^5.0.8"
+    "vite": "^8.0.11"
   }
 }

--- a/v3/internal/templates/react/frontend/package.json
+++ b/v3/internal/templates/react/frontend/package.json
@@ -17,7 +17,7 @@
   "devDependencies": {
     "@types/react": "^18.2.43",
     "@types/react-dom": "^18.2.17",
-    "@vitejs/plugin-react": "^4.2.1",
-    "vite": "^5.0.8"
+    "@vitejs/plugin-react": "^5.2.0",
+    "vite": "^8.0.11"
   }
 }

--- a/v3/internal/templates/solid-ts/frontend/package.json
+++ b/v3/internal/templates/solid-ts/frontend/package.json
@@ -15,7 +15,7 @@
   },
   "devDependencies": {
     "typescript": "^5.2.2",
-    "vite": "^5.0.8",
+    "vite": "^8.0.11",
     "vite-plugin-solid": "^2.8.0"
   }
 }

--- a/v3/internal/templates/solid/frontend/package.json
+++ b/v3/internal/templates/solid/frontend/package.json
@@ -14,7 +14,7 @@
     "solid-js": "^1.8.7"
   },
   "devDependencies": {
-    "vite": "^5.0.8",
+    "vite": "^8.0.11",
     "vite-plugin-solid": "^2.8.0"
   }
 }

--- a/v3/internal/templates/vanilla-ts/frontend/package.json
+++ b/v3/internal/templates/vanilla-ts/frontend/package.json
@@ -14,6 +14,6 @@
   },
   "devDependencies": {
     "typescript": "^4.9.3",
-    "vite": "^5.0.0"
+    "vite": "^8.0.11"
   }
 }

--- a/v3/internal/templates/vanilla/frontend/package.json
+++ b/v3/internal/templates/vanilla/frontend/package.json
@@ -13,6 +13,6 @@
     "@wailsio/runtime": "latest"
   },
   "devDependencies": {
-    "vite": "^5.0.0"
+    "vite": "^8.0.11"
   }
 }

--- a/v3/internal/templates/vue-ts/frontend/package.json
+++ b/v3/internal/templates/vue-ts/frontend/package.json
@@ -14,9 +14,9 @@
     "vue": "^3.2.45"
   },
   "devDependencies": {
-    "@vitejs/plugin-vue": "^4.0.0",
+    "@vitejs/plugin-vue": "^6.0.0",
     "typescript": "^4.9.3",
-    "vite": "^5.0.0",
+    "vite": "^8.0.11",
     "vue-tsc": "^1.0.11"
   }
 }

--- a/v3/internal/templates/vue/frontend/package.json
+++ b/v3/internal/templates/vue/frontend/package.json
@@ -14,7 +14,7 @@
     "vue": "^3.2.45"
   },
   "devDependencies": {
-    "@vitejs/plugin-vue": "^4.0.0",
-    "vite": "^5.0.0"
+    "@vitejs/plugin-vue": "^6.0.0",
+    "vite": "^8.0.11"
   }
 }


### PR DESCRIPTION
## Summary

Supersedes and closes #5374.

Dependabot's bump only updated `vite` but five template families have framework plugins with `peerDependencies` capping at Vite 7, causing ERESOLVE failures across all three CI platforms. This PR co-bumps those plugins alongside the vite upgrade.

| Template family | vite | plugin |
|---|---|---|
| react / react-ts | `^5→^8.0.11` | `@vitejs/plugin-react ^4.2.1→^5.2.0` |
| react-swc / react-swc-ts | `^5→^8.0.11` | `@vitejs/plugin-react-swc ^3.5.0→^4.0.0` |
| vue / vue-ts | `^5→^8.0.11` | `@vitejs/plugin-vue ^4.0.0→^6.0.0` |
| vanilla / vanilla-ts / lit / lit-ts | `^5→^8.0.11` | (none) |
| preact / preact-ts / solid / solid-ts | `^5→^8.0.11` | already supports ^8 |
| qwik / qwik-ts / base / ios | `^5→^8.0.11` | (none) |
| **svelte / svelte-ts** | **unchanged** | no plugin bridges Svelte 4 + Vite 8 |
| **sveltekit / sveltekit-ts** | **unchanged** | same reason |

### Why svelte templates are excluded

`@sveltejs/vite-plugin-svelte@^7` is the first release that supports `vite ^8`, but it requires `svelte ^5.46.4`. There is no plugin version that bridges Svelte 4 and Vite 8. A Svelte 5 template migration is a separate piece of work.

### Node.js requirement

Vite 8 requires Node.js ≥ 20.19.0. Users on Ubuntu 22.04 LTS (which ships Node 18) will get a crash:
```
ReferenceError: CustomEvent is not defined
```

CC @leaanthony

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development dependencies across all frontend templates. Vite upgraded from version 5.x to 8.0.11. Framework-specific Vite plugins also updated: React Vite plugin to 5.2.0, React SWC plugin to 4.0.0, and Vue plugin to 6.0.0.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wailsapp/wails/pull/5379)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->