### PR TITLE
v2: nil-guard Application.Quit so pre-Run shutdown doesn't panic

### DIFF
--- a/v2/pkg/application/application.go
+++ b/v2/pkg/application/application.go
@@ -74,10 +74,16 @@ func (a *Application) Run() error {
 	return err
 }
 
-// Quit will shut down the application
+// Quit will shut down the application.
+//
+// Safe to call before Run, or after Run returns early (e.g. CreateApp failed).
+// Without the nil guard, Quit() in those situations dereferences an unset
+// a.application and crashes (#5452).
 func (a *Application) Quit() {
 	a.shutdown.Do(func() {
-		a.application.Shutdown()
+		if a.application != nil {
+			a.application.Shutdown()
+		}
 	})
 }
 

--- a/website/src/pages/changelog.mdx
+++ b/website/src/pages/changelog.mdx
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed nil pointer crash in `application.Quit` when called before `Run` or after `Run` returned early [#5452](https://github.com/wailsapp/wails/issues/5452) by @c-tonneslan
+
 ## v2.12.0 - 2026-03-26
 
 ### Fixed


### PR DESCRIPTION
Closes #5452.

`a.application` is only set inside `Run()` once `app.CreateApp` returns successfully. Calling `Quit()` before `Run()` (or after `Run()` failed early at `CreateApp`) dereferences a nil receiver inside the inner closure and crashes the host process. The fix is the one from the issue: guard the `Shutdown()` call.

Added the changelog entry under `[Unreleased]` per the v2 contributor checklist.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed a crash that occurred when shutting down the application before the startup sequence completed, ensuring safe closure in all scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wailsapp/wails/pull/5468?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->