### PR TITLE
fix(linux): stop forcing SA_ONSTACK on SIGUSR1 to prevent WebKit freeze

### DIFF
--- a/v2/internal/frontend/desktop/linux/frontend.go
+++ b/v2/internal/frontend/desktop/linux/frontend.go
@@ -65,9 +65,12 @@ static void install_signal_handlers()
 #if defined(SIGSEGV)
     fix_signal(SIGSEGV);
 #endif
-#if defined(SIGUSR1)
-    fix_signal(SIGUSR1);
-#endif
+    // NOTE: Do NOT add SA_ONSTACK to SIGUSR1. WebKit's JavaScriptCore uses
+    // SIGUSR1 to suspend/resume threads for conservative GC stack scanning.
+    // Once JSC installs its own SIGUSR1 handler it owns the signal (Go no
+    // longer handles it), and forcing SA_ONSTACK makes that handler run on
+    // Go's alternate signal stack, breaking GC thread synchronisation and
+    // freezing WebKit during idle collection. See issue #5527.
 #if defined(SIGXCPU)
     fix_signal(SIGXCPU);
 #endif

--- a/v3/UNRELEASED_CHANGELOG.md
+++ b/v3/UNRELEASED_CHANGELOG.md
@@ -23,6 +23,7 @@ After processing, the content will be moved to the main changelog and this file 
 
 ## Fixed
 <!-- Bug fixes -->
+- Fix WebKit UI freeze on Linux when idle (e.g. with the inspector open) by no longer forcing `SA_ONSTACK` on `SIGUSR1`, which broke JavaScriptCore's GC thread synchronisation (#5527)
 
 ## Deprecated
 <!-- Soon-to-be removed features -->

--- a/v3/pkg/application/linux_cgo.c
+++ b/v3/pkg/application/linux_cgo.c
@@ -114,9 +114,12 @@ void install_signal_handlers(void) {
 #if defined(SIGSEGV)
     fix_signal(SIGSEGV);
 #endif
-#if defined(SIGUSR1)
-    fix_signal(SIGUSR1);
-#endif
+    // NOTE: Do NOT add SA_ONSTACK to SIGUSR1. WebKit's JavaScriptCore uses
+    // SIGUSR1 to suspend/resume threads for conservative GC stack scanning.
+    // Once JSC installs its own SIGUSR1 handler it owns the signal (Go no
+    // longer handles it), and forcing SA_ONSTACK makes that handler run on
+    // Go's alternate signal stack, breaking GC thread synchronisation and
+    // freezing WebKit during idle collection. See issue #5527.
 #if defined(SIGXCPU)
     fix_signal(SIGXCPU);
 #endif

--- a/v3/pkg/application/linux_cgo_gtk3.go
+++ b/v3/pkg/application/linux_cgo_gtk3.go
@@ -222,9 +222,12 @@ static void install_signal_handlers() {
 	#if defined(SIGSEGV)
 		fix_signal(SIGSEGV);
 	#endif
-	#if defined(SIGUSR1)
-		fix_signal(SIGUSR1);
-	#endif
+	// NOTE: Do NOT add SA_ONSTACK to SIGUSR1. WebKit's JavaScriptCore uses
+	// SIGUSR1 to suspend/resume threads for conservative GC stack scanning.
+	// Once JSC installs its own SIGUSR1 handler it owns the signal (Go no
+	// longer handles it), and forcing SA_ONSTACK makes that handler run on
+	// Go's alternate signal stack, breaking GC thread synchronisation and
+	// freezing WebKit during idle collection. See issue #5527.
 	#if defined(SIGXCPU)
 		fix_signal(SIGXCPU);
 	#endif


### PR DESCRIPTION
## Summary

Fixes #5527 — a regression introduced in **alpha.97** where the WebKit UI freezes on Linux while idle (most visibly with the inspector open). Only the UI hangs; the Go backend keeps running.

## Root cause

The freeze traces to PR #5507 (`6329e9d`), the only Linux/WebKit signal-handling change between alpha.96 and alpha.97. That commit added `fix_signal(SIGUSR1)` to `install_signal_handlers()`.

- **SIGUSR1** (signal 10 on Linux) is the signal WebKit's JavaScriptCore uses to **suspend/resume threads for conservative GC stack scanning**.
- `fix_signal()` ORs `SA_ONSTACK` into whatever handler is currently registered. Once JSC installs its own SIGUSR1 handler, **Go no longer handles SIGUSR1 at all**, so forcing `SA_ONSTACK` only corrupts *JSC's* handler — making it run on Go's alternate signal stack instead of the thread's normal stack.
- This breaks JSC's GC thread synchronisation, deadlocking WebKit during **idle garbage collection** (tab away → GC runs → freeze). An open inspector keeps JS/GC active, which is why it reproduces so reliably there.

The original commit even noted the `Overriding existing handler for signal 10` message — that is JSC taking ownership of SIGUSR1, which is exactly the point at which adding `SA_ONSTACK` becomes harmful rather than helpful.

## Fix

Remove `fix_signal(SIGUSR1)` from `install_signal_handlers()` in all three locations:
- `v3/pkg/application/linux_cgo.c` (GTK4)
- `v3/pkg/application/linux_cgo_gtk3.go` (GTK3)
- `v2/internal/frontend/desktop/linux/frontend.go`

Each is replaced with a comment explaining why SIGUSR1 must not be touched. The genuine #5506 fix for SIGSEGV/SIGBUS (which Go *does* require `SA_ONSTACK` for, for JIT crash recovery) is fully preserved.

## Testing

- `gofmt` clean on the modified Go file.
- A full CGO build was not possible in the dev environment (GTK4 dev headers not installed), but the change is a pure removal of two preprocessor lines plus comments.
- Runtime validation recommended with the issue's repro: set `OpenInspectorOnStartup: true`, `wails3 dev`, tab away for a few minutes.

Fixes #5527

https://claude.ai/code/session_01AtT1CjDNRArXv1eddXte2a

---
_Generated by [Claude Code](https://claude.ai/code/session_01AtT1CjDNRArXv1eddXte2a)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved UI freeze on Linux when WebKit is idle with the inspector open.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->