### PR TITLE
chore: exclude website/ docusaurus tree from FOSSA license scan

### DIFF
--- a/.fossa.yml
+++ b/.fossa.yml
@@ -1,0 +1,13 @@
+version: 3
+
+# Exclude documentation-site build tooling from license scanning.
+# Docusaurus pulls in webpack-dev-server → selfsigned → node-forge
+# whose dual SPDX expression (BSD-3-Clause OR GPL-2.0) trips the org
+# license policy. node-forge is build-time only for serving the docs
+# site locally; it is not distributed with the Wails Go module or the
+# @wailsio/runtime npm package, so it is out of scope for the license
+# compliance posture we want FOSSA to enforce.
+targets:
+  exclude:
+    - type: npm
+      path: website


### PR DESCRIPTION
## Summary

Resolves the 3 FOSSA License Compliance findings currently red on every master commit since #5443.

All three findings trace to a single package: `node-forge@1.4.0`, pulled in only at depth-4 by Docusaurus's dev-server stack:

```
website → @docusaurus/core → webpack-dev-server → selfsigned → node-forge
```

node-forge declares `(BSD-3-Clause OR GPL-2.0)`. FOSSA's default policy flags the GPL branch of any `OR` expression unless an explicit election is recorded, and its text-scanner reports both GPL-1.0 and GPL-2.0 from the bundled LICENSE file — same package, 3 findings.

## Why exclude rather than elect

`.fossa.yml` (v3 schema) has no per-dependency license-election syntax — that lives in FOSSA's web UI under a paid SKU. The available YAML mechanisms are path/target exclusion.

node-forge is build-time only for serving the docs site locally; it is not distributed with the Wails Go module or `@wailsio/runtime`. Scoping FOSSA out of `website/` keeps the compliance posture focused on what wails users actually consume.

Narrow exclusion (`website/` only) — `docs/` and `scripts/sponsors/` also carry LGPL `sharp` transitives but those aren't currently flagging, so they're left in scope.

## Test plan

- [ ] Merge, then wait for FOSSA to re-scan master — the License Compliance check should go green
- [ ] Confirm PR 5466 (and other open PRs) inherit the green status on their next push

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated FOSSA configuration file to version 3 with refined license-scanning settings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wailsapp/wails/pull/5472?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->