### PR TITLE
fix(linux): frameless window resize + scrollbar edge detection

### DIFF
--- a/v3/internal/runtime/desktop/@wailsio/runtime/src/drag.ts
+++ b/v3/internal/runtime/desktop/@wailsio/runtime/src/drag.ts
@@ -8,7 +8,7 @@ The electron alternative for Go
 (c) Lea Anthony 2019-present
 */
 
-import { invoke, IsWindows } from "./system.js";
+import { invoke, IsWindows, IsLinux } from "./system.js";
 import { GetFlag } from "./flags.js";
 import { canTrackButtons, eventTarget } from "./utils.js";
 
@@ -221,7 +221,7 @@ function onMouseMove(event: MouseEvent): void {
         return;
     }
 
-    if (!resizable || !IsWindows()) {
+    if (!resizable || (!IsWindows() && !(IsLinux() && GetFlag("frameless")))) {
         if (resizeEdge) { setResize(); }
         return;
     }
@@ -232,16 +232,23 @@ function onMouseMove(event: MouseEvent): void {
     // Extra pixels for the corner areas.
     const cornerExtra = GetFlag("resizeCornerExtra") || 10;
 
-    const rightBorder = (window.outerWidth - event.clientX) < resizeHandleWidth;
+    // When a scrollbar is present at the window edge it consumes mouse events in that strip.
+    // Shift the effective content edge inward so the resize zone sits just before the scrollbar.
+    const scrollbarWidth = Math.max(0, window.innerWidth - document.documentElement.clientWidth);
+    const scrollbarHeight = Math.max(0, window.innerHeight - document.documentElement.clientHeight);
+    const rightContentEdge = window.innerWidth - scrollbarWidth;
+    const bottomContentEdge = window.innerHeight - scrollbarHeight;
+
+    const rightBorder = event.clientX < rightContentEdge && (rightContentEdge - event.clientX) < resizeHandleWidth;
     const leftBorder = event.clientX < resizeHandleWidth;
     const topBorder = event.clientY < resizeHandleHeight;
-    const bottomBorder = (window.outerHeight - event.clientY) < resizeHandleHeight;
+    const bottomBorder = event.clientY < bottomContentEdge && (bottomContentEdge - event.clientY) < resizeHandleHeight;
 
     // Adjust for corner areas.
-    const rightCorner = (window.outerWidth - event.clientX) < (resizeHandleWidth + cornerExtra);
+    const rightCorner = event.clientX < rightContentEdge && (rightContentEdge - event.clientX) < (resizeHandleWidth + cornerExtra);
     const leftCorner = event.clientX < (resizeHandleWidth + cornerExtra);
     const topCorner = event.clientY < (resizeHandleHeight + cornerExtra);
-    const bottomCorner = (window.outerHeight - event.clientY) < (resizeHandleHeight + cornerExtra);
+    const bottomCorner = event.clientY < bottomContentEdge && (bottomContentEdge - event.clientY) < (resizeHandleHeight + cornerExtra);
 
     if (!leftCorner && !topCorner && !bottomCorner && !rightCorner) {
         // Optimisation: out of all corner areas implies out of borders.

--- a/v3/pkg/application/linux_cgo.go
+++ b/v3/pkg/application/linux_cgo.go
@@ -1487,6 +1487,7 @@ func (w *linuxWebviewWindow) setBorderless(borderless bool) {
 
 func (w *linuxWebviewWindow) setResizable(resizable bool) {
 	C.gtk_window_set_resizable(w.gtkWindow(), gtkBool(resizable))
+	w.execJS(fmt.Sprintf("if(window._wails&&window._wails.setResizable)window._wails.setResizable(%v);", resizable))
 }
 
 func (w *linuxWebviewWindow) setDefaultSize(width int, height int) {
@@ -1586,8 +1587,7 @@ func windowSetGeometryHints(window pointer, minWidth, minHeight, maxWidth, maxHe
 
 func (w *linuxWebviewWindow) setFrameless(frameless bool) {
 	C.gtk_window_set_decorated(w.gtkWindow(), gtkBool(!frameless))
-	// TODO: Deal with transparency for the titlebar if possible when !frameless
-	//       Perhaps we just make it undecorated and add a menu bar inside?
+	w.execJS(fmt.Sprintf("if(window._wails&&window._wails.flags)window._wails.flags.frameless=%v;", frameless))
 }
 
 // TODO: confirm this is working properly

--- a/v3/pkg/application/linux_cgo_gtk4.go
+++ b/v3/pkg/application/linux_cgo_gtk4.go
@@ -1240,6 +1240,7 @@ func windowSetGeometryHints(window pointer, minWidth, minHeight, maxWidth, maxHe
 
 func (w *linuxWebviewWindow) setResizable(resizable bool) {
 	C.gtk_window_set_resizable(w.gtkWindow(), gtkBool(resizable))
+	w.execJS(fmt.Sprintf("if(window._wails&&window._wails.setResizable)window._wails.setResizable(%v);", resizable))
 }
 
 func (w *linuxWebviewWindow) move(x, y int) {
@@ -1282,6 +1283,7 @@ func (w *linuxWebviewWindow) setBorderless(borderless bool) {
 
 func (w *linuxWebviewWindow) setFrameless(frameless bool) {
 	C.gtk_window_set_decorated(w.gtkWindow(), gtkBool(!frameless))
+	w.execJS(fmt.Sprintf("if(window._wails&&window._wails.flags)window._wails.flags.frameless=%v;", frameless))
 }
 
 func (w *linuxWebviewWindow) setTransparent() {

--- a/v3/pkg/application/webview_window_linux.go
+++ b/v3/pkg/application/webview_window_linux.go
@@ -396,6 +396,8 @@ func (w *linuxWebviewWindow) run() {
 		// Inject runtime core and EnableFileDrop flag together
 		js := runtime.Core(globalApplication.impl.GetFlags(globalApplication.options))
 		js += fmt.Sprintf("window._wails.flags.enableFileDrop=%v;", w.parent.options.EnableFileDrop)
+		js += fmt.Sprintf("if(window._wails&&window._wails.flags)window._wails.flags.frameless=%v;", w.parent.options.Frameless)
+		js += fmt.Sprintf("if(window._wails&&window._wails.setResizable)window._wails.setResizable(%v);", !w.parent.options.DisableResize)
 		w.execJS(js)
 	})
 	if w.parent.options.HTML != "" {


### PR DESCRIPTION
## Problem

On Linux frameless windows, the JS runtime never received the `frameless` or `resizable` flags, so the resize-edge cursor logic in `drag.ts` never activated. Additionally, the existing border detection used `window.outerWidth/outerHeight` which does not account for a scrollbar occupying the rightmost/bottommost strip — making it impossible to hit the resize zone when a scrollbar was present.

## Changes

### `drag.ts`
- Import `IsLinux` from `system.js`
- Gate resize-edge logic on `!IsWindows() && !(IsLinux() && frameless)` → frameless Linux windows now enter the resize path
- Replace `outerWidth/outerHeight` border math with `innerWidth - scrollbarWidth` / `innerHeight - scrollbarHeight` (scrollbar width derived from `window.innerWidth - document.documentElement.clientWidth`)

### `linux_cgo.go` (GTK3) / `linux_cgo_gtk4.go` (GTK4)
- `setResizable`: call `window._wails.setResizable(bool)` after the GTK call so runtime state stays in sync when resizability is toggled at runtime
- `setFrameless`: call `window._wails.flags.frameless = bool` after `gtk_window_set_decorated`

### `webview_window_linux.go`
- In the `WindowLoadFinished` hook, inject `flags.frameless` and `setResizable(bool)` alongside the existing `enableFileDrop` flag so every fresh page load gets correct state

## Notes
- Compiled runtime bundles (`runtime.js` / `runtime.debug.js`) need regenerating with `task runtime:build` in `v3/internal/runtime/desktop/@wailsio/runtime` — the TS source is the ground truth.
- Tested on Ubuntu 22.04 LTS (GTK3 / webkit2gtk-4.0).
- Supersedes #5368 (rebased, addressed CodeRabbit review comment on `outerWidth` vs `innerWidth`).

Closes #5368

CC @leaanthony

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved window resize-edge detection to account for scrollbar presence on desktop windows.
  * Extended window resizing support to Linux platforms (previously Windows-only).
  * Fixed frameless and resizable window state synchronization between frontend and backend on Linux.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wailsapp/wails/pull/5493?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->