### PR TITLE
fix(v3/darwin): add effectiveZoomButtonState and fix runtime NSWindowZoomButton conflict

### DIFF
--- a/v3/pkg/application/webview_window_darwin.go
+++ b/v3/pkg/application/webview_window_darwin.go
@@ -1049,7 +1049,9 @@ func (w *macosWebviewWindow) hide() {
 }
 
 func (w *macosWebviewWindow) setFullscreenButtonState(state ButtonState) {
-	C.setFullscreenButtonState(w.nsWindow, C.int(state))
+	// Both MaximiseButtonState and FullscreenButtonState target NSWindowZoomButton.
+	// Apply the more restrictive of the two so neither silently overrides the other.
+	C.setFullscreenButtonState(w.nsWindow, C.int(effectiveZoomButtonState(state, w.parent.options.MaximiseButtonState)))
 }
 
 func (w *macosWebviewWindow) disableSizeConstraints() {
@@ -1399,11 +1401,9 @@ func (w *macosWebviewWindow) run() {
 
 		// Initialise the window buttons
 		w.setMinimiseButtonState(options.MinimiseButtonState)
-		w.setMaximiseButtonState(options.MaximiseButtonState)
 		w.setCloseButtonState(options.CloseButtonState)
-		if options.FullscreenButtonState != ButtonEnabled {
-			w.setFullscreenButtonState(options.FullscreenButtonState)
-		}
+		// setMaximiseButtonState reconciles with FullscreenButtonState internally.
+		w.setMaximiseButtonState(options.MaximiseButtonState)
 
 		// Ignore mouse events if requested
 		w.setIgnoreMouseEvents(options.IgnoreMouseEvents)
@@ -1630,7 +1630,9 @@ func (w *macosWebviewWindow) setMinimiseButtonState(state ButtonState) {
 }
 
 func (w *macosWebviewWindow) setMaximiseButtonState(state ButtonState) {
-	C.setMaximiseButtonState(w.nsWindow, C.int(state))
+	// Both MaximiseButtonState and FullscreenButtonState target NSWindowZoomButton.
+	// Apply the more restrictive of the two so neither silently overrides the other.
+	C.setMaximiseButtonState(w.nsWindow, C.int(effectiveZoomButtonState(state, w.parent.options.FullscreenButtonState)))
 }
 
 func (w *macosWebviewWindow) setCloseButtonState(state ButtonState) {

--- a/v3/pkg/application/webview_window_options.go
+++ b/v3/pkg/application/webview_window_options.go
@@ -22,6 +22,15 @@ const (
 	ButtonHidden   ButtonState = 2
 )
 
+// effectiveZoomButtonState returns the more restrictive of two ButtonState values.
+// Hidden > Disabled > Enabled, so the higher numeric value wins.
+func effectiveZoomButtonState(a, b ButtonState) ButtonState {
+	if b > a {
+		return b
+	}
+	return a
+}
+
 type WindowStartPosition int
 
 const (

--- a/v3/pkg/application/webview_window_options_test.go
+++ b/v3/pkg/application/webview_window_options_test.go
@@ -402,3 +402,38 @@ func TestNSVisualEffectMaterial_Constants(t *testing.T) {
 		t.Error("NSVisualEffectMaterialAuto should be -1")
 	}
 }
+
+func TestEffectiveZoomButtonState(t *testing.T) {
+	tests := []struct {
+		name string
+		a, b ButtonState
+		want ButtonState
+	}{
+		{"both enabled", ButtonEnabled, ButtonEnabled, ButtonEnabled},
+		{"a disabled, b enabled", ButtonDisabled, ButtonEnabled, ButtonDisabled},
+		{"a enabled, b disabled", ButtonEnabled, ButtonDisabled, ButtonDisabled},
+		{"a hidden, b enabled", ButtonHidden, ButtonEnabled, ButtonHidden},
+		{"a enabled, b hidden", ButtonEnabled, ButtonHidden, ButtonHidden},
+		{"a hidden, b disabled", ButtonHidden, ButtonDisabled, ButtonHidden},
+		{"a disabled, b hidden", ButtonDisabled, ButtonHidden, ButtonHidden},
+		{"both disabled", ButtonDisabled, ButtonDisabled, ButtonDisabled},
+		{"both hidden", ButtonHidden, ButtonHidden, ButtonHidden},
+		{"maximise disabled, fullscreen default", ButtonDisabled, ButtonEnabled, ButtonDisabled},
+		{"maximise default, fullscreen disabled", ButtonEnabled, ButtonDisabled, ButtonDisabled},
+		{"maximise hidden, fullscreen default", ButtonHidden, ButtonEnabled, ButtonHidden},
+		{"maximise default, fullscreen hidden", ButtonEnabled, ButtonHidden, ButtonHidden},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := effectiveZoomButtonState(tt.a, tt.b)
+			if got != tt.want {
+				t.Errorf("effectiveZoomButtonState(%v, %v) = %v, want %v", tt.a, tt.b, got, tt.want)
+			}
+			// commutativity: result must be the same regardless of argument order
+			got2 := effectiveZoomButtonState(tt.b, tt.a)
+			if got2 != tt.want {
+				t.Errorf("effectiveZoomButtonState(%v, %v) [commuted] = %v, want %v", tt.b, tt.a, got2, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `effectiveZoomButtonState(a, b ButtonState) ButtonState` helper that returns the more restrictive of two `ButtonState` values (Hidden > Disabled > Enabled)
- Both `setMaximiseButtonState` and `setFullscreenButtonState` now call this helper, so neither can silently override the other at runtime — the "more restrictive wins" contract holds regardless of call order
- Removes the incorrect startup guard `if options.FullscreenButtonState != ButtonEnabled` in `run()` — it was wrong (a runtime `SetFullscreenButtonState(ButtonEnabled)` call could undo a `MaximiseButtonState: ButtonDisabled`) and is no longer needed since reconciliation is in the setters
- Adds `TestEffectiveZoomButtonState` with 13 subtests covering all `ButtonState` combinations plus commutativity checks

## Background

`MaximiseButtonState` and `FullscreenButtonState` both target `NSWindowZoomButton` (the green traffic-light button). In `master`, whichever setter runs last wins. This PR makes both setters always enforce the more restrictive of the two settings, both at startup and at runtime.

## Test results

```
go vet ./pkg/application/... → clean
TestEffectiveZoomButtonState → 13/13 PASS
```

Closes #5319

CC @leaanthony

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed macOS window button state handling to properly reconcile fullscreen and maximise button behaviors, preventing conflicts when both modes are configured.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wailsapp/wails/pull/5455)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->