### PR TITLE
fix(docs/i18n): fix MDX compilation errors causing Cloudflare Pages failure

### DIFF
--- a/docs/src/content/docs/de/concepts/architecture.mdx
+++ b/docs/src/content/docs/de/concepts/architecture.mdx
@@ -323,6 +323,333 @@ Shutdown: "Shutdown" {
     shape: rectangle
   }
   
-  Save: "Save State" {---
+  Save: "Save State" {
+    shape: rectangle
+  }
+}
+
+End: "Application End" {
+  shape: oval
+  style.fill: "#EF4444"
+}
+
+Start -> Init.Create
+Init.Create -> Init.Register
+Init.Register -> Init.Setup
+Init.Setup -> Run.Events
+Run.Events -> Run.Messages
+Run.Messages -> Run.Render
+Run.Render -> Run.Events: "Loop"
+Run.Events -> Shutdown.Cleanup: "Quit signal"
+Shutdown.Cleanup -> Shutdown.Save
+Shutdown.Save -> End
+```
+
+**Lifecycle hooks:**
+
+```go
+app := application.New(application.Options{
+    Name: "My App",
+    
+    // Called before windows are created
+    OnStartup: func(ctx context.Context) {
+        // Initialise database, load config, etc.
+    },
+    
+    // Called when app is about to quit
+    OnShutdown: func() {
+        // Save state, close connections, etc.
+    },
+})
+```
+
+[Learn more about lifecycle →](/concepts/lifecycle)
+
+## Build Process
+
+Understanding how Wails builds your application:
+
+```d2
+direction: down
+
+Source: "Source Code" {
+  Go: "Go Code\n(main.go, services)" {
+    shape: rectangle
+    style.fill: "#00ADD8"
+  }
+  
+  Frontend: "Frontend Code\n(HTML/CSS/JS)" {
+    shape: rectangle
+    style.fill: "#8B5CF6"
+  }
+}
+
+Build: "Build Process" {
+  AnalyseGo: "Analyse Go Code" {
+    shape: rectangle
+  }
+  
+  GenerateBindings: "Generate Bindings" {
+    shape: rectangle
+  }
+  
+  BuildFrontend: "Build Frontend" {
+    shape: rectangle
+  }
+  
+  CompileGo: "Compile Go" {
+    shape: rectangle
+  }
+  
+  Embed: "Embed Assets" {
+    shape: rectangle
+  }
+}
+
+Output: "Output" {
+  Binary: "Native Binary\n(myapp.exe/.app)" {
+    shape: rectangle
+    style.fill: "#10B981"
+  }
+}
+
+Source.Go -> Build.AnalyseGo
+Build.AnalyseGo -> Build.GenerateBindings: "Extract types"
+Build.GenerateBindings -> Source.Frontend: "TypeScript bindings"
+Source.Frontend -> Build.BuildFrontend: "Compile (Vite/webpack)"
+Build.BuildFrontend -> Build.Embed: "Bundled assets"
+Source.Go -> Build.CompileGo
+Build.CompileGo -> Build.Embed
+Build.Embed -> Output.Binary
+```
+
+**Build steps:**
+
+1. **Analyse Go code**
+   - Scan services for exported methods
+   - Extract parameter and return types
+   - Generate method signatures
+
+2. **Generate TypeScript bindings**
+   - Create `.ts` files for each service
+   - Include full type definitions
+   - Add JSDoc comments
+
+3. **Build frontend**
+   - Run your bundler (Vite, webpack, etc.)
+   - Minify and optimise
+   - Output to `frontend/dist/`
+
+4. **Compile Go**
+   - Compile with optimisations (`-ldflags="-s -w"`)
+   - Include build metadata
+   - Platform-specific compilation
+
+5. **Embed assets**
+   - Embed frontend files into Go binary
+   - Compress assets
+   - Create single executable
+
+**Result:** A single native executable with everything embedded.
+
+[Learn more about building →](/guides/build/building)
+
+## Development vs Production
+
+Wails behaves differently in development and production:
+
+<Tabs syncKey="mode">
+  <TabItem label="Development (wails3 dev)" icon="seti:config">
+    **Characteristics:**
+    - **Hot reload**: Frontend changes reload instantly
+    - **Source maps**: Debug with original source
+    - **DevTools**: Browser DevTools available
+    - **Logging**: Verbose logging enabled
+    - **External frontend**: Served from dev server (Vite)
+
+    **How it works:**
+    ```d2
+    direction: right
+    
+    WailsApp: "Wails App" {
+      shape: rectangle
+      style.fill: "#00ADD8"
+    }
+    
+    DevServer: "Vite Dev Server\n(localhost:5173)" {
+      shape: rectangle
+      style.fill: "#8B5CF6"
+    }
+    
+    WebView: "WebView" {
+      shape: rectangle
+      style.fill: "#6B7280"
+    }
+    
+    WailsApp -> DevServer: "Proxy requests"
+    DevServer -> WebView: "Serve with HMR"
+    WebView -> WailsApp: "Call Go methods"
+    ```
+
+    **Benefits:**
+    - Instant feedback on changes
+    - Full debugging capabilities
+    - Faster iteration
+  </TabItem>
+
+  <TabItem label="Production (wails3 build)" icon="rocket">
+    **Characteristics:**
+    - **Embedded assets**: Frontend built into binary
+    - **Optimised**: Minified, compressed
+    - **No DevTools**: Disabled by default
+    - **Minimal logging**: Errors only
+    - **Single file**: Everything in one executable
+
+    **How it works:**
+    ```d2
+    direction: right
+    
+    Binary: "Single Binary\n(myapp.exe)" {
+      GoCode: "Compiled Go" {
+        shape: rectangle
+        style.fill: "#00ADD8"
+      }
+      
+      Assets: "Embedded Assets\n(HTML/CSS/JS)" {
+        shape: rectangle
+        style.fill: "#8B5CF6"
+      }
+    }
+    
+    WebView: "WebView" {
+      shape: rectangle
+      style.fill: "#6B7280"
+    }
+    
+    Binary.Assets -> WebView: "Serve from memory"
+    WebView -> Binary.GoCode: "Call Go methods"
+    ```
+
+    **Benefits:**
+    - Single file distribution
+    - Smaller size (minified)
+    - Better performance
+    - No external dependencies
+  </TabItem>
+</Tabs>
+
+## Memory Model
+
+Understanding memory usage helps you build efficient applications.
+
+{/* VISUAL PLACEHOLDER: Memory Diagram
+Description: Memory layout diagram showing:
+1. Go Heap (services, application state)
+2. WebView Memory (DOM, JavaScript heap)
+3. Shared Memory (bridge communication)
+4. Arrows showing data flow between regions
+5. Annotations for zero-copy optimisations
+Style: Technical diagram with memory regions as boxes, clear labels, size indicators
+*/}
+
+**Memory regions:**
+
+1. **Go Heap**
+   - Your services and application state
+   - Managed by Go garbage collector
+   - Typically 5-10MB for simple apps
+
+2. **WebView Memory**
+   - DOM, JavaScript heap, CSS
+   - Managed by WebView's engine
+   - Typically 10-20MB for simple apps
+
+3. **Bridge Memory**
+   - Message buffers for communication
+   - Minimal overhead (\<1MB)
+   - Zero-copy for large data where possible
+
+**Optimisation tips:**
+- **Avoid large data transfers**: Pass IDs, fetch details on demand
+- **Use events for updates**: Don't poll from frontend
+- **Stream large files**: Don't load entirely into memory
+- **Clean up listeners**: Remove event listeners when done
+
+[Learn more about performance →](/guides/advanced/performance)
+
+## Security Model
+
+Wails provides a secure-by-default architecture:
+
+```d2
+direction: down
+
+Frontend: "Frontend (Untrusted)" {
+  shape: rectangle
+  style.fill: "#EF4444"
+}
+
+Bridge: "Wails Bridge (Validation)" {
+  shape: diamond
+  style.fill: "#F59E0B"
+}
+
+Backend: "Backend (Trusted)" {
+  shape: rectangle
+  style.fill: "#10B981"
+}
+
+Frontend -> Bridge: "Call method"
+Bridge -> Bridge: "Validate:\n- Method exists?\n- Types correct?\n- Access allowed?"
+Bridge -> Backend: "Execute if valid"
+Backend -> Bridge: "Return result"
+Bridge -> Frontend: "Send response"
+```
+
+**Security features:**
+
+1. **Method whitelisting**
+   - Only exported methods are callable
+   - Private methods are inaccessible
+   - Explicit service registration required
+
+2. **Type validation**
+   - Arguments checked against Go types
+   - Invalid types rejected
+   - Prevents injection attacks
+
+3. **No eval()**
+   - Frontend can't execute arbitrary Go code
+   - Only predefined methods callable
+   - No dynamic code execution
+
+4. **Context isolation**
+   - Each window has its own context
+   - Services can check caller context
+   - Permissions per window possible
+
+**Best practices:**
+- **Validate user input** in Go (don't trust frontend)
+- **Use context** for authentication/authorisation
+- **Sanitise file paths** before file operations
+- **Rate limit** expensive operations
+
+[Learn more about security →](/guides/advanced/security)
+
+## Next Steps
+
+**Application Lifecycle** - Understand startup, shutdown, and lifecycle hooks  
+[Learn More →](/concepts/lifecycle)
+
+**Go-Frontend Bridge** - Deep dive into how the bridge works  
+[Learn More →](/concepts/bridge)
+
+**Build System** - Understand how Wails builds your application  
+[Learn More →](/concepts/build-system)
+
+**Start Building** - Apply what you've learned in a tutorial
+[Tutorials →](/tutorials/03-notes-vanilla)
+
+---
 
 **Fragen zur Architektur?** Stellen Sie diese im [Discord](https://discord.gg/JDdSxwjhGf) oder schauen Sie in die [API-Referenz](/reference/overview).

--- a/docs/src/content/docs/de/getting-started/your-first-app.mdx
+++ b/docs/src/content/docs/de/getting-started/your-first-app.mdx
@@ -231,17 +231,19 @@ Dieser Leitfaden zeigt dir, wie du deine erste Wails v3-Anwendung erstellst, ein
        git push -u origin main
        ```
 
-    Dies stellt sicher, dass der Name deines Go-Moduls den Go-Modul-Namenskonventionen entspricht und das Teilen deines Codes erleichtert.:::tip[Profi-Tipp]
-Sie können alle Initialisierungsschritte automatisieren, indem Sie beim Erstellen Ihres Projekts das Flag `-git` verwenden:
-```bash
-wails3 init -n myfirstapp -git github.com/username/myfirstapp
-```
-Dies unterstützt verschiedene Git-URL-Formate:
-- HTTPS: `https://github.com/username/project`
-- SSH: `git@github.com:username/project` oder `ssh://git@github.com/username/project`
-- Git-Protokoll: `git://github.com/username/project`
-- Dateisystem: `file:///path/to/project.git`
-:::
+    Dies stellt sicher, dass der Name deines Go-Moduls den Go-Modul-Namenskonventionen entspricht und das Teilen deines Codes erleichtert.
+
+    :::tip[Profi-Tipp]
+    Sie können alle Initialisierungsschritte automatisieren, indem Sie beim Erstellen Ihres Projekts das Flag `-git` verwenden:
+    ```bash
+    wails3 init -n myfirstapp -git github.com/username/myfirstapp
+    ```
+    Dies unterstützt verschiedene Git-URL-Formate:
+    - HTTPS: `https://github.com/username/project`
+    - SSH: `git@github.com:username/project` oder `ssh://git@github.com/username/project`
+    - Git-Protokoll: `git://github.com/username/project`
+    - Dateisystem: `file:///path/to/project.git`
+    :::
 
 </Steps>
 

--- a/docs/src/content/docs/de/quick-start/installation.mdx
+++ b/docs/src/content/docs/de/quick-start/installation.mdx
@@ -268,7 +268,110 @@ Wenn `wails3 doctor` erfolgreich durchläuft, sind Sie fertig. [Zum ersten App-P
        ```powershell
        npm --version
        ```
-     </TabItem>#### Go-Version zu alt
+     </TabItem>
+
+     <TabItem label="macOS" icon="apple">
+       **Option 1: Offizieller Installer**
+       Von [nodejs.org](https://nodejs.org/) herunterladen
+
+       **Option 2: Homebrew**
+       ```bash
+       brew install node
+       ```
+
+       **Überprüfen:**
+       ```bash
+       npm --version
+       ```
+     </TabItem>
+
+     <TabItem label="Linux" icon="linux">
+       **Option 1: NodeSource**
+       ```bash
+       curl -fsSL https://deb.nodesource.com/setup_lts.x | sudo -E bash -
+       sudo apt-get install -y nodejs  # Ubuntu/Debian
+       ```
+
+       **Option 2: Paketmanager**
+       ```bash
+       sudo dnf install nodejs  # Fedora
+       sudo pacman -S nodejs npm  # Arch
+       ```
+
+       **Überprüfen:**
+       ```bash
+       npm --version
+       ```
+     </TabItem>
+   </Tabs>
+
+   :::tip[Alternative Paketmanager]
+   Bevorzugen Sie `pnpm`, `yarn` oder `bun`? Kein Problem! Aktualisieren Sie einfach die `Taskfile.yml` in Ihrem Projekt, um Ihr bevorzugtes Tool zu verwenden.
+   :::
+
+</Steps>
+
+## Fehlerbehebung
+
+#### `wails3`-Befehl nicht gefunden
+
+**Ursache:** `~/go/bin` (oder `%USERPROFILE%\go\bin`) ist nicht in Ihrem PATH enthalten.
+
+**Lösung:**
+
+<Tabs syncKey="os">
+  <TabItem label="Windows" icon="seti:windows">
+    1. Öffnen Sie "Umgebungsvariablen" (in der Startsuche suchen)
+    2. Unter "Benutzervariablen" den Eintrag `Path` finden
+    3. Klicken Sie auf "Bearbeiten" → "Neu"
+    4. Hinzufügen: `C:\Users\IhrName\go\bin` (ersetzen Sie IhrName)
+    5. Klicken Sie auf allen Dialogen auf "OK"
+    6. **Terminal neu starten**
+
+    **Überprüfen:**
+    ```powershell
+    $env:PATH -split ';' | Where-Object { $_ -like '*\go\bin' }
+    ```
+  </TabItem>
+
+  <TabItem label="macOS/Linux" icon="apple">
+    Fügen Sie zu `~/.zshrc` (macOS) oder `~/.bashrc` (Linux) hinzu:
+    ```bash
+    export PATH=$PATH:~/go/bin
+    ```
+
+    Neu laden:
+    ```bash
+    source ~/.zshrc  # oder ~/.bashrc
+    ```
+
+    **Überprüfen:**
+    ```bash
+    echo $PATH | grep go/bin
+    wails3 version
+    ```
+  </TabItem>
+</Tabs>
+---
+
+#### `wails3 doctor` meldet fehlende Abhängigkeiten
+
+**Linux:** Die Ausgabe zeigt genau an, welche Pakete installiert werden sollen. Beispiel:
+```
+❌ webkit2gtk nicht gefunden
+   Installation mit: sudo apt install libwebkit2gtk-4.1-dev
+```
+
+**Windows:** Falls WebView2 fehlt:
+- Von [Microsoft](https://developer.microsoft.com/microsoft-edge/webview2/) herunterladen
+- Oder es wird automatisch installiert, wenn Sie Ihre erste App ausführen
+
+**macOS:** Falls Xcode-Tools fehlen:
+```bash
+xcode-select --install
+```
+---
+#### Go-Version zu alt
 
 Wails v3 erfordert Go 1.25+. Wenn Sie eine ältere Version haben:
 

--- a/docs/src/content/docs/fr/concepts/architecture.mdx
+++ b/docs/src/content/docs/fr/concepts/architecture.mdx
@@ -323,6 +323,333 @@ Shutdown: "Shutdown" {
     shape: rectangle
   }
   
-  Save: "Save State" {---
+  Save: "Save State" {
+    shape: rectangle
+  }
+}
+
+End: "Application End" {
+  shape: oval
+  style.fill: "#EF4444"
+}
+
+Start -> Init.Create
+Init.Create -> Init.Register
+Init.Register -> Init.Setup
+Init.Setup -> Run.Events
+Run.Events -> Run.Messages
+Run.Messages -> Run.Render
+Run.Render -> Run.Events: "Loop"
+Run.Events -> Shutdown.Cleanup: "Quit signal"
+Shutdown.Cleanup -> Shutdown.Save
+Shutdown.Save -> End
+```
+
+**Lifecycle hooks:**
+
+```go
+app := application.New(application.Options{
+    Name: "My App",
+    
+    // Called before windows are created
+    OnStartup: func(ctx context.Context) {
+        // Initialise database, load config, etc.
+    },
+    
+    // Called when app is about to quit
+    OnShutdown: func() {
+        // Save state, close connections, etc.
+    },
+})
+```
+
+[Learn more about lifecycle →](/concepts/lifecycle)
+
+## Build Process
+
+Understanding how Wails builds your application:
+
+```d2
+direction: down
+
+Source: "Source Code" {
+  Go: "Go Code\n(main.go, services)" {
+    shape: rectangle
+    style.fill: "#00ADD8"
+  }
+  
+  Frontend: "Frontend Code\n(HTML/CSS/JS)" {
+    shape: rectangle
+    style.fill: "#8B5CF6"
+  }
+}
+
+Build: "Build Process" {
+  AnalyseGo: "Analyse Go Code" {
+    shape: rectangle
+  }
+  
+  GenerateBindings: "Generate Bindings" {
+    shape: rectangle
+  }
+  
+  BuildFrontend: "Build Frontend" {
+    shape: rectangle
+  }
+  
+  CompileGo: "Compile Go" {
+    shape: rectangle
+  }
+  
+  Embed: "Embed Assets" {
+    shape: rectangle
+  }
+}
+
+Output: "Output" {
+  Binary: "Native Binary\n(myapp.exe/.app)" {
+    shape: rectangle
+    style.fill: "#10B981"
+  }
+}
+
+Source.Go -> Build.AnalyseGo
+Build.AnalyseGo -> Build.GenerateBindings: "Extract types"
+Build.GenerateBindings -> Source.Frontend: "TypeScript bindings"
+Source.Frontend -> Build.BuildFrontend: "Compile (Vite/webpack)"
+Build.BuildFrontend -> Build.Embed: "Bundled assets"
+Source.Go -> Build.CompileGo
+Build.CompileGo -> Build.Embed
+Build.Embed -> Output.Binary
+```
+
+**Build steps:**
+
+1. **Analyse Go code**
+   - Scan services for exported methods
+   - Extract parameter and return types
+   - Generate method signatures
+
+2. **Generate TypeScript bindings**
+   - Create `.ts` files for each service
+   - Include full type definitions
+   - Add JSDoc comments
+
+3. **Build frontend**
+   - Run your bundler (Vite, webpack, etc.)
+   - Minify and optimise
+   - Output to `frontend/dist/`
+
+4. **Compile Go**
+   - Compile with optimisations (`-ldflags="-s -w"`)
+   - Include build metadata
+   - Platform-specific compilation
+
+5. **Embed assets**
+   - Embed frontend files into Go binary
+   - Compress assets
+   - Create single executable
+
+**Result:** A single native executable with everything embedded.
+
+[Learn more about building →](/guides/build/building)
+
+## Development vs Production
+
+Wails behaves differently in development and production:
+
+<Tabs syncKey="mode">
+  <TabItem label="Development (wails3 dev)" icon="seti:config">
+    **Characteristics:**
+    - **Hot reload**: Frontend changes reload instantly
+    - **Source maps**: Debug with original source
+    - **DevTools**: Browser DevTools available
+    - **Logging**: Verbose logging enabled
+    - **External frontend**: Served from dev server (Vite)
+
+    **How it works:**
+    ```d2
+    direction: right
+    
+    WailsApp: "Wails App" {
+      shape: rectangle
+      style.fill: "#00ADD8"
+    }
+    
+    DevServer: "Vite Dev Server\n(localhost:5173)" {
+      shape: rectangle
+      style.fill: "#8B5CF6"
+    }
+    
+    WebView: "WebView" {
+      shape: rectangle
+      style.fill: "#6B7280"
+    }
+    
+    WailsApp -> DevServer: "Proxy requests"
+    DevServer -> WebView: "Serve with HMR"
+    WebView -> WailsApp: "Call Go methods"
+    ```
+
+    **Benefits:**
+    - Instant feedback on changes
+    - Full debugging capabilities
+    - Faster iteration
+  </TabItem>
+
+  <TabItem label="Production (wails3 build)" icon="rocket">
+    **Characteristics:**
+    - **Embedded assets**: Frontend built into binary
+    - **Optimised**: Minified, compressed
+    - **No DevTools**: Disabled by default
+    - **Minimal logging**: Errors only
+    - **Single file**: Everything in one executable
+
+    **How it works:**
+    ```d2
+    direction: right
+    
+    Binary: "Single Binary\n(myapp.exe)" {
+      GoCode: "Compiled Go" {
+        shape: rectangle
+        style.fill: "#00ADD8"
+      }
+      
+      Assets: "Embedded Assets\n(HTML/CSS/JS)" {
+        shape: rectangle
+        style.fill: "#8B5CF6"
+      }
+    }
+    
+    WebView: "WebView" {
+      shape: rectangle
+      style.fill: "#6B7280"
+    }
+    
+    Binary.Assets -> WebView: "Serve from memory"
+    WebView -> Binary.GoCode: "Call Go methods"
+    ```
+
+    **Benefits:**
+    - Single file distribution
+    - Smaller size (minified)
+    - Better performance
+    - No external dependencies
+  </TabItem>
+</Tabs>
+
+## Memory Model
+
+Understanding memory usage helps you build efficient applications.
+
+{/* VISUAL PLACEHOLDER: Memory Diagram
+Description: Memory layout diagram showing:
+1. Go Heap (services, application state)
+2. WebView Memory (DOM, JavaScript heap)
+3. Shared Memory (bridge communication)
+4. Arrows showing data flow between regions
+5. Annotations for zero-copy optimisations
+Style: Technical diagram with memory regions as boxes, clear labels, size indicators
+*/}
+
+**Memory regions:**
+
+1. **Go Heap**
+   - Your services and application state
+   - Managed by Go garbage collector
+   - Typically 5-10MB for simple apps
+
+2. **WebView Memory**
+   - DOM, JavaScript heap, CSS
+   - Managed by WebView's engine
+   - Typically 10-20MB for simple apps
+
+3. **Bridge Memory**
+   - Message buffers for communication
+   - Minimal overhead (\<1MB)
+   - Zero-copy for large data where possible
+
+**Optimisation tips:**
+- **Avoid large data transfers**: Pass IDs, fetch details on demand
+- **Use events for updates**: Don't poll from frontend
+- **Stream large files**: Don't load entirely into memory
+- **Clean up listeners**: Remove event listeners when done
+
+[Learn more about performance →](/guides/advanced/performance)
+
+## Security Model
+
+Wails provides a secure-by-default architecture:
+
+```d2
+direction: down
+
+Frontend: "Frontend (Untrusted)" {
+  shape: rectangle
+  style.fill: "#EF4444"
+}
+
+Bridge: "Wails Bridge (Validation)" {
+  shape: diamond
+  style.fill: "#F59E0B"
+}
+
+Backend: "Backend (Trusted)" {
+  shape: rectangle
+  style.fill: "#10B981"
+}
+
+Frontend -> Bridge: "Call method"
+Bridge -> Bridge: "Validate:\n- Method exists?\n- Types correct?\n- Access allowed?"
+Bridge -> Backend: "Execute if valid"
+Backend -> Bridge: "Return result"
+Bridge -> Frontend: "Send response"
+```
+
+**Security features:**
+
+1. **Method whitelisting**
+   - Only exported methods are callable
+   - Private methods are inaccessible
+   - Explicit service registration required
+
+2. **Type validation**
+   - Arguments checked against Go types
+   - Invalid types rejected
+   - Prevents injection attacks
+
+3. **No eval()**
+   - Frontend can't execute arbitrary Go code
+   - Only predefined methods callable
+   - No dynamic code execution
+
+4. **Context isolation**
+   - Each window has its own context
+   - Services can check caller context
+   - Permissions per window possible
+
+**Best practices:**
+- **Validate user input** in Go (don't trust frontend)
+- **Use context** for authentication/authorisation
+- **Sanitise file paths** before file operations
+- **Rate limit** expensive operations
+
+[Learn more about security →](/guides/advanced/security)
+
+## Next Steps
+
+**Application Lifecycle** - Understand startup, shutdown, and lifecycle hooks  
+[Learn More →](/concepts/lifecycle)
+
+**Go-Frontend Bridge** - Deep dive into how the bridge works  
+[Learn More →](/concepts/bridge)
+
+**Build System** - Understand how Wails builds your application  
+[Learn More →](/concepts/build-system)
+
+**Start Building** - Apply what you've learned in a tutorial
+[Tutorials →](/tutorials/03-notes-vanilla)
+
+---
 
 **Des questions sur l'architecture ?** Posez-les sur [Discord](https://discord.gg/JDdSxwjhGf) ou consultez la [référence de l'API](/reference/overview).

--- a/docs/src/content/docs/fr/getting-started/your-first-app.mdx
+++ b/docs/src/content/docs/fr/getting-started/your-first-app.mdx
@@ -231,17 +231,19 @@ Ce guide vous montre comment créer votre première application Wails v3, couvra
        git push -u origin main
        ```
 
-    Cela assure que le nom de votre module Go est aligné avec les conventions de nommage des modules Go et facilite le partage de votre code.:::tip[Conseil]
-Vous pouvez automatiser toutes les étapes d'initialisation en utilisant le drapeau `-git` lors de la création de votre projet :
-```bash
-wails3 init -n myfirstapp -git github.com/username/myfirstapp
-```
-Cela prend en charge différents formats d'URL Git :
-- HTTPS : `https://github.com/username/project`
-- SSH : `git@github.com:username/project` ou `ssh://git@github.com/username/project`
-- Protocole Git : `git://github.com/username/project`
-- Système de fichiers : `file:///path/to/project.git`
-:::
+    Cela assure que le nom de votre module Go est aligné avec les conventions de nommage des modules Go et facilite le partage de votre code.
+
+    :::tip[Conseil]
+    Vous pouvez automatiser toutes les étapes d'initialisation en utilisant le drapeau `-git` lors de la création de votre projet :
+    ```bash
+    wails3 init -n myfirstapp -git github.com/username/myfirstapp
+    ```
+    Cela prend en charge différents formats d'URL Git :
+    - HTTPS : `https://github.com/username/project`
+    - SSH : `git@github.com:username/project` ou `ssh://git@github.com/username/project`
+    - Protocole Git : `git://github.com/username/project`
+    - Système de fichiers : `file:///path/to/project.git`
+    :::
 
 </Steps>
 

--- a/docs/src/content/docs/fr/quick-start/installation.mdx
+++ b/docs/src/content/docs/fr/quick-start/installation.mdx
@@ -268,7 +268,110 @@ Si `wails3 doctor` réussit, vous avez terminé. [Passer à la première applica
        ```powershell
        npm --version
        ```
-     </TabItem>#### Version de Go trop ancienne
+     </TabItem>
+
+     <TabItem label="macOS" icon="apple">
+       **Option 1 : Installateur officiel**
+       Téléchargez depuis [nodejs.org](https://nodejs.org/)
+
+       **Option 2 : Homebrew**
+       ```bash
+       brew install node
+       ```
+
+       **Vérifier :**
+       ```bash
+       npm --version
+       ```
+     </TabItem>
+
+     <TabItem label="Linux" icon="linux">
+       **Option 1 : NodeSource**
+       ```bash
+       curl -fsSL https://deb.nodesource.com/setup_lts.x | sudo -E bash -
+       sudo apt-get install -y nodejs  # Ubuntu/Debian
+       ```
+
+       **Option 2 : Gestionnaire de paquets**
+       ```bash
+       sudo dnf install nodejs  # Fedora
+       sudo pacman -S nodejs npm  # Arch
+       ```
+
+       **Vérifier :**
+       ```bash
+       npm --version
+       ```
+     </TabItem>
+   </Tabs>
+
+   :::tip[Gestionnaires de paquets alternatifs]
+   Vous préférez `pnpm`, `yarn` ou `bun` ? Pas de problème ! Mettez simplement à jour le `Taskfile.yml` de votre projet pour utiliser votre outil préféré.
+   :::
+
+</Steps>
+
+## Dépannage
+
+#### Commande `wails3` introuvable
+
+**Cause :** `~/go/bin` (ou `%USERPROFILE%\go\bin`) n'est pas dans votre PATH.
+
+**Solution :**
+
+<Tabs syncKey="os">
+  <TabItem label="Windows" icon="seti:windows">
+    1. Ouvrez "Variables d'environnement" (recherchez dans le menu Démarrer)
+    2. Sous "Variables utilisateur", trouvez `Path`
+    3. Cliquez sur "Modifier" → "Nouveau"
+    4. Ajoutez : `C:\Users\VotreNom\go\bin` (remplacez VotreNom)
+    5. Cliquez sur "OK" sur toutes les boîtes de dialogue
+    6. **Redémarrez votre terminal**
+
+    **Vérifier :**
+    ```powershell
+    $env:PATH -split ';' | Where-Object { $_ -like '*\go\bin' }
+    ```
+  </TabItem>
+
+  <TabItem label="macOS/Linux" icon="apple">
+    Ajoutez à `~/.zshrc` (macOS) ou `~/.bashrc` (Linux) :
+    ```bash
+    export PATH=$PATH:~/go/bin
+    ```
+
+    Rechargez :
+    ```bash
+    source ~/.zshrc  # ou ~/.bashrc
+    ```
+
+    **Vérifier :**
+    ```bash
+    echo $PATH | grep go/bin
+    wails3 version
+    ```
+  </TabItem>
+</Tabs>
+---
+
+#### `wails3 doctor` signale des dépendances manquantes
+
+**Linux :** La sortie vous indique exactement quels paquets installer. Exemple :
+```
+❌ webkit2gtk introuvable
+   Installez avec : sudo apt install libwebkit2gtk-4.1-dev
+```
+
+**Windows :** Si WebView2 est manquant :
+- Téléchargez depuis [Microsoft](https://developer.microsoft.com/microsoft-edge/webview2/)
+- Ou il sera installé automatiquement lors de l'exécution de votre première application
+
+**macOS :** Si les outils Xcode sont manquants :
+```bash
+xcode-select --install
+```
+---
+#### Version de Go trop ancienne
 
 Wails v3 nécessite Go 1.25+. Si vous avez une version plus ancienne :
 

--- a/docs/src/content/docs/ja/concepts/architecture.mdx
+++ b/docs/src/content/docs/ja/concepts/architecture.mdx
@@ -323,6 +323,333 @@ Shutdown: "Shutdown" {
     shape: rectangle
   }
   
-  Save: "Save State" {---
+  Save: "Save State" {
+    shape: rectangle
+  }
+}
+
+End: "Application End" {
+  shape: oval
+  style.fill: "#EF4444"
+}
+
+Start -> Init.Create
+Init.Create -> Init.Register
+Init.Register -> Init.Setup
+Init.Setup -> Run.Events
+Run.Events -> Run.Messages
+Run.Messages -> Run.Render
+Run.Render -> Run.Events: "Loop"
+Run.Events -> Shutdown.Cleanup: "Quit signal"
+Shutdown.Cleanup -> Shutdown.Save
+Shutdown.Save -> End
+```
+
+**Lifecycle hooks:**
+
+```go
+app := application.New(application.Options{
+    Name: "My App",
+    
+    // Called before windows are created
+    OnStartup: func(ctx context.Context) {
+        // Initialise database, load config, etc.
+    },
+    
+    // Called when app is about to quit
+    OnShutdown: func() {
+        // Save state, close connections, etc.
+    },
+})
+```
+
+[Learn more about lifecycle →](/concepts/lifecycle)
+
+## Build Process
+
+Understanding how Wails builds your application:
+
+```d2
+direction: down
+
+Source: "Source Code" {
+  Go: "Go Code\n(main.go, services)" {
+    shape: rectangle
+    style.fill: "#00ADD8"
+  }
+  
+  Frontend: "Frontend Code\n(HTML/CSS/JS)" {
+    shape: rectangle
+    style.fill: "#8B5CF6"
+  }
+}
+
+Build: "Build Process" {
+  AnalyseGo: "Analyse Go Code" {
+    shape: rectangle
+  }
+  
+  GenerateBindings: "Generate Bindings" {
+    shape: rectangle
+  }
+  
+  BuildFrontend: "Build Frontend" {
+    shape: rectangle
+  }
+  
+  CompileGo: "Compile Go" {
+    shape: rectangle
+  }
+  
+  Embed: "Embed Assets" {
+    shape: rectangle
+  }
+}
+
+Output: "Output" {
+  Binary: "Native Binary\n(myapp.exe/.app)" {
+    shape: rectangle
+    style.fill: "#10B981"
+  }
+}
+
+Source.Go -> Build.AnalyseGo
+Build.AnalyseGo -> Build.GenerateBindings: "Extract types"
+Build.GenerateBindings -> Source.Frontend: "TypeScript bindings"
+Source.Frontend -> Build.BuildFrontend: "Compile (Vite/webpack)"
+Build.BuildFrontend -> Build.Embed: "Bundled assets"
+Source.Go -> Build.CompileGo
+Build.CompileGo -> Build.Embed
+Build.Embed -> Output.Binary
+```
+
+**Build steps:**
+
+1. **Analyse Go code**
+   - Scan services for exported methods
+   - Extract parameter and return types
+   - Generate method signatures
+
+2. **Generate TypeScript bindings**
+   - Create `.ts` files for each service
+   - Include full type definitions
+   - Add JSDoc comments
+
+3. **Build frontend**
+   - Run your bundler (Vite, webpack, etc.)
+   - Minify and optimise
+   - Output to `frontend/dist/`
+
+4. **Compile Go**
+   - Compile with optimisations (`-ldflags="-s -w"`)
+   - Include build metadata
+   - Platform-specific compilation
+
+5. **Embed assets**
+   - Embed frontend files into Go binary
+   - Compress assets
+   - Create single executable
+
+**Result:** A single native executable with everything embedded.
+
+[Learn more about building →](/guides/build/building)
+
+## Development vs Production
+
+Wails behaves differently in development and production:
+
+<Tabs syncKey="mode">
+  <TabItem label="Development (wails3 dev)" icon="seti:config">
+    **Characteristics:**
+    - **Hot reload**: Frontend changes reload instantly
+    - **Source maps**: Debug with original source
+    - **DevTools**: Browser DevTools available
+    - **Logging**: Verbose logging enabled
+    - **External frontend**: Served from dev server (Vite)
+
+    **How it works:**
+    ```d2
+    direction: right
+    
+    WailsApp: "Wails App" {
+      shape: rectangle
+      style.fill: "#00ADD8"
+    }
+    
+    DevServer: "Vite Dev Server\n(localhost:5173)" {
+      shape: rectangle
+      style.fill: "#8B5CF6"
+    }
+    
+    WebView: "WebView" {
+      shape: rectangle
+      style.fill: "#6B7280"
+    }
+    
+    WailsApp -> DevServer: "Proxy requests"
+    DevServer -> WebView: "Serve with HMR"
+    WebView -> WailsApp: "Call Go methods"
+    ```
+
+    **Benefits:**
+    - Instant feedback on changes
+    - Full debugging capabilities
+    - Faster iteration
+  </TabItem>
+
+  <TabItem label="Production (wails3 build)" icon="rocket">
+    **Characteristics:**
+    - **Embedded assets**: Frontend built into binary
+    - **Optimised**: Minified, compressed
+    - **No DevTools**: Disabled by default
+    - **Minimal logging**: Errors only
+    - **Single file**: Everything in one executable
+
+    **How it works:**
+    ```d2
+    direction: right
+    
+    Binary: "Single Binary\n(myapp.exe)" {
+      GoCode: "Compiled Go" {
+        shape: rectangle
+        style.fill: "#00ADD8"
+      }
+      
+      Assets: "Embedded Assets\n(HTML/CSS/JS)" {
+        shape: rectangle
+        style.fill: "#8B5CF6"
+      }
+    }
+    
+    WebView: "WebView" {
+      shape: rectangle
+      style.fill: "#6B7280"
+    }
+    
+    Binary.Assets -> WebView: "Serve from memory"
+    WebView -> Binary.GoCode: "Call Go methods"
+    ```
+
+    **Benefits:**
+    - Single file distribution
+    - Smaller size (minified)
+    - Better performance
+    - No external dependencies
+  </TabItem>
+</Tabs>
+
+## Memory Model
+
+Understanding memory usage helps you build efficient applications.
+
+{/* VISUAL PLACEHOLDER: Memory Diagram
+Description: Memory layout diagram showing:
+1. Go Heap (services, application state)
+2. WebView Memory (DOM, JavaScript heap)
+3. Shared Memory (bridge communication)
+4. Arrows showing data flow between regions
+5. Annotations for zero-copy optimisations
+Style: Technical diagram with memory regions as boxes, clear labels, size indicators
+*/}
+
+**Memory regions:**
+
+1. **Go Heap**
+   - Your services and application state
+   - Managed by Go garbage collector
+   - Typically 5-10MB for simple apps
+
+2. **WebView Memory**
+   - DOM, JavaScript heap, CSS
+   - Managed by WebView's engine
+   - Typically 10-20MB for simple apps
+
+3. **Bridge Memory**
+   - Message buffers for communication
+   - Minimal overhead (\<1MB)
+   - Zero-copy for large data where possible
+
+**Optimisation tips:**
+- **Avoid large data transfers**: Pass IDs, fetch details on demand
+- **Use events for updates**: Don't poll from frontend
+- **Stream large files**: Don't load entirely into memory
+- **Clean up listeners**: Remove event listeners when done
+
+[Learn more about performance →](/guides/advanced/performance)
+
+## Security Model
+
+Wails provides a secure-by-default architecture:
+
+```d2
+direction: down
+
+Frontend: "Frontend (Untrusted)" {
+  shape: rectangle
+  style.fill: "#EF4444"
+}
+
+Bridge: "Wails Bridge (Validation)" {
+  shape: diamond
+  style.fill: "#F59E0B"
+}
+
+Backend: "Backend (Trusted)" {
+  shape: rectangle
+  style.fill: "#10B981"
+}
+
+Frontend -> Bridge: "Call method"
+Bridge -> Bridge: "Validate:\n- Method exists?\n- Types correct?\n- Access allowed?"
+Bridge -> Backend: "Execute if valid"
+Backend -> Bridge: "Return result"
+Bridge -> Frontend: "Send response"
+```
+
+**Security features:**
+
+1. **Method whitelisting**
+   - Only exported methods are callable
+   - Private methods are inaccessible
+   - Explicit service registration required
+
+2. **Type validation**
+   - Arguments checked against Go types
+   - Invalid types rejected
+   - Prevents injection attacks
+
+3. **No eval()**
+   - Frontend can't execute arbitrary Go code
+   - Only predefined methods callable
+   - No dynamic code execution
+
+4. **Context isolation**
+   - Each window has its own context
+   - Services can check caller context
+   - Permissions per window possible
+
+**Best practices:**
+- **Validate user input** in Go (don't trust frontend)
+- **Use context** for authentication/authorisation
+- **Sanitise file paths** before file operations
+- **Rate limit** expensive operations
+
+[Learn more about security →](/guides/advanced/security)
+
+## Next Steps
+
+**Application Lifecycle** - Understand startup, shutdown, and lifecycle hooks  
+[Learn More →](/concepts/lifecycle)
+
+**Go-Frontend Bridge** - Deep dive into how the bridge works  
+[Learn More →](/concepts/bridge)
+
+**Build System** - Understand how Wails builds your application  
+[Learn More →](/concepts/build-system)
+
+**Start Building** - Apply what you've learned in a tutorial
+[Tutorials →](/tutorials/03-notes-vanilla)
+
+---
 
 **アーキテクチャについて質問がありますか？** [Discord](https://discord.gg/JDdSxwjhGf) で質問するか、[API リファレンス](/reference/overview) を参照してください。

--- a/docs/src/content/docs/ja/getting-started/your-first-app.mdx
+++ b/docs/src/content/docs/ja/getting-started/your-first-app.mdx
@@ -229,17 +229,19 @@ import wails_dev from '../../../../assets/wails_dev.mp4';
        git push -u origin main
        ```
 
-    これにより、Go モジュール名が Go のモジュール命名規則と一致し、コードを共有しやすくなります。:::tip[Pro Tip]
-プロジェクト作成時に `-git` フラグを使用することで、初期化の全ステップを自動化できます:
-```bash
-wails3 init -n myfirstapp -git github.com/username/myfirstapp
-```
-これは以下の各種 Git URL 形式に対応しています:
-- HTTPS: `https://github.com/username/project`
-- SSH: `git@github.com:username/project` または `ssh://git@github.com/username/project`
-- Git プロトコル: `git://github.com/username/project`
-- ファイルシステム: `file:///path/to/project.git`
-:::
+    これにより、Go モジュール名が Go のモジュール命名規則と一致し、コードを共有しやすくなります。
+
+    :::tip[Pro Tip]
+    プロジェクト作成時に `-git` フラグを使用することで、初期化の全ステップを自動化できます:
+    ```bash
+    wails3 init -n myfirstapp -git github.com/username/myfirstapp
+    ```
+    これは以下の各種 Git URL 形式に対応しています:
+    - HTTPS: `https://github.com/username/project`
+    - SSH: `git@github.com:username/project` または `ssh://git@github.com/username/project`
+    - Git プロトコル: `git://github.com/username/project`
+    - ファイルシステム: `file:///path/to/project.git`
+    :::
 
 </Steps>
 

--- a/docs/src/content/docs/ja/quick-start/installation.mdx
+++ b/docs/src/content/docs/ja/quick-start/installation.mdx
@@ -268,7 +268,110 @@ wails3 doctor  # インストールの確認
        ```powershell
        npm --version
        ```
-     </TabItem>#### Go のバージョンが古すぎます
+     </TabItem>
+
+     <TabItem label="macOS" icon="apple">
+       **オプション1: 公式インストーラー**
+       [nodejs.org](https://nodejs.org/) からダウンロード
+
+       **オプション2: Homebrew**
+       ```bash
+       brew install node
+       ```
+
+       **確認:**
+       ```bash
+       npm --version
+       ```
+     </TabItem>
+
+     <TabItem label="Linux" icon="linux">
+       **オプション1: NodeSource**
+       ```bash
+       curl -fsSL https://deb.nodesource.com/setup_lts.x | sudo -E bash -
+       sudo apt-get install -y nodejs  # Ubuntu/Debian
+       ```
+
+       **オプション2: パッケージマネージャー**
+       ```bash
+       sudo dnf install nodejs  # Fedora
+       sudo pacman -S nodejs npm  # Arch
+       ```
+
+       **確認:**
+       ```bash
+       npm --version
+       ```
+     </TabItem>
+   </Tabs>
+
+   :::tip[代替パッケージマネージャー]
+   `pnpm`、`yarn`、または`bun`をお好みですか？問題ありません！プロジェクトの`Taskfile.yml`を更新して、お好みのツールを使用するようにしてください。
+   :::
+
+</Steps>
+
+## トラブルシューティング
+
+#### `wails3`コマンドが見つからない
+
+**原因：** `~/go/bin`（Windowsの場合は`%USERPROFILE%\go\bin`）がPATHに含まれていません。
+
+**解決策：**
+
+<Tabs syncKey="os">
+  <TabItem label="Windows" icon="seti:windows">
+    1. 「環境変数」を開く（スタートメニューで検索）
+    2. 「ユーザー変数」の`Path`を見つける
+    3. 「編集」→「新規」をクリック
+    4. 追加：`C:\Users\YourName\go\bin`（YourNameを置き換える）
+    5. すべてのダイアログで「OK」をクリック
+    6. **ターミナルを再起動**
+
+    **確認:**
+    ```powershell
+    $env:PATH -split ';' | Where-Object { $_ -like '*\go\bin' }
+    ```
+  </TabItem>
+
+  <TabItem label="macOS/Linux" icon="apple">
+    `~/.zshrc`（macOS）または`~/.bashrc`（Linux）に追加：
+    ```bash
+    export PATH=$PATH:~/go/bin
+    ```
+
+    再読み込み：
+    ```bash
+    source ~/.zshrc  # または ~/.bashrc
+    ```
+
+    **確認:**
+    ```bash
+    echo $PATH | grep go/bin
+    wails3 version
+    ```
+  </TabItem>
+</Tabs>
+---
+
+#### `wails3 doctor`で依存関係の不足が報告される
+
+**Linux：** 出力にインストールが必要なパッケージが正確に表示されます。例：
+```
+❌ webkit2gtk が見つかりません
+   インストール方法：sudo apt install libwebkit2gtk-4.1-dev
+```
+
+**Windows：** WebView2が見つからない場合：
+- [Microsoft](https://developer.microsoft.com/microsoft-edge/webview2/) からダウンロード
+- または最初のアプリ実行時に自動的にインストールされます
+
+**macOS：** Xcodeツールが見つからない場合：
+```bash
+xcode-select --install
+```
+---
+#### Go のバージョンが古すぎます
 
 Wails v3 には Go 1.25+ が必要です。それより古いバージョンをお使いの場合:
 

--- a/docs/src/content/docs/ko/concepts/architecture.mdx
+++ b/docs/src/content/docs/ko/concepts/architecture.mdx
@@ -7,7 +7,7 @@ sidebar:
 
 import { Tabs, TabItem } from "@astrojs/starlight/components";
 
-Wails는 **백엔드에 Go**와 **프론트엔드에 웹 기술**을 사용하여 데스크톱 애플리케이션을 구축하기 위한 프레임워크입니다. 하지만 Electron과 달리 Wails는 브라우저를 번들링하지 않으며, **운영 체제의 네이티브 WebView**를 사용합니다.
+Wails는 **백엔드에 Go**와 **프론트엔드에 웹 기술**을 사용하여 데스크탑 애플리케이션을 구축하기 위한 프레임워크입니다. 하지만 Electron과 달리 Wails는 브라우저를 번들링하지 않으며, **운영 체제의 네이티브 WebView**를 사용합니다.
 
 ```d2
 direction: right
@@ -323,6 +323,333 @@ Shutdown: "Shutdown" {
     shape: rectangle
   }
   
-  Save: "Save State" {---
+  Save: "Save State" {
+    shape: rectangle
+  }
+}
+
+End: "Application End" {
+  shape: oval
+  style.fill: "#EF4444"
+}
+
+Start -> Init.Create
+Init.Create -> Init.Register
+Init.Register -> Init.Setup
+Init.Setup -> Run.Events
+Run.Events -> Run.Messages
+Run.Messages -> Run.Render
+Run.Render -> Run.Events: "Loop"
+Run.Events -> Shutdown.Cleanup: "Quit signal"
+Shutdown.Cleanup -> Shutdown.Save
+Shutdown.Save -> End
+```
+
+**Lifecycle hooks:**
+
+```go
+app := application.New(application.Options{
+    Name: "My App",
+    
+    // Called before windows are created
+    OnStartup: func(ctx context.Context) {
+        // Initialise database, load config, etc.
+    },
+    
+    // Called when app is about to quit
+    OnShutdown: func() {
+        // Save state, close connections, etc.
+    },
+})
+```
+
+[Learn more about lifecycle →](/concepts/lifecycle)
+
+## Build Process
+
+Understanding how Wails builds your application:
+
+```d2
+direction: down
+
+Source: "Source Code" {
+  Go: "Go Code\n(main.go, services)" {
+    shape: rectangle
+    style.fill: "#00ADD8"
+  }
+  
+  Frontend: "Frontend Code\n(HTML/CSS/JS)" {
+    shape: rectangle
+    style.fill: "#8B5CF6"
+  }
+}
+
+Build: "Build Process" {
+  AnalyseGo: "Analyse Go Code" {
+    shape: rectangle
+  }
+  
+  GenerateBindings: "Generate Bindings" {
+    shape: rectangle
+  }
+  
+  BuildFrontend: "Build Frontend" {
+    shape: rectangle
+  }
+  
+  CompileGo: "Compile Go" {
+    shape: rectangle
+  }
+  
+  Embed: "Embed Assets" {
+    shape: rectangle
+  }
+}
+
+Output: "Output" {
+  Binary: "Native Binary\n(myapp.exe/.app)" {
+    shape: rectangle
+    style.fill: "#10B981"
+  }
+}
+
+Source.Go -> Build.AnalyseGo
+Build.AnalyseGo -> Build.GenerateBindings: "Extract types"
+Build.GenerateBindings -> Source.Frontend: "TypeScript bindings"
+Source.Frontend -> Build.BuildFrontend: "Compile (Vite/webpack)"
+Build.BuildFrontend -> Build.Embed: "Bundled assets"
+Source.Go -> Build.CompileGo
+Build.CompileGo -> Build.Embed
+Build.Embed -> Output.Binary
+```
+
+**Build steps:**
+
+1. **Analyse Go code**
+   - Scan services for exported methods
+   - Extract parameter and return types
+   - Generate method signatures
+
+2. **Generate TypeScript bindings**
+   - Create `.ts` files for each service
+   - Include full type definitions
+   - Add JSDoc comments
+
+3. **Build frontend**
+   - Run your bundler (Vite, webpack, etc.)
+   - Minify and optimise
+   - Output to `frontend/dist/`
+
+4. **Compile Go**
+   - Compile with optimisations (`-ldflags="-s -w"`)
+   - Include build metadata
+   - Platform-specific compilation
+
+5. **Embed assets**
+   - Embed frontend files into Go binary
+   - Compress assets
+   - Create single executable
+
+**Result:** A single native executable with everything embedded.
+
+[Learn more about building →](/guides/build/building)
+
+## Development vs Production
+
+Wails behaves differently in development and production:
+
+<Tabs syncKey="mode">
+  <TabItem label="Development (wails3 dev)" icon="seti:config">
+    **Characteristics:**
+    - **Hot reload**: Frontend changes reload instantly
+    - **Source maps**: Debug with original source
+    - **DevTools**: Browser DevTools available
+    - **Logging**: Verbose logging enabled
+    - **External frontend**: Served from dev server (Vite)
+
+    **How it works:**
+    ```d2
+    direction: right
+    
+    WailsApp: "Wails App" {
+      shape: rectangle
+      style.fill: "#00ADD8"
+    }
+    
+    DevServer: "Vite Dev Server\n(localhost:5173)" {
+      shape: rectangle
+      style.fill: "#8B5CF6"
+    }
+    
+    WebView: "WebView" {
+      shape: rectangle
+      style.fill: "#6B7280"
+    }
+    
+    WailsApp -> DevServer: "Proxy requests"
+    DevServer -> WebView: "Serve with HMR"
+    WebView -> WailsApp: "Call Go methods"
+    ```
+
+    **Benefits:**
+    - Instant feedback on changes
+    - Full debugging capabilities
+    - Faster iteration
+  </TabItem>
+
+  <TabItem label="Production (wails3 build)" icon="rocket">
+    **Characteristics:**
+    - **Embedded assets**: Frontend built into binary
+    - **Optimised**: Minified, compressed
+    - **No DevTools**: Disabled by default
+    - **Minimal logging**: Errors only
+    - **Single file**: Everything in one executable
+
+    **How it works:**
+    ```d2
+    direction: right
+    
+    Binary: "Single Binary\n(myapp.exe)" {
+      GoCode: "Compiled Go" {
+        shape: rectangle
+        style.fill: "#00ADD8"
+      }
+      
+      Assets: "Embedded Assets\n(HTML/CSS/JS)" {
+        shape: rectangle
+        style.fill: "#8B5CF6"
+      }
+    }
+    
+    WebView: "WebView" {
+      shape: rectangle
+      style.fill: "#6B7280"
+    }
+    
+    Binary.Assets -> WebView: "Serve from memory"
+    WebView -> Binary.GoCode: "Call Go methods"
+    ```
+
+    **Benefits:**
+    - Single file distribution
+    - Smaller size (minified)
+    - Better performance
+    - No external dependencies
+  </TabItem>
+</Tabs>
+
+## Memory Model
+
+Understanding memory usage helps you build efficient applications.
+
+{/* VISUAL PLACEHOLDER: Memory Diagram
+Description: Memory layout diagram showing:
+1. Go Heap (services, application state)
+2. WebView Memory (DOM, JavaScript heap)
+3. Shared Memory (bridge communication)
+4. Arrows showing data flow between regions
+5. Annotations for zero-copy optimisations
+Style: Technical diagram with memory regions as boxes, clear labels, size indicators
+*/}
+
+**Memory regions:**
+
+1. **Go Heap**
+   - Your services and application state
+   - Managed by Go garbage collector
+   - Typically 5-10MB for simple apps
+
+2. **WebView Memory**
+   - DOM, JavaScript heap, CSS
+   - Managed by WebView's engine
+   - Typically 10-20MB for simple apps
+
+3. **Bridge Memory**
+   - Message buffers for communication
+   - Minimal overhead (\<1MB)
+   - Zero-copy for large data where possible
+
+**Optimisation tips:**
+- **Avoid large data transfers**: Pass IDs, fetch details on demand
+- **Use events for updates**: Don't poll from frontend
+- **Stream large files**: Don't load entirely into memory
+- **Clean up listeners**: Remove event listeners when done
+
+[Learn more about performance →](/guides/advanced/performance)
+
+## Security Model
+
+Wails provides a secure-by-default architecture:
+
+```d2
+direction: down
+
+Frontend: "Frontend (Untrusted)" {
+  shape: rectangle
+  style.fill: "#EF4444"
+}
+
+Bridge: "Wails Bridge (Validation)" {
+  shape: diamond
+  style.fill: "#F59E0B"
+}
+
+Backend: "Backend (Trusted)" {
+  shape: rectangle
+  style.fill: "#10B981"
+}
+
+Frontend -> Bridge: "Call method"
+Bridge -> Bridge: "Validate:\n- Method exists?\n- Types correct?\n- Access allowed?"
+Bridge -> Backend: "Execute if valid"
+Backend -> Bridge: "Return result"
+Bridge -> Frontend: "Send response"
+```
+
+**Security features:**
+
+1. **Method whitelisting**
+   - Only exported methods are callable
+   - Private methods are inaccessible
+   - Explicit service registration required
+
+2. **Type validation**
+   - Arguments checked against Go types
+   - Invalid types rejected
+   - Prevents injection attacks
+
+3. **No eval()**
+   - Frontend can't execute arbitrary Go code
+   - Only predefined methods callable
+   - No dynamic code execution
+
+4. **Context isolation**
+   - Each window has its own context
+   - Services can check caller context
+   - Permissions per window possible
+
+**Best practices:**
+- **Validate user input** in Go (don't trust frontend)
+- **Use context** for authentication/authorisation
+- **Sanitise file paths** before file operations
+- **Rate limit** expensive operations
+
+[Learn more about security →](/guides/advanced/security)
+
+## Next Steps
+
+**Application Lifecycle** - Understand startup, shutdown, and lifecycle hooks  
+[Learn More →](/concepts/lifecycle)
+
+**Go-Frontend Bridge** - Deep dive into how the bridge works  
+[Learn More →](/concepts/bridge)
+
+**Build System** - Understand how Wails builds your application  
+[Learn More →](/concepts/build-system)
+
+**Start Building** - Apply what you've learned in a tutorial
+[Tutorials →](/tutorials/03-notes-vanilla)
+
+---
 
 **아키텍처에 대해 질문이 있으신가요?** [Discord](https://discord.gg/JDdSxwjhGf)에서 문의하거나 [API 레퍼런스](/reference/overview)를 확인하세요.

--- a/docs/src/content/docs/ko/getting-started/your-first-app.mdx
+++ b/docs/src/content/docs/ko/getting-started/your-first-app.mdx
@@ -1,6 +1,6 @@
 ---
 title: 첫 번째 애플리케이션 만들기
-description: 단계별로 첫 번째 Wails 데스크톱 애플리케이션을 생성하세요
+description: 단계별로 첫 번째 Wails 데스크탑 애플리케이션을 생성하세요
 sidebar:
   order: 20
 ---
@@ -229,17 +229,19 @@ import wails_dev from '../../../../assets/wails_dev.mp4';
        git push -u origin main
        ```
 
-    이렇게 하면 Go 모듈 이름이 Go의 모듈 이름 규칙과 일치하게 되어 코드를 공유하기 쉬워집니다.:::tip[Pro Tip]
-프로젝트 생성 시 `-git` 플래그를 사용하면 초기화 단계를 모두 자동화할 수 있습니다:
-```bash
-wails3 init -n myfirstapp -git github.com/username/myfirstapp
-```
-이 명령어는 다양한 Git URL 형식을 지원합니다:
-- HTTPS: `https://github.com/username/project`
-- SSH: `git@github.com:username/project` 또는 `ssh://git@github.com/username/project`
-- Git 프로토콜: `git://github.com/username/project`
-- 파일 시스템: `file:///path/to/project.git`
-:::
+    이렇게 하면 Go 모듈 이름이 Go의 모듈 이름 규칙과 일치하게 되어 코드를 공유하기 쉬워집니다.
+
+    :::tip[Pro Tip]
+    프로젝트 생성 시 `-git` 플래그를 사용하면 초기화 단계를 모두 자동화할 수 있습니다:
+    ```bash
+    wails3 init -n myfirstapp -git github.com/username/myfirstapp
+    ```
+    이 명령어는 다양한 Git URL 형식을 지원합니다:
+    - HTTPS: `https://github.com/username/project`
+    - SSH: `git@github.com:username/project` 또는 `ssh://git@github.com/username/project`
+    - Git 프로토콜: `git://github.com/username/project`
+    - 파일 시스템: `file:///path/to/project.git`
+    :::
 
 </Steps>
 

--- a/docs/src/content/docs/ko/quick-start/installation.mdx
+++ b/docs/src/content/docs/ko/quick-start/installation.mdx
@@ -268,7 +268,110 @@ wails3 doctor  # 설치 확인
        ```powershell
        npm --version
        ```
-     </TabItem>#### Go 버전이 너무 오래됨
+     </TabItem>
+
+     <TabItem label="macOS" icon="apple">
+       **옵션 1: 공식 설치 프로그램**
+       [nodejs.org](https://nodejs.org/)에서 다운로드
+
+       **옵션 2: Homebrew**
+       ```bash
+       brew install node
+       ```
+
+       **확인:**
+       ```bash
+       npm --version
+       ```
+     </TabItem>
+
+     <TabItem label="Linux" icon="linux">
+       **옵션 1: NodeSource**
+       ```bash
+       curl -fsSL https://deb.nodesource.com/setup_lts.x | sudo -E bash -
+       sudo apt-get install -y nodejs  # Ubuntu/Debian
+       ```
+
+       **옵션 2: 패키지 관리자**
+       ```bash
+       sudo dnf install nodejs  # Fedora
+       sudo pacman -S nodejs npm  # Arch
+       ```
+
+       **확인:**
+       ```bash
+       npm --version
+       ```
+     </TabItem>
+   </Tabs>
+
+   :::tip[대체 패키지 관리자]
+   `pnpm`, `yarn` 또는 `bun`을 선호하시나요? 문제없습니다! 프로젝트의 `Taskfile.yml`을 업데이트하여 원하는 도구를 사용하세요.
+   :::
+
+</Steps>
+
+## 문제 해결
+
+#### `wails3` 명령을 찾을 수 없음
+
+**원인:** `~/go/bin`(또는 Windows의 `%USERPROFILE%\go\bin`)이 PATH에 없습니다.
+
+**해결 방법:**
+
+<Tabs syncKey="os">
+  <TabItem label="Windows" icon="seti:windows">
+    1. "환경 변수"를 엽니다(시작 메뉴에서 검색)
+    2. "사용자 변수"에서 `Path`를 찾습니다
+    3. "편집" → "새로 만들기"를 클릭합니다
+    4. 추가: `C:\Users\YourName\go\bin`(YourName을 바꾸세요)
+    5. 모든 대화 상자에서 "확인"을 클릭합니다
+    6. **터미널 재시작**
+
+    **확인:**
+    ```powershell
+    $env:PATH -split ';' | Where-Object { $_ -like '*\go\bin' }
+    ```
+  </TabItem>
+
+  <TabItem label="macOS/Linux" icon="apple">
+    `~/.zshrc`(macOS) 또는 `~/.bashrc`(Linux)에 추가:
+    ```bash
+    export PATH=$PATH:~/go/bin
+    ```
+
+    재로드:
+    ```bash
+    source ~/.zshrc  # 또는 ~/.bashrc
+    ```
+
+    **확인:**
+    ```bash
+    echo $PATH | grep go/bin
+    wails3 version
+    ```
+  </TabItem>
+</Tabs>
+---
+
+#### `wails3 doctor`에서 누락된 종속성 보고
+
+**Linux:** 출력에 설치해야 할 패키지가 정확히 표시됩니다. 예:
+```
+❌ webkit2gtk를 찾을 수 없음
+   설치 명령: sudo apt install libwebkit2gtk-4.1-dev
+```
+
+**Windows:** WebView2가 없는 경우:
+- [Microsoft](https://developer.microsoft.com/microsoft-edge/webview2/)에서 다운로드
+- 또는 첫 번째 앱 실행 시 자동으로 설치됩니다
+
+**macOS:** Xcode 도구가 없는 경우:
+```bash
+xcode-select --install
+```
+---
+#### Go 버전이 너무 오래됨
 
 Wails v3에는 Go 1.25+가 필요합니다. 이전 버전이 있는 경우:
 

--- a/docs/src/content/docs/pt/concepts/architecture.mdx
+++ b/docs/src/content/docs/pt/concepts/architecture.mdx
@@ -323,6 +323,333 @@ Shutdown: "Shutdown" {
     shape: rectangle
   }
   
-  Save: "Save State" {---
+  Save: "Save State" {
+    shape: rectangle
+  }
+}
+
+End: "Application End" {
+  shape: oval
+  style.fill: "#EF4444"
+}
+
+Start -> Init.Create
+Init.Create -> Init.Register
+Init.Register -> Init.Setup
+Init.Setup -> Run.Events
+Run.Events -> Run.Messages
+Run.Messages -> Run.Render
+Run.Render -> Run.Events: "Loop"
+Run.Events -> Shutdown.Cleanup: "Quit signal"
+Shutdown.Cleanup -> Shutdown.Save
+Shutdown.Save -> End
+```
+
+**Lifecycle hooks:**
+
+```go
+app := application.New(application.Options{
+    Name: "My App",
+    
+    // Called before windows are created
+    OnStartup: func(ctx context.Context) {
+        // Initialise database, load config, etc.
+    },
+    
+    // Called when app is about to quit
+    OnShutdown: func() {
+        // Save state, close connections, etc.
+    },
+})
+```
+
+[Learn more about lifecycle →](/concepts/lifecycle)
+
+## Build Process
+
+Understanding how Wails builds your application:
+
+```d2
+direction: down
+
+Source: "Source Code" {
+  Go: "Go Code\n(main.go, services)" {
+    shape: rectangle
+    style.fill: "#00ADD8"
+  }
+  
+  Frontend: "Frontend Code\n(HTML/CSS/JS)" {
+    shape: rectangle
+    style.fill: "#8B5CF6"
+  }
+}
+
+Build: "Build Process" {
+  AnalyseGo: "Analyse Go Code" {
+    shape: rectangle
+  }
+  
+  GenerateBindings: "Generate Bindings" {
+    shape: rectangle
+  }
+  
+  BuildFrontend: "Build Frontend" {
+    shape: rectangle
+  }
+  
+  CompileGo: "Compile Go" {
+    shape: rectangle
+  }
+  
+  Embed: "Embed Assets" {
+    shape: rectangle
+  }
+}
+
+Output: "Output" {
+  Binary: "Native Binary\n(myapp.exe/.app)" {
+    shape: rectangle
+    style.fill: "#10B981"
+  }
+}
+
+Source.Go -> Build.AnalyseGo
+Build.AnalyseGo -> Build.GenerateBindings: "Extract types"
+Build.GenerateBindings -> Source.Frontend: "TypeScript bindings"
+Source.Frontend -> Build.BuildFrontend: "Compile (Vite/webpack)"
+Build.BuildFrontend -> Build.Embed: "Bundled assets"
+Source.Go -> Build.CompileGo
+Build.CompileGo -> Build.Embed
+Build.Embed -> Output.Binary
+```
+
+**Build steps:**
+
+1. **Analyse Go code**
+   - Scan services for exported methods
+   - Extract parameter and return types
+   - Generate method signatures
+
+2. **Generate TypeScript bindings**
+   - Create `.ts` files for each service
+   - Include full type definitions
+   - Add JSDoc comments
+
+3. **Build frontend**
+   - Run your bundler (Vite, webpack, etc.)
+   - Minify and optimise
+   - Output to `frontend/dist/`
+
+4. **Compile Go**
+   - Compile with optimisations (`-ldflags="-s -w"`)
+   - Include build metadata
+   - Platform-specific compilation
+
+5. **Embed assets**
+   - Embed frontend files into Go binary
+   - Compress assets
+   - Create single executable
+
+**Result:** A single native executable with everything embedded.
+
+[Learn more about building →](/guides/build/building)
+
+## Development vs Production
+
+Wails behaves differently in development and production:
+
+<Tabs syncKey="mode">
+  <TabItem label="Development (wails3 dev)" icon="seti:config">
+    **Characteristics:**
+    - **Hot reload**: Frontend changes reload instantly
+    - **Source maps**: Debug with original source
+    - **DevTools**: Browser DevTools available
+    - **Logging**: Verbose logging enabled
+    - **External frontend**: Served from dev server (Vite)
+
+    **How it works:**
+    ```d2
+    direction: right
+    
+    WailsApp: "Wails App" {
+      shape: rectangle
+      style.fill: "#00ADD8"
+    }
+    
+    DevServer: "Vite Dev Server\n(localhost:5173)" {
+      shape: rectangle
+      style.fill: "#8B5CF6"
+    }
+    
+    WebView: "WebView" {
+      shape: rectangle
+      style.fill: "#6B7280"
+    }
+    
+    WailsApp -> DevServer: "Proxy requests"
+    DevServer -> WebView: "Serve with HMR"
+    WebView -> WailsApp: "Call Go methods"
+    ```
+
+    **Benefits:**
+    - Instant feedback on changes
+    - Full debugging capabilities
+    - Faster iteration
+  </TabItem>
+
+  <TabItem label="Production (wails3 build)" icon="rocket">
+    **Characteristics:**
+    - **Embedded assets**: Frontend built into binary
+    - **Optimised**: Minified, compressed
+    - **No DevTools**: Disabled by default
+    - **Minimal logging**: Errors only
+    - **Single file**: Everything in one executable
+
+    **How it works:**
+    ```d2
+    direction: right
+    
+    Binary: "Single Binary\n(myapp.exe)" {
+      GoCode: "Compiled Go" {
+        shape: rectangle
+        style.fill: "#00ADD8"
+      }
+      
+      Assets: "Embedded Assets\n(HTML/CSS/JS)" {
+        shape: rectangle
+        style.fill: "#8B5CF6"
+      }
+    }
+    
+    WebView: "WebView" {
+      shape: rectangle
+      style.fill: "#6B7280"
+    }
+    
+    Binary.Assets -> WebView: "Serve from memory"
+    WebView -> Binary.GoCode: "Call Go methods"
+    ```
+
+    **Benefits:**
+    - Single file distribution
+    - Smaller size (minified)
+    - Better performance
+    - No external dependencies
+  </TabItem>
+</Tabs>
+
+## Memory Model
+
+Understanding memory usage helps you build efficient applications.
+
+{/* VISUAL PLACEHOLDER: Memory Diagram
+Description: Memory layout diagram showing:
+1. Go Heap (services, application state)
+2. WebView Memory (DOM, JavaScript heap)
+3. Shared Memory (bridge communication)
+4. Arrows showing data flow between regions
+5. Annotations for zero-copy optimisations
+Style: Technical diagram with memory regions as boxes, clear labels, size indicators
+*/}
+
+**Memory regions:**
+
+1. **Go Heap**
+   - Your services and application state
+   - Managed by Go garbage collector
+   - Typically 5-10MB for simple apps
+
+2. **WebView Memory**
+   - DOM, JavaScript heap, CSS
+   - Managed by WebView's engine
+   - Typically 10-20MB for simple apps
+
+3. **Bridge Memory**
+   - Message buffers for communication
+   - Minimal overhead (\<1MB)
+   - Zero-copy for large data where possible
+
+**Optimisation tips:**
+- **Avoid large data transfers**: Pass IDs, fetch details on demand
+- **Use events for updates**: Don't poll from frontend
+- **Stream large files**: Don't load entirely into memory
+- **Clean up listeners**: Remove event listeners when done
+
+[Learn more about performance →](/guides/advanced/performance)
+
+## Security Model
+
+Wails provides a secure-by-default architecture:
+
+```d2
+direction: down
+
+Frontend: "Frontend (Untrusted)" {
+  shape: rectangle
+  style.fill: "#EF4444"
+}
+
+Bridge: "Wails Bridge (Validation)" {
+  shape: diamond
+  style.fill: "#F59E0B"
+}
+
+Backend: "Backend (Trusted)" {
+  shape: rectangle
+  style.fill: "#10B981"
+}
+
+Frontend -> Bridge: "Call method"
+Bridge -> Bridge: "Validate:\n- Method exists?\n- Types correct?\n- Access allowed?"
+Bridge -> Backend: "Execute if valid"
+Backend -> Bridge: "Return result"
+Bridge -> Frontend: "Send response"
+```
+
+**Security features:**
+
+1. **Method whitelisting**
+   - Only exported methods are callable
+   - Private methods are inaccessible
+   - Explicit service registration required
+
+2. **Type validation**
+   - Arguments checked against Go types
+   - Invalid types rejected
+   - Prevents injection attacks
+
+3. **No eval()**
+   - Frontend can't execute arbitrary Go code
+   - Only predefined methods callable
+   - No dynamic code execution
+
+4. **Context isolation**
+   - Each window has its own context
+   - Services can check caller context
+   - Permissions per window possible
+
+**Best practices:**
+- **Validate user input** in Go (don't trust frontend)
+- **Use context** for authentication/authorisation
+- **Sanitise file paths** before file operations
+- **Rate limit** expensive operations
+
+[Learn more about security →](/guides/advanced/security)
+
+## Next Steps
+
+**Application Lifecycle** - Understand startup, shutdown, and lifecycle hooks  
+[Learn More →](/concepts/lifecycle)
+
+**Go-Frontend Bridge** - Deep dive into how the bridge works  
+[Learn More →](/concepts/bridge)
+
+**Build System** - Understand how Wails builds your application  
+[Learn More →](/concepts/build-system)
+
+**Start Building** - Apply what you've learned in a tutorial
+[Tutorials →](/tutorials/03-notes-vanilla)
+
+---
 
 **Dúvidas sobre a arquitetura?** Pergunte no [Discord](https://discord.gg/JDdSxwjhGf) ou consulte a [referência da API](/reference/overview).

--- a/docs/src/content/docs/pt/getting-started/your-first-app.mdx
+++ b/docs/src/content/docs/pt/getting-started/your-first-app.mdx
@@ -63,7 +63,7 @@ Este guia mostra como criar seu primeiro aplicativo Wails v3, cobrindo a configu
             - info.json          Metadados do aplicativo
             - wails.exe.manifest Arquivo de manifesto do Windows
             - nsis/              Arquivos do instalador NSIS
-                - project.nshi                    Arquivo do projeto NSIS
+                - project.nsi                    Arquivo do projeto NSIS
                 - wails_tools.nsh               Scripts auxiliares do NSIS
     - frontend/        Arquivos do aplicativo frontend
         - index.html   Arquivo HTML principal
@@ -243,17 +243,19 @@ Este guia mostra como criar seu primeiro aplicativo Wails v3, cobrindo a configu
        git push -u origin main
        ```
 
-    Isso garante que o nome do seu módulo Go esteja alinhado com as convenções de nomenclagem de módulos do Go e facilita o compartilhamento do seu código.:::tip[Dica]
-Você pode automatizar todas as etapas de inicialização usando a flag `-git` ao criar seu projeto:
-```bash
-wails3 init -n myfirstapp -git github.com/username/myfirstapp
-```
-Isso suporta vários formatos de URL do Git:
-- HTTPS: `https://github.com/username/project`
-- SSH: `git@github.com:username/project` ou `ssh://git@github.com/username/project`
-- Protocolo Git: `git://github.com/username/project`
-- Sistema de arquivos: `file:///path/to/project.git`
-:::
+    Isso garante que o nome do seu módulo Go esteja alinhado com as convenções de nomenclagem de módulos do Go e facilita o compartilhamento do seu código.
+
+    :::tip[Dica]
+    Você pode automatizar todas as etapas de inicialização usando a flag `-git` ao criar seu projeto:
+    ```bash
+    wails3 init -n myfirstapp -git github.com/username/myfirstapp
+    ```
+    Isso suporta vários formatos de URL do Git:
+    - HTTPS: `https://github.com/username/project`
+    - SSH: `git@github.com:username/project` ou `ssh://git@github.com/username/project`
+    - Protocolo Git: `git://github.com/username/project`
+    - Sistema de arquivos: `file:///path/to/project.git`
+    :::
 
 </Steps>
 

--- a/docs/src/content/docs/pt/quick-start/installation.mdx
+++ b/docs/src/content/docs/pt/quick-start/installation.mdx
@@ -1,62 +1,62 @@
 ---
 title: Instalação
-description: Instale o Wails e prepare-se para criar aplicativos
+description: Instale o Wails e prepare-se para construir aplicativos
 sidebar:
   order: 2
 ---
 
 import { Card, CardGrid, Tabs, TabItem, Steps } from "@astrojs/starlight/components";
 
-## Instalação Rápida (5 Minutos)
+## Instalação Rápida (5 minutos)
 
-:::tip[TL;DR - Desenvolvedores Experientes]
+:::tip[TL;DR - Para desenvolvedores experientes]
 ```bash
-# Instale o Go 1.25+, depois:
+# Instale o Go 1.25+ e depois:
 go install github.com/wailsapp/wails/v3/cmd/wails3@latest
-wails3 doctor  # Verifique a instalação
+wails3 doctor  # Verificar instalação
 ```
 
-Se o `wails3 doctor` passar, você terminou. [Pule para o Primeiro App →](/pt/quick-start/first-app)
+Se o `wails3 doctor` passar, você está pronto. [Pule para o Primeiro App →](/pt/quick-start/first-app)
 :::
 
 ## Instalação Passo a Passo
 
 <Steps>
 
-1. **Instale o Go (Obrigatório)**
+1. **Instalar o Go (necessário)**
 
-   O Wails requer Go 1.25 ou posterior.
+   O Wails requer Go 1.25 ou superior.
 
    <Tabs syncKey="os">
      <TabItem label="Windows" icon="seti:windows">
-       Baixe o instalador do Windows em **[go.dev/dl](https://go.dev/dl/)** e execute-o.
+       Baixe e execute o instalador Windows em **[go.dev/dl](https://go.dev/dl/)**.
 
-       **Verifique a instalação:**
+       **Verificar instalação:**
        ```powershell
-       go version  # Deve mostrar 1.25 ou posterior
+       go version  # Deve mostrar 1.25+
        ```
 
-       **Verifique o PATH:**
+       **Verificar PATH:**
        ```powershell
        $env:PATH -split ';' | Where-Object { $_ -like '*\go\bin' }
        ```
 
-       Se estiver vazio, adicione `C:\Users\YourName\go\bin` ao seu PATH.
+       Se estiver vazio, adicione `C:\Users\SeuNome\go\bin` ao PATH.
      </TabItem>
 
      <TabItem label="macOS" icon="apple">
-       **Opção 1: Instalador Oficial**
+       **Opção 1: Instalador oficial**
 
-       Baixe o instalador do macOS (arquivo .pkg) em **[go.dev/dl](https://go.dev/dl/)** e execute-o.
+       Baixe e execute o instalador macOS (arquivo .pkg) em **[go.dev/dl](https://go.dev/dl/)**.
 
        **Opção 2: Homebrew**
        ```bash
        brew install go
        ```
 
-       **Verifique a instalação:**
+       **Verificar instalação:**
        ```bash
-       go version  # Deve mostrar 1.25 ou posterior
+       go version  # Deve mostrar 1.25+
        echo $PATH | grep go/bin  # Deve mostrar ~/go/bin
        ```
 
@@ -67,15 +67,15 @@ Se o `wails3 doctor` passar, você terminou. [Pule para o Primeiro App →](/pt/
      </TabItem>
 
      <TabItem label="Linux" icon="linux">
-       **Opção 1: Tarball Oficial**
+       **Opção 1: Tarball oficial**
 
-       Baixe o tarball do Linux em **[go.dev/dl](https://go.dev/dl/)**, depois:
+       Baixe o tarball Linux em **[go.dev/dl](https://go.dev/dl/)** e depois:
        ```bash
        sudo rm -rf /usr/local/go
        sudo tar -C /usr/local -xzf go1.25.linux-amd64.tar.gz
        ```
 
-       **Opção 2: Gerenciador de Pacotes**
+       **Opção 2: Gerenciador de pacotes**
        ```bash
        # Ubuntu/Debian
        sudo apt install golang-go
@@ -87,13 +87,13 @@ Se o `wails3 doctor` passar, você terminou. [Pule para o Primeiro App →](/pt/
        sudo pacman -S go
        ```
 
-       **Adicione ao PATH** (adicione ao `~/.bashrc` ou `~/.zshrc`):
+       **Adicionar ao PATH** (adicione ao `~/.bashrc` ou `~/.zshrc`):
        ```bash
        export PATH=$PATH:/usr/local/go/bin:~/go/bin
-       source ~/.bashrc  # Recarregue
+       source ~/.bashrc  # Recarregar
        ```
 
-       **Verifique:**
+       **Verificar:**
        ```bash
        go version
        echo $PATH | grep go/bin
@@ -101,25 +101,25 @@ Se o `wails3 doctor` passar, você terminou. [Pule para o Primeiro App →](/pt/
      </TabItem>
    </Tabs>
 
-2. **Instale as Dependências da Plataforma**
+2. **Instalar dependências de plataforma**
 
    <Tabs syncKey="os">
      <TabItem label="Windows" icon="seti:windows">
        **WebView2 Runtime** (geralmente pré-instalado)
 
-       O Windows 10/11 inclui o WebView2 por padrão. Se estiver faltando:
-       - Baixe em [Microsoft](https://developer.microsoft.com/microsoft-edge/webview2/)
-       - Ou execute `wails3 doctor` mais tarde — ele irá guiá-lo
+       O Windows 10/11 vem com WebView2 por padrão. Se estiver faltando:
+       - Baixe da [Microsoft](https://developer.microsoft.com/microsoft-edge/webview2/)
+       - Ou execute `wails3 doctor` depois e ele irá guiá-lo
 
-       **Pronto!** Nenhuma outra dependência é necessária.
+       **Isso é tudo!** Nenhuma outra dependência é necessária.
 
-       :::tip[Dica de Desempenho para Windows 11]
-       Considere usar o [Dev Drive](https://learn.microsoft.com/en-us/windows/dev-drive/) para armazenar seus projetos. Os Dev Drives são otimizados para cargas de trabalho de desenvolvedores e podem melhorar significativamente os tempos de compilação e a velocidade de acesso ao disco em até 30%.
+       :::tip[Dica de desempenho para Windows 11]
+       Considere usar [Dev Drive](https://learn.microsoft.com/en-us/windows/dev-drive/) para armazenar seu projeto. O Dev Drive é otimizado para cargas de trabalho de desenvolvimento e pode melhorar os tempos de compilação e velocidades de acesso ao disco em até 30%.
        :::
      </TabItem>
 
      <TabItem label="macOS" icon="apple">
-       **Ferramentas de Linha de Comando do Xcode** (obrigatório)
+       **Xcode Command Line Tools** (necessário)
 
        ```bash
        xcode-select --install
@@ -127,19 +127,19 @@ Se o `wails3 doctor` passar, você terminou. [Pule para o Primeiro App →](/pt/
 
        Clique em "Instalar" na caixa de diálogo que aparecer.
 
-       **Verifique:**
+       **Verificar:**
        ```bash
        xcode-select -p  # Deve mostrar /Library/Developer/CommandLineTools
        ```
 
-       **Pronto!** O macOS inclui o WebKit por padrão.
+       **Isso é tudo!** O macOS vem com WebKit embutido.
      </TabItem>
 
      <TabItem label="Linux" icon="linux">
-       **Ferramentas de compilação e WebKit**
+       **Ferramentas de build e WebKit**
 
-       :::caution[Versões mínimas da distribuição]
-       O Wails v3 requer **WebKitGTK 4.1** (usa libsoup3). Lançamentos mais antigos que apenas disponibilizam a versão 4.0 — Ubuntu 20.04, Debian 11, RHEL 8/9 e suas derivações — não são suportados.
+       :::caution[Versão mínima da distribuição]
+       O Wails v3 requer **WebKitGTK 4.1** (usando libsoup3). Versões mais antigas — Ubuntu 20.04, Debian 11, RHEL 8/9 e derivados — que fornecem apenas 4.0 não são suportadas.
        :::
 
        <Tabs syncKey="distro">
@@ -182,18 +182,18 @@ Se o `wails3 doctor` passar, você terminou. [Pule para o Primeiro App →](/pt/
            ```
          </TabItem>
 
-         <TabItem label="Outro">
-           Execute `wails3 doctor` após instalar o Wails — ele mostrará os pacotes exatos necessários para sua distribuição.
+         <TabItem label="Outros">
+           Após instalar o Wails, execute `wails3 doctor`. Ele mostrará os pacotes exatos necessários para sua distribuição.
          </TabItem>
        </Tabs>
 
        :::note[Opcional: Suporte ao GTK4]
-       O Wails também possui suporte experimental ao GTK4 / WebKitGTK 6.0. Se você quiser compilar com o GTK4, instale as dependências adicionais para sua distribuição e compile com `wails3 build -tags gtk4`. Consulte [Empacotamento no Linux - GTK4](/guides/build/linux#gtk4-support-experimental) para mais detalhes.
+       O Wails também tem suporte experimental a GTK4 / WebKitGTK 6.0. Se quiser compilar com GTK4, instale as dependências adicionais para sua distribuição e compile com `wails3 build -tags gtk4`. Veja [Linux Packaging - GTK4](/guides/build/linux#gtk4-support-experimental) para detalhes.
        :::
      </TabItem>
    </Tabs>
 
-3. **Instale o Wails CLI**
+3. **Instalar o Wails CLI**
 
    ```bash
    go install github.com/wailsapp/wails/v3/cmd/wails3@latest
@@ -201,7 +201,7 @@ Se o `wails3 doctor` passar, você terminou. [Pule para o Primeiro App →](/pt/
 
    Isso instala o comando `wails3` em `~/go/bin` (ou `%USERPROFILE%\go\bin` no Windows).
 
-4. **Verifique a Instalação**
+4. **Verificar instalação**
 
    ```bash
    wails3 doctor
@@ -252,33 +252,136 @@ Se o `wails3 doctor` passar, você terminou. [Pule para o Primeiro App →](/pt/
    SUCCESS Your system is ready for Wails development!
    ```
 
-   :::note[Se o comando `wails3` não for encontrado]
-   Seu `~/go/bin` não está no PATH. Veja o passo 1 acima para corrigir isso, depois reinicie seu terminal.
+   :::note[Comando `wails3` não encontrado]
+   `~/go/bin` não está no PATH. Consulte o Passo 1 acima para corrigir e reinicie o terminal.
    :::
 
-5. **Instale o npm (Opcional, mas Recomendado)**
+5. **Instalar npm (opcional, mas recomendado)**
 
-   A maioria dos modelos do Wails usa o npm para ferramentas de frontend.
+   A maioria dos templates Wails usa npm para ferramentas de frontend.
 
    <Tabs syncKey="os">
      <TabItem label="Windows" icon="seti:windows">
-       Baixe em [nodejs.org](https://nodejs.org/) e execute o instalador.
+       Baixe de [nodejs.org](https://nodejs.org/) e execute o instalador.
 
-       **Verifique:**
+       **Verificar:**
        ```powershell
        npm --version
        ```
-     </TabItem>#### Versão do Go muito antiga
+     </TabItem>
+
+     <TabItem label="macOS" icon="apple">
+       **Opção 1: Instalador oficial**
+       Baixe de [nodejs.org](https://nodejs.org/)
+
+       **Opção 2: Homebrew**
+       ```bash
+       brew install node
+       ```
+
+       **Verificar:**
+       ```bash
+       npm --version
+       ```
+     </TabItem>
+
+     <TabItem label="Linux" icon="linux">
+       **Opção 1: NodeSource**
+       ```bash
+       curl -fsSL https://deb.nodesource.com/setup_lts.x | sudo -E bash -
+       sudo apt-get install -y nodejs  # Ubuntu/Debian
+       ```
+
+       **Opção 2: Gerenciador de pacotes**
+       ```bash
+       sudo dnf install nodejs  # Fedora
+       sudo pacman -S nodejs npm  # Arch
+       ```
+
+       **Verificar:**
+       ```bash
+       npm --version
+       ```
+     </TabItem>
+   </Tabs>
+
+   :::tip[Gerenciadores de pacotes alternativos]
+   Prefere `pnpm`, `yarn` ou `bun`? Sem problema! Atualize o `Taskfile.yml` do seu projeto para usar a ferramenta de sua preferência.
+   :::
+
+</Steps>
+
+## Solução de Problemas
+
+#### Comando `wails3` não encontrado
+
+**Causa:** `~/go/bin` (ou `%USERPROFILE%\go\bin` no Windows) não está no PATH.
+
+**Solução:**
+
+<Tabs syncKey="os">
+  <TabItem label="Windows" icon="seti:windows">
+    1. Abra "Variáveis de Ambiente" (pesquise no menu Iniciar)
+    2. Encontre `Path` em "Variáveis do usuário"
+    3. Clique em "Editar" → "Novo"
+    4. Adicione: `C:\Users\SeuNome\go\bin` (substitua SeuNome)
+    5. Clique em "OK" em todas as caixas de diálogo
+    6. **Reinicie o terminal**
+
+    **Verificar:**
+    ```powershell
+    $env:PATH -split ';' | Where-Object { $_ -like '*\go\bin' }
+    ```
+  </TabItem>
+
+  <TabItem label="macOS/Linux" icon="apple">
+    Adicione ao `~/.zshrc` (macOS) ou `~/.bashrc` (Linux):
+    ```bash
+    export PATH=$PATH:~/go/bin
+    ```
+
+    Recarregar:
+    ```bash
+    source ~/.zshrc  # ou ~/.bashrc
+    ```
+
+    **Verificar:**
+    ```bash
+    echo $PATH | grep go/bin
+    wails3 version
+    ```
+  </TabItem>
+</Tabs>
+---
+
+#### `wails3 doctor` relata dependências ausentes
+
+**Linux:** A saída mostra exatamente quais pacotes instalar. Exemplo:
+```
+❌ webkit2gtk não encontrado
+   Instale com: sudo apt install libwebkit2gtk-4.1-dev
+```
+
+**Windows:** Se o WebView2 não for encontrado:
+- Baixe da [Microsoft](https://developer.microsoft.com/microsoft-edge/webview2/)
+- Ou ele será instalado automaticamente na primeira execução do app
+
+**macOS:** Se as ferramentas Xcode não forem encontradas:
+```bash
+xcode-select --install
+```
+---
+#### Versão do Go muito antiga
 
 O Wails v3 requer Go 1.25+. Se você tiver uma versão mais antiga:
 
 <Tabs syncKey="os">
   <TabItem label="Windows/macOS" icon="seti:windows">
-    Baixe a versão mais recente em [go.dev/dl](https://go.dev/dl/) e reinstale.
+    Baixe a versão mais recente de [go.dev/dl](https://go.dev/dl/) e reinstale.
   </TabItem>
 
   <TabItem label="Linux" icon="linux">
-    Baixe o arquivo tarball mais recente em [go.dev/dl](https://go.dev/dl/), depois:
+    Baixe o tarball mais recente de [go.dev/dl](https://go.dev/dl/) e depois:
     ```bash
     sudo rm -rf /usr/local/go
     sudo tar -C /usr/local -xzf go1.25.linux-amd64.tar.gz
@@ -288,7 +391,7 @@ O Wails v3 requer Go 1.25+. Se você tiver uma versão mais antiga:
 
 ## Versão de Desenvolvimento (Bleeding Edge)
 
-Quer usar o código mais recente diretamente do branch principal de desenvolvimento? Isso dá acesso a novos recursos e correções antes que sejam lançados, mas vem com o risco de bugs e mudanças que quebram compatibilidade. Recomendado apenas para contribuidores ou para quem precisa testar recursos futuros.
+Quer usar o código mais recente do branch de desenvolvimento principal? Isso permite acesso a novos recursos e correções antes do lançamento, mas vem com o risco de bugs e mudanças que quebram compatibilidade. Recomendado apenas para colaboradores ou quem precisa testar recursos futuros.
 
 ```bash
 git clone https://github.com/wailsapp/wails.git
@@ -299,23 +402,23 @@ go install
 ```
 
 :::caution[Versão de Desenvolvimento]
-- Pode ter bugs ou mudanças que quebram compatibilidade
-- Projetos criados usarão a diretiva `replace` para apontar para o Wails local
-- Recomendado apenas para contribuidores ou para testar novos recursos
+- Pode conter bugs ou mudanças que quebram compatibilidade
+- Projetos criados usarão diretiva `replace` apontando para o Wails local
+- Recomendado apenas para colaboradores ou teste de novos recursos
 :::
 
 ## Próximos Passos
 
-**Instalação Concluída!** Seu sistema está pronto para o desenvolvimento com Wails.
+**Instalação concluída!** Seu sistema está pronto para o desenvolvimento com Wails.
 
-<Card title="Crie seu Primeiro App" icon="rocket">
+<Card title="Construa seu primeiro app" icon="rocket">
   Crie um aplicativo funcional em 10 minutos.
 
-  [Tutorial Primeiro App →](/pt/quick-start/first-app)
+  [Tutorial do Primeiro App →](/pt/quick-start/first-app)
 </Card>
 
-<Card title="Explore os Templates" icon="open-book">
-  Veja o que está disponível nativamente.
+<Card title="Explore os templates" icon="open-book">
+  Veja o que está disponível por padrão.
 
   ```bash
   wails3 init -l  # Listar templates

--- a/docs/src/content/docs/ru/concepts/architecture.mdx
+++ b/docs/src/content/docs/ru/concepts/architecture.mdx
@@ -323,6 +323,333 @@ Shutdown: "Shutdown" {
     shape: rectangle
   }
   
-  Save: "Save State" {---
+  Save: "Save State" {
+    shape: rectangle
+  }
+}
+
+End: "Application End" {
+  shape: oval
+  style.fill: "#EF4444"
+}
+
+Start -> Init.Create
+Init.Create -> Init.Register
+Init.Register -> Init.Setup
+Init.Setup -> Run.Events
+Run.Events -> Run.Messages
+Run.Messages -> Run.Render
+Run.Render -> Run.Events: "Loop"
+Run.Events -> Shutdown.Cleanup: "Quit signal"
+Shutdown.Cleanup -> Shutdown.Save
+Shutdown.Save -> End
+```
+
+**Lifecycle hooks:**
+
+```go
+app := application.New(application.Options{
+    Name: "My App",
+    
+    // Called before windows are created
+    OnStartup: func(ctx context.Context) {
+        // Initialise database, load config, etc.
+    },
+    
+    // Called when app is about to quit
+    OnShutdown: func() {
+        // Save state, close connections, etc.
+    },
+})
+```
+
+[Learn more about lifecycle →](/concepts/lifecycle)
+
+## Build Process
+
+Understanding how Wails builds your application:
+
+```d2
+direction: down
+
+Source: "Source Code" {
+  Go: "Go Code\n(main.go, services)" {
+    shape: rectangle
+    style.fill: "#00ADD8"
+  }
+  
+  Frontend: "Frontend Code\n(HTML/CSS/JS)" {
+    shape: rectangle
+    style.fill: "#8B5CF6"
+  }
+}
+
+Build: "Build Process" {
+  AnalyseGo: "Analyse Go Code" {
+    shape: rectangle
+  }
+  
+  GenerateBindings: "Generate Bindings" {
+    shape: rectangle
+  }
+  
+  BuildFrontend: "Build Frontend" {
+    shape: rectangle
+  }
+  
+  CompileGo: "Compile Go" {
+    shape: rectangle
+  }
+  
+  Embed: "Embed Assets" {
+    shape: rectangle
+  }
+}
+
+Output: "Output" {
+  Binary: "Native Binary\n(myapp.exe/.app)" {
+    shape: rectangle
+    style.fill: "#10B981"
+  }
+}
+
+Source.Go -> Build.AnalyseGo
+Build.AnalyseGo -> Build.GenerateBindings: "Extract types"
+Build.GenerateBindings -> Source.Frontend: "TypeScript bindings"
+Source.Frontend -> Build.BuildFrontend: "Compile (Vite/webpack)"
+Build.BuildFrontend -> Build.Embed: "Bundled assets"
+Source.Go -> Build.CompileGo
+Build.CompileGo -> Build.Embed
+Build.Embed -> Output.Binary
+```
+
+**Build steps:**
+
+1. **Analyse Go code**
+   - Scan services for exported methods
+   - Extract parameter and return types
+   - Generate method signatures
+
+2. **Generate TypeScript bindings**
+   - Create `.ts` files for each service
+   - Include full type definitions
+   - Add JSDoc comments
+
+3. **Build frontend**
+   - Run your bundler (Vite, webpack, etc.)
+   - Minify and optimise
+   - Output to `frontend/dist/`
+
+4. **Compile Go**
+   - Compile with optimisations (`-ldflags="-s -w"`)
+   - Include build metadata
+   - Platform-specific compilation
+
+5. **Embed assets**
+   - Embed frontend files into Go binary
+   - Compress assets
+   - Create single executable
+
+**Result:** A single native executable with everything embedded.
+
+[Learn more about building →](/guides/build/building)
+
+## Development vs Production
+
+Wails behaves differently in development and production:
+
+<Tabs syncKey="mode">
+  <TabItem label="Development (wails3 dev)" icon="seti:config">
+    **Characteristics:**
+    - **Hot reload**: Frontend changes reload instantly
+    - **Source maps**: Debug with original source
+    - **DevTools**: Browser DevTools available
+    - **Logging**: Verbose logging enabled
+    - **External frontend**: Served from dev server (Vite)
+
+    **How it works:**
+    ```d2
+    direction: right
+    
+    WailsApp: "Wails App" {
+      shape: rectangle
+      style.fill: "#00ADD8"
+    }
+    
+    DevServer: "Vite Dev Server\n(localhost:5173)" {
+      shape: rectangle
+      style.fill: "#8B5CF6"
+    }
+    
+    WebView: "WebView" {
+      shape: rectangle
+      style.fill: "#6B7280"
+    }
+    
+    WailsApp -> DevServer: "Proxy requests"
+    DevServer -> WebView: "Serve with HMR"
+    WebView -> WailsApp: "Call Go methods"
+    ```
+
+    **Benefits:**
+    - Instant feedback on changes
+    - Full debugging capabilities
+    - Faster iteration
+  </TabItem>
+
+  <TabItem label="Production (wails3 build)" icon="rocket">
+    **Characteristics:**
+    - **Embedded assets**: Frontend built into binary
+    - **Optimised**: Minified, compressed
+    - **No DevTools**: Disabled by default
+    - **Minimal logging**: Errors only
+    - **Single file**: Everything in one executable
+
+    **How it works:**
+    ```d2
+    direction: right
+    
+    Binary: "Single Binary\n(myapp.exe)" {
+      GoCode: "Compiled Go" {
+        shape: rectangle
+        style.fill: "#00ADD8"
+      }
+      
+      Assets: "Embedded Assets\n(HTML/CSS/JS)" {
+        shape: rectangle
+        style.fill: "#8B5CF6"
+      }
+    }
+    
+    WebView: "WebView" {
+      shape: rectangle
+      style.fill: "#6B7280"
+    }
+    
+    Binary.Assets -> WebView: "Serve from memory"
+    WebView -> Binary.GoCode: "Call Go methods"
+    ```
+
+    **Benefits:**
+    - Single file distribution
+    - Smaller size (minified)
+    - Better performance
+    - No external dependencies
+  </TabItem>
+</Tabs>
+
+## Memory Model
+
+Understanding memory usage helps you build efficient applications.
+
+{/* VISUAL PLACEHOLDER: Memory Diagram
+Description: Memory layout diagram showing:
+1. Go Heap (services, application state)
+2. WebView Memory (DOM, JavaScript heap)
+3. Shared Memory (bridge communication)
+4. Arrows showing data flow between regions
+5. Annotations for zero-copy optimisations
+Style: Technical diagram with memory regions as boxes, clear labels, size indicators
+*/}
+
+**Memory regions:**
+
+1. **Go Heap**
+   - Your services and application state
+   - Managed by Go garbage collector
+   - Typically 5-10MB for simple apps
+
+2. **WebView Memory**
+   - DOM, JavaScript heap, CSS
+   - Managed by WebView's engine
+   - Typically 10-20MB for simple apps
+
+3. **Bridge Memory**
+   - Message buffers for communication
+   - Minimal overhead (\<1MB)
+   - Zero-copy for large data where possible
+
+**Optimisation tips:**
+- **Avoid large data transfers**: Pass IDs, fetch details on demand
+- **Use events for updates**: Don't poll from frontend
+- **Stream large files**: Don't load entirely into memory
+- **Clean up listeners**: Remove event listeners when done
+
+[Learn more about performance →](/guides/advanced/performance)
+
+## Security Model
+
+Wails provides a secure-by-default architecture:
+
+```d2
+direction: down
+
+Frontend: "Frontend (Untrusted)" {
+  shape: rectangle
+  style.fill: "#EF4444"
+}
+
+Bridge: "Wails Bridge (Validation)" {
+  shape: diamond
+  style.fill: "#F59E0B"
+}
+
+Backend: "Backend (Trusted)" {
+  shape: rectangle
+  style.fill: "#10B981"
+}
+
+Frontend -> Bridge: "Call method"
+Bridge -> Bridge: "Validate:\n- Method exists?\n- Types correct?\n- Access allowed?"
+Bridge -> Backend: "Execute if valid"
+Backend -> Bridge: "Return result"
+Bridge -> Frontend: "Send response"
+```
+
+**Security features:**
+
+1. **Method whitelisting**
+   - Only exported methods are callable
+   - Private methods are inaccessible
+   - Explicit service registration required
+
+2. **Type validation**
+   - Arguments checked against Go types
+   - Invalid types rejected
+   - Prevents injection attacks
+
+3. **No eval()**
+   - Frontend can't execute arbitrary Go code
+   - Only predefined methods callable
+   - No dynamic code execution
+
+4. **Context isolation**
+   - Each window has its own context
+   - Services can check caller context
+   - Permissions per window possible
+
+**Best practices:**
+- **Validate user input** in Go (don't trust frontend)
+- **Use context** for authentication/authorisation
+- **Sanitise file paths** before file operations
+- **Rate limit** expensive operations
+
+[Learn more about security →](/guides/advanced/security)
+
+## Next Steps
+
+**Application Lifecycle** - Understand startup, shutdown, and lifecycle hooks  
+[Learn More →](/concepts/lifecycle)
+
+**Go-Frontend Bridge** - Deep dive into how the bridge works  
+[Learn More →](/concepts/bridge)
+
+**Build System** - Understand how Wails builds your application  
+[Learn More →](/concepts/build-system)
+
+**Start Building** - Apply what you've learned in a tutorial
+[Tutorials →](/tutorials/03-notes-vanilla)
+
+---
 
 **Вопросы об архитектуре?** Задавайте их в [Discord](https://discord.gg/JDdSxwjhGf) или смотрите [справочник API](/reference/overview).

--- a/docs/src/content/docs/ru/getting-started/your-first-app.mdx
+++ b/docs/src/content/docs/ru/getting-started/your-first-app.mdx
@@ -151,7 +151,7 @@ import wails_dev from '../../../../assets/wails_dev.mp4';
 
     1. Откройте `greetservice.go`.
     2. Измените строку `return "Hello " + name + "!"` на
-       `return "Hello there " + name + "!"`.
+       `return "Hello there " + name + "`!"`.
     3. Сохраните файл.
 
     Приложение обновится в течение нескольких секунд.
@@ -232,17 +232,19 @@ import wails_dev from '../../../../assets/wails_dev.mp4';
        git push -u origin main
        ```
 
-    Это гарантирует, что имя вашего Go-модуля соответствует соглашениям об именовании модулей Go и облегчает обмен вашим кодом.:::tip[Совет]
-Вы можете автоматизировать все шаги инициализации, используя флаг `-git` при создании проекта:
-```bash
-wails3 init -n myfirstapp -git github.com/username/myfirstapp
-```
-Эта команда поддерживает различные форматы URL Git:
-- HTTPS: `https://github.com/username/project`
-- SSH: `git@github.com:username/project` или `ssh://git@github.com/username/project`
-- Протокол Git: `git://github.com/username/project`
-- Файловая система: `file:///path/to/project.git`
-:::
+    Это гарантирует, что имя вашего Go-модуля соответствует соглашениям об именовании модулей Go и облегчает обмен вашим кодом.
+
+    :::tip[Совет]
+    Вы можете автоматизировать все шаги инициализации, используя флаг `-git` при создании проекта:
+    ```bash
+    wails3 init -n myfirstapp -git github.com/username/myfirstapp
+    ```
+    Эта команда поддерживает различные форматы URL Git:
+    - HTTPS: `https://github.com/username/project`
+    - SSH: `git@github.com:username/project` или `ssh://git@github.com/username/project`
+    - Протокол Git: `git://github.com/username/project`
+    - Файловая система: `file:///path/to/project.git`
+    :::
 
 </Steps>
 

--- a/docs/src/content/docs/ru/quick-start/installation.mdx
+++ b/docs/src/content/docs/ru/quick-start/installation.mdx
@@ -268,7 +268,110 @@ wails3 doctor  # Проверка установки
        ```powershell
        npm --version
        ```
-     </TabItem>#### Версия Go слишком старая
+     </TabItem>
+
+     <TabItem label="macOS" icon="apple">
+       **Вариант 1: Официальный установщик**
+       Скачайте с [nodejs.org](https://nodejs.org/)
+
+       **Вариант 2: Homebrew**
+       ```bash
+       brew install node
+       ```
+
+       **Проверка:**
+       ```bash
+       npm --version
+       ```
+     </TabItem>
+
+     <TabItem label="Linux" icon="linux">
+       **Вариант 1: NodeSource**
+       ```bash
+       curl -fsSL https://deb.nodesource.com/setup_lts.x | sudo -E bash -
+       sudo apt-get install -y nodejs  # Ubuntu/Debian
+       ```
+
+       **Вариант 2: Менеджер пакетов**
+       ```bash
+       sudo dnf install nodejs  # Fedora
+       sudo pacman -S nodejs npm  # Arch
+       ```
+
+       **Проверка:**
+       ```bash
+       npm --version
+       ```
+     </TabItem>
+   </Tabs>
+
+   :::tip[Альтернативные менеджеры пакетов]
+   Предпочитаете `pnpm`, `yarn` или `bun`? Без проблем! Просто обновите `Taskfile.yml` в вашем проекте для использования предпочтительного инструмента.
+   :::
+
+</Steps>
+
+## Устранение неполадок
+
+#### Команда `wails3` не найдена
+
+**Причина:** `~/go/bin` (или `%USERPROFILE%\go\bin` на Windows) не добавлен в PATH.
+
+**Решение:**
+
+<Tabs syncKey="os">
+  <TabItem label="Windows" icon="seti:windows">
+    1. Откройте «Переменные среды» (поиск в меню Пуск)
+    2. В разделе «Переменные пользователя» найдите `Path`
+    3. Нажмите «Изменить» → «Создать»
+    4. Добавьте: `C:\Users\ВашеИмя\go\bin` (замените ВашеИмя)
+    5. Нажмите «ОК» во всех диалогах
+    6. **Перезапустите терминал**
+
+    **Проверка:**
+    ```powershell
+    $env:PATH -split ';' | Where-Object { $_ -like '*\go\bin' }
+    ```
+  </TabItem>
+
+  <TabItem label="macOS/Linux" icon="apple">
+    Добавьте в `~/.zshrc` (macOS) или `~/.bashrc` (Linux):
+    ```bash
+    export PATH=$PATH:~/go/bin
+    ```
+
+    Перезагрузите:
+    ```bash
+    source ~/.zshrc  # или ~/.bashrc
+    ```
+
+    **Проверка:**
+    ```bash
+    echo $PATH | grep go/bin
+    wails3 version
+    ```
+  </TabItem>
+</Tabs>
+---
+
+#### `wails3 doctor` сообщает об отсутствующих зависимостях
+
+**Linux:** Вывод показывает точно, какие пакеты нужно установить. Пример:
+```
+❌ webkit2gtk не найден
+   Установите: sudo apt install libwebkit2gtk-4.1-dev
+```
+
+**Windows:** Если WebView2 отсутствует:
+- Скачайте с [Microsoft](https://developer.microsoft.com/microsoft-edge/webview2/)
+- Или будет установлен автоматически при первом запуске приложения
+
+**macOS:** Если инструменты Xcode отсутствуют:
+```bash
+xcode-select --install
+```
+---
+#### Версия Go слишком старая
 
 Wails v3 требует Go 1.25+. Если у вас более старая версия:
 

--- a/docs/src/content/docs/zh-tw/concepts/architecture.mdx
+++ b/docs/src/content/docs/zh-tw/concepts/architecture.mdx
@@ -323,6 +323,333 @@ Shutdown: "Shutdown" {
     shape: rectangle
   }
   
-  Save: "Save State" {---
+  Save: "Save State" {
+    shape: rectangle
+  }
+}
+
+End: "Application End" {
+  shape: oval
+  style.fill: "#EF4444"
+}
+
+Start -> Init.Create
+Init.Create -> Init.Register
+Init.Register -> Init.Setup
+Init.Setup -> Run.Events
+Run.Events -> Run.Messages
+Run.Messages -> Run.Render
+Run.Render -> Run.Events: "Loop"
+Run.Events -> Shutdown.Cleanup: "Quit signal"
+Shutdown.Cleanup -> Shutdown.Save
+Shutdown.Save -> End
+```
+
+**Lifecycle hooks:**
+
+```go
+app := application.New(application.Options{
+    Name: "My App",
+    
+    // Called before windows are created
+    OnStartup: func(ctx context.Context) {
+        // Initialise database, load config, etc.
+    },
+    
+    // Called when app is about to quit
+    OnShutdown: func() {
+        // Save state, close connections, etc.
+    },
+})
+```
+
+[Learn more about lifecycle →](/concepts/lifecycle)
+
+## Build Process
+
+Understanding how Wails builds your application:
+
+```d2
+direction: down
+
+Source: "Source Code" {
+  Go: "Go Code\n(main.go, services)" {
+    shape: rectangle
+    style.fill: "#00ADD8"
+  }
+  
+  Frontend: "Frontend Code\n(HTML/CSS/JS)" {
+    shape: rectangle
+    style.fill: "#8B5CF6"
+  }
+}
+
+Build: "Build Process" {
+  AnalyseGo: "Analyse Go Code" {
+    shape: rectangle
+  }
+  
+  GenerateBindings: "Generate Bindings" {
+    shape: rectangle
+  }
+  
+  BuildFrontend: "Build Frontend" {
+    shape: rectangle
+  }
+  
+  CompileGo: "Compile Go" {
+    shape: rectangle
+  }
+  
+  Embed: "Embed Assets" {
+    shape: rectangle
+  }
+}
+
+Output: "Output" {
+  Binary: "Native Binary\n(myapp.exe/.app)" {
+    shape: rectangle
+    style.fill: "#10B981"
+  }
+}
+
+Source.Go -> Build.AnalyseGo
+Build.AnalyseGo -> Build.GenerateBindings: "Extract types"
+Build.GenerateBindings -> Source.Frontend: "TypeScript bindings"
+Source.Frontend -> Build.BuildFrontend: "Compile (Vite/webpack)"
+Build.BuildFrontend -> Build.Embed: "Bundled assets"
+Source.Go -> Build.CompileGo
+Build.CompileGo -> Build.Embed
+Build.Embed -> Output.Binary
+```
+
+**Build steps:**
+
+1. **Analyse Go code**
+   - Scan services for exported methods
+   - Extract parameter and return types
+   - Generate method signatures
+
+2. **Generate TypeScript bindings**
+   - Create `.ts` files for each service
+   - Include full type definitions
+   - Add JSDoc comments
+
+3. **Build frontend**
+   - Run your bundler (Vite, webpack, etc.)
+   - Minify and optimise
+   - Output to `frontend/dist/`
+
+4. **Compile Go**
+   - Compile with optimisations (`-ldflags="-s -w"`)
+   - Include build metadata
+   - Platform-specific compilation
+
+5. **Embed assets**
+   - Embed frontend files into Go binary
+   - Compress assets
+   - Create single executable
+
+**Result:** A single native executable with everything embedded.
+
+[Learn more about building →](/guides/build/building)
+
+## Development vs Production
+
+Wails behaves differently in development and production:
+
+<Tabs syncKey="mode">
+  <TabItem label="Development (wails3 dev)" icon="seti:config">
+    **Characteristics:**
+    - **Hot reload**: Frontend changes reload instantly
+    - **Source maps**: Debug with original source
+    - **DevTools**: Browser DevTools available
+    - **Logging**: Verbose logging enabled
+    - **External frontend**: Served from dev server (Vite)
+
+    **How it works:**
+    ```d2
+    direction: right
+    
+    WailsApp: "Wails App" {
+      shape: rectangle
+      style.fill: "#00ADD8"
+    }
+    
+    DevServer: "Vite Dev Server\n(localhost:5173)" {
+      shape: rectangle
+      style.fill: "#8B5CF6"
+    }
+    
+    WebView: "WebView" {
+      shape: rectangle
+      style.fill: "#6B7280"
+    }
+    
+    WailsApp -> DevServer: "Proxy requests"
+    DevServer -> WebView: "Serve with HMR"
+    WebView -> WailsApp: "Call Go methods"
+    ```
+
+    **Benefits:**
+    - Instant feedback on changes
+    - Full debugging capabilities
+    - Faster iteration
+  </TabItem>
+
+  <TabItem label="Production (wails3 build)" icon="rocket">
+    **Characteristics:**
+    - **Embedded assets**: Frontend built into binary
+    - **Optimised**: Minified, compressed
+    - **No DevTools**: Disabled by default
+    - **Minimal logging**: Errors only
+    - **Single file**: Everything in one executable
+
+    **How it works:**
+    ```d2
+    direction: right
+    
+    Binary: "Single Binary\n(myapp.exe)" {
+      GoCode: "Compiled Go" {
+        shape: rectangle
+        style.fill: "#00ADD8"
+      }
+      
+      Assets: "Embedded Assets\n(HTML/CSS/JS)" {
+        shape: rectangle
+        style.fill: "#8B5CF6"
+      }
+    }
+    
+    WebView: "WebView" {
+      shape: rectangle
+      style.fill: "#6B7280"
+    }
+    
+    Binary.Assets -> WebView: "Serve from memory"
+    WebView -> Binary.GoCode: "Call Go methods"
+    ```
+
+    **Benefits:**
+    - Single file distribution
+    - Smaller size (minified)
+    - Better performance
+    - No external dependencies
+  </TabItem>
+</Tabs>
+
+## Memory Model
+
+Understanding memory usage helps you build efficient applications.
+
+{/* VISUAL PLACEHOLDER: Memory Diagram
+Description: Memory layout diagram showing:
+1. Go Heap (services, application state)
+2. WebView Memory (DOM, JavaScript heap)
+3. Shared Memory (bridge communication)
+4. Arrows showing data flow between regions
+5. Annotations for zero-copy optimisations
+Style: Technical diagram with memory regions as boxes, clear labels, size indicators
+*/}
+
+**Memory regions:**
+
+1. **Go Heap**
+   - Your services and application state
+   - Managed by Go garbage collector
+   - Typically 5-10MB for simple apps
+
+2. **WebView Memory**
+   - DOM, JavaScript heap, CSS
+   - Managed by WebView's engine
+   - Typically 10-20MB for simple apps
+
+3. **Bridge Memory**
+   - Message buffers for communication
+   - Minimal overhead (\<1MB)
+   - Zero-copy for large data where possible
+
+**Optimisation tips:**
+- **Avoid large data transfers**: Pass IDs, fetch details on demand
+- **Use events for updates**: Don't poll from frontend
+- **Stream large files**: Don't load entirely into memory
+- **Clean up listeners**: Remove event listeners when done
+
+[Learn more about performance →](/guides/advanced/performance)
+
+## Security Model
+
+Wails provides a secure-by-default architecture:
+
+```d2
+direction: down
+
+Frontend: "Frontend (Untrusted)" {
+  shape: rectangle
+  style.fill: "#EF4444"
+}
+
+Bridge: "Wails Bridge (Validation)" {
+  shape: diamond
+  style.fill: "#F59E0B"
+}
+
+Backend: "Backend (Trusted)" {
+  shape: rectangle
+  style.fill: "#10B981"
+}
+
+Frontend -> Bridge: "Call method"
+Bridge -> Bridge: "Validate:\n- Method exists?\n- Types correct?\n- Access allowed?"
+Bridge -> Backend: "Execute if valid"
+Backend -> Bridge: "Return result"
+Bridge -> Frontend: "Send response"
+```
+
+**Security features:**
+
+1. **Method whitelisting**
+   - Only exported methods are callable
+   - Private methods are inaccessible
+   - Explicit service registration required
+
+2. **Type validation**
+   - Arguments checked against Go types
+   - Invalid types rejected
+   - Prevents injection attacks
+
+3. **No eval()**
+   - Frontend can't execute arbitrary Go code
+   - Only predefined methods callable
+   - No dynamic code execution
+
+4. **Context isolation**
+   - Each window has its own context
+   - Services can check caller context
+   - Permissions per window possible
+
+**Best practices:**
+- **Validate user input** in Go (don't trust frontend)
+- **Use context** for authentication/authorisation
+- **Sanitise file paths** before file operations
+- **Rate limit** expensive operations
+
+[Learn more about security →](/guides/advanced/security)
+
+## Next Steps
+
+**Application Lifecycle** - Understand startup, shutdown, and lifecycle hooks  
+[Learn More →](/concepts/lifecycle)
+
+**Go-Frontend Bridge** - Deep dive into how the bridge works  
+[Learn More →](/concepts/bridge)
+
+**Build System** - Understand how Wails builds your application  
+[Learn More →](/concepts/build-system)
+
+**Start Building** - Apply what you've learned in a tutorial
+[Tutorials →](/tutorials/03-notes-vanilla)
+
+---
 
 **對架構有疑問？** 請在 [Discord](https://discord.gg/JDdSxwjhGf) 提問或查看 [API 參考文件](/reference/overview)。

--- a/docs/src/content/docs/zh-tw/getting-started/your-first-app.mdx
+++ b/docs/src/content/docs/zh-tw/getting-started/your-first-app.mdx
@@ -231,17 +231,19 @@ import wails_dev from '../../../../assets/wails_dev.mp4';
        git push -u origin main
        ```
 
-    這可確保你的 Go 模組名稱符合 Go 的模組命名慣例，並使分享程式碼變得更容易。:::tip[專業提示]
-您可以透過在建立專案時使用 `-git` 旗標，自動化所有初始化步驟：
-```bash
-wails3 init -n myfirstapp -git github.com/username/myfirstapp
-```
-此功能支援各種 Git URL 格式：
-- HTTPS: `https://github.com/username/project`
-- SSH: `git@github.com:username/project` 或 `ssh://git@github.com/username/project`
-- Git 協定: `git://github.com/username/project`
-- 檔案系統: `file:///path/to/project.git`
-:::
+    這可確保你的 Go 模組名稱符合 Go 的模組命名慣例，並使分享程式碼變得更容易。
+
+    :::tip[專業提示]
+    您可以透過在建立專案時使用 `-git` 旗標，自動化所有初始化步驟：
+    ```bash
+    wails3 init -n myfirstapp -git github.com/username/myfirstapp
+    ```
+    此功能支援各種 Git URL 格式：
+    - HTTPS: `https://github.com/username/project`
+    - SSH: `git@github.com:username/project` 或 `ssh://git@github.com/username/project`
+    - Git 協定: `git://github.com/username/project`
+    - 檔案系統: `file:///path/to/project.git`
+    :::
 
 </Steps>
 

--- a/docs/src/content/docs/zh-tw/index.mdx
+++ b/docs/src/content/docs/zh-tw/index.mdx
@@ -242,7 +242,7 @@ cd myapp && wails3 dev
   <Card title="用戶可感知的效能" icon="rocket">
     - 二進制檔案約 15MB，對比 Electron 的 150MB
     - 基礎記憶體約 10MB，對比 100MB+
-    - 啟動時間 <0.5 秒，對比 2-3 秒
+    - 啟動時間 &lt;0.5 秒，對比 2-3 秒
     - 使用作業系統原生的 WebView 進行渲染
     - 無需捆綁瀏覽器帶來的額外負荷
   </Card>
@@ -275,7 +275,7 @@ cd myapp && wails3 dev
 
 ## 下一步
 
-下一步：[](/zh-tw/quick-start/next-steps)，瀏覽[範例](https://github.com/wailsapp/wails/tree/master/v3/examples)，或查看 [API 參考](/reference/application)。從 v2 遷移？請參閱[升級指南](/migration/v2-to-v3)。
+下一步：[](/zh-tw/quick-start/next-steps)，瀏覽[範例](https://github.com/wailsapp/wails/tree/master/v3/examples)，或查看 [API 參考](/reference/application)。從 v2 遷移？請參閱[升級指南](/migration/v2-to-v3)。
 
 
 :::note[生產環境就緒]

--- a/docs/src/content/docs/zh-tw/quick-start/installation.mdx
+++ b/docs/src/content/docs/zh-tw/quick-start/installation.mdx
@@ -268,7 +268,110 @@ wails3 doctor  # 驗證安裝
        ```powershell
        npm --version
        ```
-     </TabItem>#### Go 版本過舊
+     </TabItem>
+
+     <TabItem label="macOS" icon="apple">
+       **選項 1：官方安裝程式**
+       從 [nodejs.org](https://nodejs.org/) 下載
+
+       **選項 2：Homebrew**
+       ```bash
+       brew install node
+       ```
+
+       **驗證：**
+       ```bash
+       npm --version
+       ```
+     </TabItem>
+
+     <TabItem label="Linux" icon="linux">
+       **選項 1：NodeSource**
+       ```bash
+       curl -fsSL https://deb.nodesource.com/setup_lts.x | sudo -E bash -
+       sudo apt-get install -y nodejs  # Ubuntu/Debian
+       ```
+
+       **選項 2：套件管理員**
+       ```bash
+       sudo dnf install nodejs  # Fedora
+       sudo pacman -S nodejs npm  # Arch
+       ```
+
+       **驗證：**
+       ```bash
+       npm --version
+       ```
+     </TabItem>
+   </Tabs>
+
+   :::tip[替代套件管理員]
+   偏好 `pnpm`、`yarn` 或 `bun`？沒問題！只需更新專案中的 `Taskfile.yml` 即可使用您偏好的工具。
+   :::
+
+</Steps>
+
+## 疑難排解
+
+#### 找不到 `wails3` 命令
+
+**原因：** `~/go/bin`（Windows 上為 `%USERPROFILE%\go\bin`）不在 PATH 中。
+
+**解決方案：**
+
+<Tabs syncKey="os">
+  <TabItem label="Windows" icon="seti:windows">
+    1. 開啟「環境變數」（在開始功能表搜尋）
+    2. 在「使用者變數」下找到 `Path`
+    3. 點選「編輯」→「新增」
+    4. 新增：`C:\Users\YourName\go\bin`（替換 YourName）
+    5. 在所有對話框點選「確定」
+    6. **重新啟動終端機**
+
+    **驗證：**
+    ```powershell
+    $env:PATH -split ';' | Where-Object { $_ -like '*\go\bin' }
+    ```
+  </TabItem>
+
+  <TabItem label="macOS/Linux" icon="apple">
+    新增至 `~/.zshrc`（macOS）或 `~/.bashrc`（Linux）：
+    ```bash
+    export PATH=$PATH:~/go/bin
+    ```
+
+    重新載入：
+    ```bash
+    source ~/.zshrc  # 或 ~/.bashrc
+    ```
+
+    **驗證：**
+    ```bash
+    echo $PATH | grep go/bin
+    wails3 version
+    ```
+  </TabItem>
+</Tabs>
+---
+
+#### `wails3 doctor` 回報缺少依賴項
+
+**Linux：** 輸出會準確告訴您需要安裝哪些套件。範例：
+```
+❌ 找不到 webkit2gtk
+   安裝方式：sudo apt install libwebkit2gtk-4.1-dev
+```
+
+**Windows：** 如果缺少 WebView2：
+- 從 [Microsoft](https://developer.microsoft.com/microsoft-edge/webview2/) 下載
+- 或在執行第一個應用程式時會自動安裝
+
+**macOS：** 如果缺少 Xcode 工具：
+```bash
+xcode-select --install
+```
+---
+#### Go 版本過舊
 
 Wails v3 需要 Go 1.25+。如果您使用的是較舊版本：
 


### PR DESCRIPTION
## Problem

The i18n batch-2 translations (committed 2026-05-07) introduced four categories of MDX compilation errors across all 7 translated locales. This causes `astro build` to exit 1, which fails the Cloudflare Pages: wails-v3-site check on all PRs.

## Root Cause

The translation pipeline merged content that should be on separate lines. Three files per locale are affected:

### Bug 1 — `concepts/architecture.mdx` (all 7 locales)
D2 lifecycle diagram truncated at line 327; `Save: "Save State" {---` (diagram close `{...}` merged with `---` footer separator).
**Fix:** Restore complete D2 diagram close + missing Build Process/Dev vs Prod/Memory/Security/Next Steps sections.

### Bug 2 — `quick-start/installation.mdx` (all 7 locales)
`</TabItem>#### heading` on same line — unclosed `<Tabs>/<Steps>` block.
**Fix:** Add missing macOS/Linux npm TabItems, close Tabs/Steps, add Troubleshooting section.

### Bug 3 — `getting-started/your-first-app.mdx` (all 7 locales)
`[sentence].:::tip[...]` merged on one line — tip admonition outside `<Steps>` list item.
**Fix:** Separate `:::tip` onto its own line with 4-space indent.

### Bug 4 — `zh-tw/index.mdx`
Bare `<0.5` — invalid MDX JSX before digit.
**Fix:** Escape as `&lt;0.5`.

## Verification

Local build on fix branch: `astro build` exits 0, 1342 pages built.

CC @leaanthony

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded architecture docs with lifecycle diagram updates (Save State & Application End), lifecycle hooks, build process, dev vs. prod flows, memory & security models, and next steps — updated in EN/DE/FR/JA/KO/PT
  * Reformatted "Tip"/callout blocks in Getting Started guides — DE/FR/JA/KO/PT
  * Added macOS/Linux npm installation guidance and package-manager notes in Quick Start — DE/FR/JA/KO/PT
  * Minor content fixes (NSIS filename, troubleshooting header/form formatting) across locales

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wailsapp/wails/pull/5460?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->