### PR TITLE
Fix GTK4 Linux menu updates

### DIFF
--- a/v3/UNRELEASED_CHANGELOG.md
+++ b/v3/UNRELEASED_CHANGELOG.md
@@ -23,6 +23,7 @@ After processing, the content will be moved to the main changelog and this file 
 
 ## Fixed
 <!-- Bug fixes -->
+- Fix GTK4 Linux menus so `Menu.Update()` rebuilds already processed menus instead of becoming a no-op (#5464)
 
 ## Deprecated
 <!-- Soon-to-be removed features -->

--- a/v3/pkg/application/linux_cgo.c
+++ b/v3/pkg/application/linux_cgo.c
@@ -349,6 +349,13 @@ gboolean get_action_state(const char *action_name) {
     return FALSE;
 }
 
+void menu_clear(GMenu *menu) {
+    gint count = g_menu_model_get_n_items(G_MENU_MODEL(menu));
+    for (gint i = count - 1; i >= 0; i--) {
+        g_menu_remove(menu, i);
+    }
+}
+
 void menu_remove_item(GMenu *menu, gint position) {
     g_menu_remove(menu, position);
 }

--- a/v3/pkg/application/linux_cgo.go
+++ b/v3/pkg/application/linux_cgo.go
@@ -357,6 +357,21 @@ func menuNew() pointer {
 	return pointer(C.g_menu_new())
 }
 
+func menuClear(menu *Menu) {
+	if menu.impl == nil {
+		return
+	}
+	impl := menu.impl.(*linuxMenu)
+	if impl.native == nil {
+		return
+	}
+	C.menu_clear((*C.GMenu)(impl.native))
+
+	menuItemCountersLock.Lock()
+	menuItemCounters[impl.native] = 0
+	menuItemCountersLock.Unlock()
+}
+
 func menuSetSubmenu(item *MenuItem, menu *Menu) {
 	if item.impl == nil || menu.impl == nil {
 		return

--- a/v3/pkg/application/linux_cgo.h
+++ b/v3/pkg/application/linux_cgo.h
@@ -124,6 +124,7 @@ char* build_accelerator_string(guint key, GdkModifierType mods);
 void set_action_enabled(const char *action_name, gboolean enabled);
 void set_action_state(const char *action_name, gboolean state);
 gboolean get_action_state(const char *action_name);
+void menu_clear(GMenu *menu);
 void menu_remove_item(GMenu *menu, gint position);
 void menu_insert_item(GMenu *menu, gint position, GMenuItem *item);
 void show_context_menu(GtkWidget *parent, GMenu *menu_model, int x, int y);

--- a/v3/pkg/application/linux_menu_regression_test.go
+++ b/v3/pkg/application/linux_menu_regression_test.go
@@ -1,0 +1,55 @@
+package application
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestLinuxGTK4MenuUpdateRebuildsProcessedMenus(t *testing.T) {
+	data, err := os.ReadFile("menu_linux.go")
+	if err != nil {
+		t.Skip("menu_linux.go not available")
+	}
+
+	body := functionBody(string(data), "func (m *linuxMenu) processMenu(menu *Menu)")
+
+	if strings.Contains(body, "if impl.processed") && strings.Contains(body, "return") {
+		t.Fatal("GTK4 processMenu must rebuild processed menus on Update, not return early")
+	}
+
+	if !strings.Contains(body, "menuClear(menu)") {
+		t.Fatal("GTK4 processMenu must clear existing native items before rebuilding")
+	}
+
+	data, err = os.ReadFile("linux_cgo.go")
+	if err != nil {
+		t.Skip("linux_cgo.go not available")
+	}
+	if !strings.Contains(string(data), "func menuClear(menu *Menu)") {
+		t.Fatal("GTK4 cgo path must provide menuClear for processMenu rebuilds")
+	}
+}
+
+func functionBody(source, signature string) string {
+	start := strings.Index(source, signature)
+	if start == -1 {
+		return ""
+	}
+
+	source = source[start:]
+	depth := 0
+	for i, r := range source {
+		switch r {
+		case '{':
+			depth++
+		case '}':
+			depth--
+			if depth == 0 {
+				return source[:i+1]
+			}
+		}
+	}
+
+	return source
+}

--- a/v3/pkg/application/menu_linux.go
+++ b/v3/pkg/application/menu_linux.go
@@ -36,10 +36,10 @@ func (m *linuxMenu) processMenu(menu *Menu) {
 
 	impl := menu.impl.(*linuxMenu)
 	if impl.processed {
-		// Menu already processed, skip re-processing to avoid duplicates
-		return
+		menuClear(menu)
+	} else {
+		impl.processed = true
 	}
-	impl.processed = true
 
 	var currentRadioGroup uint = 0
 	var checkedRadioId uint = 0


### PR DESCRIPTION
Fixes #5464

## Summary
- Rebuild GTK4 Linux menus on repeated `Menu.Update()` calls instead of returning early after the first process pass
- Add a GTK4 `menuClear` helper and reset menu item indexes before rebuilding
- Add a regression test and v3 changelog entry

## Tests
- `go test ./pkg/application -run TestLinuxGTK4MenuUpdateRebuildsProcessedMenus`
- `go test ./pkg/application`

Note: `coderabbit --plain` was not run because the command is not installed locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed GTK4 Linux menu updating behavior. Previously, calling `Menu.Update()` on a menu that had been rendered would be ignored entirely. Menus are now properly cleared and rebuilt during updates, ensuring that menu modifications take effect correctly even when updating menus that have been previously displayed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->