### PR TITLE
fix(v3): replace Unix-only shell commands in cross-compilation Taskfiles

### DIFF
--- a/v3/cmd/wails3/main.go
+++ b/v3/cmd/wails3/main.go
@@ -96,6 +96,8 @@ func main() {
 	tool.NewSubCommandFunction("version", "Bump semantic version", commands.ToolVersion)
 	tool.NewSubCommandFunction("lipo", "Create macOS universal binary from multiple architectures", commands.ToolLipo)
 	tool.NewSubCommandFunction("capabilities", "Check system build capabilities (GTK4/GTK3 availability)", commands.ToolCapabilities)
+	tool.NewSubCommandFunction("docker-mounts", "Generate Docker volume mount flags for cross-compilation", commands.ToolDockerMounts)
+	tool.NewSubCommandFunction("has-cc", "Check if a C compiler (gcc or clang) is available in PATH", commands.ToolHasCC)
 
 	// Low-level sign tool (used by Taskfiles)
 	toolSign := tool.NewSubCommand("sign", "Sign a binary or package directly")

--- a/v3/internal/commands/build_assets/darwin/Taskfile.yml
+++ b/v3/internal/commands/build_assets/darwin/Taskfile.yml
@@ -66,32 +66,19 @@ tasks:
           Docker image '{{.CROSS_IMAGE}}' not found.
           Build it first: wails3 task setup:docker
     cmds:
-      - docker run --rm -v "{{.ROOT_DIR}}:/app" {{.GO_CACHE_MOUNT}} {{.REPLACE_MOUNTS}} -e APP_NAME="{{.APP_NAME}}" {{if .EXTRA_TAGS}}-e EXTRA_TAGS="{{.EXTRA_TAGS}}"{{end}} {{.CROSS_IMAGE}} darwin {{.DOCKER_ARCH}}
-      - docker run --rm -v "{{.ROOT_DIR}}:/app" alpine chown -R $(id -u):$(id -g) /app/bin
+      - docker run --rm -v "{{.ROOT_DIR}}:/app" {{.DOCKER_MOUNTS}} -e APP_NAME="{{.APP_NAME}}" {{if .EXTRA_TAGS}}-e EXTRA_TAGS="{{.EXTRA_TAGS}}"{{end}} {{.CROSS_IMAGE}} darwin {{.DOCKER_ARCH}}
+      - cmd: docker run --rm -v "{{.ROOT_DIR}}:/app" alpine chown -R $(id -u):$(id -g) /app/bin
+        platforms: [linux, darwin]
       - mkdir -p {{.BIN_DIR}}
       - mv "bin/{{.APP_NAME}}-darwin-{{.DOCKER_ARCH}}" "{{.OUTPUT}}"
     vars:
       DOCKER_ARCH: '{{if eq .ARCH "arm64"}}arm64{{else if eq .ARCH "amd64"}}amd64{{else}}arm64{{end}}'
       DEFAULT_OUTPUT: '{{.BIN_DIR}}/{{.APP_NAME}}'
       OUTPUT: '{{ .OUTPUT | default .DEFAULT_OUTPUT }}'
-      # Mount Go module cache for faster builds
-      GO_CACHE_MOUNT:
-        sh: 'echo "-v ${GOPATH:-$HOME/go}/pkg/mod:/go/pkg/mod"'
-      # Extract replace directives from go.mod and create -v mounts for each
-      # Handles both relative (=> ../) and absolute (=> /) paths
-      REPLACE_MOUNTS:
-        sh: |
-          grep -E '^replace .* => ' go.mod 2>/dev/null | while read -r line; do
-            path=$(echo "$line" | sed -E 's/^replace .* => //' | tr -d '\r')
-            # Convert relative paths to absolute
-            if [ "${path#/}" = "$path" ]; then
-              path="$(cd "$(dirname "$path")" 2>/dev/null && pwd)/$(basename "$path")"
-            fi
-            # Only mount if directory exists
-            if [ -d "$path" ]; then
-              echo "-v $path:$path:ro"
-            fi
-          done | tr '\n' ' '
+      # Generate Docker volume mounts: Go module cache + go.mod replace directives
+      # Uses wails3 tool docker-mounts for cross-platform compatibility (Windows/Linux/macOS)
+      DOCKER_MOUNTS:
+        sh: 'wails3 tool docker-mounts'
 
   build:universal:
     summary: Builds darwin universal binary (arm64 + amd64)

--- a/v3/internal/commands/build_assets/linux/Taskfile.yml
+++ b/v3/internal/commands/build_assets/linux/Taskfile.yml
@@ -32,9 +32,9 @@ tasks:
       OUTPUT: '{{ .OUTPUT | default .DEFAULT_OUTPUT }}'
       # Determine target architecture (defaults to host ARCH if not specified)
       TARGET_ARCH: '{{.ARCH | default ARCH}}'
-      # Check if a C compiler is available (gcc or clang)
+      # Check if a C compiler is available (gcc or clang) — cross-platform via wails3 tool
       HAS_CC:
-        sh: '(command -v gcc >/dev/null 2>&1 || command -v clang >/dev/null 2>&1) && echo "true" || echo "false"'
+        sh: 'wails3 tool has-cc'
 
   build:native:
     summary: Builds the application natively on Linux
@@ -75,31 +75,19 @@ tasks:
           Docker image '{{.CROSS_IMAGE}}' not found.
           Build it first: wails3 task setup:docker
     cmds:
-      - docker run --rm -v "{{.ROOT_DIR}}:/app" {{.GO_CACHE_MOUNT}} {{.REPLACE_MOUNTS}} -e APP_NAME="{{.APP_NAME}}" {{if .EXTRA_TAGS}}-e EXTRA_TAGS="{{.EXTRA_TAGS}}"{{end}} "{{.CROSS_IMAGE}}" linux {{.DOCKER_ARCH}}
-      - docker run --rm -v "{{.ROOT_DIR}}:/app" alpine chown -R $(id -u):$(id -g) /app/bin
+      - docker run --rm -v "{{.ROOT_DIR}}:/app" {{.DOCKER_MOUNTS}} -e APP_NAME="{{.APP_NAME}}" {{if .EXTRA_TAGS}}-e EXTRA_TAGS="{{.EXTRA_TAGS}}"{{end}} "{{.CROSS_IMAGE}}" linux {{.DOCKER_ARCH}}
+      - cmd: docker run --rm -v "{{.ROOT_DIR}}:/app" alpine chown -R $(id -u):$(id -g) /app/bin
+        platforms: [linux, darwin]
       - mkdir -p {{.BIN_DIR}}
       - mv "bin/{{.APP_NAME}}-linux-{{.DOCKER_ARCH}}" "{{.OUTPUT}}"
     vars:
       DOCKER_ARCH: '{{.ARCH | default "amd64"}}'
       DEFAULT_OUTPUT: '{{.BIN_DIR}}/{{.APP_NAME}}'
       OUTPUT: '{{ .OUTPUT | default .DEFAULT_OUTPUT }}'
-      # Mount Go module cache for faster builds
-      GO_CACHE_MOUNT:
-        sh: 'echo "-v ${GOPATH:-$HOME/go}/pkg/mod:/go/pkg/mod"'
-      # Extract replace directives from go.mod and create -v mounts for each
-      REPLACE_MOUNTS:
-        sh: |
-          grep -E '^replace .* => ' go.mod 2>/dev/null | while read -r line; do
-            path=$(echo "$line" | sed -E 's/^replace .* => //' | tr -d '\r')
-            # Convert relative paths to absolute
-            if [ "${path#/}" = "$path" ]; then
-              path="$(cd "$(dirname "$path")" 2>/dev/null && pwd)/$(basename "$path")"
-            fi
-            # Only mount if directory exists
-            if [ -d "$path" ]; then
-              echo "-v $path:$path:ro"
-            fi
-          done | tr '\n' ' '
+      # Generate Docker volume mounts: Go module cache + go.mod replace directives
+      # Uses wails3 tool docker-mounts for cross-platform compatibility (Windows/Linux/macOS)
+      DOCKER_MOUNTS:
+        sh: 'wails3 tool docker-mounts'
 
   package:
     summary: Packages the application for Linux

--- a/v3/internal/commands/build_assets/windows/Taskfile.yml
+++ b/v3/internal/commands/build_assets/windows/Taskfile.yml
@@ -73,28 +73,16 @@ tasks:
       - task: generate:syso
         vars:
           ARCH: '{{.ARCH}}'
-      - docker run --rm -v "{{.ROOT_DIR}}:/app" {{.GO_CACHE_MOUNT}} {{.REPLACE_MOUNTS}} -e APP_NAME="{{.APP_NAME}}" {{if .EXTRA_TAGS}}-e EXTRA_TAGS="{{.EXTRA_TAGS}}"{{end}} {{.CROSS_IMAGE}} windows {{.DOCKER_ARCH}}
-      - docker run --rm -v "{{.ROOT_DIR}}:/app" alpine chown -R $(id -u):$(id -g) /app/bin
+      - docker run --rm -v "{{.ROOT_DIR}}:/app" {{.DOCKER_MOUNTS}} -e APP_NAME="{{.APP_NAME}}" {{if .EXTRA_TAGS}}-e EXTRA_TAGS="{{.EXTRA_TAGS}}"{{end}} {{.CROSS_IMAGE}} windows {{.DOCKER_ARCH}}
+      - cmd: docker run --rm -v "{{.ROOT_DIR}}:/app" alpine chown -R $(id -u):$(id -g) /app/bin
+        platforms: [linux, darwin]
       - rm -f *.syso
     vars:
       DOCKER_ARCH: '{{.ARCH | default "amd64"}}'
-      # Mount Go module cache for faster builds
-      GO_CACHE_MOUNT:
-        sh: 'echo "-v ${GOPATH:-$HOME/go}/pkg/mod:/go/pkg/mod"'
-      # Extract replace directives from go.mod and create -v mounts for each
-      REPLACE_MOUNTS:
-        sh: |
-          grep -E '^replace .* => ' go.mod 2>/dev/null | while read -r line; do
-            path=$(echo "$line" | sed -E 's/^replace .* => //' | tr -d '\r')
-            # Convert relative paths to absolute
-            if [ "${path#/}" = "$path" ]; then
-              path="$(cd "$(dirname "$path")" 2>/dev/null && pwd)/$(basename "$path")"
-            fi
-            # Only mount if directory exists
-            if [ -d "$path" ]; then
-              echo "-v $path:$path:ro"
-            fi
-          done | tr '\n' ' '
+      # Generate Docker volume mounts: Go module cache + go.mod replace directives
+      # Uses wails3 tool docker-mounts for cross-platform compatibility (Windows/Linux/macOS)
+      DOCKER_MOUNTS:
+        sh: 'wails3 tool docker-mounts'
 
   package:
     summary: Packages the application

--- a/v3/internal/commands/tool_docker_mounts.go
+++ b/v3/internal/commands/tool_docker_mounts.go
@@ -1,0 +1,131 @@
+package commands
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path"
+	"path/filepath"
+	"strings"
+
+	"golang.org/x/mod/modfile"
+)
+
+// DockerMountsOptions holds options for the docker-mounts command.
+type DockerMountsOptions struct{}
+
+// HasCCOptions holds options for the has-cc command.
+type HasCCOptions struct{}
+
+// ToolHasCC checks if a C compiler (gcc or clang) is available in PATH.
+// Outputs "true" or "false" for use in Taskfile sh: variables, replacing the
+// bash-only `command -v gcc` pattern which fails on Windows.
+func ToolHasCC(_ *HasCCOptions) error {
+	DisableFooter = true
+	_, gccErr := exec.LookPath("gcc")
+	_, clangErr := exec.LookPath("clang")
+	if gccErr == nil || clangErr == nil {
+		fmt.Print("true")
+	} else {
+		fmt.Print("false")
+	}
+	return nil
+}
+
+// ToolDockerMounts outputs Docker volume mount flags for cross-compilation.
+// It generates mounts for the Go module cache and any local replace directives
+// in go.mod. This is a cross-platform replacement for the bash pipeline that
+// was previously used in Taskfile templates.
+//
+// The project is assumed to be mounted at /app inside the container (matching
+// the Taskfile `docker run -v "{{.ROOT_DIR}}:/app"` convention). Each -v flag
+// is double-quoted so paths with spaces survive shell tokenisation in both
+// POSIX sh and cmd.exe (go-task may use either on Windows).
+func ToolDockerMounts(_ *DockerMountsOptions) error {
+	DisableFooter = true
+
+	var mounts []string
+
+	// Add Go module cache mount. GOPATH may contain multiple entries
+	// (os.PathListSeparator-separated); use only the first, falling back to ~/go.
+	gopath := firstGOPATHEntry()
+	if gopath != "" {
+		hostPath := filepath.ToSlash(gopath)
+		mounts = append(mounts, fmt.Sprintf(`-v "%s/pkg/mod:/go/pkg/mod"`, hostPath))
+	}
+
+	// Parse go.mod for local replace directives and add volume mounts.
+	// The container project root is /app; replace paths must be remapped accordingly.
+	gomodDir, _ := filepath.Abs(".")
+	data, err := os.ReadFile("go.mod")
+	if err == nil {
+		f, err := modfile.Parse("go.mod", data, nil)
+		if err == nil {
+			for _, r := range f.Replace {
+				// Only handle local directory replacements (no version = local path)
+				if r.New.Version != "" {
+					continue
+				}
+				relPath := r.New.Path // forward-slash path as written in go.mod
+
+				// Resolve absolute host path from the (possibly relative) replace path.
+				hostAbsPath := relPath
+				if !filepath.IsAbs(relPath) {
+					abs, err := filepath.Abs(relPath)
+					if err != nil {
+						continue
+					}
+					hostAbsPath = abs
+				}
+				if info, err := os.Stat(hostAbsPath); err != nil || !info.IsDir() {
+					continue
+				}
+				hostDockerPath := filepath.ToSlash(hostAbsPath)
+
+				// Compute the container-side destination.
+				// Relative replace paths in go.mod are relative to the project root,
+				// which maps to /app inside the container. path.Clean handles ".." correctly.
+				var containerPath string
+				if filepath.IsAbs(relPath) {
+					// Windows drive-letter absolute paths (e.g. C:\vendor\lib) cannot be
+					// mapped to valid Linux container destination paths — skip them.
+					if len(relPath) >= 2 && relPath[1] == ':' {
+						continue
+					}
+					// Unix absolute paths: compute the offset from the project root so
+					// the container destination stays under /app, matching where Go
+					// resolves the module inside the container.
+					rel, err := filepath.Rel(gomodDir, hostAbsPath)
+					if err != nil {
+						continue
+					}
+					containerPath = path.Clean("/app/" + filepath.ToSlash(rel))
+				} else {
+					containerPath = path.Clean("/app/" + relPath)
+				}
+
+				mounts = append(mounts, fmt.Sprintf(`-v "%s:%s:ro"`, hostDockerPath, containerPath))
+			}
+		}
+	}
+
+	fmt.Print(strings.Join(mounts, " "))
+	return nil
+}
+
+// firstGOPATHEntry returns the first entry from GOPATH, or ~/go when unset.
+func firstGOPATHEntry() string {
+	gopath := os.Getenv("GOPATH")
+	if gopath == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return ""
+		}
+		return filepath.Join(home, "go")
+	}
+	entries := filepath.SplitList(gopath)
+	if len(entries) == 0 {
+		return ""
+	}
+	return entries[0]
+}


### PR DESCRIPTION
## Summary

Supersedes #5332 — same change, with all reviewer feedback addressed.

Replaces bash-only shell pipelines (`grep`/`sed`/`tr`, `${GOPATH:-$HOME/go}`, `command -v gcc`) in the darwin/linux/windows cross-compilation Taskfiles with two new `wails3` subcommands that work on Windows, Linux, and macOS:

### `wails3 tool docker-mounts`
Outputs `-v` flags for the Go module cache and any local `replace` directives in `go.mod`. Addresses all coderabbitai/copilot review comments from #5332:
- **Double-quoted** `-v` flags: single quotes are POSIX-only; `cmd.exe` treats them literally, breaking paths with spaces when go-task falls back to `cmd.exe` on Windows
- **GOPATH multi-entry**: uses `filepath.SplitList(gopath)[0]` — only the first entry
- **Container path mapping**: relative replace paths → `/app/<relpath>`; absolute Unix paths → `/app/<relative-to-project-root>`; Windows drive-letter paths (`C:\...`) → skipped (invalid Linux container destinations)

### `wails3 tool has-cc`
Outputs `true`/`false` via `exec.LookPath("gcc"/"clang")`, replacing the bash-only `command -v gcc` check.

The `chown $(id -u):$(id -g)` step is gated with `platforms: [linux, darwin]` — Docker Desktop on Windows handles ownership automatically.

## Test plan
- [ ] `go build ./v3/cmd/wails3/...` — exit 0
- [ ] `go test ./v3/internal/commands/...` — all pass
- [ ] `wails3 tool docker-mounts` on Windows outputs `-v "C:/Users/.../go/pkg/mod:/go/pkg/mod"`
- [ ] `wails3 tool has-cc` on Windows outputs `true` or `false` (no bash dependency)
- [ ] `wails3 build GOOS=darwin` on Windows with Docker Desktop (requires Docker)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added two new CLI utility commands: `docker-mounts` (generates Docker volume mount flags) and `has-cc` (detects compiler availability).

* **Refactor**
  * Simplified cross-compilation build configuration by centralizing Docker mount logic into the new utility command, reducing redundant mount handling across macOS, Linux, and Windows build tasks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wailsapp/wails/pull/5456)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->