### PR TITLE
fix(v3/darwin): preserve empty plist containers; broaden stub detection in test

### DIFF
--- a/v3/internal/commands/build-assets.go
+++ b/v3/internal/commands/build-assets.go
@@ -459,15 +459,15 @@ func sanitizePlistValue(v any) (any, bool) {
 		return val, true
 	case map[string]any:
 		sanitized := sanitizePlistDict(val)
-		return sanitized, len(sanitized) > 0
+		return sanitized, true
 	case []any:
-		var result []any
+		result := make([]any, 0, len(val))
 		for _, item := range val {
 			if sanitized, keep := sanitizePlistValue(item); keep {
 				result = append(result, sanitized)
 			}
 		}
-		return result, len(result) > 0
+		return result, true
 	default:
 		return v, true
 	}

--- a/v3/internal/commands/build-assets_test.go
+++ b/v3/internal/commands/build-assets_test.go
@@ -731,12 +731,9 @@ func TestOldFormatPlistMigration(t *testing.T) {
 
 	contentStr := string(content)
 
-	// No template stub should survive in the output.
-	stubs := []string{"{{.Ext}}", "{{.Name}}", "{{.Role}}", "{{.IconName}}", "{{.Scheme}}"}
-	for _, stub := range stubs {
-		if strings.Contains(contentStr, stub) {
-			t.Errorf("Output Info.plist still contains template stub %q — old-format template was not sanitized correctly", stub)
-		}
+	// No Go template syntax should survive in the output.
+	if strings.Contains(contentStr, "{{") {
+		t.Errorf("Output Info.plist still contains Go template syntax — old-format template was not sanitized correctly:\n%s", contentStr)
 	}
 
 	// User-added keys that are real values must be preserved.


### PR DESCRIPTION
Addresses review feedback on #5312.

- `sanitizePlistValue`: return `true` unconditionally for dict/array types so legitimately empty containers in user plists are preserved (previously `keep=false` was returned for any empty container, even those with no template stubs).
- `TestOldFormatPlistMigration`: broaden the assertion from five named stub checks to a single `strings.Contains(contentStr, "{{")` check so any surviving template syntax fails the test.

These two commits can be cherry-picked onto the PR #5312 branch directly.

Closes #5312