### PR TITLE
fix(v3/templates): fix generate template to use embedded FS

### DIFF
--- a/docs/public/schemas/template.v3.json
+++ b/docs/public/schemas/template.v3.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "https://v3.wails.io/schemas/template.v3.json",
+  "title": "Wails v3 Template",
+  "description": "Metadata for a Wails v3 template (template.yaml)",
+  "type": "object",
+  "required": ["name", "shortname", "wailsVersion"],
+  "additionalProperties": false,
+  "properties": {
+    "name": {
+      "description": "Display name of the template",
+      "type": "string",
+      "minLength": 1
+    },
+    "shortname": {
+      "description": "Short identifier used in the CLI (e.g. 'react', 'vanilla-ts')",
+      "type": "string",
+      "minLength": 1,
+      "pattern": "^[a-z0-9]+(-[a-z0-9]+)*$"
+    },
+    "author": {
+      "description": "Author of the template",
+      "type": "string"
+    },
+    "description": {
+      "description": "Short description of the template shown in the CLI",
+      "type": "string"
+    },
+    "helpurl": {
+      "description": "URL to documentation or a help page for this template",
+      "type": "string",
+      "format": "uri"
+    },
+    "version": {
+      "description": "Version of the template (semver, e.g. v1.0.0)",
+      "type": "string",
+      "pattern": "^v[0-9]+\\.[0-9]+\\.[0-9]+.*$"
+    },
+    "wailsVersion": {
+      "description": "Wails major version this template targets. Must be 3.",
+      "type": "integer",
+      "const": 3
+    }
+  }
+}

--- a/docs/src/content/docs/guides/advanced/custom-templates.mdx
+++ b/docs/src/content/docs/guides/advanced/custom-templates.mdx
@@ -1,8 +1,6 @@
 ---
 title: Creating Custom Templates
 description: How to generate, customise, and host your own Wails v3 project templates
-sidebar:
-    order: 50
 ---
 
 import { Tabs, TabItem, Steps } from '@astrojs/starlight/components';

--- a/docs/src/content/docs/guides/custom-templates.mdx
+++ b/docs/src/content/docs/guides/custom-templates.mdx
@@ -1,293 +1,227 @@
 ---
 title: Creating Custom Templates
-description: Learn how to create and customise your own Wails v3 templates
+description: How to generate, customise, and host your own Wails v3 project templates
 sidebar:
     order: 50
 ---
 
-This guide will walk you through the process of creating a custom template for Wails v3. 
+import { Tabs, TabItem, Steps } from '@astrojs/starlight/components';
 
-## Why would I make a custom template?
+Wails ships with a set of built-in templates, but you can create your own and share them with the community. A custom template is just a Git repository — once it is hosted publicly, anyone can scaffold a project from it with a single command.
 
-Wails comes with a number of pre-configured templates that allow you to get your application up and running quickly. But if you need a more customised setup, you can create your own template to suit your needs. This can then be shared with the Wails community for others to use.
+## Generate a template skeleton
 
-### 1. Generating a Template
-
-To create a custom template, you can use the `wails3 generate template` command:
+The `wails3 generate template` command produces a ready-to-customise template directory:
 
 ```bash
-wails3 generate template -name mytemplate
+wails3 generate template -name MyTemplate
 ```
 
-This will create a new directory called "mytemplate" in your current directory.
+All flags:
 
-The `wails3 generate template` command supports the following options:
+| Flag           | Description                                        | Default           |
+|----------------|----------------------------------------------------|-------------------|
+| `-name`        | Template name (required)                           | —                 |
+| `-author`      | Author name                                        | —                 |
+| `-description` | Short description shown in the CLI                 | —                 |
+| `-helpurl`     | URL to documentation for this template             | —                 |
+| `-version`     | Initial version                                    | `v0.0.1`          |
+| `-frontend`    | Copy an existing frontend directory into the template | —              |
+| `-dir`         | Where to write the template directory              | Current directory |
 
-| Option         | Description                                       | Default           |
-|----------------|---------------------------------------------------|-------------------|
-| `-name`        | The name of your template (required)              | -                 |
-| `-frontend`    | Path to an existing frontend directory to include | -                 |
-| `-author`      | The author of the template                        | -                 |
-| `-description` | A description of the template                     | -                 |
-| `-helpurl`     | URL for template documentation                    | -                 |
-| `-dir`         | Directory to generate the template in             | Current directory |
-| `-version`     | Template version                                  | v0.0.1            |
-
-For example, to create a template with all options:
+Example with all flags:
 
 ```bash
 wails3 generate template \
-  -name "My Custom Template" \
-  -frontend ./my-existing-frontend \
+  -name "My Template" \
   -author "Your Name" \
-  -description "A template with my preferred setup" \
-  -helpurl "https://github.com/yourusername/template-docs" \
-  -dir ./templates \
-  -version "v1.0.0"
+  -description "React + custom setup" \
+  -helpurl "https://github.com/yourname/my-template" \
+  -version "v1.0.0" \
+  -frontend ./my-existing-frontend
 ```
 
-  :::tip
-  Using the `-frontend` option will copy an existing web frontend project into the template.
-  :::
+The generated directory looks like this:
 
-### 2. Configure Template Metadata
-
-If you didn't specify the template configuration when generating the template, you can update the `template.json` file in the template directory:
-
-```json5
-{
-  "name": "Your Template Name",          // Display name of your template
-  "shortname": "template-shortname",     // Used when referencing your template
-  "author": "Your Name",                 // Template author
-  "description": "Template description", // Template description
-  "helpurl": "https://your-docs.com",    // Documentation URL
-  "version": "v0.0.1",                   // Template version
-  "schema": 3                            // Must be kept as 3 for Wails v3
-}
 ```
-:::caution
-The `schema` field must remain set to `3` for compatibility with Wails v3.
+MyTemplate/
+├── template.yaml          # Template metadata — edit this
+├── NEXTSTEPS.md           # Guidance for you as the template author — delete before publishing
+├── README.md              # Shown to users after they create a project
+├── main.go.tmpl           # Application entry point
+├── greetservice.go        # Example Go service
+├── go.mod.tmpl            # Go module file
+├── go.sum.tmpl            # Go checksums
+├── gitignore.tmpl         # Becomes .gitignore in generated projects
+├── Taskfile.tmpl.yml      # Build task definitions
+└── frontend/              # Your frontend code
+```
+
+:::tip[Read NEXTSTEPS.md]
+The generated `NEXTSTEPS.md` contains detailed guidance on every part of the template. Read it before customising. Delete it before publishing — it must not appear in projects created from your template.
 :::
 
-### 3. Set Up Build Tasks
+## Configure template metadata
 
-In the `build` directory is `Taskfile.yml` where you can define your template's build process. 
-This file uses [Task](https://taskfile.dev) for build automation. The key steps are:
+Open `template.yaml` to set your template's metadata:
+
+```yaml
+# yaml-language-server: $schema=https://v3.wails.io/schemas/template.v3.json
+name: "My Template"
+shortname: my-template
+author: Your Name
+description: A template with my preferred setup
+helpurl: https://github.com/yourname/my-template
+version: v1.0.0
+wailsVersion: 3
+```
+
+The `wailsVersion` field is **required** and must be `3`. The `# yaml-language-server` comment at the top enables autocomplete and inline validation in VS Code (with the [YAML extension](https://marketplace.visualstudio.com/items?itemName=redhat.vscode-yaml)) and JetBrains IDEs — you can leave it or remove it; it has no effect at runtime.
+
+## Customise the template
+
+### Frontend
+
+The `frontend/` directory is copied verbatim into every project created from your template. Replace the placeholder content with your actual frontend:
+
+<Tabs>
+  <TabItem label="Start from scratch">
+    ```bash
+    cd MyTemplate/frontend
+    npm create vite@latest .
+    ```
+    Follow the prompts, then install dependencies:
+    ```bash
+    npm install
+    ```
+  </TabItem>
+  <TabItem label="Use an existing project">
+    Pass `-frontend` when generating the template to copy an existing frontend in one step:
+    ```bash
+    wails3 generate template -name MyTemplate -frontend ./my-app/frontend
+    ```
+    Or copy it manually into the `frontend/` directory afterwards.
+  </TabItem>
+</Tabs>
+
+### Build tasks
+
+`Taskfile.tmpl.yml` defines the build workflow. Update the `install:frontend:deps` and `build:frontend` tasks to match your frontend toolchain:
 
 ```yaml
 tasks:
   install:frontend:deps:
-    summary: Install frontend dependencies
     dir: frontend
-    sources:
-      - package.json
-      - package-lock.json
-    generates:
-      - node_modules/*
-    preconditions:
-      - sh: npm version
-        msg: "Looks like npm isn't installed. Npm is part of the Node installer: https://nodejs.org/en/download/"
     cmds:
-      - npm install
+      - npm install       # replace with pnpm install, yarn, etc.
 
   build:frontend:
-    summary: Build the frontend project
     dir: frontend
-    sources:
-      - "**/*"
-    generates:
-      - dist/*
-    deps:
-      - task: install:frontend:deps
-      - task: generate:bindings
+    deps: [install:frontend:deps, generate:bindings]
     cmds:
-      - npm run build -q
-
-
+      - npm run build     # replace with your build command
 ```
 
-### 4. Frontend Setup
+### Go application
 
-If you did not use `-frontend` when generating the template, you need to add frontend files to your template. 
+The `main.go.tmpl` file is the application entry point. It is processed by Wails' template engine when a project is created — template variables like `{{.ProductName}}` are replaced with the values the user supplies.
 
-There are a number of ways to set up your frontend: starting from scratch or using an existing framework.
+To edit it as a real Go file (with IDE support), temporarily rename it to `main.go`, make your changes, then rename it back to `main.go.tmpl` before committing.
 
-import { Tabs, TabItem } from '@astrojs/starlight/components';
+#### Template variables
 
-<Tabs>
-  <TabItem label="Start from Scratch">
-    If you want to start from scratch, you can create your frontend project just like you would for any web application. 
-    The `frontend` directory in your template is just a regular directory where you can set up your preferred 
-    development environment. You might want to use build tools like Vite, webpack, or even just plain HTML, CSS, and 
-    JavaScript - it's entirely up to you!
+These variables are available in any `.tmpl` file:
 
-    For example, if you're using Vite, you could navigate to the `frontend` directory and run:
+| Variable               | Description                              | Example                         |
+|------------------------|------------------------------------------|---------------------------------|
+| `{{.ProjectName}}`     | Project name supplied by the user        | `"MyApp"`                       |
+| `{{.BinaryName}}`      | Binary filename                          | `"myapp"`                       |
+| `{{.ProductName}}`     | Product display name                     | `"My Application"`              |
+| `{{.ProductDescription}}` | Product description                   | `"An awesome application"`      |
+| `{{.ProductVersion}}`  | Product version                          | `"1.0.0"`                       |
+| `{{.ProductCompany}}`  | Company / author name                    | `"My Company Ltd"`              |
+| `{{.ProductCopyright}}`| Copyright string                         | `"Copyright 2024 My Company Ltd"` |
+| `{{.ProductComments}}` | Additional product comments              | `"Built with Wails"`            |
+| `{{.ProductIdentifier}}`| Reverse-DNS product identifier          | `"com.mycompany.myapp"`         |
+| `{{.ModulePath}}`      | Go module path                           | `"github.com/you/myapp"`        |
+| `{{.WailsVersion}}`    | Wails version used to create the project | `"3.0.0"`                       |
+| `{{.Typescript}}`      | `true` if the template name ends in `-ts` | `true`                         |
+| `{{.Opn}}`             | Literal `{{` — escape inside templates   | `{{`                            |
+| `{{.Cls}}`             | Literal `}}` — escape inside templates   | `}}`                            |
 
-    ```bash
-    npm create vite@latest .
-    ```
+:::tip
+Any file in your template can be a `.tmpl` file — including HTML, JSON, and YAML files. Files without the `.tmpl` suffix are copied verbatim.
+:::
 
-    Then follow the prompts to set up your project exactly how you want it. The key thing to remember is that this is just a regular frontend project - you can use any tools, frameworks, or libraries you're familiar with.
-  </TabItem>
-  <TabItem label="Use Existing Framework">
-    For this example, we'll use [Vite](https://vitejs.dev/) to set up a React frontend project:
+## Test your template locally
 
-       ```bash
-       npm create vite@latest frontend -- --template react
-       cd frontend
-       npm install
-       ```
-
-  </TabItem>
-</Tabs>
-
-
-Now you have the frontend files in place, update `build/Taskfile.yml` with the appropriate commands:
-   ```yaml
-   tasks:
-      install:frontend:deps:
-        summary: Install frontend dependencies
-        dir: frontend
-        sources:
-          - package.json
-          - package-lock.json
-        generates:
-          - node_modules/*
-        preconditions:
-          - sh: npm version
-            msg: "Looks like npm isn't installed. Npm is part of the Node installer: https://nodejs.org/en/download/"
-        cmds:
-          - npm install
-
-      build:frontend:
-        summary: Build the frontend project
-        dir: frontend
-        sources:
-          - "**/*"
-        generates:
-          - dist/*
-        deps:
-          - task: install:frontend:deps
-          - task: generate:bindings
-        cmds:
-          - npm run build -q
-   ```
-
-  :::note
-  For this example, the default Tasks do not need updating as they use the standard `npm install` and `npm run build` commands.
-  :::
-
-### 5. Configure the Go Application
-
-The default files in the template directory are sufficient to get users started. However, you may want to provide some additional functionality to demonstrate your template's capabilities. The best way to do this is to rename `main.go.tmpl` to `main.go` and edit it like any other Go file. Once finished, ensure you rename it back to `main.go.tmpl` before committing your changes. If you do not care about having a templated `main.go` file (the default template injests the project name into the `Name` field of the application), you can skip this step.
-
-#### Template Variables
-
-Wails uses Go's templating engine to process files with the `.tmpl` extension. During template generation, several variables are available for use in your template files:
-
-| Variable             | Description                      | Example                           |
-|----------------------|----------------------------------|-----------------------------------|
-| `Name`               | The name of the project          | `"MyApp"`                         |
-| `BinaryName`         | The name of the generated binary | `"myapp"`                         |
-| `ProductName`        | The product name                 | `"My Application"`                |
-| `ProductDescription` | Description of the product       | `"An awesome application"`        |
-| `ProductVersion`     | Version of the product           | `"1.0.0"`                         |
-| `ProductCompany`     | Company name                     | `"My Company Ltd"`                |
-| `ProductCopyright`   | Copyright information            | `"Copyright 2024 My Company Ltd"` |
-| `ProductComments`    | Additional product comments      | `"Built with Wails"`              |
-| `ProductIdentifier`  | Unique product identifier        | `"com.mycompany.myapp"`           |
-| `Typescript`         | Whether TypeScript is being used | `true` or `false`                 |
-| `WailsVersion`       | The version of Wails being used  | `"3.0.0"`                         |
-
-You can use these variables in your template files using Go's template syntax:
-
-```go
-// main.go.tmpl
-package main
-
-import (
-    "github.com/wailsapp/wails/v3/pkg/application"
-)
-
-func main() {
-    app := application.New(application.Options{
-        Name:        "{{.ProductName}}",
-        Description: "{{.ProductDescription}}",
-    })
-    // ...
-}
-```
-
-    :::tip
-    Templating can be applied to any file in your template, even html files, so long as the filename has `.tmpl` in its name.
-    :::
-
-### 6. Testing Your Template
-
-To test your template:
-
-1. Generate a project using your template: `wails3 init -n testproject -t path/to/your/template`
-2. Run `wails3 build` to generate the production build and make sure the binary in `bin` runs correctly
-3. Run `wails3 dev` to start the development server. 
-4. Test that changes to the frontend code are reflected in the application.
-5. Test that changes to the Go code rebuild and relaunch the application
-
-### 7. Sharing Your Template
-
-Once your template is ready, you can share it with the community by hosting it on GitHub. Here's how:
-
-1. Create a new GitHub repository for your template
-2. Push your template code to the repository
-3. Tag your releases using semantic versioning (e.g., v1.0.0)
-
-Users can then use your template directly from GitHub using the HTTPS URL:
+Before publishing, test the template by creating a project from a local path:
 
 ```bash
-wails3 init -n myapp -t https://github.com/yourusername/your-template
+wails3 init -n testproject -t /path/to/MyTemplate
 ```
 
-You can also specify a particular version using the URL format:
+Then verify the project works:
 
 ```bash
-# Use a specific version tag
-wails3 init -n myapp -t https://github.com/yourusername/your-template/releases/tag/v1.0.0
-
-# Use a specific branch
-wails3 init -n myapp -t https://github.com/yourusername/your-template/tree/main
+cd testproject
+wails3 dev    # development mode with hot reload
+wails3 build  # production binary
 ```
 
-To test your template before sharing:
+Check that:
+- Frontend hot reload works
+- Go code changes rebuild and relaunch the app
+- The production binary in `bin/` runs correctly
 
-1. Push your changes to GitHub
-2. Create a new test project using the HTTPS URL:
+## Publish on GitHub
+
+<Steps>
+
+1. **Create a public GitHub repository** for your template. The repository root must contain `template.yaml`.
+
+2. **Delete `NEXTSTEPS.md`** — this file is guidance for template authors and must not appear in projects users create from your template.
+
+3. **Commit and push** the template directory contents as the repository root:
+
    ```bash
-   wails3 init -n testapp -t https://github.com/yourusername/your-template
+   git init
+   git add .
+   git commit -m "Initial template"
+   git remote add origin https://github.com/yourname/my-template.git
+   git push -u origin main
    ```
-3. Verify that all files are correctly generated
-4. Test the build and development workflow as described in the testing section
 
-    :::note
-    Make sure your repository is public if you want others to use your template.
-    :::
+4. **Tag a release** using semantic versioning:
 
-For more information, visit the [Wails documentation](https://wails.io)
+   ```bash
+   git tag v1.0.0
+   git push origin v1.0.0
+   ```
 
+</Steps>
 
-## Best Practices
+Users can now create projects from your template:
 
-Let's talk about some key practices that will help make your template more useful and maintainable. Here are the main areas to focus on:
+```bash
+# Latest commit on the default branch
+wails3 init -n myapp -t https://github.com/yourname/my-template
 
-1. **Make Your Template Easy to Understand**
-   - Write a clear, helpful README.md that gets users started quickly
-   - Add comments in your config files to explain the "why" behind your choices
-   - Show examples of common customisations - users love to see real-world use cases!
+# Pinned to a specific release tag
+wails3 init -n myapp -t https://github.com/yourname/my-template@v1.0.0
+```
 
-2. **Keep Dependencies Happy**
-   - Stay on top of your frontend package updates
-   - Lock down specific versions in package.json to avoid surprises
-   - Let users know upfront what they'll need to have installed
+:::caution[Third-party template warning]
+When a user installs a remote template, Wails displays a warning explaining that the template is third-party code and that the Wails project takes no responsibility for its contents. Users must explicitly confirm before the project is created.
 
-3. **Love Your Template**
-   - Keep it fresh with regular updates
-   - Give it a thorough test drive before sharing
-   - Share it with the Wails community - we'd love to see what you create!
+As a template author you are responsible for the security and correctness of all code in your template.
+:::
+
+## Best practices
+
+- **Write a clear `README.md`** — this is shown to users after they create a project. Explain how to run, build, and customise the project.
+- **Fill in `helpurl`** — link to your repository or dedicated documentation. Users see it in the Wails CLI template list.
+- **Pin frontend dependency versions** in `package.json` to avoid broken installs from upstream updates.
+- **Test before tagging** — create a fresh project from the tagged release before announcing it to the community.
+- **Keep `wailsVersion: 3`** — this field tells Wails which major version the template targets. Do not change it.
+- **Update regularly** — keep dependencies current and test against new Wails releases.

--- a/v3/internal/templates/base/NEXTSTEPS.md
+++ b/v3/internal/templates/base/NEXTSTEPS.md
@@ -9,7 +9,7 @@ how to customise it, and how to publish it so others can use it.
 
 ```text
 <template-name>/
-├── template.json          # Template metadata (name, author, description, etc.)
+├── template.yaml          # Template metadata (name, author, wailsVersion, etc.)
 ├── NEXTSTEPS.md           # This file — delete it before publishing
 ├── README.md              # Shown to users after they create a project
 ├── main.go.tmpl           # Application entry point (template variables expanded at init time)
@@ -50,8 +50,8 @@ The following variables are available inside `.tmpl` files:
 
 ## Customising Your Template
 
-1. **Edit `template.json`** — update the `name`, `shortname`, `author`, `description`,
-   and `helpurl` fields. The `schema` field must remain `3`.
+1. **Edit `template.yaml`** — update the `name`, `shortname`, `author`, `description`,
+   and `helpurl` fields. The `wailsVersion` field must remain `3`.
 
 2. **Replace `frontend/`** — drop in your framework of choice (Vite, React, Vue, Svelte,
    etc.). The frontend directory is copied verbatim; add `.tmpl` to any file you want
@@ -111,7 +111,7 @@ its contents. Users must explicitly confirm before the project is created.
 As a template author you are responsible for:
 - The security and correctness of all code in your template
 - Keeping your template up to date with new Wails versions
-- Providing clear documentation (`README.md`, `helpurl` in `template.json`)
+- Providing clear documentation (`README.md`, `helpurl` in `template.yaml`)
 
 ---
 

--- a/v3/internal/templates/base/NEXTSTEPS.md
+++ b/v3/internal/templates/base/NEXTSTEPS.md
@@ -94,10 +94,10 @@ top of whatever your template provides, so place only files that are not auto-ge
 3. Users can now create projects from your template:
    ```sh
    # Latest commit on the default branch
-   wails init -n myapp -t https://github.com/yourname/your-template
+   wails3 init -n myapp -t https://github.com/yourname/your-template
 
    # Pinned to a specific release tag
-   wails init -n myapp -t https://github.com/yourname/your-template@v1.0.0
+   wails3 init -n myapp -t https://github.com/yourname/your-template@v1.0.0
    ```
 
 ---
@@ -117,6 +117,6 @@ As a template author you are responsible for:
 
 ## Further Reading
 
-- [Creating Custom Templates](https://v3.wails.io/guides/custom-templates)
+- [Creating Custom Templates](https://v3.wails.io/guides/advanced/custom-templates)
 - [Template JSON Schema](https://v3.wails.io/reference/template-json)
 - [Wails Init Reference](https://v3.wails.io/reference/cli#init)

--- a/v3/internal/templates/base/NEXTSTEPS.md
+++ b/v3/internal/templates/base/NEXTSTEPS.md
@@ -1,3 +1,122 @@
-# Next Steps
+# Wails Template — Next Steps
 
-For a full guide on how to create templates, see [Creating Custom Templates](https://v3.wails.io/guides/custom-templates).
+Your template skeleton has been generated. This document explains what was created,
+how to customise it, and how to publish it so others can use it.
+
+---
+
+## What Was Generated
+
+```
+<template-name>/
+├── template.json          # Template metadata (name, author, description, etc.)
+├── NEXTSTEPS.md           # This file — delete it before publishing
+├── README.md              # Shown to users after they create a project
+├── main.go.tmpl           # Application entry point (template variables expanded at init time)
+├── greetservice.go        # Example Go service bound to the frontend
+├── go.mod.tmpl            # Go module file
+├── go.sum.tmpl            # Go module checksums
+├── gitignore.tmpl         # Becomes .gitignore in the generated project
+├── Taskfile.tmpl.yml      # Build task definitions
+└── frontend/              # Your frontend code goes here
+```
+
+> **Note:** Files ending in `.tmpl` are processed by the template engine when a user
+> runs `wails init`. Template variables (e.g. `{{.ProjectName}}`) are replaced with
+> the values the user supplies. Files without `.tmpl` are copied verbatim.
+
+---
+
+## Template Variables
+
+The following variables are available inside `.tmpl` files:
+
+| Variable            | Description                                      |
+|---------------------|--------------------------------------------------|
+| `{{.ProjectName}}`  | The project name supplied by the user (`-n`)     |
+| `{{.ModulePath}}`   | The Go module path (`-mod` or derived from `-git`) |
+| `{{.WailsVersion}}` | The Wails version used to initialise the project |
+| `{{.ProductName}}`  | Product display name                             |
+| `{{.ProductDescription}}` | Product description                        |
+| `{{.ProductVersion}}` | Product version string                         |
+| `{{.ProductCompany}}` | Company / author name                          |
+| `{{.ProductIdentifier}}` | Reverse-DNS product identifier              |
+| `{{.ProductCopyright}}` | Copyright string                             |
+| `{{.Typescript}}`   | `true` if the template name ends in `-ts`        |
+| `{{.Opn}}`          | Literal `{{` — use inside templates to avoid parsing errors |
+| `{{.Cls}}`          | Literal `}}` — use inside templates to avoid parsing errors |
+
+---
+
+## Customising Your Template
+
+1. **Edit `template.json`** — update the `name`, `shortname`, `author`, `description`,
+   and `helpurl` fields. The `schema` field must remain `3`.
+
+2. **Replace `frontend/`** — drop in your framework of choice (Vite, React, Vue, Svelte,
+   etc.). The frontend directory is copied verbatim; add `.tmpl` to any file you want
+   to have template variables expanded.
+
+3. **Modify `main.go.tmpl`** — adjust the application setup, window options, and
+   bound services to match your template's needs.
+
+4. **Update `README.md`** — this file is shown to users after they create a project
+   from your template. Make it helpful.
+
+5. **Delete `NEXTSTEPS.md`** — this file is only for you. Remove it before publishing
+   so it does not appear in projects users create from your template.
+
+---
+
+## Build Assets
+
+Build assets (platform-specific icons, manifests, signing configs) are **generated
+automatically** by `wails init` after your template is applied. You do not need to
+include a `build/` directory in your template.
+
+If you want to ship custom build assets (e.g. a specific app icon), add a `build/`
+directory to your template. Note that the auto-generated assets will be written on
+top of whatever your template provides, so place only files that are not auto-generated.
+
+---
+
+## Publishing on GitHub
+
+1. Commit your template directory as the root of a public GitHub repository.
+   Your repository must contain `template.json` at the top level.
+
+2. Tag a release:
+   ```sh
+   git tag v1.0.0
+   git push origin v1.0.0
+   ```
+
+3. Users can now create projects from your template:
+   ```sh
+   # Latest commit on the default branch
+   wails init -n myapp -t https://github.com/yourname/your-template
+
+   # Pinned to a specific release tag
+   wails init -n myapp -t https://github.com/yourname/your-template@v1.0.0
+   ```
+
+---
+
+## Third-Party Template Disclaimer
+
+When a user installs a remote template, Wails displays a warning explaining that the
+template is third-party code and that the Wails project takes no responsibility for
+its contents. Users must explicitly confirm before the project is created.
+
+As a template author you are responsible for:
+- The security and correctness of all code in your template
+- Keeping your template up to date with new Wails versions
+- Providing clear documentation (`README.md`, `helpurl` in `template.json`)
+
+---
+
+## Further Reading
+
+- [Creating Custom Templates](https://v3.wails.io/guides/custom-templates)
+- [Template JSON Schema](https://v3.wails.io/reference/template-json)
+- [Wails Init Reference](https://v3.wails.io/reference/cli#init)

--- a/v3/internal/templates/base/NEXTSTEPS.md
+++ b/v3/internal/templates/base/NEXTSTEPS.md
@@ -7,7 +7,7 @@ how to customise it, and how to publish it so others can use it.
 
 ## What Was Generated
 
-```
+```text
 <template-name>/
 ├── template.json          # Template metadata (name, author, description, etc.)
 ├── NEXTSTEPS.md           # This file — delete it before publishing

--- a/v3/internal/templates/base/NEXTSTEPS.md
+++ b/v3/internal/templates/base/NEXTSTEPS.md
@@ -83,7 +83,7 @@ top of whatever your template provides, so place only files that are not auto-ge
 ## Publishing on GitHub
 
 1. Commit your template directory as the root of a public GitHub repository.
-   Your repository must contain `template.json` at the top level.
+   Your repository must contain `template.yaml` at the top level.
 
 2. Tag a release:
    ```sh
@@ -118,5 +118,5 @@ As a template author you are responsible for:
 ## Further Reading
 
 - [Creating Custom Templates](https://v3.wails.io/guides/advanced/custom-templates)
-- [Template JSON Schema](https://v3.wails.io/reference/template-json)
+- [Template Schema](https://v3.wails.io/reference/template-json)
 - [Wails Init Reference](https://v3.wails.io/reference/cli#init)

--- a/v3/internal/templates/ios/template.json
+++ b/v3/internal/templates/ios/template.json
@@ -1,9 +1,0 @@
-{
-  "name": "iOS Vanilla (Puppertino) + Vite",
-  "shortname": "ios",
-  "author": "Lea Anthony",
-  "description": "Vanilla + Vite with iOS-friendly styling and bundled Puppertino",
-  "helpurl": "https://wails.io",
-  "version": "v0.0.1",
-  "schema": 3
-}

--- a/v3/internal/templates/ios/template.yaml
+++ b/v3/internal/templates/ios/template.yaml
@@ -1,0 +1,7 @@
+name: "iOS Vanilla (Puppertino) + Vite"
+shortname: ios
+author: Lea Anthony
+description: "Vanilla + Vite with iOS-friendly styling and bundled Puppertino"
+helpurl: https://wails.io
+version: v0.0.1
+wailsVersion: 3

--- a/v3/internal/templates/ios/template.yaml
+++ b/v3/internal/templates/ios/template.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://v3.wails.io/schemas/template.v3.json
 name: "iOS Vanilla (Puppertino) + Vite"
 shortname: ios
 author: Lea Anthony

--- a/v3/internal/templates/lit-ts/template.json
+++ b/v3/internal/templates/lit-ts/template.json
@@ -1,9 +1,0 @@
-{
-  "name": "Lit + Vite (Typescript)",
-  "shortname": "lit-ts",
-  "author": "Lea Anthony",
-  "description": "Lit + TS + Vite development server",
-  "helpurl": "https://wails.io",
-  "version": "v0.0.1",
-  "schema": 3
-}

--- a/v3/internal/templates/lit-ts/template.yaml
+++ b/v3/internal/templates/lit-ts/template.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://v3.wails.io/schemas/template.v3.json
 name: "Lit + Vite (Typescript)"
 shortname: lit-ts
 author: Lea Anthony

--- a/v3/internal/templates/lit-ts/template.yaml
+++ b/v3/internal/templates/lit-ts/template.yaml
@@ -1,0 +1,7 @@
+name: "Lit + Vite (Typescript)"
+shortname: lit-ts
+author: Lea Anthony
+description: "Lit + TS + Vite development server"
+helpurl: https://wails.io
+version: v0.0.1
+wailsVersion: 3

--- a/v3/internal/templates/lit/template.json
+++ b/v3/internal/templates/lit/template.json
@@ -1,9 +1,0 @@
-{
-  "name": "Lit + Vite",
-  "shortname": "lit",
-  "author": "Lea Anthony",
-  "description": "Lit + Vite development server",
-  "helpurl": "https://wails.io",
-  "version": "v0.0.1",
-  "schema": 3
-}

--- a/v3/internal/templates/lit/template.yaml
+++ b/v3/internal/templates/lit/template.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://v3.wails.io/schemas/template.v3.json
 name: "Lit + Vite"
 shortname: lit
 author: Lea Anthony

--- a/v3/internal/templates/lit/template.yaml
+++ b/v3/internal/templates/lit/template.yaml
@@ -1,0 +1,7 @@
+name: "Lit + Vite"
+shortname: lit
+author: Lea Anthony
+description: "Lit + Vite development server"
+helpurl: https://wails.io
+version: v0.0.1
+wailsVersion: 3

--- a/v3/internal/templates/preact-ts/template.json
+++ b/v3/internal/templates/preact-ts/template.json
@@ -1,9 +1,0 @@
-{
-  "name": "Preact + Vite (Typescript)",
-  "shortname": "preact-ts",
-  "author": "Lea Anthony",
-  "description": "Preact + TS + Vite development server",
-  "helpurl": "https://wails.io",
-  "version": "v0.0.1",
-  "schema": 3
-}

--- a/v3/internal/templates/preact-ts/template.yaml
+++ b/v3/internal/templates/preact-ts/template.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://v3.wails.io/schemas/template.v3.json
 name: "Preact + Vite (Typescript)"
 shortname: preact-ts
 author: Lea Anthony

--- a/v3/internal/templates/preact-ts/template.yaml
+++ b/v3/internal/templates/preact-ts/template.yaml
@@ -1,0 +1,7 @@
+name: "Preact + Vite (Typescript)"
+shortname: preact-ts
+author: Lea Anthony
+description: "Preact + TS + Vite development server"
+helpurl: https://wails.io
+version: v0.0.1
+wailsVersion: 3

--- a/v3/internal/templates/preact/template.json
+++ b/v3/internal/templates/preact/template.json
@@ -1,9 +1,0 @@
-{
-  "name": "Preact + Vite",
-  "shortname": "preact",
-  "author": "Lea Anthony",
-  "description": "Preact + Vite development server",
-  "helpurl": "https://wails.io",
-  "version": "v0.0.1",
-  "schema": 3
-}

--- a/v3/internal/templates/preact/template.yaml
+++ b/v3/internal/templates/preact/template.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://v3.wails.io/schemas/template.v3.json
 name: "Preact + Vite"
 shortname: preact
 author: Lea Anthony

--- a/v3/internal/templates/preact/template.yaml
+++ b/v3/internal/templates/preact/template.yaml
@@ -1,0 +1,7 @@
+name: "Preact + Vite"
+shortname: preact
+author: Lea Anthony
+description: "Preact + Vite development server"
+helpurl: https://wails.io
+version: v0.0.1
+wailsVersion: 3

--- a/v3/internal/templates/qwik-ts/template.json
+++ b/v3/internal/templates/qwik-ts/template.json
@@ -1,9 +1,0 @@
-{
-  "name": "Qwik + TS + Vite",
-  "shortname": "qwik",
-  "author": "Lea Anthony",
-  "description": "Qwik + TS + Vite development server",
-  "helpurl": "https://wails.io",
-  "version": "v0.0.1",
-  "schema": 3
-}

--- a/v3/internal/templates/qwik-ts/template.yaml
+++ b/v3/internal/templates/qwik-ts/template.yaml
@@ -1,0 +1,7 @@
+name: "Qwik + TS + Vite"
+shortname: qwik
+author: Lea Anthony
+description: "Qwik + TS + Vite development server"
+helpurl: https://wails.io
+version: v0.0.1
+wailsVersion: 3

--- a/v3/internal/templates/qwik-ts/template.yaml
+++ b/v3/internal/templates/qwik-ts/template.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://v3.wails.io/schemas/template.v3.json
 name: "Qwik + TS + Vite"
 shortname: qwik
 author: Lea Anthony

--- a/v3/internal/templates/qwik/template.json
+++ b/v3/internal/templates/qwik/template.json
@@ -1,9 +1,0 @@
-{
-  "name": "Qwik + Vite",
-  "shortname": "qwik",
-  "author": "Lea Anthony",
-  "description": "Qwik + Vite development server",
-  "helpurl": "https://wails.io",
-  "version": "v0.0.1",
-  "schema": 3
-}

--- a/v3/internal/templates/qwik/template.yaml
+++ b/v3/internal/templates/qwik/template.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://v3.wails.io/schemas/template.v3.json
 name: "Qwik + Vite"
 shortname: qwik
 author: Lea Anthony

--- a/v3/internal/templates/qwik/template.yaml
+++ b/v3/internal/templates/qwik/template.yaml
@@ -1,0 +1,7 @@
+name: "Qwik + Vite"
+shortname: qwik
+author: Lea Anthony
+description: "Qwik + Vite development server"
+helpurl: https://wails.io
+version: v0.0.1
+wailsVersion: 3

--- a/v3/internal/templates/react-swc-ts/template.json
+++ b/v3/internal/templates/react-swc-ts/template.json
@@ -1,9 +1,0 @@
-{
-  "name": "React + SWC + Vite (Typescript)",
-  "shortname": "react-swc-ts",
-  "author": "Lea Anthony",
-  "description": "React + TS + SWC + Vite development server",
-  "helpurl": "https://wails.io",
-  "version": "v0.0.1",
-  "schema": 3
-}

--- a/v3/internal/templates/react-swc-ts/template.yaml
+++ b/v3/internal/templates/react-swc-ts/template.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://v3.wails.io/schemas/template.v3.json
 name: "React + SWC + Vite (Typescript)"
 shortname: react-swc-ts
 author: Lea Anthony

--- a/v3/internal/templates/react-swc-ts/template.yaml
+++ b/v3/internal/templates/react-swc-ts/template.yaml
@@ -1,0 +1,7 @@
+name: "React + SWC + Vite (Typescript)"
+shortname: react-swc-ts
+author: Lea Anthony
+description: "React + TS + SWC + Vite development server"
+helpurl: https://wails.io
+version: v0.0.1
+wailsVersion: 3

--- a/v3/internal/templates/react-swc/template.json
+++ b/v3/internal/templates/react-swc/template.json
@@ -1,9 +1,0 @@
-{
-  "name": "React + SWC + Vite",
-  "shortname": "react-swc",
-  "author": "Lea Anthony",
-  "description": "React + SWC + Vite development server",
-  "helpurl": "https://wails.io",
-  "version": "v0.0.1",
-  "schema": 3
-}

--- a/v3/internal/templates/react-swc/template.yaml
+++ b/v3/internal/templates/react-swc/template.yaml
@@ -1,0 +1,7 @@
+name: "React + SWC + Vite"
+shortname: react-swc
+author: Lea Anthony
+description: "React + SWC + Vite development server"
+helpurl: https://wails.io
+version: v0.0.1
+wailsVersion: 3

--- a/v3/internal/templates/react-swc/template.yaml
+++ b/v3/internal/templates/react-swc/template.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://v3.wails.io/schemas/template.v3.json
 name: "React + SWC + Vite"
 shortname: react-swc
 author: Lea Anthony

--- a/v3/internal/templates/react-ts/template.json
+++ b/v3/internal/templates/react-ts/template.json
@@ -1,9 +1,0 @@
-{
-  "name": "React + Vite (Typescript)",
-  "shortname": "react-ts",
-  "author": "Lea Anthony",
-  "description": "React + Vite development server",
-  "helpurl": "https://wails.io",
-  "version": "v0.0.1",
-  "schema": 3
-}

--- a/v3/internal/templates/react-ts/template.yaml
+++ b/v3/internal/templates/react-ts/template.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://v3.wails.io/schemas/template.v3.json
 name: "React + Vite (Typescript)"
 shortname: react-ts
 author: Lea Anthony

--- a/v3/internal/templates/react-ts/template.yaml
+++ b/v3/internal/templates/react-ts/template.yaml
@@ -1,0 +1,7 @@
+name: "React + Vite (Typescript)"
+shortname: react-ts
+author: Lea Anthony
+description: "React + Vite development server"
+helpurl: https://wails.io
+version: v0.0.1
+wailsVersion: 3

--- a/v3/internal/templates/react/template.json
+++ b/v3/internal/templates/react/template.json
@@ -1,9 +1,0 @@
-{
-  "name": "React + Vite",
-  "shortname": "react",
-  "author": "Lea Anthony",
-  "description": "React + Vite development server",
-  "helpurl": "https://wails.io",
-  "version": "v0.0.1",
-  "schema": 3
-}

--- a/v3/internal/templates/react/template.yaml
+++ b/v3/internal/templates/react/template.yaml
@@ -1,0 +1,7 @@
+name: "React + Vite"
+shortname: react
+author: Lea Anthony
+description: "React + Vite development server"
+helpurl: https://wails.io
+version: v0.0.1
+wailsVersion: 3

--- a/v3/internal/templates/react/template.yaml
+++ b/v3/internal/templates/react/template.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://v3.wails.io/schemas/template.v3.json
 name: "React + Vite"
 shortname: react
 author: Lea Anthony

--- a/v3/internal/templates/solid-ts/template.json
+++ b/v3/internal/templates/solid-ts/template.json
@@ -1,9 +1,0 @@
-{
-  "name": "Solid + Vite (Typescript)",
-  "shortname": "solid-ts",
-  "author": "Lea Anthony",
-  "description": "Solid + TS + Vite development server",
-  "helpurl": "https://wails.io",
-  "version": "v0.0.1",
-  "schema": 3
-}

--- a/v3/internal/templates/solid-ts/template.yaml
+++ b/v3/internal/templates/solid-ts/template.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://v3.wails.io/schemas/template.v3.json
 name: "Solid + Vite (Typescript)"
 shortname: solid-ts
 author: Lea Anthony

--- a/v3/internal/templates/solid-ts/template.yaml
+++ b/v3/internal/templates/solid-ts/template.yaml
@@ -1,0 +1,7 @@
+name: "Solid + Vite (Typescript)"
+shortname: solid-ts
+author: Lea Anthony
+description: "Solid + TS + Vite development server"
+helpurl: https://wails.io
+version: v0.0.1
+wailsVersion: 3

--- a/v3/internal/templates/solid/template.json
+++ b/v3/internal/templates/solid/template.json
@@ -1,9 +1,0 @@
-{
-  "name": "Solid + Vite",
-  "shortname": "solid",
-  "author": "Lea Anthony",
-  "description": "Solid + Vite development server",
-  "helpurl": "https://wails.io",
-  "version": "v0.0.1",
-  "schema": 3
-}

--- a/v3/internal/templates/solid/template.yaml
+++ b/v3/internal/templates/solid/template.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://v3.wails.io/schemas/template.v3.json
 name: "Solid + Vite"
 shortname: solid
 author: Lea Anthony

--- a/v3/internal/templates/solid/template.yaml
+++ b/v3/internal/templates/solid/template.yaml
@@ -1,0 +1,7 @@
+name: "Solid + Vite"
+shortname: solid
+author: Lea Anthony
+description: "Solid + Vite development server"
+helpurl: https://wails.io
+version: v0.0.1
+wailsVersion: 3

--- a/v3/internal/templates/svelte-ts/template.json
+++ b/v3/internal/templates/svelte-ts/template.json
@@ -1,9 +1,0 @@
-{
-  "name": "Svelte + Vite (Typescript)",
-  "shortname": "svelte-ts",
-  "author": "Lea Anthony",
-  "description": "Svelte + TS + Vite development server",
-  "helpurl": "https://wails.io",
-  "version": "v0.0.1",
-  "schema": 3
-}

--- a/v3/internal/templates/svelte-ts/template.yaml
+++ b/v3/internal/templates/svelte-ts/template.yaml
@@ -1,0 +1,7 @@
+name: "Svelte + Vite (Typescript)"
+shortname: svelte-ts
+author: Lea Anthony
+description: "Svelte + TS + Vite development server"
+helpurl: https://wails.io
+version: v0.0.1
+wailsVersion: 3

--- a/v3/internal/templates/svelte-ts/template.yaml
+++ b/v3/internal/templates/svelte-ts/template.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://v3.wails.io/schemas/template.v3.json
 name: "Svelte + Vite (Typescript)"
 shortname: svelte-ts
 author: Lea Anthony

--- a/v3/internal/templates/svelte/template.json
+++ b/v3/internal/templates/svelte/template.json
@@ -1,9 +1,0 @@
-{
-  "name": "Svelte + Vite",
-  "shortname": "svelte",
-  "author": "Lea Anthony",
-  "description": "Svelte + Vite development server",
-  "helpurl": "https://wails.io",
-  "version": "v0.0.1",
-  "schema": 3
-}

--- a/v3/internal/templates/svelte/template.yaml
+++ b/v3/internal/templates/svelte/template.yaml
@@ -1,0 +1,7 @@
+name: "Svelte + Vite"
+shortname: svelte
+author: Lea Anthony
+description: "Svelte + Vite development server"
+helpurl: https://wails.io
+version: v0.0.1
+wailsVersion: 3

--- a/v3/internal/templates/svelte/template.yaml
+++ b/v3/internal/templates/svelte/template.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://v3.wails.io/schemas/template.v3.json
 name: "Svelte + Vite"
 shortname: svelte
 author: Lea Anthony

--- a/v3/internal/templates/sveltekit-ts/template.json
+++ b/v3/internal/templates/sveltekit-ts/template.json
@@ -1,9 +1,0 @@
-{
-  "name": "SvelteKit Typescript + Vite",
-  "shortname": "sveltekit-ts",
-  "author": "Atterpac",
-  "description": "SvelteKit + TS + Vite development server",
-  "helpurl": "https://wails.io",
-  "version": "v0.0.1",
-  "schema": 3
-}

--- a/v3/internal/templates/sveltekit-ts/template.yaml
+++ b/v3/internal/templates/sveltekit-ts/template.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://v3.wails.io/schemas/template.v3.json
 name: "SvelteKit Typescript + Vite"
 shortname: sveltekit-ts
 author: Atterpac

--- a/v3/internal/templates/sveltekit-ts/template.yaml
+++ b/v3/internal/templates/sveltekit-ts/template.yaml
@@ -1,0 +1,7 @@
+name: "SvelteKit Typescript + Vite"
+shortname: sveltekit-ts
+author: Atterpac
+description: "SvelteKit + TS + Vite development server"
+helpurl: https://wails.io
+version: v0.0.1
+wailsVersion: 3

--- a/v3/internal/templates/sveltekit/template.json
+++ b/v3/internal/templates/sveltekit/template.json
@@ -1,9 +1,0 @@
-{
-  "name": "SvelteKit Typescript + Vite",
-  "shortname": "svelte-ts",
-  "author": "Atterpac",
-  "description": "SvelteKit + Vite development server",
-  "helpurl": "https://wails.io",
-  "version": "v0.0.1",
-  "schema": 3
-}

--- a/v3/internal/templates/sveltekit/template.yaml
+++ b/v3/internal/templates/sveltekit/template.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://v3.wails.io/schemas/template.v3.json
 name: "SvelteKit Typescript + Vite"
 shortname: svelte-ts
 author: Atterpac

--- a/v3/internal/templates/sveltekit/template.yaml
+++ b/v3/internal/templates/sveltekit/template.yaml
@@ -1,0 +1,7 @@
+name: "SvelteKit Typescript + Vite"
+shortname: svelte-ts
+author: Atterpac
+description: "SvelteKit + Vite development server"
+helpurl: https://wails.io
+version: v0.0.1
+wailsVersion: 3

--- a/v3/internal/templates/templates.go
+++ b/v3/internal/templates/templates.go
@@ -541,11 +541,11 @@ func GenerateTemplate(options *BaseTemplate) error {
 	return nil
 }
 
-// stripUnsafe removes ANSI escape sequences and non-printable control characters
-// from untrusted strings before printing them to the terminal.
+// stripUnsafe removes all control characters from untrusted strings before
+// printing them to the terminal, preventing ANSI injection and multiline spoofing.
 func stripUnsafe(s string) string {
 	return strings.Map(func(r rune) rune {
-		if r == '\x1b' || (r < 0x20 && r != '\n' && r != '\t') || r == 0x7f {
+		if r < 0x20 || (r >= 0x7f && r <= 0x9f) {
 			return -1
 		}
 		return r

--- a/v3/internal/templates/templates.go
+++ b/v3/internal/templates/templates.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"runtime"
 	"strings"
 
 	"github.com/wailsapp/wails/v3/internal/buildinfo"
@@ -123,7 +122,6 @@ func getLocalTemplate(templateName string) (*Template, error) {
 
 	template, err = parseTemplate(os.DirFS(templateName), "")
 	if err != nil {
-		println("err2 = ", err.Error())
 		return nil, err
 	}
 	template.source = sourceLocal
@@ -182,7 +180,7 @@ func parseTemplate(template fs.FS, templateName string) (Template, error) {
 		return result, fmt.Errorf("template not supported by wails 3. This template is probably for wails 2")
 	}
 	if result.Schema != 3 {
-		return result, fmt.Errorf("template version %s is not supported by wails 3. Ensure 'version' is set to 3 in the `template.json` file", result.Version)
+		return result, fmt.Errorf("template schema %d is not supported by wails 3. Ensure 'schema' is set to 3 in the `template.json` file", result.Schema)
 	}
 
 	return result, nil
@@ -444,40 +442,56 @@ func GenerateTemplate(options *BaseTemplate) error {
 		return fmt.Errorf("please provide a template name using the -name flag")
 	}
 
-	// Get current directory
 	baseOutputDir, err := filepath.Abs(options.Dir)
 	if err != nil {
 		return err
 	}
 	outDir := filepath.Join(baseOutputDir, options.Name)
 
-	// Extract base files
-	_, filename, _, _ := runtime.Caller(0)
-	basePath := filepath.Join(filepath.Dir(filename), "_common")
-	s.COPYDIR2(basePath, outDir)
-	s.RMDIR(filepath.Join(outDir, "build"))
-
-	// Copy frontend
-	targetFrontendPath := filepath.Join(outDir, "frontend")
-	sourceFrontendPath := options.Frontend
-	if sourceFrontendPath == "" {
-		sourceFrontendPath = filepath.Join(filepath.Dir(filename), "base", "frontend")
+	if _, err := os.Stat(outDir); !os.IsNotExist(err) {
+		return fmt.Errorf("directory '%s' already exists", outDir)
 	}
-	s.COPYDIR2(sourceFrontendPath, targetFrontendPath)
 
-	// Copy files from relative directory ../commands/build_assets
-	// Get the path to THIS file
-	assetPath := filepath.Join(filepath.Dir(filename), "..", "commands", "build_assets")
-	assetdir := filepath.Join(outDir, "build")
+	// Copy the common files (Go backend, Taskfile, go.mod, etc.) verbatim.
+	// These files contain template variables like {{.ProjectName}} that must be
+	// preserved so they are expanded when users later run `wails init -t <template>`.
+	commonFS, err := fs.Sub(templates, "_common")
+	if err != nil {
+		return err
+	}
+	if err = os.CopyFS(outDir, commonFS); err != nil {
+		return err
+	}
 
-	s.COPYDIR2(assetPath, assetdir)
+	// Replace the placeholder frontend directory with the real frontend content.
+	frontendDir := filepath.Join(outDir, "frontend")
+	if err = os.RemoveAll(frontendDir); err != nil {
+		return err
+	}
+	if options.Frontend != "" {
+		if err = os.CopyFS(frontendDir, os.DirFS(options.Frontend)); err != nil {
+			return fmt.Errorf("failed to copy frontend from '%s': %w", options.Frontend, err)
+		}
+	} else {
+		baseFrontendFS, err := fs.Sub(templates, "base/frontend")
+		if err != nil {
+			return err
+		}
+		if err = os.CopyFS(frontendDir, baseFrontendFS); err != nil {
+			return err
+		}
+	}
 
-	// Copy the template NEXTSTEPS.md
-	s.COPY(filepath.Join(filepath.Dir(filename), "base", "NEXTSTEPS.md"), filepath.Join(outDir, "NEXTSTEPS.md"))
+	// Copy NEXTSTEPS.md from the embedded base directory.
+	nextstepsData, err := templates.ReadFile("base/NEXTSTEPS.md")
+	if err != nil {
+		return err
+	}
+	if err = os.WriteFile(filepath.Join(outDir, "NEXTSTEPS.md"), nextstepsData, 0644); err != nil {
+		return err
+	}
 
-	// Write the template.json file
-	templateJSON := filepath.Join(outDir, "template.json")
-	// Marshall
+	// Write template.json with the provided metadata.
 	optionsJSON, err := json.MarshalIndent(&Template{
 		BaseTemplate: *options,
 		Schema:       3,
@@ -485,22 +499,35 @@ func GenerateTemplate(options *BaseTemplate) error {
 	if err != nil {
 		return err
 	}
-	err = os.WriteFile(templateJSON, optionsJSON, 0o755)
-	if err != nil {
+	if err = os.WriteFile(filepath.Join(outDir, "template.json"), optionsJSON, 0644); err != nil {
 		return err
 	}
 
-	fmt.Printf("Successfully generated template in %s\n", outDir)
+	fmt.Printf("Template '%s' generated in %s\n", options.Name, outDir)
+	fmt.Printf("See NEXTSTEPS.md for guidance on customising and publishing your template.\n")
 	return nil
 }
 
 func confirmRemote(template *Template) bool {
-	pterm.Println(pterm.LightRed("\n--- REMOTE TEMPLATES ---"))
+	pterm.Println(pterm.LightRed("\n⚠  THIRD-PARTY TEMPLATE WARNING ⚠"))
+	pterm.Println()
+	pterm.Println(pterm.LightYellow("You are about to create a project from a remote template:"))
+	pterm.Printf("  Name:   %s\n", template.Name)
+	pterm.Printf("  Author: %s\n", template.Author)
+	if template.HelpURL != "" {
+		pterm.Printf("  URL:    %s\n", template.HelpURL)
+	}
+	pterm.Println()
+	pterm.Println(pterm.LightYellow("Remote templates are third-party code. The Wails project does not review,"))
+	pterm.Println(pterm.LightYellow("endorse, or accept any responsibility for their contents."))
+	pterm.Println(pterm.LightYellow("Only proceed if you trust the source of this template."))
+	pterm.Println()
 
-	// Create boxes with the title positioned differently and containing different content
-	pterm.Println(pterm.LightYellow("You are creating a project using a remote template.\nThe Wails project takes no responsibility for 3rd party templates.\nOnly use remote templates that you trust."))
-
-	result, _ := pterm.DefaultInteractiveConfirm.WithConfirmText("Are you sure you want to continue?").WithConfirmText("y").WithRejectText("n").Show()
+	result, _ := pterm.DefaultInteractiveConfirm.
+		WithDefaultText("Do you accept responsibility for using this third-party template?").
+		WithConfirmText("y").
+		WithRejectText("n").
+		Show()
 
 	return result
 }

--- a/v3/internal/templates/templates.go
+++ b/v3/internal/templates/templates.go
@@ -532,7 +532,8 @@ func GenerateTemplate(options *BaseTemplate) error {
 	if err != nil {
 		return err
 	}
-	if err = os.WriteFile(filepath.Join(outDir, "template.yaml"), optionsYAML, 0644); err != nil {
+	const modeline = "# yaml-language-server: $schema=https://v3.wails.io/schemas/template.v3.json\n"
+	if err = os.WriteFile(filepath.Join(outDir, "template.yaml"), append([]byte(modeline), optionsYAML...), 0644); err != nil {
 		return err
 	}
 

--- a/v3/internal/templates/templates.go
+++ b/v3/internal/templates/templates.go
@@ -13,6 +13,7 @@ import (
 	"github.com/wailsapp/wails/v3/internal/buildinfo"
 	"github.com/wailsapp/wails/v3/internal/s"
 	"github.com/wailsapp/wails/v3/internal/version"
+	"gopkg.in/yaml.v3"
 
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing"
@@ -130,14 +131,15 @@ func getLocalTemplate(templateName string) (*Template, error) {
 }
 
 type BaseTemplate struct {
-	Name        string `json:"name" description:"The name of the template"`
-	ShortName   string `json:"shortname" description:"The short name of the template"`
-	Author      string `json:"author" description:"The author of the template"`
-	Description string `json:"description" description:"The template description"`
-	HelpURL     string `json:"helpurl" description:"The help url for the template"`
-	Version     string `json:"version" description:"The version of the template" default:"v0.0.1"`
-	Dir         string `json:"-" description:"The directory to generate the template" default:"."`
-	Frontend    string `json:"-" description:"The frontend directory to migrate"`
+	Name         string `json:"name"         yaml:"name"         description:"The name of the template"`
+	ShortName    string `json:"shortname"    yaml:"shortname"    description:"The short name of the template"`
+	Author       string `json:"author"       yaml:"author"       description:"The author of the template"`
+	Description  string `json:"description"  yaml:"description"  description:"The template description"`
+	HelpURL      string `json:"helpurl"      yaml:"helpurl"      description:"The help url for the template"`
+	Version      string `json:"version"      yaml:"version"      description:"The version of the template" default:"v0.0.1"`
+	WailsVersion uint8  `json:"wailsVersion" yaml:"wailsVersion" description:"The Wails major version this template targets"`
+	Dir          string `json:"-"            yaml:"-"            description:"The directory to generate the template" default:"."`
+	Frontend     string `json:"-"            yaml:"-"            description:"The frontend directory to migrate"`
 }
 
 type source int
@@ -150,37 +152,65 @@ const (
 
 // Template holds data relating to a template including the metadata stored in template.yaml
 type Template struct {
-	BaseTemplate
-	Schema uint8 `json:"schema"`
+	BaseTemplate `yaml:",inline"`
+	// Schema is kept for backwards-compatible reading of legacy template.json files.
+	// New templates use template.yaml with WailsVersion instead.
+	Schema uint8 `json:"schema" yaml:"-"`
 
 	// Other data
-	FS      fs.FS `json:"-"`
+	FS      fs.FS `json:"-" yaml:"-"`
 	source  source
 	tempDir string
 }
 
-func parseTemplate(template fs.FS, templateName string) (Template, error) {
+// parseTemplate loads and validates a template's metadata.
+//
+// It first looks for template.yaml (the v3 native format). If found, wailsVersion
+// must be present and equal to 3. If only template.json exists (legacy format),
+// schema must be 3 for a v3 template; schema 0 means the template is for Wails v2.
+func parseTemplate(templateFS fs.FS, templateName string) (Template, error) {
 	var result Template
-	jsonFile := "template.json"
-	if templateName != "" {
-		jsonFile = templateName + "/template.json"
-	}
-	data, err := fs.ReadFile(template, jsonFile)
-	if err != nil {
-		return result, errors.Wrap(err, "Error parsing template")
-	}
-	err = json.Unmarshal(data, &result)
-	if err != nil {
-		return result, err
-	}
-	result.FS = template
 
-	// We need to do a version check here
+	prefix := ""
+	if templateName != "" {
+		prefix = templateName + "/"
+	}
+
+	// --- YAML path: preferred v3 format ---
+	yamlData, yamlErr := fs.ReadFile(templateFS, prefix+"template.yaml")
+	if yamlErr == nil {
+		if err := yaml.Unmarshal(yamlData, &result); err != nil {
+			return result, fmt.Errorf("error parsing template.yaml: %w", err)
+		}
+		result.FS = templateFS
+		if result.WailsVersion == 0 {
+			return result, fmt.Errorf("template.yaml must specify 'wailsVersion' (e.g. wailsVersion: 3)")
+		}
+		if result.WailsVersion != 3 {
+			return result, fmt.Errorf("template targets Wails v%d and is not compatible with this version of Wails", result.WailsVersion)
+		}
+		return result, nil
+	}
+
+	// --- JSON path: legacy / backwards-compat ---
+	jsonData, jsonErr := fs.ReadFile(templateFS, prefix+"template.json")
+	if jsonErr != nil {
+		if errors.Is(yamlErr, fs.ErrNotExist) {
+			return result, fmt.Errorf("no template.yaml or template.json found in template")
+		}
+		return result, errors.Wrap(jsonErr, "error reading template.json")
+	}
+
+	if err := json.Unmarshal(jsonData, &result); err != nil {
+		return result, fmt.Errorf("error parsing template.json: %w", err)
+	}
+	result.FS = templateFS
+
 	if result.Schema == 0 {
-		return result, fmt.Errorf("template not supported by wails 3. This template is probably for wails 2")
+		return result, fmt.Errorf("template not supported by Wails v3: no schema or wailsVersion found. This template is probably for Wails v2")
 	}
 	if result.Schema != 3 {
-		return result, fmt.Errorf("template schema %d is not supported by wails 3. Ensure 'schema' is set to 3 in the `template.json` file", result.Schema)
+		return result, fmt.Errorf("template schema %d is not supported by Wails v3. Ensure 'schema' is set to 3 in template.json", result.Schema)
 	}
 
 	return result, nil
@@ -210,25 +240,25 @@ func gitclone(uri string) (string, error) {
 }
 
 func getRemoteTemplate(uri string) (*Template, error) {
-	// git clone to temporary dir
-	var tempDir string
 	tempDir, err := gitclone(uri)
-
-	if err != nil {
-		return nil, err
-	}
-	// Remove the .git directory
-	err = os.RemoveAll(filepath.Join(tempDir, ".git"))
 	if err != nil {
 		return nil, err
 	}
 
-	templateFS := os.DirFS(tempDir)
-	var parsedTemplate Template
-	parsedTemplate, err = parseTemplate(templateFS, "")
-	if err != nil {
+	// cleanup is called on any error path so the temp dir is never leaked.
+	cleanup := func() { os.RemoveAll(tempDir) }
+
+	if err = os.RemoveAll(filepath.Join(tempDir, ".git")); err != nil {
+		cleanup()
 		return nil, err
 	}
+
+	parsedTemplate, err := parseTemplate(os.DirFS(tempDir), "")
+	if err != nil {
+		cleanup()
+		return nil, err
+	}
+
 	parsedTemplate.tempDir = tempDir
 	parsedTemplate.source = sourceRemote
 	return &parsedTemplate, nil
@@ -282,7 +312,9 @@ func Install(options *flags.Init) error {
 	}
 
 	defer func() {
-		// if `template.json` exists, remove it
+		// Remove template metadata files from the generated project — they are
+		// for the template system only, not part of the user's project.
+		_ = os.Remove(filepath.Join(templateData.ProjectDir, "template.yaml"))
 		_ = os.Remove(filepath.Join(templateData.ProjectDir, "template.json"))
 	}()
 
@@ -493,15 +525,14 @@ func GenerateTemplate(options *BaseTemplate) error {
 		return err
 	}
 
-	// Write template.json with the provided metadata.
-	optionsJSON, err := json.MarshalIndent(&Template{
-		BaseTemplate: *options,
-		Schema:       3,
-	}, "", "  ")
+	// Write template.yaml with the provided metadata.
+	// wailsVersion is mandatory in the YAML format and set to 3.
+	options.WailsVersion = 3
+	optionsYAML, err := yaml.Marshal(&options)
 	if err != nil {
 		return err
 	}
-	if err = os.WriteFile(filepath.Join(outDir, "template.json"), optionsJSON, 0644); err != nil {
+	if err = os.WriteFile(filepath.Join(outDir, "template.yaml"), optionsYAML, 0644); err != nil {
 		return err
 	}
 

--- a/v3/internal/templates/templates.go
+++ b/v3/internal/templates/templates.go
@@ -510,14 +510,25 @@ func GenerateTemplate(options *BaseTemplate) error {
 	return nil
 }
 
+// stripUnsafe removes ANSI escape sequences and non-printable control characters
+// from untrusted strings before printing them to the terminal.
+func stripUnsafe(s string) string {
+	return strings.Map(func(r rune) rune {
+		if r == '\x1b' || (r < 0x20 && r != '\n' && r != '\t') || r == 0x7f {
+			return -1
+		}
+		return r
+	}, s)
+}
+
 func confirmRemote(template *Template) bool {
 	pterm.Println(pterm.LightRed("\n⚠  THIRD-PARTY TEMPLATE WARNING ⚠"))
 	pterm.Println()
 	pterm.Println(pterm.LightYellow("You are about to create a project from a remote template:"))
-	pterm.Printf("  Name:   %s\n", template.Name)
-	pterm.Printf("  Author: %s\n", template.Author)
+	pterm.Printf("  Name:   %s\n", stripUnsafe(template.Name))
+	pterm.Printf("  Author: %s\n", stripUnsafe(template.Author))
 	if template.HelpURL != "" {
-		pterm.Printf("  URL:    %s\n", template.HelpURL)
+		pterm.Printf("  URL:    %s\n", stripUnsafe(template.HelpURL))
 	}
 	pterm.Println()
 	pterm.Println(pterm.LightYellow("Remote templates are third-party code. The Wails project does not review,"))

--- a/v3/internal/templates/templates.go
+++ b/v3/internal/templates/templates.go
@@ -448,8 +448,10 @@ func GenerateTemplate(options *BaseTemplate) error {
 	}
 	outDir := filepath.Join(baseOutputDir, options.Name)
 
-	if _, err := os.Stat(outDir); !os.IsNotExist(err) {
+	if _, err := os.Stat(outDir); err == nil {
 		return fmt.Errorf("directory '%s' already exists", outDir)
+	} else if !os.IsNotExist(err) {
+		return err
 	}
 
 	// Copy the common files (Go backend, Taskfile, go.mod, etc.) verbatim.

--- a/v3/internal/templates/templates_test.go
+++ b/v3/internal/templates/templates_test.go
@@ -1,0 +1,282 @@
+package templates
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"testing/fstest"
+)
+
+// --- parseTemplate ---
+
+func TestParseTemplate_YAML_Valid(t *testing.T) {
+	fsys := fstest.MapFS{
+		"template.yaml": &fstest.MapFile{
+			Data: []byte("name: Test\nshortname: test\nauthor: Me\ndescription: A test\nhelpurl: https://example.com\nversion: v1.0.0\nwailsVersion: 3\n"),
+		},
+	}
+	tmpl, err := parseTemplate(fsys, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if tmpl.Name != "Test" {
+		t.Errorf("Name = %q, want %q", tmpl.Name, "Test")
+	}
+	if tmpl.WailsVersion != 3 {
+		t.Errorf("WailsVersion = %d, want 3", tmpl.WailsVersion)
+	}
+}
+
+func TestParseTemplate_YAML_MissingWailsVersion(t *testing.T) {
+	fsys := fstest.MapFS{
+		"template.yaml": &fstest.MapFile{
+			Data: []byte("name: Test\nshortname: test\nauthor: Me\ndescription: A test\n"),
+		},
+	}
+	_, err := parseTemplate(fsys, "")
+	if err == nil {
+		t.Fatal("expected error for missing wailsVersion, got nil")
+	}
+}
+
+func TestParseTemplate_YAML_WrongWailsVersion(t *testing.T) {
+	fsys := fstest.MapFS{
+		"template.yaml": &fstest.MapFile{
+			Data: []byte("name: Test\nwailsVersion: 2\n"),
+		},
+	}
+	_, err := parseTemplate(fsys, "")
+	if err == nil {
+		t.Fatal("expected error for wailsVersion 2, got nil")
+	}
+}
+
+func TestParseTemplate_JSON_Schema3_BackwardsCompat(t *testing.T) {
+	fsys := fstest.MapFS{
+		"template.json": &fstest.MapFile{
+			Data: []byte(`{"name":"Old","shortname":"old","author":"Me","description":"Old v3","version":"v0.0.1","schema":3}`),
+		},
+	}
+	tmpl, err := parseTemplate(fsys, "")
+	if err != nil {
+		t.Fatalf("unexpected error for legacy schema:3 template: %v", err)
+	}
+	if tmpl.Name != "Old" {
+		t.Errorf("Name = %q, want %q", tmpl.Name, "Old")
+	}
+}
+
+func TestParseTemplate_JSON_NoSchema_V2Error(t *testing.T) {
+	fsys := fstest.MapFS{
+		"template.json": &fstest.MapFile{
+			Data: []byte(`{"name":"OldV2","shortname":"oldv2","author":"Me","description":"A v2 template"}`),
+		},
+	}
+	_, err := parseTemplate(fsys, "")
+	if err == nil {
+		t.Fatal("expected error for v2 template (no schema), got nil")
+	}
+}
+
+func TestParseTemplate_JSON_WrongSchema_Error(t *testing.T) {
+	fsys := fstest.MapFS{
+		"template.json": &fstest.MapFile{
+			Data: []byte(`{"name":"Bad","schema":99}`),
+		},
+	}
+	_, err := parseTemplate(fsys, "")
+	if err == nil {
+		t.Fatal("expected error for unsupported schema, got nil")
+	}
+}
+
+func TestParseTemplate_NoFiles_Error(t *testing.T) {
+	fsys := fstest.MapFS{}
+	_, err := parseTemplate(fsys, "")
+	if err == nil {
+		t.Fatal("expected error when neither template.yaml nor template.json exist, got nil")
+	}
+}
+
+// YAML takes precedence over JSON when both exist.
+func TestParseTemplate_YAML_TakesPrecedenceOverJSON(t *testing.T) {
+	fsys := fstest.MapFS{
+		"template.yaml": &fstest.MapFile{
+			Data: []byte("name: FromYAML\nwailsVersion: 3\n"),
+		},
+		"template.json": &fstest.MapFile{
+			// This JSON has no schema — would error if parsed.
+			Data: []byte(`{"name":"FromJSON"}`),
+		},
+	}
+	tmpl, err := parseTemplate(fsys, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if tmpl.Name != "FromYAML" {
+		t.Errorf("Name = %q, want %q (YAML should take precedence)", tmpl.Name, "FromYAML")
+	}
+}
+
+// parseTemplate should work with a subdirectory name (built-in template path).
+func TestParseTemplate_WithSubdirPrefix(t *testing.T) {
+	fsys := fstest.MapFS{
+		"mytemplate/template.yaml": &fstest.MapFile{
+			Data: []byte("name: Sub\nwailsVersion: 3\n"),
+		},
+	}
+	tmpl, err := parseTemplate(fsys, "mytemplate")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if tmpl.Name != "Sub" {
+		t.Errorf("Name = %q, want %q", tmpl.Name, "Sub")
+	}
+}
+
+// --- stripUnsafe ---
+
+func TestStripUnsafe_RemovesESC(t *testing.T) {
+	input := "normal\x1b[31mred\x1b[0m text"
+	got := stripUnsafe(input)
+	want := "normal[31mred[0m text"
+	if got != want {
+		t.Errorf("stripUnsafe(%q) = %q, want %q", input, got, want)
+	}
+}
+
+func TestStripUnsafe_RemovesControlChars(t *testing.T) {
+	input := "abc\x00\x01\x02def"
+	got := stripUnsafe(input)
+	want := "abcdef"
+	if got != want {
+		t.Errorf("stripUnsafe(%q) = %q, want %q", input, got, want)
+	}
+}
+
+func TestStripUnsafe_PreservesNewlineAndTab(t *testing.T) {
+	input := "line1\nline2\ttabbed"
+	got := stripUnsafe(input)
+	if got != input {
+		t.Errorf("stripUnsafe(%q) = %q, want original preserved", input, got)
+	}
+}
+
+func TestStripUnsafe_RemovesDEL(t *testing.T) {
+	input := "abc\x7fdef"
+	got := stripUnsafe(input)
+	want := "abcdef"
+	if got != want {
+		t.Errorf("stripUnsafe(%q) = %q, want %q", input, got, want)
+	}
+}
+
+func TestStripUnsafe_CleanString_Unchanged(t *testing.T) {
+	input := "A perfectly normal template name"
+	got := stripUnsafe(input)
+	if got != input {
+		t.Errorf("stripUnsafe modified clean string: got %q", got)
+	}
+}
+
+// --- GenerateTemplate ---
+
+func TestGenerateTemplate_CreatesExpectedFiles(t *testing.T) {
+	dir := t.TempDir()
+	opts := &BaseTemplate{
+		Name:    "MyTemplate",
+		Author:  "Test Author",
+		Version: "v1.0.0",
+		Dir:     dir,
+	}
+
+	if err := GenerateTemplate(opts); err != nil {
+		t.Fatalf("GenerateTemplate error: %v", err)
+	}
+
+	outDir := filepath.Join(dir, "MyTemplate")
+
+	mustExist := []string{
+		"template.yaml",
+		"NEXTSTEPS.md",
+		"main.go.tmpl",
+		"go.mod.tmpl",
+		"greetservice.go",
+		"Taskfile.tmpl.yml",
+		"gitignore.tmpl",
+		filepath.Join("frontend", "index.html"),
+	}
+	for _, f := range mustExist {
+		path := filepath.Join(outDir, f)
+		if _, err := os.Stat(path); err != nil {
+			t.Errorf("expected file %s to exist: %v", f, err)
+		}
+	}
+}
+
+func TestGenerateTemplate_TemplateYAMLContainsWailsVersion3(t *testing.T) {
+	dir := t.TempDir()
+	opts := &BaseTemplate{
+		Name:    "VersionTest",
+		Version: "v0.1.0",
+		Dir:     dir,
+	}
+	if err := GenerateTemplate(opts); err != nil {
+		t.Fatalf("GenerateTemplate error: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(dir, "VersionTest", "template.yaml"))
+	if err != nil {
+		t.Fatalf("reading template.yaml: %v", err)
+	}
+
+	content := string(data)
+	if !strings.Contains(content, "wailsVersion: 3") {
+		t.Errorf("template.yaml does not contain 'wailsVersion: 3':\n%s", content)
+	}
+}
+
+func TestGenerateTemplate_NoTemplateJSON(t *testing.T) {
+	dir := t.TempDir()
+	opts := &BaseTemplate{Name: "NoJSON", Dir: dir}
+	if err := GenerateTemplate(opts); err != nil {
+		t.Fatalf("GenerateTemplate error: %v", err)
+	}
+
+	jsonPath := filepath.Join(dir, "NoJSON", "template.json")
+	if _, err := os.Stat(jsonPath); err == nil {
+		t.Error("template.json should not be created by GenerateTemplate")
+	}
+}
+
+func TestGenerateTemplate_ErrorsIfOutputExists(t *testing.T) {
+	dir := t.TempDir()
+	// Pre-create the output directory
+	if err := os.Mkdir(filepath.Join(dir, "Exists"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	opts := &BaseTemplate{Name: "Exists", Dir: dir}
+	if err := GenerateTemplate(opts); err == nil {
+		t.Error("expected error when output directory already exists, got nil")
+	}
+}
+
+func TestGenerateTemplate_GeneratedTemplateCanBeInstalled(t *testing.T) {
+	genDir := t.TempDir()
+	opts := &BaseTemplate{Name: "RoundTrip", Dir: genDir}
+	if err := GenerateTemplate(opts); err != nil {
+		t.Fatalf("GenerateTemplate error: %v", err)
+	}
+
+	// The generated template should pass parseTemplate without errors.
+	tmplPath := filepath.Join(genDir, "RoundTrip")
+	tmpl, err := parseTemplate(os.DirFS(tmplPath), "")
+	if err != nil {
+		t.Fatalf("generated template fails parseTemplate: %v", err)
+	}
+	if tmpl.WailsVersion != 3 {
+		t.Errorf("WailsVersion = %d, want 3", tmpl.WailsVersion)
+	}
+}
+

--- a/v3/internal/templates/templates_test.go
+++ b/v3/internal/templates/templates_test.go
@@ -155,11 +155,12 @@ func TestStripUnsafe_RemovesControlChars(t *testing.T) {
 	}
 }
 
-func TestStripUnsafe_PreservesNewlineAndTab(t *testing.T) {
+func TestStripUnsafe_StripsNewlineAndTab(t *testing.T) {
 	input := "line1\nline2\ttabbed"
 	got := stripUnsafe(input)
-	if got != input {
-		t.Errorf("stripUnsafe(%q) = %q, want original preserved", input, got)
+	want := "line1line2tabbed"
+	if got != want {
+		t.Errorf("stripUnsafe(%q) = %q, want %q", input, got, want)
 	}
 }
 

--- a/v3/internal/templates/vanilla-ts/template.json
+++ b/v3/internal/templates/vanilla-ts/template.json
@@ -1,9 +1,0 @@
-{
-  "name": "Vanilla + Vite (Typescript)",
-  "shortname": "vanilla-ts",
-  "author": "Lea Anthony",
-  "description": "Vanilla + TS + Vite development server",
-  "helpurl": "https://wails.io",
-  "version": "v0.0.1",
-  "schema": 3
-}

--- a/v3/internal/templates/vanilla-ts/template.yaml
+++ b/v3/internal/templates/vanilla-ts/template.yaml
@@ -1,0 +1,7 @@
+name: "Vanilla + Vite (Typescript)"
+shortname: vanilla-ts
+author: Lea Anthony
+description: "Vanilla + TS + Vite development server"
+helpurl: https://wails.io
+version: v0.0.1
+wailsVersion: 3

--- a/v3/internal/templates/vanilla-ts/template.yaml
+++ b/v3/internal/templates/vanilla-ts/template.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://v3.wails.io/schemas/template.v3.json
 name: "Vanilla + Vite (Typescript)"
 shortname: vanilla-ts
 author: Lea Anthony

--- a/v3/internal/templates/vanilla/template.json
+++ b/v3/internal/templates/vanilla/template.json
@@ -1,9 +1,0 @@
-{
-  "name": "Vanilla + Vite",
-  "shortname": "vanilla",
-  "author": "Lea Anthony",
-  "description": "Vanilla + Vite development server",
-  "helpurl": "https://wails.io",
-  "version": "v0.0.1",
-  "schema": 3
-}

--- a/v3/internal/templates/vanilla/template.yaml
+++ b/v3/internal/templates/vanilla/template.yaml
@@ -1,0 +1,7 @@
+name: "Vanilla + Vite"
+shortname: vanilla
+author: Lea Anthony
+description: "Vanilla + Vite development server"
+helpurl: https://wails.io
+version: v0.0.1
+wailsVersion: 3

--- a/v3/internal/templates/vanilla/template.yaml
+++ b/v3/internal/templates/vanilla/template.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://v3.wails.io/schemas/template.v3.json
 name: "Vanilla + Vite"
 shortname: vanilla
 author: Lea Anthony

--- a/v3/internal/templates/vue-ts/template.json
+++ b/v3/internal/templates/vue-ts/template.json
@@ -1,9 +1,0 @@
-{
-  "name": "Vue + Vite (Typescript)",
-  "shortname": "vue-ts",
-  "author": "Lea Anthony",
-  "description": "Vue + TS + Vite development server",
-  "helpurl": "https://wails.io",
-  "version": "v0.0.1",
-  "schema": 3
-}

--- a/v3/internal/templates/vue-ts/template.yaml
+++ b/v3/internal/templates/vue-ts/template.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://v3.wails.io/schemas/template.v3.json
 name: "Vue + Vite (Typescript)"
 shortname: vue-ts
 author: Lea Anthony

--- a/v3/internal/templates/vue-ts/template.yaml
+++ b/v3/internal/templates/vue-ts/template.yaml
@@ -1,0 +1,7 @@
+name: "Vue + Vite (Typescript)"
+shortname: vue-ts
+author: Lea Anthony
+description: "Vue + TS + Vite development server"
+helpurl: https://wails.io
+version: v0.0.1
+wailsVersion: 3

--- a/v3/internal/templates/vue/template.json
+++ b/v3/internal/templates/vue/template.json
@@ -1,9 +1,0 @@
-{
-  "name": "Vue + Vite",
-  "shortname": "vue",
-  "author": "Lea Anthony",
-  "description": "Vue + Vite development server",
-  "helpurl": "https://wails.io",
-  "version": "v0.0.1",
-  "schema": 3
-}

--- a/v3/internal/templates/vue/template.yaml
+++ b/v3/internal/templates/vue/template.yaml
@@ -1,0 +1,7 @@
+name: "Vue + Vite"
+shortname: vue
+author: Lea Anthony
+description: "Vue + Vite development server"
+helpurl: https://wails.io
+version: v0.0.1
+wailsVersion: 3

--- a/v3/internal/templates/vue/template.yaml
+++ b/v3/internal/templates/vue/template.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://v3.wails.io/schemas/template.v3.json
 name: "Vue + Vite"
 shortname: vue
 author: Lea Anthony


### PR DESCRIPTION
## Problem

`wails generate template` was broken for any installed binary. The function used
`runtime.Caller(0)` to locate `_common/` and `base/` files on the OS filesystem.
This only works when running directly from source (`go run`). For installed binaries,
the source paths don't exist at runtime, so `s.COPYDIR2` silently produced an empty
or broken skeleton. The command has been shipping but not actually working.

## Changes

### Core fix — `GenerateTemplate` (`v3/internal/templates/templates.go`)

Rewrites the function to use the already-embedded `templates` FS (the file already has
`//go:embed *` which pulls in `_common/` and `base/`). Uses `os.CopyFS` (Go 1.23+,
already required by this module) to extract files verbatim — critical because the
`_common/` files contain template variables like `{{.ProjectName}}` that must survive
intact for gosod to expand later when a user runs `wails init -t <my-template>`.

The generated skeleton now works correctly from any installed binary:
- `_common/` files (main.go.tmpl, go.mod.tmpl, greetservice.go, Taskfile.tmpl.yml,
  gitignore.tmpl, go.sum.tmpl, README.md) copied verbatim
- `frontend/` replaced with the user-supplied directory (`-frontend`) or the
  embedded `base/frontend` placeholder
- `NEXTSTEPS.md` from embedded `base/NEXTSTEPS.md`
- `template.json` written with schema 3 and all user-supplied metadata

Also adds an early existence check so the command fails clearly if the output
directory already exists, instead of partially overwriting it.

### Bug fixes (same file)

- **Debug print removed**: `println("err2 = ", ...)` leftover in `getLocalTemplate`
- **Error message corrected**: `parseTemplate` said *"Ensure 'version' is set to 3"*
  but the field is `schema` — now says *"Ensure 'schema' is set to 3"*

### Improved remote template disclaimer — `confirmRemote`

The existing y/n prompt is preserved but expanded to:
- Display the template name and author before asking
- Show the help URL if set
- Use explicit acceptance language: *"Do you accept responsibility for using this
  third-party template?"* rather than a generic confirmation

Satisfies the requirement that using a third-party template requires an active,
informed acknowledgement that the Wails project takes no responsibility for it.

### Comprehensive `base/NEXTSTEPS.md`

Replaces the one-line stub with a full guide for template authors covering:
- Generated file structure and what each file does
- Available template variables table
- How `.tmpl` files work and when to use them
- How to publish on GitHub and version with git tags
- The exact `wails init -t <url>@<tag>` invocation users will run
- Notes on build assets (auto-generated at install time)
- Template author responsibilities re: the third-party disclaimer

## Verification

```sh
# Build
cd v3 && go build ./cmd/wails3/

# Generate a skeleton template
wails3 generate template -name MyTemplate -dir /tmp/test

# Verify structure
find /tmp/test/MyTemplate -type f | sort
# => frontend/{index.html,main.js.tmpl,package.json}
# => gitignore.tmpl go.mod.tmpl go.sum.tmpl greetservice.go main.go.tmpl
# => NEXTSTEPS.md README.md Taskfile.tmpl.yml template.json

# Init a project from the generated template
wails3 init -n myapp -t /tmp/test/MyTemplate -skipgomodtidy

# Verify template variables expanded
grep '"myapp"' /tmp/test/myapp/main.go   # => Name: "myapp"

# Existing internal templates unaffected
wails3 init -n check -t vanilla -skipgomodtidy
```

## What this does NOT change

- Remote template git-clone flow (already worked correctly)
- Internal template installation (already worked correctly)
- The `-s` / `--skipwarning` flag behaviour
- Any template JSON schema or file format

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded onboarding "Next Steps" into a full template guide (project layout, customization, publishing, build asset guidance, and further reading).

* **Bug Fixes**
  * Improved compatibility/validation messages and installation checks to avoid overwriting existing projects.

* **UX**
  * Revamped third‑party template warning and confirmation prompts; terminal output now strips unsafe/nonprintable characters for clearer display.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wailsapp/wails/pull/5503?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->