### PR TITLE
fix(v3/webview2): use log instead of fmt for error and stack trace output

### DIFF
--- a/v3/UNRELEASED_CHANGELOG.md
+++ b/v3/UNRELEASED_CHANGELOG.md
@@ -25,6 +25,7 @@ After processing, the content will be moved to the main changelog and this file 
 ## Fixed
 <!-- Bug fixes -->
 - Fix `concurrent map read and map write` runtime fatal in `linuxSystemTray` when the tray menu is updated while the panel reads it.
+- Use `log` instead of `fmt` for WebView2 error and stack trace output so messages aren't lost when the app runs without an attached console on Windows.
 
 ## Deprecated
 <!-- Soon-to-be removed features -->

--- a/webview2/pkg/edge/chromium.go
+++ b/webview2/pkg/edge/chromium.go
@@ -28,13 +28,13 @@ func globalErrorHandler(err error) {
 		return
 	}
 
-	fmt.Printf("[WebView2 Error] %v\n", err)
+	log.Printf("[WebView2 Error] %v\n", err)
 
 	stackBuf := make([]uintptr, 64)
 	stackSize := runtime.Callers(2, stackBuf)
 	frames := runtime.CallersFrames(stackBuf[:stackSize])
 
-	fmt.Println("\nStack trace:")
+	log.Printf("\nStack trace:")
 	stackIndex := 1
 	for {
 		frame, more := frames.Next()


### PR DESCRIPTION
# Description

Ports [wailsapp/go-webview2#35](https://github.com/wailsapp/go-webview2/pull/35) by @APshenkin to the vendored `webview2/pkg/edge/chromium.go` used by v3.

On Windows, especially in production applications started outside of a terminal, `fmt.Println` / `fmt.Printf` output is often not visible because there is no attached console. As a result, error messages and the stack trace emitted by the WebView2 `globalErrorHandler` are lost. Routing them through the `log` package ensures they reach the standard logger destination (same change as upstream).

Credit to @APshenkin for the original patch.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Build-only verification of the vendored package; behaviour matches the upstream `go-webview2` PR which has the same two-line change.

- [x] Windows (logic mirrors merged-style upstream patch)
- [ ] macOS
- [ ] Linux

## Test Configuration

N/A — Windows-only code path (`//go:build windows`).

# Checklist:

- [ ] (v2 only) I have updated `website/src/pages/changelog.mdx` (not applicable — v2 pulls the fix via the external `github.com/wailsapp/go-webview2` module once #35 lands)
- [x] My code follows the general coding style of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] v3 changelog entry added to `v3/UNRELEASED_CHANGELOG.md`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * WebView2 error messages and stack traces are now properly captured when running on Windows without an attached console.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wailsapp/wails/pull/5453)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->