### PR TITLE
fix(buildinfo): Development should reflect local source, not vcs=git

### DIFF
--- a/v3/internal/buildinfo/buildinfo.go
+++ b/v3/internal/buildinfo/buildinfo.go
@@ -24,7 +24,7 @@ type Info struct {
 	// => /v3` directive in scaffolded projects, breaking `wails3 init`
 	// outright.
 	//
-	// `debug.LocalModulePath` is set by the debug package's init() only
+	// [wdebug.LocalModulePath] is set by the debug package's init() only
 	// when `.git` is found at a path resolved relative to the live
 	// source file location — i.e. only when the dev's checkout is
 	// actually there to be replaced into. That's exactly the precondition

--- a/v3/internal/buildinfo/buildinfo.go
+++ b/v3/internal/buildinfo/buildinfo.go
@@ -3,12 +3,32 @@ package buildinfo
 import (
 	"fmt"
 	"runtime/debug"
-	"slices"
 
+	wdebug "github.com/wailsapp/wails/v3/internal/debug"
 	"github.com/wailsapp/wails/v3/internal/lo"
 )
 
 type Info struct {
+	// Development is true when the running wails3 binary was built from a
+	// local Wails source tree that is still resolvable on disk at runtime,
+	// i.e. when [wdebug.LocalModulePath] resolved to a real directory.
+	//
+	// Earlier versions of this field derived Development from the
+	// `vcs=git` build setting that Go's toolchain embeds automatically.
+	// That signal is unsafe to rely on for "is this a local dev build?":
+	// Go emits `vcs=git` for any binary built inside a git checkout,
+	// including release artefacts produced by CI. A user running a
+	// tagged `wails3.exe` on Windows would therefore see Development=true
+	// even though the Wails source tree is nowhere on their machine.
+	// The downstream effect was a malformed `replace github.com/wailsapp/wails/v3
+	// => /v3` directive in scaffolded projects, breaking `wails3 init`
+	// outright (see #XXXX).
+	//
+	// `debug.LocalModulePath` is set by the debug package's init() only
+	// when `.git` is found at a path resolved relative to the live
+	// source file location — i.e. only when the dev's checkout is
+	// actually there to be replaced into. That's exactly the precondition
+	// the only consumer of this field (templates.Install) needs.
 	Development   bool
 	Version       string
 	BuildSettings map[string]string
@@ -31,9 +51,7 @@ func Get() (*Info, error) {
 		return setting.Key, setting.Value
 	})
 	result.Version = BuildInfo.Main.Version
-	result.Development = -1 != slices.IndexFunc(BuildInfo.Settings, func(setting debug.BuildSetting) bool {
-		return setting.Key == "vcs" && setting.Value == "git"
-	})
+	result.Development = wdebug.LocalModulePath != ""
 
 	return &result, nil
 

--- a/v3/internal/buildinfo/buildinfo.go
+++ b/v3/internal/buildinfo/buildinfo.go
@@ -22,7 +22,7 @@ type Info struct {
 	// even though the Wails source tree is nowhere on their machine.
 	// The downstream effect was a malformed `replace github.com/wailsapp/wails/v3
 	// => /v3` directive in scaffolded projects, breaking `wails3 init`
-	// outright (see #XXXX).
+	// outright.
 	//
 	// `debug.LocalModulePath` is set by the debug package's init() only
 	// when `.git` is found at a path resolved relative to the live

--- a/v3/internal/buildinfo/buildinfo_test.go
+++ b/v3/internal/buildinfo/buildinfo_test.go
@@ -22,7 +22,7 @@ func TestGet(t *testing.T) {
 // emitting a stray `replace ... => /v3` in the scaffolded go.mod.
 //
 // These tests pin the new semantics in place: Development tracks
-// debug.LocalModulePath, and nothing else.
+// wdebug.LocalModulePath, and nothing else.
 func TestDevelopmentFalseWhenNoLocalSource(t *testing.T) {
 	saved := wdebug.LocalModulePath
 	t.Cleanup(func() { wdebug.LocalModulePath = saved })

--- a/v3/internal/buildinfo/buildinfo_test.go
+++ b/v3/internal/buildinfo/buildinfo_test.go
@@ -2,6 +2,8 @@ package buildinfo
 
 import (
 	"testing"
+
+	wdebug "github.com/wailsapp/wails/v3/internal/debug"
 )
 
 func TestGet(t *testing.T) {
@@ -10,4 +12,43 @@ func TestGet(t *testing.T) {
 		t.Error(err)
 	}
 	_ = result
+}
+
+// Development must reflect whether a local Wails source tree is resolvable
+// at runtime — not whether the binary happens to have been built inside a
+// git checkout. CI-built release artefacts carry `vcs=git` in their build
+// metadata, so the old "Development = (vcs == git)" heuristic produced a
+// false positive on every user's machine and broke `wails3 init` by
+// emitting a stray `replace ... => /v3` in the scaffolded go.mod.
+//
+// These tests pin the new semantics in place: Development tracks
+// debug.LocalModulePath, and nothing else.
+func TestDevelopmentFalseWhenNoLocalSource(t *testing.T) {
+	saved := wdebug.LocalModulePath
+	t.Cleanup(func() { wdebug.LocalModulePath = saved })
+
+	wdebug.LocalModulePath = ""
+
+	info, err := Get()
+	if err != nil {
+		t.Fatalf("buildinfo.Get() returned error: %v", err)
+	}
+	if info.Development {
+		t.Fatalf("Development = true with empty LocalModulePath; want false (this is the released-binary case where vcs=git would have false-positived)")
+	}
+}
+
+func TestDevelopmentTrueWhenLocalSourceResolves(t *testing.T) {
+	saved := wdebug.LocalModulePath
+	t.Cleanup(func() { wdebug.LocalModulePath = saved })
+
+	wdebug.LocalModulePath = t.TempDir()
+
+	info, err := Get()
+	if err != nil {
+		t.Fatalf("buildinfo.Get() returned error: %v", err)
+	}
+	if !info.Development {
+		t.Fatalf("Development = false with LocalModulePath=%q; want true", wdebug.LocalModulePath)
+	}
 }


### PR DESCRIPTION
## Summary

`buildinfo.Info.Development` was implemented as **"the binary's BuildInfo carries a `vcs=git` build setting."** That signal is emitted by Go's toolchain for *any* binary built inside a git checkout, including release artefacts produced by CI from a tagged commit. As a result, every released `wails3` binary reports `Development = true` on every user's machine.

The only consumer of the field — `templates.Install` in `internal/templates/templates.go` — uses it to decide whether to inject a local `replace github.com/wailsapp/wails/v3 => …` directive into the scaffolded `go.mod`. With `Development = true` but the source tree absent (`debug.LocalModulePath == ""`), the replace path collapses to `/v3` (different `filepath.VolumeName` for an empty path under Windows) and the generated `go.mod` is broken from the start.

The user-facing symptom on Windows with a tagged release:

```
PS C:\Users\leaan> .\wails3.exe init -n waketest
 Wails (v3.0.0-alpha.95)  Init project
…
  ERROR   failed to run go mod tidy: exit status 1
          go: changeme imports
                github.com/wailsapp/wails/v3/pkg/application:
                github.com/wailsapp/wails/v3@v3.0.0-alpha.95:
                replacement directory /v3 does not exist
```

## Fix

Redefine `Development` as: **"this binary was built from a local Wails source tree that is still resolvable on disk at runtime."** That's exactly the precondition the templates code needs. The single source of truth becomes `debug.LocalModulePath`, which is set by `debug`'s `init()` only when `.git` is found relative to the live source-file location, and is empty on every binary that was built then shipped to a different machine.

```go
// before
result.Development = -1 != slices.IndexFunc(BuildInfo.Settings, func(setting debug.BuildSetting) bool {
    return setting.Key == "vcs" && setting.Value == "git"
})

// after
result.Development = wdebug.LocalModulePath != ""
```

The doc comment on the field explains the rationale and links the change to the symptom for posterity.

## Test plan

- [x] `go test ./internal/buildinfo/...` — two new regression tests:
  - `TestDevelopmentFalseWhenNoLocalSource` — empty `LocalModulePath` → `Development = false` (the released-binary case)
  - `TestDevelopmentTrueWhenLocalSourceResolves` — non-empty `LocalModulePath` → `Development = true`
- [ ] Manual: build `wails3` with `go build -trimpath ./cmd/wails3`, copy to a different machine without the Wails source, run `wails3 init -n test`, confirm the scaffolded `go.mod` has no `replace` directive and `go mod tidy` succeeds.
- [ ] Verify dev workflow still works: from a local Wails checkout, run `go run ./cmd/wails3 init -n test`, confirm the scaffolded project's `go.mod` still gets the `replace` directive pointing at the local source tree.

## Notes

- Only one production caller of `Development` exists (`internal/templates/templates.go`), so no other behaviour changes.
- The `vcs=git` check is removed rather than renamed — it was load-bearing for the buggy gate and has no other consumers. Build settings are still available on `Info.BuildSettings` for any future use.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable detection of development vs. release builds to prevent misclassification and ensure correct runtime behavior.

* **Tests**
  * Added tests to validate development-mode detection across different build/runtime scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->