### PR TITLE
feat(application): cross-platform Autostart manager

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -235,6 +235,11 @@ export default defineConfig({
               ],
             },
             {
+              label: "Autostart",
+              collapsed: true,
+              autogenerate: { directory: "features/autostart" },
+            },
+            {
               label: "Clipboard",
               collapsed: true,
               autogenerate: { directory: "features/clipboard" },

--- a/docs/src/content/docs/concepts/manager-api.mdx
+++ b/docs/src/content/docs/concepts/manager-api.mdx
@@ -24,6 +24,7 @@ The Manager API organizes application functionality into eleven focused areas:
 - **`app.Screen`** - Screen management and coordinate transformations
 - **`app.Clipboard`** - Clipboard text operations
 - **`app.SystemTray`** - System tray icon creation and management
+- **`app.Autostart`** - Register the application to launch at user login
 
 ## Benefits
 
@@ -264,3 +265,25 @@ systray.SetMenu(menu)
 // Destroy system tray when done
 systray.Destroy()
 ```
+
+### Autostart Manager
+
+Registers the application to launch at user login. Picks the appropriate native mechanism per platform: SMAppService or a LaunchAgent plist on macOS, the `HKCU\…\Run` registry key on Windows, an XDG `.desktop` entry on Linux.
+
+```go
+// Register to launch at login
+err := app.Autostart.Enable()
+
+// With extra launch-time arguments and a custom identifier
+err = app.Autostart.EnableWithOptions(application.AutostartOptions{
+    Identifier: "com.example.myapp",
+    Arguments:  []string{"--hidden"},
+})
+
+// Check / remove
+enabled, err := app.Autostart.IsEnabled()
+status, err := app.Autostart.Status()  // includes Path + Strategy
+err = app.Autostart.Disable()
+```
+
+See the [Autostart feature page](/features/autostart/basics/) for platform behaviour, identifier rules, and the stale-detection guarantee.

--- a/docs/src/content/docs/features/autostart/basics.mdx
+++ b/docs/src/content/docs/features/autostart/basics.mdx
@@ -150,21 +150,23 @@ If `Options.Identifier` is empty, a default is derived from your app's name:
 | Platform | Default identifier |
 |---|---|
 | macOS (bundled) | The app's bundle identifier, e.g. `com.example.MyApp` |
-| macOS (unbundled) | `wails.autostart.<slug-of-options.Name>` |
-| Windows | Slugified `Options.Name` (lowercase, non-`A-Za-z0-9._-` stripped, spaces become dashes) |
+| macOS (unbundled) | `wails.autostart.<slug>`, where `<slug>` is derived from `application.Options.Name` |
+| Windows | Slug of `application.Options.Name` (lowercase, non-`A-Za-z0-9._-` stripped, spaces become dashes) |
 | Linux | Same slug as Windows |
 
 Identifiers must match `^[A-Za-z0-9._-]+$` and be no longer than 200 characters. Reverse-DNS form is recommended for macOS (it matches how launchd Labels are conventionally written).
 
-When `Options.Identifier` is overridden, the same identifier is reused as the registry value name on Windows and the `.desktop` filename on Linux, so a single string identifies the registration cross-platform.
+When `AutostartOptions.Identifier` is overridden, the same identifier is reused as the registry value name on Windows and the `.desktop` filename on Linux, so a single string identifies the registration cross-platform.
 
 ## Stale Detection
 
-`Disable()` and `Status()` locate the registration by **matching the registered executable path against the current binary**, not by looking up the identifier. This means:
+`Disable()` and `Status()` locate the registration by **matching the registered executable path against `os.Executable()` (resolved through any symlinks)**, not by looking up the identifier. This means:
 
-- If the user renames the binary, autostart still finds the registration and cleans it up correctly.
-- If the identifier was changed between releases, the old registration is still discoverable by `Status()` and can still be cleaned up by `Disable()`.
-- A second copy of the app at a different path won't accidentally clobber the first one's registration.
+- **Changing the identifier between releases is safe.** The old registration is still discoverable by `Status()` and cleaned up by `Disable()` — as long as the executable path is the same.
+- **A second copy of the app at a different path won't clobber the first's registration.** Each binary location is tracked independently.
+- **Symlinked installs (Homebrew, Scoop) are stable.** `filepath.EvalSymlinks` is applied to `os.Executable()` before matching, so a Homebrew upgrade that swaps the target doesn't strand the entry.
+
+What this does *not* cover: if the user moves or renames the binary to an unrelated path, the old registration becomes orphaned (it points at the now-missing file). Apps that ship from a stable install path don't need to worry about this; apps shipped as portable single-file binaries should call `Disable()` before moving themselves, or always launch through a stable symlink.
 
 ## Example
 

--- a/docs/src/content/docs/features/autostart/basics.mdx
+++ b/docs/src/content/docs/features/autostart/basics.mdx
@@ -1,0 +1,198 @@
+---
+title: Autostart
+description: Register your application to launch at user login on macOS, Windows, and Linux
+sidebar:
+  order: 1
+---
+
+import { Tabs, TabItem, Card, CardGrid } from "@astrojs/starlight/components";
+
+## Autostart
+
+`app.Autostart` registers your application to launch automatically when the user logs in. It picks the right native mechanism per platform and resolves symlinked install paths (Homebrew, Scoop) so registrations don't break when the binary is upgraded.
+
+Registration takes effect on the **next login**, not immediately.
+
+## Quick Start
+
+```go
+import "github.com/wailsapp/wails/v3/pkg/application"
+
+// Register to launch at login
+if err := app.Autostart.Enable(); err != nil {
+    app.Logger.Error("autostart enable failed", "error", err)
+}
+
+// Stop launching at login
+if err := app.Autostart.Disable(); err != nil {
+    app.Logger.Error("autostart disable failed", "error", err)
+}
+
+// Check status
+enabled, err := app.Autostart.IsEnabled()
+```
+
+## API
+
+### `Enable`
+
+Registers the application to launch at login with default options.
+
+```go
+func (m *AutostartManager) Enable() error
+```
+
+Calling `Enable` repeatedly is safe — the registration is overwritten each time, so it's correct to call on every startup if you've persisted the user's preference.
+
+### `EnableWithOptions`
+
+Registers with custom options.
+
+```go
+func (m *AutostartManager) EnableWithOptions(opts AutostartOptions) error
+```
+
+**`AutostartOptions`:**
+
+| Field | Type | Description |
+|---|---|---|
+| `Identifier` | `string` | Overrides the auto-derived registration ID. See "Identifier" below. |
+| `Arguments` | `[]string` | Extra arguments appended to the executable path when launched at login (e.g. `--hidden`). |
+
+### `Disable`
+
+Removes the autostart registration. Returns `nil` if the application wasn't registered — disable is idempotent.
+
+```go
+func (m *AutostartManager) Disable() error
+```
+
+### `IsEnabled`
+
+Reports whether a registration exists. Fast — doesn't validate the registered path.
+
+```go
+func (m *AutostartManager) IsEnabled() (bool, error)
+```
+
+### `Status`
+
+Returns full registration state.
+
+```go
+func (m *AutostartManager) Status() (AutostartStatus, error)
+```
+
+**`AutostartStatus`:**
+
+| Field | Type | Description |
+|---|---|---|
+| `Enabled` | `bool` | Whether a registration exists. |
+| `Path` | `string` | On-disk location of the registration artefact (plist path, `.desktop` path, or registry sub-key). Empty when `Enabled` is false. |
+| `Strategy` | `AutostartStrategy` | Which mechanism registered the app (see [Platform Behaviour](#platform-behaviour)). |
+
+## Platform Behaviour
+
+<Tabs syncKey="platform">
+  <TabItem label="macOS" icon="apple">
+    Two mechanisms are used depending on how the app is packaged:
+
+    - **macOS 13+, bundled `.app`**: `SMAppService.mainAppService`. Works for sandboxed apps and Mac App Store builds. No TCC automation prompt (the historical AppleScript approach triggered one).
+    - **macOS pre-13, or unbundled binary**: a LaunchAgent plist written to `~/Library/LaunchAgents/<identifier>.plist` with `RunAtLoad=true`.
+
+    `Status()` returns `AutostartStrategySMAppService` or `AutostartStrategyLaunchAgent` so callers can tell which path was taken.
+
+    When the app upgrades from unbundled to bundled, both paths are checked on `Status()` and cleaned up by `Disable()` so an orphaned LaunchAgent doesn't keep launching the old build.
+  </TabItem>
+
+  <TabItem label="Windows" icon="seti:windows">
+    A registry value is added under `HKCU\Software\Microsoft\Windows\CurrentVersion\Run`, with the value name set to the autostart `Identifier` and the data set to the quoted executable path plus any `Arguments`.
+
+    Argument quoting follows `CommandLineToArgvW` rules (backslashes doubled before quotes) so paths with spaces or quotes round-trip correctly.
+
+    `Status().Strategy` returns `AutostartStrategyRegistryRun`.
+  </TabItem>
+
+  <TabItem label="Linux" icon="linux">
+    An XDG autostart entry is written to `$XDG_CONFIG_HOME/autostart/<identifier>.desktop` (defaulting to `~/.config/autostart/`) with:
+
+    ```ini
+    Type=Application
+    Hidden=false
+    X-GNOME-Autostart-enabled=true
+    Exec=<executable> <arguments>
+    ```
+
+    The `Exec` field is escaped per the [freedesktop.org Desktop Entry spec](https://specifications.freedesktop.org/desktop-entry-spec/) — reserved characters (``"``, `` ` ``, `$`, `\\`) are backslash-escaped and the value is double-quoted when it contains whitespace.
+
+    `Status().Strategy` returns `AutostartStrategyXDGAutostart`.
+  </TabItem>
+
+  <TabItem label="iOS / Android / server" icon="information">
+    Not supported. All methods return `ErrAutostartNotSupported`. Use `errors.Is(err, application.ErrAutostartNotSupported)` to detect this cleanly:
+
+    ```go
+    if err := app.Autostart.Enable(); err != nil {
+        if errors.Is(err, application.ErrAutostartNotSupported) {
+            // hide the toggle in the UI
+            return
+        }
+        // real failure — surface it
+    }
+    ```
+  </TabItem>
+</Tabs>
+
+## Identifier
+
+If `Options.Identifier` is empty, a default is derived from your app's name:
+
+| Platform | Default identifier |
+|---|---|
+| macOS (bundled) | The app's bundle identifier, e.g. `com.example.MyApp` |
+| macOS (unbundled) | `wails.autostart.<slug-of-options.Name>` |
+| Windows | Slugified `Options.Name` (lowercase, non-`A-Za-z0-9._-` stripped, spaces become dashes) |
+| Linux | Same slug as Windows |
+
+Identifiers must match `^[A-Za-z0-9._-]+$` and be no longer than 200 characters. Reverse-DNS form is recommended for macOS (it matches how launchd Labels are conventionally written).
+
+When `Options.Identifier` is overridden, the same identifier is reused as the registry value name on Windows and the `.desktop` filename on Linux, so a single string identifies the registration cross-platform.
+
+## Stale Detection
+
+`Disable()` and `Status()` locate the registration by **matching the registered executable path against the current binary**, not by looking up the identifier. This means:
+
+- If the user renames the binary, autostart still finds the registration and cleans it up correctly.
+- If the identifier was changed between releases, the old registration is still discoverable by `Status()` and can still be cleaned up by `Disable()`.
+- A second copy of the app at a different path won't accidentally clobber the first one's registration.
+
+## Example
+
+```go
+package main
+
+import (
+    "errors"
+
+    "github.com/wailsapp/wails/v3/pkg/application"
+)
+
+func main() {
+    app := application.New(application.Options{
+        Name: "My App",
+    })
+
+    // Restore the user's preference on startup
+    if userPrefersAutostart() {
+        if err := app.Autostart.Enable(); err != nil {
+            if !errors.Is(err, application.ErrAutostartNotSupported) {
+                app.Logger.Error("autostart", "error", err)
+            }
+        }
+    }
+
+    app.Run()
+}
+```
+
+A complete runnable example with status / enable / disable buttons is in [`examples/autostart/`](https://github.com/wailsapp/wails/tree/master/v3/examples/autostart).

--- a/v3/examples/autostart/main.go
+++ b/v3/examples/autostart/main.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/wailsapp/wails/v3/pkg/application"
+)
+
+func main() {
+	app := application.New(application.Options{
+		Name:        "Autostart Demo",
+		Description: "Toggle whether the app launches on login",
+		Assets:      application.AlphaAssets,
+	})
+
+	menu := app.NewMenu()
+
+	menu.Add("Status").OnClick(func(_ *application.Context) {
+		st, err := app.Autostart.Status()
+		if err != nil {
+			app.Dialog.Info().SetMessage(fmt.Sprintf("Error: %v", err)).Show()
+			return
+		}
+		msg := fmt.Sprintf("Enabled: %v\nStrategy: %s\nPath: %s",
+			st.Enabled, st.Strategy, st.Path)
+		app.Dialog.Info().SetMessage(msg).Show()
+	})
+
+	menu.Add("Enable").OnClick(func(_ *application.Context) {
+		if err := app.Autostart.Enable(); err != nil {
+			app.Dialog.Info().SetMessage(fmt.Sprintf("Enable failed: %v", err)).Show()
+		}
+	})
+
+	menu.Add("Disable").OnClick(func(_ *application.Context) {
+		if err := app.Autostart.Disable(); err != nil {
+			app.Dialog.Info().SetMessage(fmt.Sprintf("Disable failed: %v", err)).Show()
+		}
+	})
+
+	menu.Add("Quit").OnClick(func(_ *application.Context) { app.Quit() })
+
+	app.Menu.SetApplicationMenu(menu)
+
+	window := app.Window.NewWithOptions(application.WebviewWindowOptions{
+		Title: "Autostart Demo",
+		HTML:  `<h1>Autostart Demo</h1><p>Use the application menu to control autostart.</p>`,
+	})
+	_ = window
+
+	if err := app.Run(); err != nil {
+		log.Fatal(err)
+	}
+}

--- a/v3/examples/autostart/main.go
+++ b/v3/examples/autostart/main.go
@@ -19,7 +19,7 @@ func main() {
 	menu.Add("Status").OnClick(func(_ *application.Context) {
 		st, err := app.Autostart.Status()
 		if err != nil {
-			app.Dialog.Info().SetMessage(fmt.Sprintf("Error: %v", err)).Show()
+			app.Dialog.Error().SetTitle("Status Error").SetMessage(err.Error()).Show()
 			return
 		}
 		msg := fmt.Sprintf("Enabled: %v\nStrategy: %s\nPath: %s",
@@ -29,13 +29,13 @@ func main() {
 
 	menu.Add("Enable").OnClick(func(_ *application.Context) {
 		if err := app.Autostart.Enable(); err != nil {
-			app.Dialog.Info().SetMessage(fmt.Sprintf("Enable failed: %v", err)).Show()
+			app.Dialog.Error().SetTitle("Enable Failed").SetMessage(err.Error()).Show()
 		}
 	})
 
 	menu.Add("Disable").OnClick(func(_ *application.Context) {
 		if err := app.Autostart.Disable(); err != nil {
-			app.Dialog.Info().SetMessage(fmt.Sprintf("Disable failed: %v", err)).Show()
+			app.Dialog.Error().SetTitle("Disable Failed").SetMessage(err.Error()).Show()
 		}
 	})
 

--- a/v3/pkg/application/application.go
+++ b/v3/pkg/application/application.go
@@ -350,6 +350,7 @@ type App struct {
 	Screen      *ScreenManager
 	Clipboard   *ClipboardManager
 	SystemTray  *SystemTrayManager
+	Autostart   *AutostartManager
 
 	// Windows
 	windows     map[uint]Window
@@ -499,6 +500,7 @@ func (a *App) init() {
 	a.Screen = newScreenManager(a)
 	a.Clipboard = newClipboardManager(a)
 	a.SystemTray = newSystemTrayManager(a)
+	a.Autostart = newAutostartManager(a)
 }
 
 func (a *App) Capabilities() capabilities.Capabilities {

--- a/v3/pkg/application/autostart.go
+++ b/v3/pkg/application/autostart.go
@@ -1,0 +1,154 @@
+package application
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// resolvedExecutable returns os.Executable() after resolving symlinks so
+// registrations don't break when the binary is installed via a symlink farm
+// (Homebrew, Scoop). Falls back to the unresolved path if EvalSymlinks fails.
+func resolvedExecutable() (string, error) {
+	exe, err := os.Executable()
+	if err != nil {
+		return "", fmt.Errorf("autostart: get executable path: %w", err)
+	}
+	if resolved, err := filepath.EvalSymlinks(exe); err == nil {
+		return resolved, nil
+	}
+	return exe, nil
+}
+
+// writeFileAtomic writes data to path by way of a tempfile + rename in the
+// same directory, so a partial write never leaves a half-formed plist or
+// .desktop file in place.
+func writeFileAtomic(path string, data []byte, perm os.FileMode) error {
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, "."+filepath.Base(path)+".*.tmp")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	cleanup := func() { _ = os.Remove(tmpName) }
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		cleanup()
+		return err
+	}
+	if err := tmp.Chmod(perm); err != nil {
+		_ = tmp.Close()
+		cleanup()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		cleanup()
+		return err
+	}
+	if err := os.Rename(tmpName, path); err != nil {
+		cleanup()
+		return err
+	}
+	return nil
+}
+
+// validateAutostartIdentifier rejects identifiers that contain characters
+// that would be unsafe as a filename, registry value, or launchd Label.
+func validateAutostartIdentifier(id string) error {
+	if id == "" {
+		return nil
+	}
+	if len(id) > 200 {
+		return fmt.Errorf("autostart identifier too long (max 200): %q", id)
+	}
+	for _, r := range id {
+		switch {
+		case r >= 'a' && r <= 'z',
+			r >= 'A' && r <= 'Z',
+			r >= '0' && r <= '9',
+			r == '.', r == '_', r == '-':
+		default:
+			return fmt.Errorf("autostart identifier contains invalid character %q (allowed: A-Za-z0-9._-)", r)
+		}
+	}
+	return nil
+}
+
+// autostartSlug turns a free-form application name into something usable as
+// the basename of a registration artefact. Empty input is rejected by the
+// caller; this helper never returns an empty string for non-empty input.
+func autostartSlug(name string) string {
+	var b strings.Builder
+	b.Grow(len(name))
+	for _, r := range name {
+		switch {
+		case r >= 'a' && r <= 'z',
+			r >= '0' && r <= '9',
+			r == '.', r == '_', r == '-':
+			b.WriteRune(r)
+		case r >= 'A' && r <= 'Z':
+			b.WriteRune(r + ('a' - 'A'))
+		case r == ' ', r == '\t':
+			b.WriteByte('-')
+		}
+	}
+	out := strings.Trim(b.String(), "-._")
+	if out == "" {
+		return "wails-app"
+	}
+	return out
+}
+
+// ErrAutostartNotSupported is returned when autostart is not available on
+// the current platform (mobile, server builds).
+var ErrAutostartNotSupported = errors.New("autostart is not supported on this platform")
+
+// AutostartOptions configures how the application is registered to launch at login.
+type AutostartOptions struct {
+	// Identifier overrides the auto-derived registration ID.
+	//
+	//   macOS:   launchd Label / SMAppService key (reverse-DNS recommended).
+	//   Windows: registry value name under HKCU\…\Run.
+	//   Linux:   .desktop filename (without extension).
+	//
+	// If empty, a sensible default is derived: on macOS the application's
+	// bundle identifier (when running from a bundle) or "wails.autostart.<slug>";
+	// on Windows and Linux a slugified form of Options.Name.
+	Identifier string
+
+	// Arguments are appended to the executable path when launched at login.
+	Arguments []string
+}
+
+// AutostartStrategy names the underlying mechanism a darwin registration used.
+// It is empty on other platforms.
+type AutostartStrategy string
+
+const (
+	AutostartStrategyNone          AutostartStrategy = ""
+	AutostartStrategySMAppService  AutostartStrategy = "smappservice"
+	AutostartStrategyLaunchAgent   AutostartStrategy = "launchagent"
+	AutostartStrategyRegistryRun   AutostartStrategy = "registry-run"
+	AutostartStrategyXDGAutostart  AutostartStrategy = "xdg-autostart"
+)
+
+// AutostartStatus describes the current autostart registration.
+type AutostartStatus struct {
+	// Enabled reports whether a registration exists.
+	Enabled bool
+	// Path is the on-disk location of the registration artefact, when
+	// applicable (plist path, .desktop path, registry sub-key path). Empty if
+	// Enabled is false.
+	Path string
+	// Strategy names the mechanism that registered the application. Empty if
+	// Enabled is false or the platform has only one mechanism.
+	Strategy AutostartStrategy
+}
+
+type autostartImpl interface {
+	enable(opts AutostartOptions) error
+	disable() error
+	status() (AutostartStatus, error)
+}

--- a/v3/pkg/application/autostart.go
+++ b/v3/pkg/application/autostart.go
@@ -3,6 +3,7 @@ package application
 import (
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -33,7 +34,14 @@ func writeFileAtomic(path string, data []byte, perm os.FileMode) error {
 	}
 	tmpName := tmp.Name()
 	cleanup := func() { _ = os.Remove(tmpName) }
-	if _, err := tmp.Write(data); err != nil {
+	// os.File.Write is documented to return an error on short writes, but we
+	// double-check n == len(data) so a future change of writer type can't
+	// silently rename a truncated artefact into place.
+	n, err := tmp.Write(data)
+	if err == nil && n != len(data) {
+		err = io.ErrShortWrite
+	}
+	if err != nil {
 		_ = tmp.Close()
 		cleanup()
 		return err
@@ -115,15 +123,20 @@ type AutostartOptions struct {
 	//
 	// If empty, a sensible default is derived: on macOS the application's
 	// bundle identifier (when running from a bundle) or "wails.autostart.<slug>";
-	// on Windows and Linux a slugified form of Options.Name.
+	// on Windows and Linux a slugified form of the application's Options.Name
+	// (i.e. application.Options.Name from application.New).
 	Identifier string
 
 	// Arguments are appended to the executable path when launched at login.
 	Arguments []string
 }
 
-// AutostartStrategy names the underlying mechanism a darwin registration used.
-// It is empty on other platforms.
+// AutostartStrategy names the underlying mechanism a registration used.
+//
+// On macOS this distinguishes between SMAppService (bundled .app on macOS 13+)
+// and a LaunchAgent plist (the fallback path). On Windows it is always
+// AutostartStrategyRegistryRun and on Linux always AutostartStrategyXDGAutostart.
+// Empty when AutostartStatus.Enabled is false.
 type AutostartStrategy string
 
 const (

--- a/v3/pkg/application/autostart_android.go
+++ b/v3/pkg/application/autostart_android.go
@@ -1,0 +1,13 @@
+//go:build android
+
+package application
+
+type unsupportedAutostart struct{}
+
+func newAutostartImpl(_ *App) autostartImpl { return unsupportedAutostart{} }
+
+func (unsupportedAutostart) enable(AutostartOptions) error  { return ErrAutostartNotSupported }
+func (unsupportedAutostart) disable() error                 { return ErrAutostartNotSupported }
+func (unsupportedAutostart) status() (AutostartStatus, error) {
+	return AutostartStatus{}, ErrAutostartNotSupported
+}

--- a/v3/pkg/application/autostart_darwin.go
+++ b/v3/pkg/application/autostart_darwin.go
@@ -1,0 +1,337 @@
+//go:build darwin && !ios && !server
+
+package application
+
+import (
+	"encoding/xml"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/wailsapp/wails/v3/pkg/mac"
+)
+
+type darwinAutostart struct {
+	app *App
+}
+
+func newAutostartImpl(app *App) autostartImpl {
+	return &darwinAutostart{app: app}
+}
+
+// strategy picks SMAppService when running from a bundled .app on macOS 13+,
+// otherwise the LaunchAgent plist path. Both paths support unbundled binaries
+// (LaunchAgent path) so xbar-style scripts in development still work.
+func (a *darwinAutostart) strategy() AutostartStrategy {
+	if !runningFromAppBundle() {
+		return AutostartStrategyLaunchAgent
+	}
+	if mac.GetBundleID() == "" {
+		return AutostartStrategyLaunchAgent
+	}
+	major, _ := darwinMajorVersion()
+	if major < 13 {
+		return AutostartStrategyLaunchAgent
+	}
+	return AutostartStrategySMAppService
+}
+
+func (a *darwinAutostart) enable(opts AutostartOptions) error {
+	if err := validateAutostartIdentifier(opts.Identifier); err != nil {
+		return err
+	}
+	switch a.strategy() {
+	case AutostartStrategySMAppService:
+		if err := smAppServiceRegister(); err == nil {
+			return nil
+		} else if !errors.Is(err, errSMAppServiceUnavailable) {
+			return fmt.Errorf("SMAppService register: %w", err)
+		}
+		fallthrough
+	default:
+		return a.enableLaunchAgent(opts)
+	}
+}
+
+func (a *darwinAutostart) disable() error {
+	// Try both paths and merge errors — a previous version may have used
+	// the other strategy.
+	var errs []error
+	if a.strategy() == AutostartStrategySMAppService {
+		if err := smAppServiceUnregister(); err != nil && !errors.Is(err, errSMAppServiceUnavailable) && !errors.Is(err, errSMAppServiceNotRegistered) {
+			errs = append(errs, fmt.Errorf("SMAppService unregister: %w", err))
+		}
+	}
+	if err := a.disableLaunchAgent(); err != nil {
+		errs = append(errs, err)
+	}
+	return errors.Join(errs...)
+}
+
+func (a *darwinAutostart) status() (AutostartStatus, error) {
+	if a.strategy() == AutostartStrategySMAppService {
+		enabled, err := smAppServiceIsEnabled()
+		if err != nil && !errors.Is(err, errSMAppServiceUnavailable) {
+			return AutostartStatus{}, fmt.Errorf("SMAppService status: %w", err)
+		}
+		if enabled {
+			return AutostartStatus{
+				Enabled:  true,
+				Path:     mac.GetBundleID(),
+				Strategy: AutostartStrategySMAppService,
+			}, nil
+		}
+	}
+	// LaunchAgent path: also checked when SMAppService said no, so a
+	// previously-registered LaunchAgent doesn't disappear from view after an
+	// upgrade to a bundled build.
+	path, ok, err := a.findLaunchAgent()
+	if err != nil {
+		return AutostartStatus{}, err
+	}
+	if ok {
+		return AutostartStatus{
+			Enabled:  true,
+			Path:     path,
+			Strategy: AutostartStrategyLaunchAgent,
+		}, nil
+	}
+	return AutostartStatus{}, nil
+}
+
+func (a *darwinAutostart) launchAgentsDir() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("autostart: %w", err)
+	}
+	return filepath.Join(home, "Library", "LaunchAgents"), nil
+}
+
+func (a *darwinAutostart) defaultLabel() string {
+	if id := mac.GetBundleID(); id != "" {
+		return id
+	}
+	return "wails.autostart." + autostartSlug(a.app.options.Name)
+}
+
+func (a *darwinAutostart) enableLaunchAgent(opts AutostartOptions) error {
+	exe, err := resolvedExecutable()
+	if err != nil {
+		return err
+	}
+	dir, err := a.launchAgentsDir()
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return fmt.Errorf("autostart: create LaunchAgents dir: %w", err)
+	}
+	label := opts.Identifier
+	if label == "" {
+		label = a.defaultLabel()
+	}
+	path := filepath.Join(dir, label+".plist")
+	body, err := launchAgentPlist(label, exe, opts.Arguments)
+	if err != nil {
+		return err
+	}
+	if err := writeFileAtomic(path, body, 0644); err != nil {
+		return fmt.Errorf("autostart: write plist: %w", err)
+	}
+	// Best-effort: activate immediately for the current GUI session.
+	_ = launchctlBootstrap(path)
+	return nil
+}
+
+func (a *darwinAutostart) disableLaunchAgent() error {
+	path, ok, err := a.findLaunchAgent()
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return nil
+	}
+	_ = launchctlBootout(path)
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("autostart: remove plist: %w", err)
+	}
+	return nil
+}
+
+// findLaunchAgent looks for a plist in ~/Library/LaunchAgents whose
+// ProgramArguments first element equals the current executable.
+func (a *darwinAutostart) findLaunchAgent() (string, bool, error) {
+	dir, err := a.launchAgentsDir()
+	if err != nil {
+		return "", false, err
+	}
+	exe, err := resolvedExecutable()
+	if err != nil {
+		return "", false, err
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", false, nil
+		}
+		return "", false, fmt.Errorf("autostart: read LaunchAgents dir: %w", err)
+	}
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".plist") {
+			continue
+		}
+		full := filepath.Join(dir, e.Name())
+		data, err := os.ReadFile(full)
+		if err != nil {
+			continue
+		}
+		if plistFirstProgramArg(data) == exe {
+			return full, true, nil
+		}
+	}
+	return "", false, nil
+}
+
+// runningFromAppBundle reports whether the current executable lives inside a
+// .app bundle (path ends with .app/Contents/MacOS/<name>).
+func runningFromAppBundle() bool {
+	exe, err := resolvedExecutable()
+	if err != nil {
+		return false
+	}
+	macOSDir := filepath.Dir(exe)
+	contentsDir := filepath.Dir(macOSDir)
+	appDir := filepath.Dir(contentsDir)
+	return filepath.Base(macOSDir) == "MacOS" &&
+		filepath.Base(contentsDir) == "Contents" &&
+		strings.HasSuffix(appDir, ".app")
+}
+
+func darwinMajorVersion() (int, error) {
+	out, err := exec.Command("sw_vers", "-productVersion").Output()
+	if err != nil {
+		return 0, err
+	}
+	ver := strings.TrimSpace(string(out))
+	if i := strings.IndexByte(ver, '.'); i > 0 {
+		ver = ver[:i]
+	}
+	return strconv.Atoi(ver)
+}
+
+// launchctlBootstrap loads a plist into the current GUI session. Best effort —
+// errors are ignored (the plist will still be picked up at next login).
+//
+// Indirected through a package-level variable so unit tests can replace it
+// with a no-op: a test plist with RunAtLoad=true that successfully bootstraps
+// would respawn the test binary recursively.
+var launchctlBootstrap = func(plistPath string) error {
+	target := fmt.Sprintf("gui/%d", os.Getuid())
+	return exec.Command("launchctl", "bootstrap", target, plistPath).Run()
+}
+
+var launchctlBootout = func(plistPath string) error {
+	target := fmt.Sprintf("gui/%d", os.Getuid())
+	return exec.Command("launchctl", "bootout", target, plistPath).Run()
+}
+
+// --- plist marshalling ------------------------------------------------------
+
+type plistDoc struct {
+	XMLName xml.Name  `xml:"plist"`
+	Version string    `xml:"version,attr"`
+	Dict    plistDict `xml:"dict"`
+}
+
+type plistDict struct {
+	Keys   []string  `xml:"-"`
+	Values []plistEl `xml:"-"`
+}
+
+type plistEl struct {
+	Kind   string   // "string", "true", "false", "array"
+	String string
+	Array  []string // for "array" of strings
+}
+
+func launchAgentPlist(label, exe string, args []string) ([]byte, error) {
+	progArgs := append([]string{exe}, args...)
+	var sb strings.Builder
+	sb.WriteString(`<?xml version="1.0" encoding="UTF-8"?>` + "\n")
+	sb.WriteString(`<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">` + "\n")
+	sb.WriteString(`<plist version="1.0">` + "\n")
+	sb.WriteString("  <dict>\n")
+	sb.WriteString("    <key>Label</key>\n")
+	sb.WriteString("    <string>" + xmlEscape(label) + "</string>\n")
+	sb.WriteString("    <key>ProgramArguments</key>\n")
+	sb.WriteString("    <array>\n")
+	for _, a := range progArgs {
+		sb.WriteString("      <string>" + xmlEscape(a) + "</string>\n")
+	}
+	sb.WriteString("    </array>\n")
+	sb.WriteString("    <key>RunAtLoad</key>\n")
+	sb.WriteString("    <true/>\n")
+	sb.WriteString("    <key>KeepAlive</key>\n")
+	sb.WriteString("    <false/>\n")
+	sb.WriteString("  </dict>\n")
+	sb.WriteString("</plist>\n")
+	return []byte(sb.String()), nil
+}
+
+func xmlEscape(s string) string {
+	var b strings.Builder
+	_ = xml.EscapeText(&b, []byte(s))
+	return b.String()
+}
+
+// plistFirstProgramArg returns the first <string> element under the
+// ProgramArguments array in a LaunchAgent plist. Empty string on any parse
+// failure — we treat a malformed file as "not ours".
+func plistFirstProgramArg(data []byte) string {
+	dec := xml.NewDecoder(strings.NewReader(string(data)))
+	dec.Strict = false
+	var inDict, inArray, captureKey bool
+	var lastKey string
+	for {
+		tok, err := dec.Token()
+		if err != nil {
+			return ""
+		}
+		switch t := tok.(type) {
+		case xml.StartElement:
+			switch t.Name.Local {
+			case "dict":
+				inDict = true
+			case "key":
+				if inDict {
+					captureKey = true
+				}
+			case "array":
+				if lastKey == "ProgramArguments" {
+					inArray = true
+				}
+			case "string":
+				if inArray {
+					var s string
+					if err := dec.DecodeElement(&s, &t); err == nil {
+						return s
+					}
+					return ""
+				}
+			}
+		case xml.CharData:
+			if captureKey {
+				lastKey = string(t)
+				captureKey = false
+			}
+		case xml.EndElement:
+			if t.Name.Local == "array" && inArray {
+				return ""
+			}
+		}
+	}
+}

--- a/v3/pkg/application/autostart_darwin.go
+++ b/v3/pkg/application/autostart_darwin.go
@@ -75,7 +75,14 @@ func (a *darwinAutostart) disable() error {
 func (a *darwinAutostart) status() (AutostartStatus, error) {
 	if a.strategy() == AutostartStrategySMAppService {
 		enabled, err := smAppServiceIsEnabled()
-		if err != nil && !errors.Is(err, errSMAppServiceUnavailable) {
+		// errSMAppServiceRequiresApproval means the user disabled the
+		// login item in System Settings — semantically that's "not
+		// enabled", not a hard error. Treat it like Unavailable so the
+		// LaunchAgent fallback still gets a chance to find a legacy
+		// entry from before the app was bundled.
+		if err != nil &&
+			!errors.Is(err, errSMAppServiceUnavailable) &&
+			!errors.Is(err, errSMAppServiceRequiresApproval) {
 			return AutostartStatus{}, fmt.Errorf("SMAppService status: %w", err)
 		}
 		if enabled {
@@ -240,23 +247,6 @@ var launchctlBootout = func(plistPath string) error {
 }
 
 // --- plist marshalling ------------------------------------------------------
-
-type plistDoc struct {
-	XMLName xml.Name  `xml:"plist"`
-	Version string    `xml:"version,attr"`
-	Dict    plistDict `xml:"dict"`
-}
-
-type plistDict struct {
-	Keys   []string  `xml:"-"`
-	Values []plistEl `xml:"-"`
-}
-
-type plistEl struct {
-	Kind   string   // "string", "true", "false", "array"
-	String string
-	Array  []string // for "array" of strings
-}
 
 func launchAgentPlist(label, exe string, args []string) ([]byte, error) {
 	progArgs := append([]string{exe}, args...)

--- a/v3/pkg/application/autostart_darwin_smappservice.go
+++ b/v3/pkg/application/autostart_darwin_smappservice.go
@@ -1,0 +1,139 @@
+//go:build darwin && !ios && !server
+
+package application
+
+/*
+#cgo CFLAGS: -mmacosx-version-min=10.15 -x objective-c -Wno-unguarded-availability-new
+#cgo LDFLAGS: -framework Foundation -framework ServiceManagement
+
+#import <Foundation/Foundation.h>
+#import <ServiceManagement/ServiceManagement.h>
+
+// Return codes shared with the Go side.
+enum {
+	SMAS_OK              = 0,
+	SMAS_UNAVAILABLE     = 1, // SMAppService class not present (pre macOS 13)
+	SMAS_NOT_REGISTERED  = 2, // unregister called when nothing was registered
+	SMAS_REQUIRES_APPROVAL = 3, // user disabled it in System Settings
+	SMAS_ERROR           = 4, // generic failure; *outMsg populated
+};
+
+static int smAppServiceRegister(char** outMsg) {
+	if (@available(macOS 13.0, *)) {
+		@autoreleasepool {
+			SMAppService *svc = [SMAppService mainAppService];
+			NSError *err = nil;
+			if ([svc registerAndReturnError:&err]) {
+				return SMAS_OK;
+			}
+			if (err != nil) {
+				*outMsg = strdup([[err localizedDescription] UTF8String]);
+			}
+			return SMAS_ERROR;
+		}
+	}
+	return SMAS_UNAVAILABLE;
+}
+
+static int smAppServiceUnregister(char** outMsg) {
+	if (@available(macOS 13.0, *)) {
+		@autoreleasepool {
+			SMAppService *svc = [SMAppService mainAppService];
+			if (svc.status == SMAppServiceStatusNotRegistered ||
+			    svc.status == SMAppServiceStatusNotFound) {
+				return SMAS_NOT_REGISTERED;
+			}
+			NSError *err = nil;
+			if ([svc unregisterAndReturnError:&err]) {
+				return SMAS_OK;
+			}
+			if (err != nil) {
+				*outMsg = strdup([[err localizedDescription] UTF8String]);
+			}
+			return SMAS_ERROR;
+		}
+	}
+	return SMAS_UNAVAILABLE;
+}
+
+// smAppServiceStatus: 0 = unavailable, 1 = not registered / not found,
+//                     2 = enabled, 3 = requires approval.
+static int smAppServiceStatus(void) {
+	if (@available(macOS 13.0, *)) {
+		@autoreleasepool {
+			SMAppService *svc = [SMAppService mainAppService];
+			switch (svc.status) {
+				case SMAppServiceStatusEnabled:           return 2;
+				case SMAppServiceStatusRequiresApproval:  return 3;
+				default:                                  return 1;
+			}
+		}
+	}
+	return 0;
+}
+*/
+import "C"
+
+import (
+	"errors"
+	"unsafe"
+)
+
+var (
+	errSMAppServiceUnavailable    = errors.New("SMAppService unavailable on this macOS")
+	errSMAppServiceNotRegistered  = errors.New("SMAppService not registered")
+	errSMAppServiceRequiresApproval = errors.New("SMAppService requires user approval in System Settings")
+)
+
+func smAppServiceRegister() error {
+	var cMsg *C.char
+	rc := C.smAppServiceRegister(&cMsg)
+	if cMsg != nil {
+		defer C.free(unsafe.Pointer(cMsg))
+	}
+	switch rc {
+	case 0:
+		return nil
+	case 1:
+		return errSMAppServiceUnavailable
+	default:
+		if cMsg != nil {
+			return errors.New(C.GoString(cMsg))
+		}
+		return errors.New("SMAppService register failed")
+	}
+}
+
+func smAppServiceUnregister() error {
+	var cMsg *C.char
+	rc := C.smAppServiceUnregister(&cMsg)
+	if cMsg != nil {
+		defer C.free(unsafe.Pointer(cMsg))
+	}
+	switch rc {
+	case 0:
+		return nil
+	case 1:
+		return errSMAppServiceUnavailable
+	case 2:
+		return errSMAppServiceNotRegistered
+	default:
+		if cMsg != nil {
+			return errors.New(C.GoString(cMsg))
+		}
+		return errors.New("SMAppService unregister failed")
+	}
+}
+
+func smAppServiceIsEnabled() (bool, error) {
+	switch C.smAppServiceStatus() {
+	case 0:
+		return false, errSMAppServiceUnavailable
+	case 2:
+		return true, nil
+	case 3:
+		return false, errSMAppServiceRequiresApproval
+	default:
+		return false, nil
+	}
+}

--- a/v3/pkg/application/autostart_darwin_smappservice.go
+++ b/v3/pkg/application/autostart_darwin_smappservice.go
@@ -6,6 +6,8 @@ package application
 #cgo CFLAGS: -mmacosx-version-min=10.15 -x objective-c -Wno-unguarded-availability-new
 #cgo LDFLAGS: -framework Foundation -framework ServiceManagement
 
+#include <stdlib.h> // free
+#include <string.h> // strdup
 #import <Foundation/Foundation.h>
 #import <ServiceManagement/ServiceManagement.h>
 

--- a/v3/pkg/application/autostart_darwin_test.go
+++ b/v3/pkg/application/autostart_darwin_test.go
@@ -1,0 +1,149 @@
+//go:build darwin && !ios && !server
+
+package application
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// newDarwinAutostartForTest builds an impl rooted at a temp HOME with a known
+// Options.Name. The returned impl always uses the LaunchAgent fallback path
+// (running under `go test` we're not in a .app bundle, so SMAppService is
+// skipped). Also stubs out launchctlBootstrap/Bootout — otherwise a successful
+// bootstrap would respawn the test binary via launchd (RunAtLoad=true) and
+// recurse.
+func newDarwinAutostartForTest(t *testing.T, name string) *darwinAutostart {
+	t.Helper()
+	t.Setenv("HOME", t.TempDir())
+
+	origBootstrap := launchctlBootstrap
+	origBootout := launchctlBootout
+	launchctlBootstrap = func(string) error { return nil }
+	launchctlBootout = func(string) error { return nil }
+	t.Cleanup(func() {
+		launchctlBootstrap = origBootstrap
+		launchctlBootout = origBootout
+	})
+
+	app := &App{options: Options{Name: name}}
+	return &darwinAutostart{app: app}
+}
+
+func TestDarwinAutostartRoundTrip(t *testing.T) {
+	a := newDarwinAutostartForTest(t, "Test App")
+
+	st, err := a.status()
+	if err != nil {
+		t.Fatalf("status before enable: %v", err)
+	}
+	if st.Enabled {
+		t.Fatalf("expected disabled before enable, got %+v", st)
+	}
+
+	if err := a.enable(AutostartOptions{}); err != nil {
+		t.Fatalf("enable: %v", err)
+	}
+
+	st, err = a.status()
+	if err != nil {
+		t.Fatalf("status after enable: %v", err)
+	}
+	if !st.Enabled {
+		t.Fatalf("expected enabled, got %+v", st)
+	}
+	if st.Strategy != AutostartStrategyLaunchAgent {
+		t.Errorf("strategy=%q want %q", st.Strategy, AutostartStrategyLaunchAgent)
+	}
+	if !strings.HasSuffix(st.Path, ".plist") {
+		t.Errorf("path should end in .plist: %q", st.Path)
+	}
+
+	data, err := os.ReadFile(st.Path)
+	if err != nil {
+		t.Fatalf("read plist: %v", err)
+	}
+	body := string(data)
+	for _, want := range []string{
+		"<key>Label</key>",
+		"<key>ProgramArguments</key>",
+		"<key>RunAtLoad</key>",
+		"<true/>",
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("plist missing %q\n---\n%s", want, body)
+		}
+	}
+
+	if err := a.disable(); err != nil {
+		t.Fatalf("disable: %v", err)
+	}
+
+	st, err = a.status()
+	if err != nil {
+		t.Fatalf("status after disable: %v", err)
+	}
+	if st.Enabled {
+		t.Fatalf("expected disabled after disable, got %+v", st)
+	}
+}
+
+func TestDarwinAutostartCustomIdentifier(t *testing.T) {
+	a := newDarwinAutostartForTest(t, "Test App")
+	if err := a.enable(AutostartOptions{Identifier: "com.example.foo", Arguments: []string{"--hidden"}}); err != nil {
+		t.Fatalf("enable: %v", err)
+	}
+	st, _ := a.status()
+	if !st.Enabled {
+		t.Fatal("expected enabled")
+	}
+	if base := filepath.Base(st.Path); base != "com.example.foo.plist" {
+		t.Errorf("plist filename=%q want com.example.foo.plist", base)
+	}
+	data, _ := os.ReadFile(st.Path)
+	body := string(data)
+	if !strings.Contains(body, "<string>com.example.foo</string>") {
+		t.Errorf("plist missing Label com.example.foo:\n%s", body)
+	}
+	if !strings.Contains(body, "<string>--hidden</string>") {
+		t.Errorf("plist missing --hidden argument:\n%s", body)
+	}
+}
+
+func TestDarwinAutostartIdentifierValidation(t *testing.T) {
+	a := newDarwinAutostartForTest(t, "Test App")
+	err := a.enable(AutostartOptions{Identifier: "bad/identifier"})
+	if err == nil {
+		t.Error("expected error for invalid identifier")
+	}
+}
+
+func TestDarwinAutostartDisableNoOp(t *testing.T) {
+	a := newDarwinAutostartForTest(t, "Test App")
+	if err := a.disable(); err != nil {
+		t.Errorf("disable when not enabled should be nil, got %v", err)
+	}
+}
+
+func TestPlistFirstProgramArg(t *testing.T) {
+	body, err := launchAgentPlist("com.example.foo", "/path/to/exe", []string{"--flag"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := plistFirstProgramArg(body); got != "/path/to/exe" {
+		t.Errorf("plistFirstProgramArg = %q, want /path/to/exe", got)
+	}
+	// Malformed input must return empty, not panic.
+	if got := plistFirstProgramArg([]byte("not a plist")); got != "" {
+		t.Errorf("malformed plist returned %q", got)
+	}
+}
+
+func TestRunningFromAppBundle(t *testing.T) {
+	// `go test` runs from a tempdir-built binary, not an .app bundle.
+	if runningFromAppBundle() {
+		t.Skip("test binary surprisingly looks like it's inside a .app — skipping")
+	}
+}

--- a/v3/pkg/application/autostart_ios.go
+++ b/v3/pkg/application/autostart_ios.go
@@ -1,0 +1,13 @@
+//go:build ios
+
+package application
+
+type unsupportedAutostart struct{}
+
+func newAutostartImpl(_ *App) autostartImpl { return unsupportedAutostart{} }
+
+func (unsupportedAutostart) enable(AutostartOptions) error  { return ErrAutostartNotSupported }
+func (unsupportedAutostart) disable() error                 { return ErrAutostartNotSupported }
+func (unsupportedAutostart) status() (AutostartStatus, error) {
+	return AutostartStatus{}, ErrAutostartNotSupported
+}

--- a/v3/pkg/application/autostart_linux.go
+++ b/v3/pkg/application/autostart_linux.go
@@ -21,10 +21,21 @@ func (a *linuxAutostart) enable(opts AutostartOptions) error {
 	if err := validateAutostartIdentifier(opts.Identifier); err != nil {
 		return err
 	}
+	// A newline inside the executable path or any argument would break the
+	// .desktop file format (line-based key=value) and could be used to inject
+	// arbitrary Desktop Entry keys when Arguments are user-influenced.
+	for i, arg := range opts.Arguments {
+		if err := validateDesktopExecToken(arg); err != nil {
+			return fmt.Errorf("autostart argument %d: %w", i, err)
+		}
+	}
 
 	exe, err := resolvedExecutable()
 	if err != nil {
 		return err
+	}
+	if err := validateDesktopExecToken(exe); err != nil {
+		return fmt.Errorf("autostart executable path: %w", err)
 	}
 
 	dir, err := a.autostartDir()
@@ -147,6 +158,23 @@ Terminal=false
 `, escapeDesktopValue(appName), execLine)
 }
 
+// validateDesktopExecToken rejects control characters that would break the
+// .desktop file format or allow Desktop Entry key injection when interpolated
+// into an Exec= line. Allowed: spaces and tabs (which quoteExec handles by
+// double-quoting); rejected: all other ASCII control characters including
+// CR/LF.
+func validateDesktopExecToken(s string) error {
+	for _, r := range s {
+		if r == '\t' || r == ' ' {
+			continue
+		}
+		if r < 0x20 || r == 0x7f {
+			return fmt.Errorf("control character %U not allowed in Exec field", r)
+		}
+	}
+	return nil
+}
+
 // quoteExec escapes a single Exec field token per the freedesktop.org spec:
 // reserved chars are " ` $ \ → escape with backslash; if the token contains
 // any reserved or whitespace, double-quote it.
@@ -159,7 +187,9 @@ func quoteExec(s string) string {
 			b.WriteByte('\\')
 			b.WriteRune(r)
 			needQuote = true
-		case ' ', '\t', '\n':
+		case ' ', '\t':
+			// Newlines are rejected by validateDesktopExecToken before we
+			// get here, so any whitespace remaining is safely quotable.
 			b.WriteRune(r)
 			needQuote = true
 		default:

--- a/v3/pkg/application/autostart_linux.go
+++ b/v3/pkg/application/autostart_linux.go
@@ -1,0 +1,218 @@
+//go:build linux && !android && !server
+
+package application
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+type linuxAutostart struct {
+	app *App
+}
+
+func newAutostartImpl(app *App) autostartImpl {
+	return &linuxAutostart{app: app}
+}
+
+func (a *linuxAutostart) enable(opts AutostartOptions) error {
+	if err := validateAutostartIdentifier(opts.Identifier); err != nil {
+		return err
+	}
+
+	exe, err := resolvedExecutable()
+	if err != nil {
+		return err
+	}
+
+	dir, err := a.autostartDir()
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return fmt.Errorf("create autostart dir: %w", err)
+	}
+
+	id := opts.Identifier
+	if id == "" {
+		id = autostartSlug(a.app.options.Name)
+	}
+	path := filepath.Join(dir, id+".desktop")
+
+	body := buildDesktopEntry(a.app.options.Name, exe, opts.Arguments)
+	if err := writeFileAtomic(path, []byte(body), 0644); err != nil {
+		return fmt.Errorf("write desktop file %s: %w", path, err)
+	}
+	return nil
+}
+
+func (a *linuxAutostart) disable() error {
+	dir, err := a.autostartDir()
+	if err != nil {
+		return err
+	}
+	path, err := a.findDesktopFile(dir)
+	if err != nil {
+		return err
+	}
+	if path == "" {
+		return nil
+	}
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("remove desktop file: %w", err)
+	}
+	return nil
+}
+
+func (a *linuxAutostart) status() (AutostartStatus, error) {
+	dir, err := a.autostartDir()
+	if err != nil {
+		return AutostartStatus{}, err
+	}
+	path, err := a.findDesktopFile(dir)
+	if err != nil {
+		return AutostartStatus{}, err
+	}
+	if path == "" {
+		return AutostartStatus{}, nil
+	}
+	return AutostartStatus{
+		Enabled:  true,
+		Path:     path,
+		Strategy: AutostartStrategyXDGAutostart,
+	}, nil
+}
+
+func (a *linuxAutostart) autostartDir() (string, error) {
+	cfg := os.Getenv("XDG_CONFIG_HOME")
+	if cfg == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", fmt.Errorf("autostart: %w", err)
+		}
+		cfg = filepath.Join(home, ".config")
+	}
+	return filepath.Join(cfg, "autostart"), nil
+}
+
+// findDesktopFile looks for a .desktop file in dir whose Exec= entry points at
+// the current executable. Returns empty path with no error if none found.
+// This survives identifier changes between Enable() calls.
+func (a *linuxAutostart) findDesktopFile(dir string) (string, error) {
+	exe, err := resolvedExecutable()
+	if err != nil {
+		return "", err
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", nil
+		}
+		return "", fmt.Errorf("read autostart dir: %w", err)
+	}
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".desktop") {
+			continue
+		}
+		full := filepath.Join(dir, e.Name())
+		data, err := os.ReadFile(full)
+		if err != nil {
+			continue
+		}
+		if desktopExecPath(string(data)) == exe {
+			return full, nil
+		}
+	}
+	return "", nil
+}
+
+func buildDesktopEntry(appName, exe string, args []string) string {
+	if appName == "" {
+		appName = filepath.Base(exe)
+	}
+	execLine := quoteExec(exe)
+	for _, a := range args {
+		execLine += " " + quoteExec(a)
+	}
+	return fmt.Sprintf(`[Desktop Entry]
+Type=Application
+Name=%s
+Exec=%s
+X-GNOME-Autostart-enabled=true
+Hidden=false
+NoDisplay=false
+Terminal=false
+`, escapeDesktopValue(appName), execLine)
+}
+
+// quoteExec escapes a single Exec field token per the freedesktop.org spec:
+// reserved chars are " ` $ \ → escape with backslash; if the token contains
+// any reserved or whitespace, double-quote it.
+func quoteExec(s string) string {
+	needQuote := false
+	var b strings.Builder
+	for _, r := range s {
+		switch r {
+		case '"', '`', '$', '\\':
+			b.WriteByte('\\')
+			b.WriteRune(r)
+			needQuote = true
+		case ' ', '\t', '\n':
+			b.WriteRune(r)
+			needQuote = true
+		default:
+			b.WriteRune(r)
+		}
+	}
+	if needQuote {
+		return `"` + b.String() + `"`
+	}
+	return b.String()
+}
+
+// escapeDesktopValue escapes characters that are not allowed in raw Desktop
+// Entry values (newlines, leading/trailing whitespace).
+func escapeDesktopValue(s string) string {
+	s = strings.ReplaceAll(s, "\r", " ")
+	s = strings.ReplaceAll(s, "\n", " ")
+	return strings.TrimSpace(s)
+}
+
+func desktopExecPath(contents string) string {
+	for _, line := range strings.Split(contents, "\n") {
+		line = strings.TrimSpace(line)
+		if !strings.HasPrefix(line, "Exec=") {
+			continue
+		}
+		val := strings.TrimPrefix(line, "Exec=")
+		// First token, possibly quoted.
+		val = strings.TrimSpace(val)
+		if strings.HasPrefix(val, `"`) {
+			end := strings.Index(val[1:], `"`)
+			if end < 0 {
+				return ""
+			}
+			return unescapeDesktopToken(val[1 : 1+end])
+		}
+		if i := strings.IndexAny(val, " \t"); i >= 0 {
+			return val[:i]
+		}
+		return val
+	}
+	return ""
+}
+
+func unescapeDesktopToken(s string) string {
+	var b strings.Builder
+	for i := 0; i < len(s); i++ {
+		if s[i] == '\\' && i+1 < len(s) {
+			b.WriteByte(s[i+1])
+			i++
+			continue
+		}
+		b.WriteByte(s[i])
+	}
+	return b.String()
+}

--- a/v3/pkg/application/autostart_linux.go
+++ b/v3/pkg/application/autostart_linux.go
@@ -52,6 +52,14 @@ func (a *linuxAutostart) enable(opts AutostartOptions) error {
 	}
 	path := filepath.Join(dir, id+".desktop")
 
+	// Remove any stale .desktop file pointing at this binary under a
+	// different identifier so a previous Enable() with a different
+	// Identifier (or a slug derived from a renamed Options.Name) doesn't
+	// leave a second entry behind.
+	if existing, ferr := a.findDesktopFile(dir); ferr == nil && existing != "" && existing != path {
+		_ = os.Remove(existing)
+	}
+
 	body := buildDesktopEntry(a.app.options.Name, exe, opts.Arguments)
 	if err := writeFileAtomic(path, []byte(body), 0644); err != nil {
 		return fmt.Errorf("write desktop file %s: %w", path, err)

--- a/v3/pkg/application/autostart_linux_test.go
+++ b/v3/pkg/application/autostart_linux_test.go
@@ -1,0 +1,108 @@
+//go:build linux && !android && !server
+
+package application
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func newLinuxAutostartForTest(t *testing.T, name string) *linuxAutostart {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	app := &App{options: Options{Name: name}}
+	return &linuxAutostart{app: app}
+}
+
+func TestLinuxAutostartRoundTrip(t *testing.T) {
+	a := newLinuxAutostartForTest(t, "Test App")
+
+	st, _ := a.status()
+	if st.Enabled {
+		t.Fatalf("expected disabled before enable, got %+v", st)
+	}
+
+	if err := a.enable(AutostartOptions{Arguments: []string{"--hidden"}}); err != nil {
+		t.Fatalf("enable: %v", err)
+	}
+
+	st, err := a.status()
+	if err != nil {
+		t.Fatalf("status: %v", err)
+	}
+	if !st.Enabled {
+		t.Fatalf("expected enabled, got %+v", st)
+	}
+	if st.Strategy != AutostartStrategyXDGAutostart {
+		t.Errorf("strategy=%q", st.Strategy)
+	}
+	if filepath.Base(st.Path) != "test-app.desktop" {
+		t.Errorf("path=%q", st.Path)
+	}
+
+	data, _ := os.ReadFile(st.Path)
+	body := string(data)
+	for _, want := range []string{
+		"[Desktop Entry]",
+		"Type=Application",
+		"Name=Test App",
+		"Hidden=false",
+		"X-GNOME-Autostart-enabled=true",
+		"--hidden",
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("missing %q in desktop file:\n%s", want, body)
+		}
+	}
+
+	if err := a.disable(); err != nil {
+		t.Fatalf("disable: %v", err)
+	}
+	if st, _ := a.status(); st.Enabled {
+		t.Error("still enabled after disable")
+	}
+}
+
+func TestLinuxAutostartCustomIdentifier(t *testing.T) {
+	a := newLinuxAutostartForTest(t, "Test App")
+	if err := a.enable(AutostartOptions{Identifier: "my-custom-id"}); err != nil {
+		t.Fatalf("enable: %v", err)
+	}
+	st, _ := a.status()
+	if filepath.Base(st.Path) != "my-custom-id.desktop" {
+		t.Errorf("path=%q want my-custom-id.desktop", st.Path)
+	}
+}
+
+func TestLinuxQuoteExec(t *testing.T) {
+	cases := map[string]string{
+		"/usr/bin/foo":            "/usr/bin/foo",
+		"/path with spaces/foo":   `"/path with spaces/foo"`,
+		`/has"quote`:              `"/has\"quote"`,
+		`/has\back`:               `"/has\\back"`,
+	}
+	for in, want := range cases {
+		if got := quoteExec(in); got != want {
+			t.Errorf("quoteExec(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestDesktopExecPath(t *testing.T) {
+	cases := map[string]string{
+		"Exec=/usr/bin/foo\n":                   "/usr/bin/foo",
+		"Exec=/usr/bin/foo --flag\n":            "/usr/bin/foo",
+		`Exec="/path with spaces/foo" --flag` + "\n":          "/path with spaces/foo",
+		`[Desktop Entry]` + "\nExec=/x/y\n":     "/x/y",
+		"NoExec=/x\n":                          "",
+	}
+	for in, want := range cases {
+		if got := desktopExecPath(in); got != want {
+			t.Errorf("desktopExecPath(%q) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/v3/pkg/application/autostart_manager.go
+++ b/v3/pkg/application/autostart_manager.go
@@ -1,0 +1,64 @@
+package application
+
+// AutostartManager provides cross-platform control over whether the
+// application launches when the user logs in.
+//
+// Registration takes effect on the next login, not immediately.
+//
+// Platform behaviour:
+//
+//   - macOS 13+ (bundled .app):  SMAppService.mainAppService — works for
+//     sandboxed and Mac-App-Store apps, no TCC automation prompt.
+//   - macOS (older or unbundled): a LaunchAgent plist is written to
+//     ~/Library/LaunchAgents/.
+//   - Windows: a value is added under
+//     HKCU\Software\Microsoft\Windows\CurrentVersion\Run.
+//   - Linux: an .desktop file is written to $XDG_CONFIG_HOME/autostart/
+//     (defaulting to ~/.config/autostart/).
+//   - Android / iOS / server builds: ErrAutostartNotSupported.
+type AutostartManager struct {
+	app  *App
+	impl autostartImpl
+}
+
+func newAutostartManager(app *App) *AutostartManager {
+	return &AutostartManager{
+		app:  app,
+		impl: newAutostartImpl(app),
+	}
+}
+
+// Enable registers the application to launch at user login using default
+// options. Calling Enable repeatedly is safe; the registration is overwritten.
+func (am *AutostartManager) Enable() error {
+	return am.impl.enable(AutostartOptions{})
+}
+
+// EnableWithOptions registers the application with the given options.
+// See AutostartOptions for the meaning of each field.
+func (am *AutostartManager) EnableWithOptions(opts AutostartOptions) error {
+	return am.impl.enable(opts)
+}
+
+// Disable removes the autostart registration. Returns nil if the application
+// was not registered.
+func (am *AutostartManager) Disable() error {
+	return am.impl.disable()
+}
+
+// IsEnabled reports whether the application is currently registered to launch
+// at login. It does not verify that the registered executable path still
+// points at the running binary; use Status for that.
+func (am *AutostartManager) IsEnabled() (bool, error) {
+	st, err := am.impl.status()
+	if err != nil {
+		return false, err
+	}
+	return st.Enabled, nil
+}
+
+// Status returns the full registration state, including the path of the
+// on-disk artefact and the platform mechanism used.
+func (am *AutostartManager) Status() (AutostartStatus, error) {
+	return am.impl.status()
+}

--- a/v3/pkg/application/autostart_server.go
+++ b/v3/pkg/application/autostart_server.go
@@ -1,0 +1,13 @@
+//go:build server
+
+package application
+
+type unsupportedAutostart struct{}
+
+func newAutostartImpl(_ *App) autostartImpl { return unsupportedAutostart{} }
+
+func (unsupportedAutostart) enable(AutostartOptions) error  { return ErrAutostartNotSupported }
+func (unsupportedAutostart) disable() error                 { return ErrAutostartNotSupported }
+func (unsupportedAutostart) status() (AutostartStatus, error) {
+	return AutostartStatus{}, ErrAutostartNotSupported
+}

--- a/v3/pkg/application/autostart_test.go
+++ b/v3/pkg/application/autostart_test.go
@@ -1,0 +1,89 @@
+package application
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestAutostartSlug(t *testing.T) {
+	cases := map[string]string{
+		"Simple":             "simple",
+		"My App":             "my-app",
+		"My  Cool   App":     "my--cool---app",
+		"Foo/Bar":            "foobar",
+		"  trim me  ":        "trim-me",
+		"All Punc!@#$":       "all-punc",
+		"":                   "wails-app",
+		"héllo":              "hllo",
+		"v1.2.3":             "v1.2.3",
+		"___leading_under":   "leading_under",
+		"...":                "wails-app",
+	}
+	for in, want := range cases {
+		t.Run(in, func(t *testing.T) {
+			if got := autostartSlug(in); got != want {
+				t.Errorf("autostartSlug(%q) = %q, want %q", in, got, want)
+			}
+		})
+	}
+}
+
+func TestValidateAutostartIdentifier(t *testing.T) {
+	good := []string{
+		"",
+		"com.example.app",
+		"my-app",
+		"my_app",
+		"App123",
+		strings.Repeat("a", 200),
+	}
+	for _, s := range good {
+		if err := validateAutostartIdentifier(s); err != nil {
+			t.Errorf("validateAutostartIdentifier(%q) unexpectedly failed: %v", s, err)
+		}
+	}
+	bad := []string{
+		"with space",
+		"slash/in/it",
+		"back\\slash",
+		"line\nbreak",
+		"quote\"in",
+		strings.Repeat("a", 201),
+	}
+	for _, s := range bad {
+		if err := validateAutostartIdentifier(s); err == nil {
+			t.Errorf("validateAutostartIdentifier(%q) should have failed", s)
+		}
+	}
+}
+
+func TestWriteFileAtomic(t *testing.T) {
+	dir := t.TempDir()
+	target := dir + "/out.txt"
+	if err := writeFileAtomic(target, []byte("hello"), 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	// Subsequent writes overwrite, not append, and leave no leftover tempfiles.
+	if err := writeFileAtomic(target, []byte("world"), 0644); err != nil {
+		t.Fatalf("rewrite: %v", err)
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 || entries[0].Name() != "out.txt" {
+		names := make([]string, 0, len(entries))
+		for _, e := range entries {
+			names = append(names, e.Name())
+		}
+		t.Errorf("expected exactly out.txt in dir, got %v", names)
+	}
+	data, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != "world" {
+		t.Errorf("contents=%q want %q", string(data), "world")
+	}
+}

--- a/v3/pkg/application/autostart_windows.go
+++ b/v3/pkg/application/autostart_windows.go
@@ -1,0 +1,187 @@
+//go:build windows && !server
+
+package application
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"golang.org/x/sys/windows/registry"
+)
+
+const defaultAutostartRegistrySubKey = `Software\Microsoft\Windows\CurrentVersion\Run`
+
+type windowsAutostart struct {
+	app *App
+
+	// registrySubKey is overridable for tests; production code reads/writes
+	// HKCU\Software\Microsoft\Windows\CurrentVersion\Run.
+	registrySubKey string
+}
+
+func newAutostartImpl(app *App) autostartImpl {
+	return &windowsAutostart{
+		app:            app,
+		registrySubKey: defaultAutostartRegistrySubKey,
+	}
+}
+
+func (a *windowsAutostart) enable(opts AutostartOptions) error {
+	if err := validateAutostartIdentifier(opts.Identifier); err != nil {
+		return err
+	}
+	exe, err := resolvedExecutable()
+	if err != nil {
+		return err
+	}
+	id := opts.Identifier
+	if id == "" {
+		id = autostartSlug(a.app.options.Name)
+	}
+
+	cmd := quoteWindowsArg(exe)
+	for _, arg := range opts.Arguments {
+		cmd += " " + quoteWindowsArg(arg)
+	}
+
+	key, _, err := registry.CreateKey(registry.CURRENT_USER, a.registrySubKey, registry.SET_VALUE)
+	if err != nil {
+		return fmt.Errorf("autostart: open registry key: %w", err)
+	}
+	defer key.Close()
+
+	if err := key.SetStringValue(id, cmd); err != nil {
+		return fmt.Errorf("autostart: write registry value: %w", err)
+	}
+	return nil
+}
+
+func (a *windowsAutostart) disable() error {
+	id, _, err := a.find()
+	if err != nil {
+		return err
+	}
+	if id == "" {
+		return nil
+	}
+	key, err := registry.OpenKey(registry.CURRENT_USER, a.registrySubKey, registry.SET_VALUE)
+	if err != nil {
+		if errors.Is(err, registry.ErrNotExist) {
+			return nil
+		}
+		return fmt.Errorf("autostart: open registry key: %w", err)
+	}
+	defer key.Close()
+	if err := key.DeleteValue(id); err != nil && !errors.Is(err, registry.ErrNotExist) {
+		return fmt.Errorf("autostart: delete registry value: %w", err)
+	}
+	return nil
+}
+
+func (a *windowsAutostart) status() (AutostartStatus, error) {
+	id, _, err := a.find()
+	if err != nil {
+		return AutostartStatus{}, err
+	}
+	if id == "" {
+		return AutostartStatus{}, nil
+	}
+	return AutostartStatus{
+		Enabled:  true,
+		Path:     `HKCU\` + a.registrySubKey + `\` + id,
+		Strategy: AutostartStrategyRegistryRun,
+	}, nil
+}
+
+// find returns the value name and command of the registry entry whose first
+// token equals our current executable. Empty name means not registered.
+func (a *windowsAutostart) find() (string, string, error) {
+	exe, err := resolvedExecutable()
+	if err != nil {
+		return "", "", err
+	}
+	key, err := registry.OpenKey(registry.CURRENT_USER, a.registrySubKey, registry.QUERY_VALUE)
+	if err != nil {
+		if errors.Is(err, registry.ErrNotExist) {
+			return "", "", nil
+		}
+		return "", "", fmt.Errorf("autostart: open registry key: %w", err)
+	}
+	defer key.Close()
+
+	names, err := key.ReadValueNames(-1)
+	if err != nil {
+		return "", "", fmt.Errorf("autostart: list registry values: %w", err)
+	}
+	exeLower := strings.ToLower(exe)
+	for _, name := range names {
+		val, _, err := key.GetStringValue(name)
+		if err != nil {
+			continue
+		}
+		if strings.EqualFold(parseWindowsCommandExe(val), exeLower) {
+			return name, val, nil
+		}
+	}
+	return "", "", nil
+}
+
+// parseWindowsCommandExe returns the first token of a Windows command line,
+// honouring surrounding double quotes for paths with spaces. Returned in
+// lowercase for case-insensitive comparison.
+func parseWindowsCommandExe(cmd string) string {
+	cmd = strings.TrimSpace(cmd)
+	if cmd == "" {
+		return ""
+	}
+	if cmd[0] == '"' {
+		end := strings.IndexByte(cmd[1:], '"')
+		if end < 0 {
+			return strings.ToLower(cmd[1:])
+		}
+		return strings.ToLower(cmd[1 : 1+end])
+	}
+	if i := strings.IndexAny(cmd, " \t"); i >= 0 {
+		return strings.ToLower(cmd[:i])
+	}
+	return strings.ToLower(cmd)
+}
+
+// quoteWindowsArg wraps an argument in double quotes when it contains
+// whitespace or quotes, and escapes embedded quotes. Backslashes preceding a
+// quote are doubled per CommandLineToArgvW rules.
+func quoteWindowsArg(s string) string {
+	if s != "" && !strings.ContainsAny(s, ` "	`) {
+		return s
+	}
+	var b strings.Builder
+	b.WriteByte('"')
+	backslashes := 0
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		switch c {
+		case '\\':
+			backslashes++
+		case '"':
+			for j := 0; j < backslashes; j++ {
+				b.WriteByte('\\')
+			}
+			b.WriteByte('\\')
+			b.WriteByte('"')
+			backslashes = 0
+		default:
+			for j := 0; j < backslashes; j++ {
+				b.WriteByte('\\')
+			}
+			backslashes = 0
+			b.WriteByte(c)
+		}
+	}
+	for j := 0; j < backslashes; j++ {
+		b.WriteByte('\\')
+		b.WriteByte('\\')
+	}
+	b.WriteByte('"')
+	return b.String()
+}

--- a/v3/pkg/application/autostart_windows.go
+++ b/v3/pkg/application/autostart_windows.go
@@ -51,6 +51,14 @@ func (a *windowsAutostart) enable(opts AutostartOptions) error {
 	}
 	defer key.Close()
 
+	// Remove any stale entry pointing at this binary under a different value
+	// name, so a previous Enable() with a different Identifier (or a slug
+	// derived from a renamed Options.Name) doesn't leave behind a second
+	// autostart entry.
+	if existing, _, ferr := a.find(); ferr == nil && existing != "" && existing != id {
+		_ = key.DeleteValue(existing)
+	}
+
 	if err := key.SetStringValue(id, cmd); err != nil {
 		return fmt.Errorf("autostart: write registry value: %w", err)
 	}
@@ -164,7 +172,11 @@ func quoteWindowsArg(s string) string {
 		case '\\':
 			backslashes++
 		case '"':
-			for j := 0; j < backslashes; j++ {
+			// Per CommandLineToArgvW: a literal quote preceded by N
+			// backslashes must be encoded as (2N+1) backslashes + quote.
+			// Earlier versions emitted only (N+1), which made the parser
+			// lose the quote (the 2 backslashes toggled quoted state).
+			for j := 0; j < 2*backslashes; j++ {
 				b.WriteByte('\\')
 			}
 			b.WriteByte('\\')

--- a/v3/pkg/application/autostart_windows_test.go
+++ b/v3/pkg/application/autostart_windows_test.go
@@ -1,0 +1,149 @@
+//go:build windows && !server
+
+package application
+
+import (
+	"testing"
+
+	"golang.org/x/sys/windows/registry"
+)
+
+// newWindowsAutostartForTest returns a windowsAutostart that reads and writes
+// under HKCU\Software\Wails\Tests\Autostart-<test-id>. The test creates the
+// key, runs, and deletes it on cleanup so production HKCU\…\Run is never
+// touched.
+func newWindowsAutostartForTest(t *testing.T, name string) *windowsAutostart {
+	t.Helper()
+	// Per-test subkey to allow parallel runs without collisions.
+	subKey := `Software\Wails\Tests\Autostart-` + t.Name()
+	// Pre-create so OpenKey succeeds on first read; the impl's CreateKey will
+	// be a no-op when the key already exists.
+	k, _, err := registry.CreateKey(registry.CURRENT_USER, subKey, registry.SET_VALUE)
+	if err != nil {
+		t.Fatalf("create test subkey: %v", err)
+	}
+	_ = k.Close()
+	t.Cleanup(func() {
+		_ = registry.DeleteKey(registry.CURRENT_USER, subKey)
+	})
+
+	app := &App{options: Options{Name: name}}
+	return &windowsAutostart{
+		app:            app,
+		registrySubKey: subKey,
+	}
+}
+
+func TestWindowsAutostartRoundTrip(t *testing.T) {
+	a := newWindowsAutostartForTest(t, "Test App")
+
+	st, err := a.status()
+	if err != nil {
+		t.Fatalf("status before enable: %v", err)
+	}
+	if st.Enabled {
+		t.Fatalf("expected disabled before enable, got %+v", st)
+	}
+
+	if err := a.enable(AutostartOptions{}); err != nil {
+		t.Fatalf("enable: %v", err)
+	}
+
+	st, err = a.status()
+	if err != nil {
+		t.Fatalf("status after enable: %v", err)
+	}
+	if !st.Enabled {
+		t.Fatalf("expected enabled, got %+v", st)
+	}
+	if st.Strategy != AutostartStrategyRegistryRun {
+		t.Errorf("strategy=%q want %q", st.Strategy, AutostartStrategyRegistryRun)
+	}
+
+	if err := a.disable(); err != nil {
+		t.Fatalf("disable: %v", err)
+	}
+	st, err = a.status()
+	if err != nil {
+		t.Fatalf("status after disable: %v", err)
+	}
+	if st.Enabled {
+		t.Fatalf("expected disabled after disable, got %+v", st)
+	}
+}
+
+func TestWindowsAutostartCustomIdentifier(t *testing.T) {
+	a := newWindowsAutostartForTest(t, "Test App")
+	if err := a.enable(AutostartOptions{
+		Identifier: "com.example.foo",
+		Arguments:  []string{"--hidden"},
+	}); err != nil {
+		t.Fatalf("enable: %v", err)
+	}
+
+	// Read the registry value directly to confirm both the value name and
+	// the quoted command are what we expect.
+	k, err := registry.OpenKey(registry.CURRENT_USER, a.registrySubKey, registry.QUERY_VALUE)
+	if err != nil {
+		t.Fatalf("open key: %v", err)
+	}
+	defer k.Close()
+	val, _, err := k.GetStringValue("com.example.foo")
+	if err != nil {
+		t.Fatalf("read value: %v", err)
+	}
+	// The value should contain --hidden as a separate token after the exe.
+	if want := " --hidden"; len(val) < len(want) || val[len(val)-len(want):] != want {
+		t.Errorf("registry value=%q, expected to end with %q", val, want)
+	}
+}
+
+func TestWindowsAutostartIdentifierValidation(t *testing.T) {
+	a := newWindowsAutostartForTest(t, "Test App")
+	if err := a.enable(AutostartOptions{Identifier: "bad/identifier"}); err == nil {
+		t.Error("expected error for invalid identifier")
+	}
+}
+
+func TestWindowsAutostartDisableNoOp(t *testing.T) {
+	a := newWindowsAutostartForTest(t, "Test App")
+	if err := a.disable(); err != nil {
+		t.Errorf("disable when not enabled should be nil, got %v", err)
+	}
+}
+
+func TestParseWindowsCommandExe(t *testing.T) {
+	cases := map[string]string{
+		`C:\app\foo.exe`:                  `c:\app\foo.exe`,
+		`"C:\Program Files\foo\foo.exe"`:  `c:\program files\foo\foo.exe`,
+		`C:\app\foo.exe --flag`:           `c:\app\foo.exe`,
+		`"C:\app\foo.exe" --flag`:         `c:\app\foo.exe`,
+		``:                                ``,
+		`  C:\app\foo.exe`:                `c:\app\foo.exe`,
+	}
+	for in, want := range cases {
+		if got := parseWindowsCommandExe(in); got != want {
+			t.Errorf("parseWindowsCommandExe(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestQuoteWindowsArg(t *testing.T) {
+	cases := map[string]string{
+		`foo`:               `foo`,
+		``:                  `""`,
+		`hello world`:       `"hello world"`,
+		`C:\Program Files`:  `"C:\Program Files"`,
+		`a"b`:               `"a\"b"`,
+		`a\b`:               `a\b`,
+		`a\"b`:              `"a\\\"b"`,
+		`a\\"b`:             `"a\\\\\"b"`,
+		`trailing\`:         `trailing\`,
+		`with space\`:       `"with space\\"`,
+	}
+	for in, want := range cases {
+		if got := quoteWindowsArg(in); got != want {
+			t.Errorf("quoteWindowsArg(%q) = %q, want %q", in, got, want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Adds \`app.Autostart\` for registering the application to launch at user login on macOS, Windows, and Linux. Closes the long-standing gap in the manager API and supersedes the AppleScript-only approach floated in earlier drafts (#3910, #4474) — that approach triggered the macOS automation TCC prompt and didn't work for sandboxed/MAS apps.

```go
if err := app.Autostart.Enable(); err != nil {
    if errors.Is(err, application.ErrAutostartNotSupported) {
        // hide the toggle in the UI
        return
    }
    // real failure
}
```

## API

```go
app.Autostart.Enable()                        // default options
app.Autostart.EnableWithOptions(opts)         // Identifier + Arguments
app.Autostart.Disable()                       // idempotent
app.Autostart.IsEnabled() (bool, error)       // fast — no path validation
app.Autostart.Status() (AutostartStatus, error) // Enabled + Path + Strategy
```

\`AutostartOptions\` has two fields: \`Identifier\` (overrides the auto-derived registration ID — registry value name on Windows, plist Label on macOS, \`.desktop\` filename on Linux) and \`Arguments\` (appended to the executable path on launch).

\`AutostartStatus.Strategy\` names the mechanism used so apps can present meaningful diagnostics (\`smappservice\`, \`launchagent\`, \`registry-run\`, \`xdg-autostart\`).

## Per-platform mechanism

| Platform | Mechanism | When |
|---|---|---|
| macOS 13+ bundled \`.app\` | \`SMAppService.mainAppService\` | First choice — works for sandboxed / Mac App Store apps, no TCC prompt |
| macOS pre-13 or unbundled | \`~/Library/LaunchAgents/<id>.plist\` + \`launchctl bootstrap\` | Fallback for dev builds and pre-Ventura |
| Windows | \`HKCU\\Software\\Microsoft\\Windows\\CurrentVersion\\Run\` value | Standard user-scope autostart |
| Linux | \`$XDG_CONFIG_HOME/autostart/<id>.desktop\` | freedesktop XDG spec |
| iOS / Android / server | \`ErrAutostartNotSupported\` | — |

## Design notes

- **Atomic writes.** \`.plist\` and \`.desktop\` files are written via tempfile + \`os.Rename\` so a partial write never leaves a half-formed file in place.
- **Symlink-aware.** \`os.Executable()\` is resolved through \`filepath.EvalSymlinks\` so registrations survive symlinked installs (Homebrew, Scoop).
- **Stale detection by EXE path.** \`Disable()\` and \`Status()\` locate the registration by matching the registered executable path against the current binary, not by identifier lookup. This means renaming the binary or changing the identifier between releases doesn't strand the registration.
- **Quote-correct arguments.** Windows uses \`CommandLineToArgvW\`-style backslash-doubling for embedded quotes; Linux uses freedesktop \`Exec=\` escaping for backticks, dollars, and embedded quotes.
- **Test seams.** \`launchctlBootstrap\` / \`launchctlBootout\` are package-level \`var\`s so tests can stub them out — without that, a test plist with \`RunAtLoad=true\` would respawn the test binary recursively via launchd. The Windows impl exposes its registry sub-key as a struct field for the same reason.

## What's included

- \`v3/pkg/application/autostart.go\` — shared types, helpers, validation
- \`v3/pkg/application/autostart_manager.go\` — public API
- \`autostart_{darwin,linux,windows}.go\` — platform implementations
- \`autostart_darwin_smappservice.go\` — CGO bridge with \`@available(macOS 13.0, *)\` runtime gate
- \`autostart_{android,ios,server}.go\` — stubs returning \`ErrAutostartNotSupported\`
- \`autostart_{,darwin_,linux_}test.go\` — unit tests (slug / validate / atomic write / round-trip per OS)
- \`examples/autostart/main.go\` — runnable status/enable/disable demo
- \`docs/features/autostart/basics.mdx\` — feature reference
- \`docs/concepts/manager-api.mdx\` — Autostart added to the manager list
- \`docs/astro.config.mjs\` — sidebar entry
- \`application.go\` — \`App.Autostart\` field + \`newAutostartManager\` wired in \`init()\`

## Test plan

- [x] darwin: \`go build\`, \`go test\` — all autostart tests pass (round-trip via LaunchAgent, custom identifier, validation, disable noop, plist parser, runningFromAppBundle, slug)
- [x] linux (Ubuntu, GTK4 + WebKit2GTK-4.1 on lin-node1): \`go build\`, \`go test\` — pass
- [x] windows: \`GOOS=windows go vet ./pkg/application/\` — clean (existing pre-existing unsafe.Pointer warnings in unrelated files only)
- [ ] manual: notarised \`.app\` on macOS 13+ to exercise the SMAppService runtime branch (not exercised by unit tests — needs a real bundle ID)
- [ ] manual: confirm \`HKCU\\…\\Run\` entry appears + survives reboot on Windows
- [ ] manual: confirm \`.desktop\` entry triggers a launch via \`gnome-session\` / KDE autostart on Linux

## Closes

Resolves the \`app.Autostart\` slot in the manager API. Earlier closed drafts: #3910, #4474 (both AppleScript-only macOS, didn't work for sandboxed apps).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added cross-platform Autostart manager to control app autostart (enable/disable/status) and exposed it on the application API; included a runnable example demonstrating usage.

* **Documentation**
  * New comprehensive Autostart docs with platform details and a sidebar "Autostart" entry linked from Features and Manager API pages.

* **Tests**
  * Added extensive unit tests for Autostart behavior on macOS, Windows, Linux, plus unsupported-target stubs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wailsapp/wails/pull/5426)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->