### PR TITLE
fix(v3): fix Android runtime crash when calling Go bindings

### DIFF
--- a/v3/internal/runtime/desktop/@wailsio/runtime/src/index.ts
+++ b/v3/internal/runtime/desktop/@wailsio/runtime/src/index.ts
@@ -64,7 +64,25 @@ export {
     clientId,
 } from "./runtime.js";
 
-import { clientId } from "./runtime.js";
+import { clientId, setTransport } from "./runtime.js";
+
+// On Android, route runtime calls through the JNI bridge instead of HTTP fetch
+// because Android's shouldInterceptRequest cannot access POST bodies.
+if ((window as any).wails?.invoke) {
+    setTransport({
+        call: async (objectID: number, method: number, windowName: string, args: any) => {
+            const body: any = { object: objectID, method };
+            if (args !== null && args !== undefined) {
+                body.args = args;
+            }
+            const responseStr = (window as any).wails.invoke(JSON.stringify(body));
+            if (typeof responseStr === "string" && responseStr.length > 0) {
+                try { return JSON.parse(responseStr); } catch { return responseStr; }
+            }
+            return responseStr;
+        }
+    });
+}
 
 // Notify backend
 window._wails.invoke = System.invoke;

--- a/v3/pkg/application/application_android.go
+++ b/v3/pkg/application/application_android.go
@@ -139,6 +139,7 @@ static void executeJavaScriptOnBridge(const char* js) {
 import "C"
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -169,6 +170,10 @@ var (
 	// App ready signal
 	appReady     = make(chan struct{})
 	appReadyOnce sync.Once
+
+	// Global message processor for handling runtime calls via JNI bridge
+	globalMessageProc     *MessageProcessor
+	globalMessageProcLock sync.RWMutex
 )
 
 func init() {
@@ -220,6 +225,11 @@ func (a *App) platformRun() {
 	globalAppLock.Lock()
 	globalApp = a
 	globalAppLock.Unlock()
+
+	// Initialize the global message processor for Android JNI calls
+	globalMessageProcLock.Lock()
+	globalMessageProc = NewMessageProcessor(a.Logger)
+	globalMessageProcLock.Unlock()
 
 	// Signal that the app is ready to serve requests
 	signalAppReady()
@@ -622,15 +632,71 @@ func serveAssetForAndroid(app *App, path string) ([]byte, error) {
 }
 
 func handleMessageForAndroid(app *App, message string) string {
-	// Parse the message
-	var msg map[string]interface{}
-	if err := json.Unmarshal([]byte(message), &msg); err != nil {
+	// Some messages are plain strings (e.g. "wails:runtime:ready"), not JSON.
+	// The JS bridge sends: typeof m==='string' ? m : JSON.stringify(m)
+	if len(message) == 0 || message[0] != '{' {
+		androidLogf("debug", "🤖 [handleMessageForAndroid] Non-JSON message: %s", message)
+
+		if message == "wails:runtime:ready" {
+			windows := app.Window.GetAll()
+			for _, win := range windows {
+				if ww, ok := win.(*WebviewWindow); ok {
+					ww.pendingJSMutex.Lock()
+					ww.runtimeLoaded = true
+					pending := ww.pendingJS
+					ww.pendingJS = nil
+					ww.pendingJSMutex.Unlock()
+					for _, js := range pending {
+						executeJavaScript(js)
+					}
+				}
+			}
+		}
+
+		return `{"success":true}`
+	}
+
+	var req RuntimeRequest
+	if err := json.Unmarshal([]byte(message), &req); err != nil {
+		androidLogf("error", "🤖 [handleMessageForAndroid] Failed to parse: %v", err)
 		return fmt.Sprintf(`{"error":"%s"}`, err.Error())
 	}
 
-	// TODO: Route to appropriate handler based on message type
-	// For now, return success
-	return `{"success":true}`
+	// Fill in a window ID if none was provided (Android typically has one window)
+	if req.WebviewWindowID == 0 && req.WebviewWindowName == "" {
+		windows := app.Window.GetAll()
+		if len(windows) > 0 {
+			req.WebviewWindowID = uint32(windows[0].ID())
+		}
+	}
+
+	globalMessageProcLock.RLock()
+	messageProc := globalMessageProc
+	globalMessageProcLock.RUnlock()
+
+	if messageProc == nil {
+		androidLogf("error", "🤖 [handleMessageForAndroid] MessageProcessor not initialized")
+		return `{"error":"MessageProcessor not initialized"}`
+	}
+
+	androidLogf("debug", "🤖 [handleMessageForAndroid] Calling HandleRuntimeCallWithIDs: object=%d method=%d windowID=%d", req.Object, req.Method, req.WebviewWindowID)
+	ctx := context.Background()
+	result, err := messageProc.HandleRuntimeCallWithIDs(ctx, &req)
+	if err != nil {
+		androidLogf("error", "🤖 [handleMessageForAndroid] Error: %v", err)
+		return fmt.Sprintf(`{"error":"%s"}`, err.Error())
+	}
+
+	if result == nil {
+		return `{"success":true}`
+	}
+
+	resp, err := json.Marshal(result)
+	if err != nil {
+		androidLogf("error", "🤖 [handleMessageForAndroid] Marshal error: %v", err)
+		return fmt.Sprintf(`{"error":"%s"}`, err.Error())
+	}
+	return string(resp)
 }
 
 func getMimeTypeForPath(path string) string {

--- a/v3/pkg/application/transport_http.go
+++ b/v3/pkg/application/transport_http.go
@@ -157,9 +157,11 @@ func (t *HTTPTransport) handleRuntimeRequest(rw http.ResponseWriter, r *http.Req
 		}
 	}()
 
-	if _, err := io.Copy(buf, r.Body); err != nil {
-		t.httpError(rw, errs.WrapInvalidRuntimeCallErrorf(err, "Unable to read request body"))
-		return
+	if r.Body != nil {
+		if _, err := io.Copy(buf, r.Body); err != nil {
+			t.httpError(rw, errs.WrapInvalidRuntimeCallErrorf(err, "Unable to read request body"))
+			return
+		}
 	}
 
 	t.processBody(rw, r, buf.Bytes())


### PR DESCRIPTION
## Summary

- **Guard nil `r.Body` in `transport_http.go`** — Android's `WebViewClient.shouldInterceptRequest` cannot access POST request bodies, so when the JS runtime calls Go bindings via `fetch POST /wails/runtime`, the Go-side handler receives a nil Body causing `io.Copy(buf, r.Body)` to panic.
- **Implement `handleMessageForAndroid` properly** — The stub `handleMessageForAndroid` returned `{"success":true}` for all messages. This replaces it with a real implementation that routes runtime calls through the `MessageProcessor` (binding calls, clipboard, events, etc.) and handles the `wails:runtime:ready` lifecycle message to flush pending JS.
- **Initialize `globalMessageProc` in `platformRun()`** — The `MessageProcessor` was never created for Android, so even if calls reached `handleMessageForAndroid`, they would fail.
- **Set Android JNI transport in `index.ts`** — Detects `window.wails.invoke` (the `addJavascriptInterface` JNI bridge) and calls `setTransport()` to route all `runtimeCallWithID` calls through it instead of HTTP fetch, completely bypassing the `shouldInterceptRequest` POST body limitation.

### Root cause

Android's `WebResourceRequest` API [does not provide access to POST request bodies](https://developer.android.com/reference/android/webkit/WebResourceRequest). The Wails JS runtime uses `fetch('POST', '/wails/runtime', { body: JSON.stringify(...) })` for all binding calls. On Android, `shouldInterceptRequest` intercepts this but can only see the URL/headers — the body is lost. The Go handler then creates a request with `nil` body, and `io.Copy` panics.

### How it works now

```
JS binding call → setTransport.call() → window.wails.invoke(JSON.stringify({...}))
  → WailsJSBridge.invoke() (Java) → nativeHandleMessage (JNI)
  → handleMessageForAndroid (Go) → MessageProcessor.HandleRuntimeCallWithIDs()
  → response returned synchronously back through the JNI bridge
```

## Test plan

- [ ] Build and run on Android emulator — verify app loads without crash
- [ ] Tap any Go binding button (e.g. "Random Person") — verify data returns to UI
- [ ] Test counter increment/decrement on Events tab — verify stateful service works
- [ ] Verify Go→JS events (time ticker) continue working
- [ ] Verify no regression on desktop platforms (nil body guard is defensive only)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced Android integration with improved JNI bridge communication for runtime calls
  * Better message processing and error handling for platform-specific runtime operations

* **Bug Fixes**
  * Improved HTTP transport robustness in request handling

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wailsapp/wails/pull/5510?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->