### PR TITLE
chore(templates): upgrade Svelte templates to Svelte 5 + Vite 8

### DIFF
--- a/v3/internal/templates/svelte-ts/frontend/package.json
+++ b/v3/internal/templates/svelte-ts/frontend/package.json
@@ -20,6 +20,6 @@
     "svelte-check": "^4.4.8",
     "tslib": "^2.6.2",
     "typescript": "^5.2.2",
-    "vite": "^8.0.0"
+    "vite": "^8.0.5"
   }
 }

--- a/v3/internal/templates/svelte-ts/frontend/package.json
+++ b/v3/internal/templates/svelte-ts/frontend/package.json
@@ -14,12 +14,12 @@
     "@wailsio/runtime": "latest"
   },
   "devDependencies": {
-    "@sveltejs/vite-plugin-svelte": "^3.0.1",
-    "@tsconfig/svelte": "^5.0.2",
-    "svelte": "^4.2.8",
-    "svelte-check": "^3.6.2",
+    "@sveltejs/vite-plugin-svelte": "^7.0.0",
+    "@tsconfig/svelte": "^5.0.8",
+    "svelte": "^5.0.0",
+    "svelte-check": "^4.4.8",
     "tslib": "^2.6.2",
     "typescript": "^5.2.2",
-    "vite": "^5.0.8"
+    "vite": "^8.0.0"
   }
 }

--- a/v3/internal/templates/svelte-ts/frontend/package.json
+++ b/v3/internal/templates/svelte-ts/frontend/package.json
@@ -16,7 +16,7 @@
   "devDependencies": {
     "@sveltejs/vite-plugin-svelte": "^7.0.0",
     "@tsconfig/svelte": "^5.0.8",
-    "svelte": "^5.0.0",
+    "svelte": "^5.46.4",
     "svelte-check": "^4.4.8",
     "tslib": "^2.6.2",
     "typescript": "^5.2.2",

--- a/v3/internal/templates/svelte-ts/frontend/src/App.svelte.tmpl
+++ b/v3/internal/templates/svelte-ts/frontend/src/App.svelte.tmpl
@@ -2,9 +2,9 @@
   import {Events} from "@wailsio/runtime";
   import {GreetService} from "../bindings/{{js .ModulePath}}";
 
-  let name: string = '';
-  let result: string = 'Please enter your name below 👇';
-  let time: string = 'Listening for Time event...';
+  let name: string = $state('');
+  let result: string = $state('Please enter your name below 👇');
+  let time: string = $state('Listening for Time event...');
 
   const doGreet = (): void => {
     let localName = name;
@@ -37,7 +37,7 @@
   <div class="card">
     <div class="input-box">
       <input aria-label="input" class="input" bind:value={name} type="text" autocomplete="off"/>
-      <button aria-label="greet-btn" class="btn" on:click={doGreet}>Greet</button>
+      <button aria-label="greet-btn" class="btn" onclick={doGreet}>Greet</button>
     </div>
   </div>
   <div class="footer">

--- a/v3/internal/templates/svelte-ts/frontend/src/main.ts
+++ b/v3/internal/templates/svelte-ts/frontend/src/main.ts
@@ -1,7 +1,4 @@
+import { mount } from 'svelte'
 import App from './App.svelte'
 
-const app = new App({
-  target: document.getElementById('app'),
-})
-
-export default app
+mount(App, { target: document.getElementById('app')! })

--- a/v3/internal/templates/svelte/frontend/package.json
+++ b/v3/internal/templates/svelte/frontend/package.json
@@ -13,8 +13,8 @@
     "@wailsio/runtime": "latest"
   },
   "devDependencies": {
-    "@sveltejs/vite-plugin-svelte": "^3.0.1",
-    "svelte": "^4.2.8",
-    "vite": "^5.0.8"
+    "@sveltejs/vite-plugin-svelte": "^7.0.0",
+    "svelte": "^5.0.0",
+    "vite": "^8.0.0"
   }
 }

--- a/v3/internal/templates/svelte/frontend/package.json
+++ b/v3/internal/templates/svelte/frontend/package.json
@@ -14,7 +14,7 @@
   },
   "devDependencies": {
     "@sveltejs/vite-plugin-svelte": "^7.0.0",
-    "svelte": "^5.0.0",
+    "svelte": "^5.46.4",
     "vite": "^8.0.0"
   }
 }

--- a/v3/internal/templates/svelte/frontend/package.json
+++ b/v3/internal/templates/svelte/frontend/package.json
@@ -15,6 +15,6 @@
   "devDependencies": {
     "@sveltejs/vite-plugin-svelte": "^7.0.0",
     "svelte": "^5.46.4",
-    "vite": "^8.0.0"
+    "vite": "^8.0.5"
   }
 }

--- a/v3/internal/templates/svelte/frontend/src/App.svelte.tmpl
+++ b/v3/internal/templates/svelte/frontend/src/App.svelte.tmpl
@@ -2,9 +2,9 @@
 import {Events} from "@wailsio/runtime";
 import {GreetService} from "../bindings/{{js .ModulePath}}";
 
-let name = '';
-let result = 'Please enter your name below 👇';
-let time = 'Listening for Time event...';
+let name = $state('');
+let result = $state('Please enter your name below 👇');
+let time = $state('Listening for Time event...');
 
 const doGreet = () => {
   let localName = name;
@@ -37,7 +37,7 @@ Events.On('time', (timeValue) => {
   <div class="card">
     <div class="input-box">
       <input aria-label="input" class="input" bind:value={name} type="text" autocomplete="off"/>
-      <button aria-label="greet-btn" class="btn" on:click={doGreet}>Greet</button>
+      <button aria-label="greet-btn" class="btn" onclick={doGreet}>Greet</button>
     </div>
   </div>
   <div class="footer">

--- a/v3/internal/templates/svelte/frontend/src/main.js
+++ b/v3/internal/templates/svelte/frontend/src/main.js
@@ -1,7 +1,4 @@
+import { mount } from 'svelte'
 import App from './App.svelte'
 
-const app = new App({
-  target: document.getElementById('app'),
-})
-
-export default app
+mount(App, { target: document.getElementById('app') })

--- a/v3/internal/templates/sveltekit-ts/frontend/package.json
+++ b/v3/internal/templates/sveltekit-ts/frontend/package.json
@@ -21,6 +21,6 @@
     "svelte": "^5.46.4",
     "svelte-check": "^4.4.8",
     "typescript": "^5.0.0",
-    "vite": "^8.0.0"
+    "vite": "^8.0.5"
   }
 }

--- a/v3/internal/templates/sveltekit-ts/frontend/package.json
+++ b/v3/internal/templates/sveltekit-ts/frontend/package.json
@@ -15,12 +15,12 @@
     "@wailsio/runtime": "latest"
   },
   "devDependencies": {
-    "@sveltejs/adapter-static": "^3.0.5",
+    "@sveltejs/adapter-static": "^3.0.10",
     "@sveltejs/kit": "^2.0.0",
-    "@sveltejs/vite-plugin-svelte": "^3.0.0",
-    "svelte": "^4.2.7",
-    "svelte-check": "^4.0.0",
+    "@sveltejs/vite-plugin-svelte": "^7.0.0",
+    "svelte": "^5.0.0",
+    "svelte-check": "^4.4.8",
     "typescript": "^5.0.0",
-    "vite": "^5.0.3"
+    "vite": "^8.0.0"
   }
 }

--- a/v3/internal/templates/sveltekit-ts/frontend/package.json
+++ b/v3/internal/templates/sveltekit-ts/frontend/package.json
@@ -16,9 +16,9 @@
   },
   "devDependencies": {
     "@sveltejs/adapter-static": "^3.0.10",
-    "@sveltejs/kit": "^2.0.0",
+    "@sveltejs/kit": "^2.53.0",
     "@sveltejs/vite-plugin-svelte": "^7.0.0",
-    "svelte": "^5.0.0",
+    "svelte": "^5.46.4",
     "svelte-check": "^4.4.8",
     "typescript": "^5.0.0",
     "vite": "^8.0.0"

--- a/v3/internal/templates/sveltekit-ts/frontend/src/routes/+page.svelte.tmpl
+++ b/v3/internal/templates/sveltekit-ts/frontend/src/routes/+page.svelte.tmpl
@@ -2,9 +2,9 @@
 import {Events} from "@wailsio/runtime";
 import {GreetService} from "../../bindings/{{js .ModulePath}}";
 
-let name = '';
-let result = 'Please enter your name below 👇';
-let time = 'Listening for Time event...';
+let name = $state('');
+let result = $state('Please enter your name below 👇');
+let time = $state('Listening for Time event...');
 
 const doGreet = () => {
   let localName = name;
@@ -37,7 +37,7 @@ Events.On('time', (timeValue) => {
   <div class="card">
     <div class="input-box">
       <input aria-label="input" class="input" bind:value={name} type="text" autocomplete="off"/>
-      <button aria-label="greet-btn" class="btn" on:click={doGreet}>Greet</button>
+      <button aria-label="greet-btn" class="btn" onclick={doGreet}>Greet</button>
     </div>
   </div>
   <div class="footer">

--- a/v3/internal/templates/sveltekit/frontend/package.json
+++ b/v3/internal/templates/sveltekit/frontend/package.json
@@ -8,17 +8,18 @@
     "build:dev": "vite build --minify false --mode development",
     "build": "vite build --mode production",
     "preview": "vite preview",
-    "check": "svelte-kit sync && svelte-check --tsconfig ./jsconfig.json",
-    "check:watch": "svelte-kit sync && svelte-check --tsconfig ./jsconfig.json --watch"
+    "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
+    "check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch"
   },
   "dependencies": {
     "@wailsio/runtime": "latest"
   },
   "devDependencies": {
     "@sveltejs/adapter-static": "^3.0.10",
-    "@sveltejs/kit": "^2.0.0",
+    "@sveltejs/kit": "^2.53.0",
     "@sveltejs/vite-plugin-svelte": "^7.0.0",
-    "svelte": "^5.0.0",
+    "svelte": "^5.46.4",
+    "svelte-check": "^4.4.8",
     "vite": "^8.0.0"
   }
 }

--- a/v3/internal/templates/sveltekit/frontend/package.json
+++ b/v3/internal/templates/sveltekit/frontend/package.json
@@ -15,10 +15,10 @@
     "@wailsio/runtime": "latest"
   },
   "devDependencies": {
-    "@sveltejs/adapter-static": "^3.0.5",
+    "@sveltejs/adapter-static": "^3.0.10",
     "@sveltejs/kit": "^2.0.0",
-    "@sveltejs/vite-plugin-svelte": "^3.0.0",
-    "svelte": "^4.2.7",
-    "vite": "^5.0.3"
+    "@sveltejs/vite-plugin-svelte": "^7.0.0",
+    "svelte": "^5.0.0",
+    "vite": "^8.0.0"
   }
 }

--- a/v3/internal/templates/sveltekit/frontend/package.json
+++ b/v3/internal/templates/sveltekit/frontend/package.json
@@ -20,6 +20,6 @@
     "@sveltejs/vite-plugin-svelte": "^7.0.0",
     "svelte": "^5.46.4",
     "svelte-check": "^4.4.8",
-    "vite": "^8.0.0"
+    "vite": "^8.0.5"
   }
 }

--- a/v3/internal/templates/sveltekit/frontend/src/routes/+page.svelte.tmpl
+++ b/v3/internal/templates/sveltekit/frontend/src/routes/+page.svelte.tmpl
@@ -2,9 +2,9 @@
 import {Events} from "@wailsio/runtime";
 import {GreetService} from "../../bindings/{{js .ModulePath}}";
 
-let name = '';
-let result = 'Please enter your name below 👇';
-let time = 'Listening for Time event...';
+let name = $state('');
+let result = $state('Please enter your name below 👇');
+let time = $state('Listening for Time event...');
 
 const doGreet = () => {
   let localName = name;
@@ -37,7 +37,7 @@ Events.On('time', (timeValue) => {
   <div class="card">
     <div class="input-box">
       <input aria-label="input" class="input" bind:value={name} type="text" autocomplete="off"/>
-      <button aria-label="greet-btn" class="btn" on:click={doGreet}>Greet</button>
+      <button aria-label="greet-btn" class="btn" onclick={doGreet}>Greet</button>
     </div>
   </div>
   <div class="footer">


### PR DESCRIPTION
## Summary

Upgrades all four Svelte templates to Svelte 5 (stable since Oct 2024) and Vite 8.

| Template | svelte | vite-plugin-svelte | vite |
|---|---|---|---|
| svelte / svelte-ts | ^4 → **^5** | ^3 → **^7** | ^5 → **^8** |
| sveltekit / sveltekit-ts | ^4 → **^5** | ^3 → **^7** | ^5 → **^8** |

Also bumps `@tsconfig/svelte` 5.0.2 → 5.0.8 and `svelte-check` ^3 → ^4.4.8.

## Component changes

Svelte 5 deprecates/removes the `on:` event directive and the `new App()` constructor. Updated templates to idiomatic Svelte 5:

- `let x = ''` → `let x = $state('')` (runes)
- `on:click={fn}` → `onclick={fn}`
- `new App({ target })` → `mount(App, { target })` in `main.js` / `main.ts`

## Notes

- `@sveltejs/kit` stays at `^2.0.0` — already supports Svelte 5
- `@sveltejs/adapter-static` minor bump ^3.0.5 → ^3.0.10
- `bind:value` is unchanged — still valid in Svelte 5
- This PR intentionally does not touch vite config `server.host/port` — that's handled by the in-flight PR #5365

## Test plan

- [ ] `wails3 init -n test -t svelte && cd test && wails3 dev` — window loads
- [ ] Same for `svelte-ts`, `sveltekit`, `sveltekit-ts`
- [ ] Greet button calls backend and displays result
- [ ] No Svelte deprecation warnings in browser console

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated development dependencies across Svelte templates (Svelte v5, Vite v8, and related tooling).
  * Adjusted project check scripts to reference the correct TypeScript config where applicable.

* **Refactor**
  * Converted component state to the new reactive rune-style.
  * Switched component initialization to the mount API and standardized button/event binding syntax.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wailsapp/wails/pull/5385)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->