### PR TITLE
chore(templates): upgrade all remaining templates to Vite 8

### DIFF
--- a/v3/internal/templates/base/frontend/package.json
+++ b/v3/internal/templates/base/frontend/package.json
@@ -10,7 +10,7 @@
     "preview": "vite preview"
   },
   "devDependencies": {
-    "vite": "^5.0.0",
+    "vite": "^8.0.0",
     "@wailsio/runtime": "latest"
   }
 }

--- a/v3/internal/templates/base/frontend/package.json
+++ b/v3/internal/templates/base/frontend/package.json
@@ -10,7 +10,7 @@
     "preview": "vite preview"
   },
   "devDependencies": {
-    "vite": "^8.0.0",
+    "vite": "^8.0.5",
     "@wailsio/runtime": "latest"
   }
 }

--- a/v3/internal/templates/ios/frontend/package.json
+++ b/v3/internal/templates/ios/frontend/package.json
@@ -13,6 +13,6 @@
     "@wailsio/runtime": "latest"
   },
   "devDependencies": {
-    "vite": "^8.0.0"
+    "vite": "^8.0.5"
   }
 }

--- a/v3/internal/templates/ios/frontend/package.json
+++ b/v3/internal/templates/ios/frontend/package.json
@@ -13,6 +13,6 @@
     "@wailsio/runtime": "latest"
   },
   "devDependencies": {
-    "vite": "^5.0.0"
+    "vite": "^8.0.0"
   }
 }

--- a/v3/internal/templates/lit-ts/frontend/package.json
+++ b/v3/internal/templates/lit-ts/frontend/package.json
@@ -15,6 +15,6 @@
   },
   "devDependencies": {
     "typescript": "^5.2.2",
-    "vite": "^8.0.0"
+    "vite": "^8.0.5"
   }
 }

--- a/v3/internal/templates/lit-ts/frontend/package.json
+++ b/v3/internal/templates/lit-ts/frontend/package.json
@@ -15,6 +15,6 @@
   },
   "devDependencies": {
     "typescript": "^5.2.2",
-    "vite": "^5.0.0"
+    "vite": "^8.0.0"
   }
 }

--- a/v3/internal/templates/lit/frontend/package.json
+++ b/v3/internal/templates/lit/frontend/package.json
@@ -14,6 +14,6 @@
     "lit": "^3.1.0"
   },
   "devDependencies": {
-    "vite": "^8.0.0"
+    "vite": "^8.0.5"
   }
 }

--- a/v3/internal/templates/lit/frontend/package.json
+++ b/v3/internal/templates/lit/frontend/package.json
@@ -14,6 +14,6 @@
     "lit": "^3.1.0"
   },
   "devDependencies": {
-    "vite": "^5.0.0"
+    "vite": "^8.0.0"
   }
 }

--- a/v3/internal/templates/preact-ts/frontend/package.json
+++ b/v3/internal/templates/preact-ts/frontend/package.json
@@ -16,6 +16,6 @@
   "devDependencies": {
     "@preact/preset-vite": "^2.7.0",
     "typescript": "^5.2.2",
-    "vite": "^8.0.0"
+    "vite": "^8.0.5"
   }
 }

--- a/v3/internal/templates/preact-ts/frontend/package.json
+++ b/v3/internal/templates/preact-ts/frontend/package.json
@@ -16,6 +16,6 @@
   "devDependencies": {
     "@preact/preset-vite": "^2.7.0",
     "typescript": "^5.2.2",
-    "vite": "^5.0.8"
+    "vite": "^8.0.0"
   }
 }

--- a/v3/internal/templates/preact/frontend/package.json
+++ b/v3/internal/templates/preact/frontend/package.json
@@ -15,6 +15,6 @@
   },
   "devDependencies": {
     "@preact/preset-vite": "^2.7.0",
-    "vite": "^5.0.8"
+    "vite": "^8.0.0"
   }
 }

--- a/v3/internal/templates/preact/frontend/package.json
+++ b/v3/internal/templates/preact/frontend/package.json
@@ -15,6 +15,6 @@
   },
   "devDependencies": {
     "@preact/preset-vite": "^2.7.0",
-    "vite": "^8.0.0"
+    "vite": "^8.0.5"
   }
 }

--- a/v3/internal/templates/qwik-ts/frontend/package.json
+++ b/v3/internal/templates/qwik-ts/frontend/package.json
@@ -15,6 +15,6 @@
   },
   "devDependencies": {
     "typescript": "^5.2.2",
-    "vite": "^8.0.0"
+    "vite": "^8.0.5"
   }
 }

--- a/v3/internal/templates/qwik-ts/frontend/package.json
+++ b/v3/internal/templates/qwik-ts/frontend/package.json
@@ -15,6 +15,6 @@
   },
   "devDependencies": {
     "typescript": "^5.2.2",
-    "vite": "^5.0.8"
+    "vite": "^8.0.0"
   }
 }

--- a/v3/internal/templates/qwik/frontend/package.json
+++ b/v3/internal/templates/qwik/frontend/package.json
@@ -15,6 +15,6 @@
   },
   "devDependencies": {
     "typescript": "^5.2.2",
-    "vite": "^8.0.0"
+    "vite": "^8.0.5"
   }
 }

--- a/v3/internal/templates/qwik/frontend/package.json
+++ b/v3/internal/templates/qwik/frontend/package.json
@@ -15,6 +15,6 @@
   },
   "devDependencies": {
     "typescript": "^5.2.2",
-    "vite": "^5.0.8"
+    "vite": "^8.0.0"
   }
 }

--- a/v3/internal/templates/react-swc-ts/frontend/package.json
+++ b/v3/internal/templates/react-swc-ts/frontend/package.json
@@ -19,6 +19,6 @@
     "@types/react-dom": "^18.2.17",
     "@vitejs/plugin-react-swc": "^4.0.0",
     "typescript": "^5.2.2",
-    "vite": "^8.0.0"
+    "vite": "^8.0.5"
   }
 }

--- a/v3/internal/templates/react-swc-ts/frontend/package.json
+++ b/v3/internal/templates/react-swc-ts/frontend/package.json
@@ -17,8 +17,8 @@
   "devDependencies": {
     "@types/react": "^18.2.43",
     "@types/react-dom": "^18.2.17",
-    "@vitejs/plugin-react-swc": "^3.5.0",
+    "@vitejs/plugin-react-swc": "^4.0.0",
     "typescript": "^5.2.2",
-    "vite": "^5.0.8"
+    "vite": "^8.0.0"
   }
 }

--- a/v3/internal/templates/react-swc/frontend/package.json
+++ b/v3/internal/templates/react-swc/frontend/package.json
@@ -17,7 +17,7 @@
   "devDependencies": {
     "@types/react": "^18.2.43",
     "@types/react-dom": "^18.2.17",
-    "@vitejs/plugin-react-swc": "^3.5.0",
-    "vite": "^5.0.8"
+    "@vitejs/plugin-react-swc": "^4.0.0",
+    "vite": "^8.0.0"
   }
 }

--- a/v3/internal/templates/react-swc/frontend/package.json
+++ b/v3/internal/templates/react-swc/frontend/package.json
@@ -18,6 +18,6 @@
     "@types/react": "^18.2.43",
     "@types/react-dom": "^18.2.17",
     "@vitejs/plugin-react-swc": "^4.0.0",
-    "vite": "^8.0.0"
+    "vite": "^8.0.5"
   }
 }

--- a/v3/internal/templates/react-ts/frontend/package.json
+++ b/v3/internal/templates/react-ts/frontend/package.json
@@ -17,8 +17,8 @@
   "devDependencies": {
     "@types/react": "^18.2.43",
     "@types/react-dom": "^18.2.17",
-    "@vitejs/plugin-react": "^4.2.1",
+    "@vitejs/plugin-react": "^6.0.0",
     "typescript": "^5.2.2",
-    "vite": "^5.0.8"
+    "vite": "^8.0.0"
   }
 }

--- a/v3/internal/templates/react-ts/frontend/package.json
+++ b/v3/internal/templates/react-ts/frontend/package.json
@@ -19,6 +19,6 @@
     "@types/react-dom": "^18.2.17",
     "@vitejs/plugin-react": "^6.0.0",
     "typescript": "^5.2.2",
-    "vite": "^8.0.0"
+    "vite": "^8.0.5"
   }
 }

--- a/v3/internal/templates/react/frontend/package.json
+++ b/v3/internal/templates/react/frontend/package.json
@@ -18,6 +18,6 @@
     "@types/react": "^18.2.43",
     "@types/react-dom": "^18.2.17",
     "@vitejs/plugin-react": "^6.0.0",
-    "vite": "^8.0.0"
+    "vite": "^8.0.5"
   }
 }

--- a/v3/internal/templates/react/frontend/package.json
+++ b/v3/internal/templates/react/frontend/package.json
@@ -17,7 +17,7 @@
   "devDependencies": {
     "@types/react": "^18.2.43",
     "@types/react-dom": "^18.2.17",
-    "@vitejs/plugin-react": "^4.2.1",
-    "vite": "^5.0.8"
+    "@vitejs/plugin-react": "^6.0.0",
+    "vite": "^8.0.0"
   }
 }

--- a/v3/internal/templates/solid-ts/frontend/package.json
+++ b/v3/internal/templates/solid-ts/frontend/package.json
@@ -15,7 +15,7 @@
   },
   "devDependencies": {
     "typescript": "^5.2.2",
-    "vite": "^5.0.8",
+    "vite": "^8.0.0",
     "vite-plugin-solid": "^2.8.0"
   }
 }

--- a/v3/internal/templates/solid-ts/frontend/package.json
+++ b/v3/internal/templates/solid-ts/frontend/package.json
@@ -15,7 +15,7 @@
   },
   "devDependencies": {
     "typescript": "^5.2.2",
-    "vite": "^8.0.0",
+    "vite": "^8.0.5",
     "vite-plugin-solid": "^2.8.0"
   }
 }

--- a/v3/internal/templates/solid/frontend/package.json
+++ b/v3/internal/templates/solid/frontend/package.json
@@ -14,7 +14,7 @@
     "solid-js": "^1.8.7"
   },
   "devDependencies": {
-    "vite": "^5.0.8",
+    "vite": "^8.0.0",
     "vite-plugin-solid": "^2.8.0"
   }
 }

--- a/v3/internal/templates/solid/frontend/package.json
+++ b/v3/internal/templates/solid/frontend/package.json
@@ -14,7 +14,7 @@
     "solid-js": "^1.8.7"
   },
   "devDependencies": {
-    "vite": "^8.0.0",
+    "vite": "^8.0.5",
     "vite-plugin-solid": "^2.8.0"
   }
 }

--- a/v3/internal/templates/vanilla-ts/frontend/package.json
+++ b/v3/internal/templates/vanilla-ts/frontend/package.json
@@ -14,6 +14,6 @@
   },
   "devDependencies": {
     "typescript": "^4.9.3",
-    "vite": "^8.0.0"
+    "vite": "^8.0.5"
   }
 }

--- a/v3/internal/templates/vanilla-ts/frontend/package.json
+++ b/v3/internal/templates/vanilla-ts/frontend/package.json
@@ -14,6 +14,6 @@
   },
   "devDependencies": {
     "typescript": "^4.9.3",
-    "vite": "^5.0.0"
+    "vite": "^8.0.0"
   }
 }

--- a/v3/internal/templates/vanilla/frontend/package.json
+++ b/v3/internal/templates/vanilla/frontend/package.json
@@ -13,6 +13,6 @@
     "@wailsio/runtime": "latest"
   },
   "devDependencies": {
-    "vite": "^8.0.0"
+    "vite": "^8.0.5"
   }
 }

--- a/v3/internal/templates/vanilla/frontend/package.json
+++ b/v3/internal/templates/vanilla/frontend/package.json
@@ -13,6 +13,6 @@
     "@wailsio/runtime": "latest"
   },
   "devDependencies": {
-    "vite": "^5.0.0"
+    "vite": "^8.0.0"
   }
 }

--- a/v3/internal/templates/vue-ts/frontend/package.json
+++ b/v3/internal/templates/vue-ts/frontend/package.json
@@ -14,9 +14,9 @@
     "vue": "^3.2.45"
   },
   "devDependencies": {
-    "@vitejs/plugin-vue": "^4.0.0",
+    "@vitejs/plugin-vue": "^6.0.0",
     "typescript": "^4.9.3",
-    "vite": "^5.0.0",
+    "vite": "^8.0.0",
     "vue-tsc": "^1.0.11"
   }
 }

--- a/v3/internal/templates/vue-ts/frontend/package.json
+++ b/v3/internal/templates/vue-ts/frontend/package.json
@@ -16,7 +16,7 @@
   "devDependencies": {
     "@vitejs/plugin-vue": "^6.0.0",
     "typescript": "^4.9.3",
-    "vite": "^8.0.0",
+    "vite": "^8.0.5",
     "vue-tsc": "^1.0.11"
   }
 }

--- a/v3/internal/templates/vue/frontend/package.json
+++ b/v3/internal/templates/vue/frontend/package.json
@@ -14,7 +14,7 @@
     "vue": "^3.2.45"
   },
   "devDependencies": {
-    "@vitejs/plugin-vue": "^4.0.0",
-    "vite": "^5.0.0"
+    "@vitejs/plugin-vue": "^6.0.0",
+    "vite": "^8.0.0"
   }
 }

--- a/v3/internal/templates/vue/frontend/package.json
+++ b/v3/internal/templates/vue/frontend/package.json
@@ -15,6 +15,6 @@
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "^6.0.0",
-    "vite": "^8.0.0"
+    "vite": "^8.0.5"
   }
 }


### PR DESCRIPTION
## Summary

Upgrades Vite from `^5.x` to `^8.0.0` across all remaining templates (18 templates). Svelte/SvelteKit templates are excluded — they are covered by PR #5385 which is in review.

### Plugin changes required for Vite 8

Some plugins needed a major bump to be compatible with Vite 8:

| Template | Plugin | Old | New |
|---|---|---|---|
| react, react-ts | `@vitejs/plugin-react` | `^4.2.1` | `^6.0.0` |
| react-swc, react-swc-ts | `@vitejs/plugin-react-swc` | `^3.5.0` | `^4.0.0` |
| vue, vue-ts | `@vitejs/plugin-vue` | `^4.0.0` | `^6.0.0` |

Plugins that already declare Vite 8 in their peer dep range — `vite-plugin-solid` and `@preact/preset-vite` — are left at their current ranges.

### Templates updated

`base`, `ios`, `vanilla`, `vanilla-ts`, `lit`, `lit-ts`, `preact`, `preact-ts`, `solid`, `solid-ts`, `qwik`, `qwik-ts`, `react`, `react-ts`, `react-swc`, `react-swc-ts`, `vue`, `vue-ts`

## Test plan

- [ ] `wails3 init -n test -t react && cd test && npm install` — no ERESOLVE errors
- [ ] Same for `react-ts`, `vue`, `vue-ts`
- [ ] `npm run build` completes in a vanilla project
- [ ] No breaking changes from Vite 5 → 8 in template code (templates only use standard Vite build/dev — no Vite-internal APIs)

CC @leaanthony

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped Vite dev dependency across all frontend templates to 8.0.5.
  * Updated framework Vite plugins: Vue plugin → 6.0.0; React plugin → 6.0.0; React SWC plugin → 4.0.0; other template-specific plugin updates included to ensure compatibility.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wailsapp/wails/pull/5386)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->