### PR TITLE
feat(mac/v3): expose mediaTypesRequiringUserActionForPlayback on WKWebView

### DIFF
--- a/v3/pkg/application/webview_window_darwin.go
+++ b/v3/pkg/application/webview_window_darwin.go
@@ -19,6 +19,7 @@ struct WebviewPreferences {
     bool *TextInteractionEnabled;
     bool *FullscreenEnabled;
     bool *AllowsBackForwardNavigationGestures;
+    bool *EnableAutoplayWithoutUserAction;
 };
 
 extern void registerListener(unsigned int event);
@@ -91,6 +92,10 @@ void* windowNew(unsigned int id, int width, int height, bool fraudulentWebsiteWa
          config.preferences.fraudulentWebsiteWarningEnabled = fraudulentWebsiteWarningEnabled;
 	}
 #endif
+
+	if (preferences.EnableAutoplayWithoutUserAction != NULL && *preferences.EnableAutoplayWithoutUserAction) {
+		config.mediaTypesRequiringUserActionForPlayback = WKAudiovisualMediaTypeNone;
+	}
 
 	// Setup user content controller
     WKUserContentController* userContentController = [WKUserContentController new];
@@ -1338,6 +1343,9 @@ func (w *macosWebviewWindow) getWebviewPreferences() C.struct_WebviewPreferences
 	}
 	if wvprefs.AllowsBackForwardNavigationGestures.IsSet() {
 		result.AllowsBackForwardNavigationGestures = bool2CboolPtr(wvprefs.AllowsBackForwardNavigationGestures.Get())
+	}
+	if wvprefs.EnableAutoplayWithoutUserAction.IsSet() {
+		result.EnableAutoplayWithoutUserAction = bool2CboolPtr(wvprefs.EnableAutoplayWithoutUserAction.Get())
 	}
 
 	return result

--- a/v3/pkg/application/webview_window_options.go
+++ b/v3/pkg/application/webview_window_options.go
@@ -596,6 +596,11 @@ type MacWebviewPreferences struct {
 	FullscreenEnabled u.Bool
 	// AllowsBackForwardNavigationGestures enables horizontal swipe gestures for back/forward navigation
 	AllowsBackForwardNavigationGestures u.Bool
+	// EnableAutoplayWithoutUserAction allows media to start playing automatically
+	// without requiring a user gesture. When unset or false, WebKit's default
+	// behaviour is preserved (gesture required).
+	// Maps to WKWebViewConfiguration.mediaTypesRequiringUserActionForPlayback.
+	EnableAutoplayWithoutUserAction u.Bool
 }
 
 // MacTitleBar contains options for the Mac titlebar


### PR DESCRIPTION
## Summary

Adds `EnableAutoplayWithoutUserAction` to `MacWebviewPreferences`, mapping to `WKWebViewConfiguration.mediaTypesRequiringUserActionForPlayback`. Without it, there is no way to autoplay HTML5 video/audio in a Wails v3 macOS app — every `<video autoplay>` is blocked.

Closes #5511. Companion v2 PR: #5512.

## Implementation

Mirrors the existing preference-passing pattern (compare `TabFocusesLinks`, `AllowsBackForwardNavigationGestures`):

1. Add `EnableAutoplayWithoutUserAction u.Bool` to `MacWebviewPreferences` (`webview_window_options.go`)
2. Extend C `struct WebviewPreferences` with the matching pointer field (`webview_window_darwin.go`)
3. Populate it in `getWebviewPreferences()` via `IsSet()` + `bool2CboolPtr(...)`
4. Apply on `WKWebViewConfiguration` inside `windowNew()`:
   ```objc
   if (preferences.EnableAutoplayWithoutUserAction != NULL && *preferences.EnableAutoplayWithoutUserAction) {
       config.mediaTypesRequiringUserActionForPlayback = WKAudiovisualMediaTypeNone;
   }
   ```

Defaults preserve WebKit's current behaviour (user gesture required) — opt-in only.

iOS already does the equivalent in `webview_window_ios.m` driven by `EnableAutoplayWithoutUserAction` in `application_options.go`; this brings macOS to parity.

Note: `allowsInlineMediaPlayback` is iOS-only on `WKWebViewConfiguration` (verified by macos-latest compile failure), so it is intentionally not exposed on macOS — videos always play inline on macOS WKWebView anyway.

## Test plan

- [ ] Build on macOS (validated via fork CI on `macos-latest` / Xcode 16.4)
- [ ] Manual: a v3 app with `<video autoplay src="...">` and `MacWebviewPreferences{EnableAutoplayWithoutUserAction: u.True}` autoplays without a click
- [ ] Regression: unset/false preserves prior behaviour (gesture required)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new WebView preference option for macOS enabling media autoplay without requiring explicit user interaction.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wailsapp/wails/pull/5513?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->