### PR TITLE
feat(mac/v3): extend MacWebviewPreferences with additional WKWebView config options

### DIFF
--- a/docs/src/content/docs/features/windows/options.mdx
+++ b/docs/src/content/docs/features/windows/options.mdx
@@ -849,6 +849,38 @@ Mac: application.MacWindow{
 },
 ```
 
+**WebviewPreferences** (`MacWebviewPreferences`)
+
+Fine-grained control over the underlying `WKWebView` configuration. All fields are optional — unset fields leave the WebKit default unchanged.
+
+```go
+Mac: application.MacWindow{
+    WebviewPreferences: application.MacWebviewPreferences{
+        TabFocusesLinks:                       optional.True,
+        TextInteractionEnabled:                optional.True,
+        FullscreenEnabled:                     optional.False,
+        AllowsBackForwardNavigationGestures:   optional.False,
+        AllowsMagnification:                   optional.True,
+        AllowsAirPlayForMediaPlayback:         optional.True,
+        JavaScriptCanOpenWindowsAutomatically: optional.False,
+        MinimumFontSize:                       optional.NewVar(12.0),
+        ApplicationNameForUserAgent:           "MyApp",
+        EnableAutoplayWithoutUserAction:       optional.True,
+    },
+},
+```
+
+- `TabFocusesLinks` — When `true`, pressing Tab moves focus to links and form controls (default: `false`)
+- `TextInteractionEnabled` — When `true`, users can select and interact with text in the webview (default: `true`)
+- `FullscreenEnabled` — When `true`, web content can enter fullscreen via the HTML Fullscreen API (default: `false`). Requires macOS 12.3+.
+- `AllowsBackForwardNavigationGestures` — When `true`, horizontal swipe gestures trigger back/forward navigation (default: `false`)
+- `AllowsMagnification` — When `true`, pinch-to-zoom is enabled on the webview (default: `false`)
+- `AllowsAirPlayForMediaPlayback` — When `true`, media can be streamed to AirPlay devices (default: `true`)
+- `JavaScriptCanOpenWindowsAutomatically` — When `true`, JavaScript can open new windows without a user gesture (default: `false`)
+- `MinimumFontSize` — Minimum font size in points. Use `optional.NewVar(12.0)` to set. Unset leaves WebKit default.
+- `ApplicationNameForUserAgent` — Overrides the application-name suffix in the WebKit user-agent string. Useful when sites reject the default `"wails.io"` identifier (e.g. YouTube embeds). Leave empty to keep the default.
+- `EnableAutoplayWithoutUserAction` — When `true`, audio and video can autoplay without a user gesture. Maps to `WKWebViewConfiguration.mediaTypesRequiringUserActionForPlayback = WKAudiovisualMediaTypeNone` (default: `false`)
+
 ### Windows Options (per-window)
 
 The per-window struct is `application.WindowsWindow` — **not** `WindowsOptions` (that's the *application*-level struct).

--- a/v3/pkg/application/webview_window_darwin.go
+++ b/v3/pkg/application/webview_window_darwin.go
@@ -19,12 +19,17 @@ struct WebviewPreferences {
     bool *TextInteractionEnabled;
     bool *FullscreenEnabled;
     bool *AllowsBackForwardNavigationGestures;
+    bool *AllowsMagnification;
+    bool *AllowsAirPlayForMediaPlayback;
+    bool *JavaScriptCanOpenWindowsAutomatically;
+    double *MinimumFontSize;
+    bool *EnableAutoplayWithoutUserAction;
 };
 
 extern void registerListener(unsigned int event);
 
 // Create a new Window
-void* windowNew(unsigned int id, int width, int height, bool fraudulentWebsiteWarningEnabled, bool frameless, bool enableDragAndDrop, struct WebviewPreferences preferences) {
+void* windowNew(unsigned int id, int width, int height, bool fraudulentWebsiteWarningEnabled, bool frameless, bool enableDragAndDrop, struct WebviewPreferences preferences, const char* applicationNameForUserAgent) {
 	NSWindowStyleMask styleMask = NSWindowStyleMaskTitled | NSWindowStyleMaskClosable | NSWindowStyleMaskMiniaturizable | NSWindowStyleMaskResizable;
 	if (frameless) {
 		styleMask = NSWindowStyleMaskBorderless | NSWindowStyleMaskResizable | NSWindowStyleMaskMiniaturizable;
@@ -82,8 +87,24 @@ void* windowNew(unsigned int id, int width, int height, bool fraudulentWebsiteWa
      }
 #endif
 
+	if (preferences.AllowsAirPlayForMediaPlayback != NULL) {
+		config.allowsAirPlayForMediaPlayback = *preferences.AllowsAirPlayForMediaPlayback;
+	}
+	if (preferences.EnableAutoplayWithoutUserAction != NULL && *preferences.EnableAutoplayWithoutUserAction) {
+		config.mediaTypesRequiringUserActionForPlayback = WKAudiovisualMediaTypeNone;
+	}
+	if (preferences.JavaScriptCanOpenWindowsAutomatically != NULL) {
+		config.preferences.javaScriptCanOpenWindowsAutomatically = *preferences.JavaScriptCanOpenWindowsAutomatically;
+	}
+	if (preferences.MinimumFontSize != NULL) {
+		config.preferences.minimumFontSize = *preferences.MinimumFontSize;
+	}
 	config.suppressesIncrementalRendering = true;
-    config.applicationNameForUserAgent = @"wails.io";
+	if (applicationNameForUserAgent != NULL && strlen(applicationNameForUserAgent) > 0) {
+		config.applicationNameForUserAgent = [NSString stringWithUTF8String:applicationNameForUserAgent];
+	} else {
+		config.applicationNameForUserAgent = @"wails.io";
+	}
 	[config setURLSchemeHandler:delegate forURLScheme:@"wails"];
 
 #if MAC_OS_X_VERSION_MAX_ALLOWED >= 101500
@@ -102,10 +123,12 @@ void* windowNew(unsigned int id, int width, int height, bool fraudulentWebsiteWa
 	WKWebView* webView = [[WKWebView alloc] initWithFrame:frame configuration:config];
 	[webView autorelease];
 
-    // Set allowsBackForwardNavigationGestures if specified
     if (preferences.AllowsBackForwardNavigationGestures != NULL) {
         webView.allowsBackForwardNavigationGestures = *preferences.AllowsBackForwardNavigationGestures;
     }
+	if (preferences.AllowsMagnification != NULL) {
+		webView.allowsMagnification = *preferences.AllowsMagnification;
+	}
 
 	[view addSubview:webView];
 
@@ -1342,6 +1365,22 @@ func (w *macosWebviewWindow) getWebviewPreferences() C.struct_WebviewPreferences
 	if wvprefs.AllowsBackForwardNavigationGestures.IsSet() {
 		result.AllowsBackForwardNavigationGestures = bool2CboolPtr(wvprefs.AllowsBackForwardNavigationGestures.Get())
 	}
+	if wvprefs.AllowsMagnification.IsSet() {
+		result.AllowsMagnification = bool2CboolPtr(wvprefs.AllowsMagnification.Get())
+	}
+	if wvprefs.AllowsAirPlayForMediaPlayback.IsSet() {
+		result.AllowsAirPlayForMediaPlayback = bool2CboolPtr(wvprefs.AllowsAirPlayForMediaPlayback.Get())
+	}
+	if wvprefs.JavaScriptCanOpenWindowsAutomatically.IsSet() {
+		result.JavaScriptCanOpenWindowsAutomatically = bool2CboolPtr(wvprefs.JavaScriptCanOpenWindowsAutomatically.Get())
+	}
+	if wvprefs.MinimumFontSize.IsSet() {
+		v := C.double(wvprefs.MinimumFontSize.Get())
+		result.MinimumFontSize = &v
+	}
+	if wvprefs.EnableAutoplayWithoutUserAction.IsSet() {
+		result.EnableAutoplayWithoutUserAction = bool2CboolPtr(wvprefs.EnableAutoplayWithoutUserAction.Get())
+	}
 
 	return result
 }
@@ -1354,6 +1393,8 @@ func (w *macosWebviewWindow) run() {
 		options := w.parent.options
 		macOptions := options.Mac
 
+		appName := C.CString(macOptions.WebviewPreferences.ApplicationNameForUserAgent)
+		defer C.free(unsafe.Pointer(appName))
 		w.nsWindow = C.windowNew(C.uint(w.parent.id),
 			C.int(options.Width),
 			C.int(options.Height),
@@ -1361,6 +1402,7 @@ func (w *macosWebviewWindow) run() {
 			C.bool(options.Frameless),
 			C.bool(options.EnableFileDrop),
 			w.getWebviewPreferences(),
+			appName,
 		)
 		if macOptions.DisableEscapeExitsFullscreen {
 			C.windowSetDisableEscapeExitsFullscreen(w.nsWindow, C.bool(true))

--- a/v3/pkg/application/webview_window_darwin.go
+++ b/v3/pkg/application/webview_window_darwin.go
@@ -100,7 +100,7 @@ void* windowNew(unsigned int id, int width, int height, bool fraudulentWebsiteWa
 		config.preferences.minimumFontSize = *preferences.MinimumFontSize;
 	}
 	config.suppressesIncrementalRendering = true;
-	if (applicationNameForUserAgent != NULL && strlen(applicationNameForUserAgent) > 0) {
+	if (applicationNameForUserAgent != NULL && applicationNameForUserAgent[0] != '\0') {
 		config.applicationNameForUserAgent = [NSString stringWithUTF8String:applicationNameForUserAgent];
 	} else {
 		config.applicationNameForUserAgent = @"wails.io";
@@ -1393,8 +1393,11 @@ func (w *macosWebviewWindow) run() {
 		options := w.parent.options
 		macOptions := options.Mac
 
-		appName := C.CString(macOptions.WebviewPreferences.ApplicationNameForUserAgent)
-		defer C.free(unsafe.Pointer(appName))
+		var appName *C.char
+		if s := macOptions.WebviewPreferences.ApplicationNameForUserAgent; s != "" {
+			appName = C.CString(s)
+			defer C.free(unsafe.Pointer(appName))
+		}
 		w.nsWindow = C.windowNew(C.uint(w.parent.id),
 			C.int(options.Width),
 			C.int(options.Height),

--- a/v3/pkg/application/webview_window_options.go
+++ b/v3/pkg/application/webview_window_options.go
@@ -596,6 +596,20 @@ type MacWebviewPreferences struct {
 	FullscreenEnabled optional.Bool
 	// AllowsBackForwardNavigationGestures enables horizontal swipe gestures for back/forward navigation
 	AllowsBackForwardNavigationGestures optional.Bool
+	// AllowsMagnification enables pinch-to-zoom on the webview
+	AllowsMagnification optional.Bool
+	// AllowsAirPlayForMediaPlayback enables AirPlay media playback
+	AllowsAirPlayForMediaPlayback optional.Bool
+	// JavaScriptCanOpenWindowsAutomatically allows JS to open windows without a user gesture
+	JavaScriptCanOpenWindowsAutomatically optional.Bool
+	// MinimumFontSize sets the minimum font size in points
+	MinimumFontSize optional.Var[float64]
+	// ApplicationNameForUserAgent overrides the application name portion of the user agent string.
+	// Leave empty to use the default "wails.io" suffix.
+	ApplicationNameForUserAgent string
+	// EnableAutoplayWithoutUserAction allows media to start playing automatically
+	// without requiring a user gesture. Maps to WKWebViewConfiguration.mediaTypesRequiringUserActionForPlayback.
+	EnableAutoplayWithoutUserAction optional.Bool
 }
 
 // MacTitleBar contains options for the Mac titlebar


### PR DESCRIPTION
## Summary

Adds v3 parity for WKWebView configuration options, including the `EnableAutoplayWithoutUserAction` feature from #5512.

New fields in `MacWebviewPreferences`:

| Field | Maps to |
|---|---|
| `EnableAutoplayWithoutUserAction` | `config.mediaTypesRequiringUserActionForPlayback = WKAudiovisualMediaTypeNone` |
| `AllowsAirPlayForMediaPlayback` | `config.allowsAirPlayForMediaPlayback` |
| `AllowsMagnification` | `webView.allowsMagnification` |
| `JavaScriptCanOpenWindowsAutomatically` | `config.preferences.javaScriptCanOpenWindowsAutomatically` |
| `MinimumFontSize` | `config.preferences.minimumFontSize` |
| `ApplicationNameForUserAgent` | `config.applicationNameForUserAgent` (falls back to `"wails.io"` if empty) |

## Related

Closes the v3 gap for #5512.

## Test plan

- [ ] Build on macOS: `go build ./v3/pkg/application/`
- [ ] Verify autoplay works without user gesture when `EnableAutoplayWithoutUserAction: optional.True`
- [ ] Verify `ApplicationNameForUserAgent` override appears in the webview's user agent string

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * macOS WebView windows gain new preferences: pinch-to-zoom (magnification), AirPlay media playback, JavaScript automatic window opening, minimum font size, user-agent application-name override, and autoplay without user gesture.
* **Documentation**
  * Added macOS per-window WebviewPreferences docs with examples and field-by-field explanations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->