### PR TITLE
fix(v3): regenerate go.sum after refresh v1.0.0 bump (#5526)

### DIFF
--- a/v3/go.mod
+++ b/v3/go.mod
@@ -57,7 +57,7 @@ require (
 	github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/konoui/go-qsort v0.1.0 // indirect
-	github.com/lmittmann/tint v1.0.3 // indirect
+	github.com/lmittmann/tint v1.1.3 // indirect
 	github.com/mattn/go-localereader v0.0.1 // indirect
 	github.com/muesli/ansi v0.0.0-20230316100256-276c6243b2f6 // indirect
 	github.com/ncruces/go-strftime v1.0.0 // indirect

--- a/v3/go.sum
+++ b/v3/go.sum
@@ -61,8 +61,8 @@ github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkY
 github.com/atomicgo/cursor v0.0.1/go.mod h1:cBON2QmmrysudxNBFthvMtN32r3jxVRIvzkUiF/RuIk=
 github.com/atotto/clipboard v0.1.4 h1:EH0zSVneZPSuFR11BlR9YppQTVDbh5+16AmcJi4g1z4=
 github.com/atotto/clipboard v0.1.4/go.mod h1:ZY9tmq7sm5xIbd9bOK4onWV4S6X0u6GY7Vn0Yu86PYI=
-github.com/atterpac/refresh v0.8.6 h1:Q5miKV2qs9jW+USw8WZ/54Zz8/RSh/bOz5U6JvvDZmM=
-github.com/atterpac/refresh v0.8.6/go.mod h1:fJpWySLdpbANS8Ej5OvfZVZIVvi/9bmnhTjKS5EjQes=
+github.com/atterpac/refresh v1.0.0 h1:IK/rh3w5cD7nb6GuqzfScIdNuAz/E0sZz10k1pioIFE=
+github.com/atterpac/refresh v1.0.0/go.mod h1:+vQ8OHgGmZ7wwoZfxxkT6Nr/gKA8j78Rbt+qcLLDEoc=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiErDT4WkJ2k=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1/go.mod h1:uYgXzlJ7ZpABp8OJ+exZzJJhRNQ2ASbcXHWsFqH8hp8=
 github.com/aymanbagabas/go-udiff v0.3.1 h1:LV+qyBQ2pqe0u42ZsUEtPiCaUoqgA9gYRDs3vj1nolY=
@@ -256,8 +256,8 @@ github.com/leaanthony/winicon v1.0.0 h1:ZNt5U5dY71oEoKZ97UVwJRT4e+5xo5o/ieKuHuk8
 github.com/leaanthony/winicon v1.0.0/go.mod h1:en5xhijl92aphrJdmRPlh4NI1L6wq3gEm0LpXAPghjU=
 github.com/lithammer/fuzzysearch v1.1.8 h1:/HIuJnjHuXS8bKaiTMeeDlW2/AyIWk2brx1V8LFgLN4=
 github.com/lithammer/fuzzysearch v1.1.8/go.mod h1:IdqeyBClc3FFqSzYq/MXESsS4S0FsZ5ajtkr5xPLts4=
-github.com/lmittmann/tint v1.0.3 h1:W5PHeA2D8bBJVvabNfQD/XW9HPLZK1XoPZH0cq8NouQ=
-github.com/lmittmann/tint v1.0.3/go.mod h1:HIS3gSy7qNwGCj+5oRjAutErFBl4BzdQP6cJZ0NfMwE=
+github.com/lmittmann/tint v1.1.3 h1:Hv4EaHWXQr+GTFnOU4VKf8UvAtZgn0VuKT+G0wFlO3I=
+github.com/lmittmann/tint v1.1.3/go.mod h1:HIS3gSy7qNwGCj+5oRjAutErFBl4BzdQP6cJZ0NfMwE=
 github.com/lucasb-eyer/go-colorful v1.3.0 h1:2/yBRLdWBZKrf7gB40FoiKfAWYQ0lqNcbuQwVHXptag=
 github.com/lucasb-eyer/go-colorful v1.3.0/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
 github.com/matryer/is v1.4.1 h1:55ehd8zaGABKLXQUe2awZ99BD/PTc2ls+KV/dXphgEQ=


### PR DESCRIPTION
## Problem

Commit ff529b75d ("Update refresh dependency to version 1.0.0", #5526) bumped `github.com/atterpac/refresh` to **v1.0.0** in `v3/go.mod` but left `v3/go.sum` carrying only the **v0.8.6** checksums.

Any module-aware build that runs with the default `-mod=readonly` therefore fails. The most visible case is the **"Build Wails3 CLI"** CI step (`task install` → `go install ./cmd/wails3`):

```
internal/commands/watcher.go:6:2: missing go.sum entry for module providing
package github.com/atterpac/refresh/engine (imported by .../v3/internal/commands)
```

This breaks the **template-build matrix on every open PR** (e.g. #5530), not just one branch. The "Run Go Tests v3" jobs stayed green only because `task test:examples` runs `go mod tidy` first, which regenerates `go.sum` on disk before the tests compile — masking the bug.

## Fix

`cd v3 && go mod tidy`, which:

- adds the missing `github.com/atterpac/refresh v1.0.0` checksums, and
- propagates the indirect bump `github.com/lmittmann/tint v1.0.3 → v1.1.3` that `refresh v1.0.0`'s own `go.mod` requires. (A "refresh-only" `go.sum` patch would simply fail next on a missing `tint v1.1.3` checksum.)

This is exactly the consistent module state the repo's own `test:examples` target produces.

## Verification

- Reproduced the `go install ./cmd/wails3` failure on `master`.
- After the fix: `go build ./...`, `go build ./cmd/wails3`, and `go install ./cmd/wails3` all succeed.
- Diff is limited to `v3/go.mod` (+1/−1) and `v3/go.sum` (+4/−4).

Once merged, open PRs (including #5530) need a rebase / CI re-run to pick up the corrected `go.sum`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated indirect dependencies to the latest compatible versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->