### PR TITLE
fix(v3): mapsEqual test helper panics on slice values

### DIFF
--- a/v3/internal/commands/build-assets_test.go
+++ b/v3/internal/commands/build-assets_test.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -778,7 +779,7 @@ func mapsEqual(a, b map[string]any) bool {
 			}
 		} else if aIsMap != bIsMap {
 			return false
-		} else if av != bv {
+		} else if !reflect.DeepEqual(av, bv) {
 			return false
 		}
 	}


### PR DESCRIPTION
## Summary

- `mapsEqual` in `v3/internal/commands/build-assets_test.go` compares leaf values with `==`, which panics at runtime when the value is a slice (`[]any`).
- `TestPreserveOriginallyEmptyContainers/originally_empty_array_is_preserved` deliberately puts an empty `[]any` into a `map[string]any`, hitting that line and panicking — which takes down the **entire** `internal/commands` package test run on every OS, blocking unrelated PRs (e.g. #5400).
- Replace just that leaf comparison with `reflect.DeepEqual`. Nested-map recursion and the `len(a) != len(b)` early-out are preserved, so nil-vs-empty semantics are unchanged.

## Diff

```go
-		} else if av != bv {
+		} else if !reflect.DeepEqual(av, bv) {
 			return false
 		}
```

## Test plan

- [x] `go test -count=1 ./v3/internal/commands/...` — passes locally (was panicking before).
- [ ] CI green on ubuntu / windows / macOS Go test jobs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced equality comparison for complex data structures in build-assets validation
  * Added test coverage to verify proper preservation of originally empty containers during sanitization

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wailsapp/wails/pull/5402)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->