### PR TITLE
ci: fix 'Run Go Tests' required check never reporting on PRs

### DIFF
--- a/.github/workflows/pr-master.yml
+++ b/.github/workflows/pr-master.yml
@@ -10,6 +10,8 @@ on:
   workflow_dispatch: {}
 
 name: PR Checks (master)
+permissions:
+  contents: read
 
 jobs:
   check_docs:
@@ -109,3 +111,35 @@ jobs:
           echo "Skipping tests for sponsor update branch"
           echo "This is an automated update of the sponsors image."
         continue-on-error: true
+
+  go_test_results:
+    name: Run Go Tests
+    permissions: {}
+    if: >
+      always() &&
+      github.repository == 'wailsapp/wails' &&
+      (
+        github.event_name == 'workflow_dispatch' ||
+        github.event.pull_request.base.ref == 'master'
+      )
+    needs: [test_go, skip_tests]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check matrix result
+        run: |
+          test_result="${{ needs.test_go.result }}"
+          skip_result="${{ needs.skip_tests.result }}"
+
+          if [[ "$test_result" == "success" || "$test_result" == "skipped" ]]; then
+            echo "Go tests result: $test_result — passed"
+            exit 0
+          fi
+
+          if [[ "$skip_result" == "success" ]]; then
+            echo "Tests skipped (sponsor update) — passed"
+            exit 0
+          fi
+
+          echo "Go tests result: $test_result"
+          echo "Skip tests result: $skip_result"
+          exit 1


### PR DESCRIPTION
## Summary

- Add `permissions: contents: read` at workflow level to satisfy CodeQL
- Add `go_test_results` fan-in job that posts a single `Run Go Tests` status check, matching the branch protection required check name
- The job uses `if: always()` and `needs: [test_go, skip_tests]` so it always reports, covering both normal PRs and sponsor-update PRs

## Background

The `test_go` matrix job reports per-platform checks like `Run Go Tests (ubuntu-22.04, 1.23)`. No aggregate `Run Go Tests` check is ever posted, so the branch protection requirement (which expects exactly that name) is permanently unsatisfied on every PR.

## Changes

| File | Change |
|------|--------|
| `.github/workflows/pr-master.yml` | Add `permissions: contents: read`; add `go_test_results` fan-in job |

Closes #5316

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved CI/CD pipeline configuration to enhance security and reliability of automated testing workflows.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wailsapp/wails/pull/5389)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->