### PR TITLE
fix(bindings): strip debug info on Windows to avoid Go 1.25 DWARF5 PE bug

### DIFF
--- a/v2/pkg/commands/bindings/bindings.go
+++ b/v2/pkg/commands/bindings/bindings.go
@@ -60,7 +60,17 @@ func GenerateBindings(options Options) (string, error) {
 	// So, use the default C compiler, not the one set for cross compiling.
 	envBuild = shell.RemoveEnv(envBuild, "CC")
 
-	stdout, stderr, err = shell.RunCommandWithEnv(envBuild, workingDirectory, options.Compiler, "build", "-buildvcs=false", "-tags", tagString, "-o", filename)
+	buildArgs := []string{"build", "-buildvcs=false", "-tags", tagString, "-o", filename}
+	if runtime.GOOS == "windows" {
+		// Go 1.25 switched to DWARF5 by default, which causes the internal
+		// linker to emit malformed PE section headers on Windows — the binary
+		// won't run ("not a valid Win32 application" / "not compatible with
+		// the version of Windows"). Stripping debug info avoids DWARF5
+		// entirely and is appropriate for a temporary tool binary.
+		// See golang/go#75077, golang/go#75121, wails#4551, wails#4605.
+		buildArgs = append(buildArgs, "-ldflags=-s -w")
+	}
+	stdout, stderr, err = shell.RunCommandWithEnv(envBuild, workingDirectory, options.Compiler, buildArgs...)
 	if err != nil {
 		return stdout, fmt.Errorf("%s\n%s\n%s", stdout, stderr, err)
 	}


### PR DESCRIPTION
## Summary

Fixes #4605 and #4551.

Go 1.25 switched to DWARF5 debug format by default. On Windows, the internal linker emits malformed PE section headers when DWARF5 sections are present ([golang/go#75077](https://github.com/golang/go/issues/75077), [golang/go#75121](https://github.com/golang/go/issues/75121)). The generated `wailsbindings.exe` fails to launch with:

```
fork/exec C:\Users\...\AppData\Local\Temp\wailsbindings.exe: %1 is not a valid Win32 application.
```
or
```
fork/exec C:\...\wailsbindings.exe: This version of %1 is not compatible with the version of Windows you're running.
```

Downgrading to Go 1.24 fixes it because Go 1.24 used DWARF4 by default.

## Root cause

golang/go#75077 documents the issue: DWARF5 sections are placed at virtual addresses outside the normal Windows PE address space, making the binary unrunnable. The fix in that issue is to strip debug info entirely with `-s -w`.

## Fix

On Windows, pass `-ldflags="-s -w"` to the `go build` that compiles `wailsbindings.exe`. This strips debug symbols and DWARF sections from the binary, producing clean PE headers. It is appropriate for this binary because:

- `wailsbindings.exe` is a temporary tool deleted immediately after use (`defer os.Remove(filename)`) — it is never debugged
- The fix works whether or not the user's project uses CGO

The flag is only added on `runtime.GOOS == "windows"` — no effect on macOS/Linux builds.

## Test plan

- [ ] `wails dev` with Go 1.25.x on Windows (amd64), project without CGO — bindings generate successfully
- [ ] `wails dev` with Go 1.25.x on Windows (amd64), project with CGO — bindings generate successfully  
- [ ] `wails dev` with Go 1.24 on Windows — still works
- [ ] `wails dev` on macOS / Linux with Go 1.25 — unchanged (flag not added)
- [ ] `go test ./v2/pkg/commands/bindings/...` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Frontend build output is automatically synchronized into embed targets so embedded assets match the built frontend during packaging.

* **Bug Fixes**
  * Windows native build now strips debug info for temporary tool binaries to improve build reliability.
  * Cleanup restores placeholder files to keep embed targets consistent after failed builds.

* **Tests**
  * Added filesystem tests covering embed discovery, sync, cleanup, and no-op scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->