### PR TITLE
[v3, windows] Fix generate bindings failing with "Access is denied" when Vite dev server is running

### DIFF
--- a/v3/UNRELEASED_CHANGELOG.md
+++ b/v3/UNRELEASED_CHANGELOG.md
@@ -23,6 +23,7 @@ After processing, the content will be moved to the main changelog and this file 
 
 ## Fixed
 <!-- Bug fixes -->
+- Fix `wails3 generate bindings` failing with "Access is denied" on Windows when the Vite dev server is running, by syncing generated files into the output directory instead of renaming over it (#5515)
 
 ## Deprecated
 <!-- Soon-to-be removed features -->

--- a/v3/internal/commands/bindings.go
+++ b/v3/internal/commands/bindings.go
@@ -39,10 +39,11 @@ func GenerateBindings(options *flags.GenerateBindingsOptions, patterns []string)
 	}
 
 	// When clean mode is active and we're writing real files, generate bindings
-	// into a dot-prefixed sibling temp directory first, then swap it into place
-	// with RemoveAll+Rename. This prevents chokidar (used by Vite) from entering
-	// a rename-event loop caused by rapid directory delete+recreate, which would
-	// otherwise cause the node process to leak memory at ~2-6 MB/s.
+	// into a dot-prefixed sibling temp directory first, then sync the result
+	// into the output directory file by file. This prevents chokidar (used by
+	// Vite) from entering a rename-event loop caused by rapid directory
+	// delete+recreate, which would otherwise cause the node process to leak
+	// memory at ~2-6 MB/s.
 	// Dot-prefixed directories are ignored by chokidar's default glob pattern,
 	// so no spurious HMR events fire during file generation.
 	generationDir := absPath
@@ -132,14 +133,13 @@ func GenerateBindings(options *flags.GenerateBindingsOptions, patterns []string)
 		}
 	}
 
-	// Swap the temp dir into place. The -clean contract does not guarantee
-	// atomic replacement; RemoveAll+Rename matches the existing behaviour.
+	// Sync the generated output into place. Files are updated individually
+	// rather than swapping the whole directory: on Windows, deleting or
+	// renaming over the output directory fails with "Access is denied" while
+	// a file watcher (e.g. Vite's dev server) holds it open (#5515).
 	if !swapped && generationDir != absPath {
-		if err := os.RemoveAll(absPath); err != nil {
-			return fmt.Errorf("failed to remove old bindings directory %q: %w\nExisting bindings are untouched; generated output has been discarded.", absPath, err)
-		}
-		if err := os.Rename(generationDir, absPath); err != nil {
-			return fmt.Errorf("failed to install new bindings at %q: %w\nOld bindings have been removed. Re-run the command to regenerate them.", absPath, err)
+		if err := syncDirs(generationDir, absPath); err != nil {
+			return fmt.Errorf("failed to install new bindings at %q: %w\nThe bindings directory may be partially updated. Re-run the command to retry.", absPath, err)
 		}
 		swapped = true
 	}

--- a/v3/internal/commands/bindings.go
+++ b/v3/internal/commands/bindings.go
@@ -49,7 +49,7 @@ func GenerateBindings(options *flags.GenerateBindingsOptions, patterns []string)
 	generationDir := absPath
 	swapped := false
 	if options.Clean && !options.DryRun {
-		if err := os.MkdirAll(filepath.Dir(absPath), 0o777); err != nil {
+		if err := os.MkdirAll(filepath.Dir(absPath), 0o755); err != nil {
 			return fmt.Errorf("failed to create bindings parent directory: %w", err)
 		}
 		tmpDir, err := os.MkdirTemp(filepath.Dir(absPath), ".bindings-tmp-")

--- a/v3/internal/commands/bindings_sync.go
+++ b/v3/internal/commands/bindings_sync.go
@@ -1,0 +1,144 @@
+package commands
+
+import (
+	"bytes"
+	"errors"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"runtime"
+	"time"
+)
+
+// syncDirs makes dst's contents identical to src's, then removes src.
+//
+// Unlike a RemoveAll+Rename swap, dst itself is never deleted or renamed:
+// on Windows a file watcher (e.g. Vite's chokidar) holds an open handle on
+// watched directories, which makes deleting or renaming over them fail with
+// "Access is denied" (#5515). Updating individual files also avoids the
+// chokidar rename-event loop caused by deleting and recreating the watched
+// directory (#3976), and leaves unchanged files untouched so the dev server
+// only reloads what actually changed.
+func syncDirs(src, dst string) error {
+	// Fast path: no destination, move the whole tree at once.
+	if _, err := os.Lstat(dst); errors.Is(err, fs.ErrNotExist) {
+		if renameErr := withRetry(func() error { return os.Rename(src, dst) }); renameErr == nil {
+			return nil
+		}
+		// Fall through to the per-file sync, which recreates dst below.
+	} else if err != nil {
+		return err
+	}
+
+	if err := os.MkdirAll(dst, 0o777); err != nil {
+		return err
+	}
+
+	// Copy phase: bring every entry of src into dst, skipping identical files.
+	keep := make(map[string]bool)
+	err := filepath.WalkDir(src, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, err := filepath.Rel(src, path)
+		if err != nil {
+			return err
+		}
+		if rel == "." {
+			return nil
+		}
+		keep[rel] = true
+		target := filepath.Join(dst, rel)
+		if d.IsDir() {
+			if info, err := os.Lstat(target); err == nil && !info.IsDir() {
+				if err := withRetry(func() error { return os.Remove(target) }); err != nil {
+					return err
+				}
+			}
+			return os.MkdirAll(target, 0o777)
+		}
+		if sameFileContent(path, target) {
+			return nil
+		}
+		return replaceFile(path, target)
+	})
+	if err != nil {
+		return err
+	}
+
+	// Delete phase: drop anything in dst that the generator did not produce.
+	var stale []string
+	err = filepath.WalkDir(dst, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, err := filepath.Rel(dst, path)
+		if err != nil {
+			return err
+		}
+		if rel == "." || keep[rel] {
+			return nil
+		}
+		stale = append(stale, path)
+		if d.IsDir() {
+			return fs.SkipDir
+		}
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+	for _, path := range stale {
+		if err := withRetry(func() error { return os.RemoveAll(path) }); err != nil {
+			return err
+		}
+	}
+
+	return os.RemoveAll(src)
+}
+
+// replaceFile moves src over dst, clearing dst first if it is not a regular
+// file (e.g. a directory now replaced by a file of the same name).
+func replaceFile(src, dst string) error {
+	if info, err := os.Lstat(dst); err == nil && !info.Mode().IsRegular() {
+		if err := withRetry(func() error { return os.RemoveAll(dst) }); err != nil {
+			return err
+		}
+	}
+	return withRetry(func() error { return os.Rename(src, dst) })
+}
+
+// sameFileContent reports whether a and b are regular files with equal
+// content. Generated bindings are small, so a full read is fine.
+func sameFileContent(a, b string) bool {
+	infoA, errA := os.Stat(a)
+	infoB, errB := os.Stat(b)
+	if errA != nil || errB != nil || !infoA.Mode().IsRegular() || !infoB.Mode().IsRegular() || infoA.Size() != infoB.Size() {
+		return false
+	}
+	dataA, err := os.ReadFile(a)
+	if err != nil {
+		return false
+	}
+	dataB, err := os.ReadFile(b)
+	if err != nil {
+		return false
+	}
+	return bytes.Equal(dataA, dataB)
+}
+
+// withRetry retries op with backoff on Windows, where file watchers and
+// antivirus scanners briefly lock files and directories. Other platforms get
+// a single attempt.
+func withRetry(op func() error) error {
+	var err error
+	delay := 8 * time.Millisecond
+	for attempt := 0; attempt < 6; attempt++ {
+		if err = op(); err == nil || runtime.GOOS != "windows" {
+			return err
+		}
+		time.Sleep(delay)
+		delay *= 2
+	}
+	return err
+}

--- a/v3/internal/commands/bindings_sync.go
+++ b/v3/internal/commands/bindings_sync.go
@@ -20,23 +20,34 @@ import (
 // directory (#3976), and leaves unchanged files untouched so the dev server
 // only reloads what actually changed.
 func syncDirs(src, dst string) error {
-	// Fast path: no destination, move the whole tree at once.
-	if _, err := os.Lstat(dst); errors.Is(err, fs.ErrNotExist) {
+	info, err := os.Lstat(dst)
+	switch {
+	case errors.Is(err, fs.ErrNotExist):
+		// Fast path: no destination, move the whole tree at once.
 		if renameErr := withRetry(func() error { return os.Rename(src, dst) }); renameErr == nil {
 			return nil
 		}
 		// Fall through to the per-file sync, which recreates dst below.
-	} else if err != nil {
+	case err != nil:
 		return err
+	case !info.IsDir():
+		// The destination exists but is not a directory: clear it, then
+		// move the tree into place.
+		if err := withRetry(func() error { return os.RemoveAll(dst) }); err != nil {
+			return err
+		}
+		if renameErr := withRetry(func() error { return os.Rename(src, dst) }); renameErr == nil {
+			return nil
+		}
 	}
 
-	if err := os.MkdirAll(dst, 0o777); err != nil {
+	if err := os.MkdirAll(dst, 0o755); err != nil {
 		return err
 	}
 
 	// Copy phase: bring every entry of src into dst, skipping identical files.
 	keep := make(map[string]bool)
-	err := filepath.WalkDir(src, func(path string, d fs.DirEntry, err error) error {
+	err = filepath.WalkDir(src, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
@@ -55,7 +66,7 @@ func syncDirs(src, dst string) error {
 					return err
 				}
 			}
-			return os.MkdirAll(target, 0o777)
+			return os.MkdirAll(target, 0o755)
 		}
 		if sameFileContent(path, target) {
 			return nil
@@ -94,7 +105,7 @@ func syncDirs(src, dst string) error {
 		}
 	}
 
-	return os.RemoveAll(src)
+	return withRetry(func() error { return os.RemoveAll(src) })
 }
 
 // replaceFile moves src over dst, clearing dst first if it is not a regular
@@ -105,7 +116,16 @@ func replaceFile(src, dst string) error {
 			return err
 		}
 	}
-	return withRetry(func() error { return os.Rename(src, dst) })
+	err := withRetry(func() error { return os.Rename(src, dst) })
+	if err == nil {
+		return nil
+	}
+	// os.Rename replaces existing files on Windows (MOVEFILE_REPLACE_EXISTING),
+	// but not when dst has the read-only attribute set. Clear dst and retry.
+	if removeErr := withRetry(func() error { return os.Remove(dst) }); removeErr == nil {
+		err = withRetry(func() error { return os.Rename(src, dst) })
+	}
+	return err
 }
 
 // sameFileContent reports whether a and b are regular files with equal

--- a/v3/internal/commands/bindings_sync.go
+++ b/v3/internal/commands/bindings_sync.go
@@ -133,12 +133,11 @@ func sameFileContent(a, b string) bool {
 func withRetry(op func() error) error {
 	var err error
 	delay := 8 * time.Millisecond
-	for attempt := 0; attempt < 6; attempt++ {
-		if err = op(); err == nil || runtime.GOOS != "windows" {
+	for attempt := 0; ; attempt++ {
+		if err = op(); err == nil || runtime.GOOS != "windows" || attempt == 5 {
 			return err
 		}
 		time.Sleep(delay)
 		delay *= 2
 	}
-	return err
 }

--- a/v3/internal/commands/bindings_sync_test.go
+++ b/v3/internal/commands/bindings_sync_test.go
@@ -1,0 +1,160 @@
+package commands
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func writeFiles(t *testing.T, root string, files map[string]string) {
+	t.Helper()
+	for name, content := range files {
+		path := filepath.Join(root, filepath.FromSlash(name))
+		if err := os.MkdirAll(filepath.Dir(path), 0o777); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte(content), 0o666); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+func readTree(t *testing.T, root string) map[string]string {
+	t.Helper()
+	tree := make(map[string]string)
+	err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+		if err != nil || d.IsDir() {
+			return err
+		}
+		rel, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		tree[filepath.ToSlash(rel)] = string(data)
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return tree
+}
+
+func checkTree(t *testing.T, root string, want map[string]string) {
+	t.Helper()
+	got := readTree(t, root)
+	if len(got) != len(want) {
+		t.Errorf("got %d files, want %d: %v", len(got), len(want), got)
+	}
+	for name, content := range want {
+		if got[name] != content {
+			t.Errorf("file %q: got %q, want %q", name, got[name], content)
+		}
+	}
+}
+
+func TestSyncDirsNoDestination(t *testing.T) {
+	root := t.TempDir()
+	src := filepath.Join(root, ".bindings-tmp-1")
+	dst := filepath.Join(root, "bindings")
+	files := map[string]string{"svc/a.ts": "a", "index.ts": "idx"}
+	writeFiles(t, src, files)
+
+	if err := syncDirs(src, dst); err != nil {
+		t.Fatal(err)
+	}
+	checkTree(t, dst, files)
+	if _, err := os.Lstat(src); !os.IsNotExist(err) {
+		t.Errorf("source directory should be gone, got err=%v", err)
+	}
+}
+
+func TestSyncDirsUpdatesAndDeletes(t *testing.T) {
+	root := t.TempDir()
+	src := filepath.Join(root, ".bindings-tmp-1")
+	dst := filepath.Join(root, "bindings")
+	writeFiles(t, src, map[string]string{
+		"svc/a.ts": "new a",
+		"svc/b.ts": "same b",
+		"new.ts":   "brand new",
+	})
+	writeFiles(t, dst, map[string]string{
+		"svc/a.ts":       "old a",
+		"svc/b.ts":       "same b",
+		"stale.ts":       "stale",
+		"gone/nested.ts": "stale dir",
+	})
+
+	// Backdate the unchanged file so we can verify it is left untouched.
+	past := time.Now().Add(-time.Hour)
+	unchanged := filepath.Join(dst, "svc", "b.ts")
+	if err := os.Chtimes(unchanged, past, past); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := syncDirs(src, dst); err != nil {
+		t.Fatal(err)
+	}
+	checkTree(t, dst, map[string]string{
+		"svc/a.ts": "new a",
+		"svc/b.ts": "same b",
+		"new.ts":   "brand new",
+	})
+	if _, err := os.Lstat(filepath.Join(dst, "gone")); !os.IsNotExist(err) {
+		t.Errorf("stale directory should be gone, got err=%v", err)
+	}
+	info, err := os.Stat(unchanged)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !info.ModTime().Equal(past) {
+		t.Errorf("unchanged file was rewritten: mtime %v, want %v", info.ModTime(), past)
+	}
+	if _, err := os.Lstat(src); !os.IsNotExist(err) {
+		t.Errorf("source directory should be gone, got err=%v", err)
+	}
+}
+
+func TestSyncDirsTypeMismatch(t *testing.T) {
+	root := t.TempDir()
+	src := filepath.Join(root, ".bindings-tmp-1")
+	dst := filepath.Join(root, "bindings")
+	// In src, "thing" is a file and "other" is a directory; in dst the
+	// types are reversed.
+	writeFiles(t, src, map[string]string{
+		"thing":    "now a file",
+		"other/x":  "in dir",
+		"plain.ts": "p",
+	})
+	writeFiles(t, dst, map[string]string{
+		"thing/nested": "was a dir",
+		"other":        "was a file",
+	})
+
+	if err := syncDirs(src, dst); err != nil {
+		t.Fatal(err)
+	}
+	checkTree(t, dst, map[string]string{
+		"thing":    "now a file",
+		"other/x":  "in dir",
+		"plain.ts": "p",
+	})
+}
+
+func TestSyncDirsIdenticalContent(t *testing.T) {
+	root := t.TempDir()
+	src := filepath.Join(root, ".bindings-tmp-1")
+	dst := filepath.Join(root, "bindings")
+	files := map[string]string{"a.ts": "a", "sub/b.ts": "b"}
+	writeFiles(t, src, files)
+	writeFiles(t, dst, files)
+
+	if err := syncDirs(src, dst); err != nil {
+		t.Fatal(err)
+	}
+	checkTree(t, dst, files)
+}

--- a/v3/internal/commands/bindings_sync_test.go
+++ b/v3/internal/commands/bindings_sync_test.go
@@ -145,6 +145,25 @@ func TestSyncDirsTypeMismatch(t *testing.T) {
 	})
 }
 
+func TestSyncDirsDestinationIsFile(t *testing.T) {
+	root := t.TempDir()
+	src := filepath.Join(root, ".bindings-tmp-1")
+	dst := filepath.Join(root, "bindings")
+	files := map[string]string{"a.ts": "a"}
+	writeFiles(t, src, files)
+	if err := os.WriteFile(dst, []byte("not a directory"), 0o666); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := syncDirs(src, dst); err != nil {
+		t.Fatal(err)
+	}
+	checkTree(t, dst, files)
+	if _, err := os.Lstat(src); !os.IsNotExist(err) {
+		t.Errorf("source directory should be gone, got err=%v", err)
+	}
+}
+
 func TestSyncDirsIdenticalContent(t *testing.T) {
 	root := t.TempDir()
 	src := filepath.Join(root, ".bindings-tmp-1")


### PR DESCRIPTION
## Description

Fixes #5515 — a regression introduced in v3.0.0-alpha.96 by #5367.

The atomic directory swap from #5367 (`os.RemoveAll` + `os.Rename`) fails on Windows when a file watcher such as Vite's dev server is running: the watcher holds an open handle on the watched `bindings` directory (via `ReadDirectoryChangesW`), so deleting it leaves the name in delete-pending state and the subsequent rename over it is rejected with `Access is denied`.

### The fix

Bindings are still generated into a dot-prefixed sibling temp directory (invisible to chokidar during generation, as before), but the result is now installed by **syncing files into the output directory** instead of replacing the directory itself:

- The output directory is never deleted or renamed, so Windows watcher handles are never violated — fixes #5515.
- The directory delete+recreate cascade that caused the chokidar rename-event loop (the memory leak fixed by #5367 / #3976) still never happens, so that fix is preserved.
- Unchanged files are left untouched (content-compared before replacing), so the dev server only reloads files that actually changed — strictly fewer HMR events than the directory swap, which invalidated everything.
- File operations retry briefly with exponential backoff on Windows to ride out transient locks from watchers and antivirus scanners.

If the output directory doesn't exist at all, the whole tree is still moved with a single rename (fast path).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- New unit tests for `syncDirs` covering: no pre-existing destination, update+stale-delete with unchanged files verified untouched (mtime preserved), file↔directory type mismatches, and fully identical content.
- End-to-end on macOS: built `wails3` and ran `generate bindings -clean` against `v3/examples/binding` twice — second run over existing output with planted stale files/dirs. Stale entries were removed, unchanged files kept their original mtimes (i.e. were not rewritten), and no temp directories were left behind.
- `go test ./internal/commands/` passes; `go vet` clean.

The Windows-with-Vite-running scenario from the issue would be good to confirm on a Windows machine, but the failing operation (rename over a watched directory) is structurally eliminated rather than retried around.

## Checklist:

- [x] My code follows the general coding style of this project
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated `v3/UNRELEASED_CHANGELOG.md`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * wails3 generate bindings no longer fails on Windows with "Access is denied" when the Vite dev server is running; bindings are now synced into the output to avoid watcher/rename issues and improve reliability.

* **Tests**
  * Added comprehensive cross-platform tests for bindings synchronization to ensure correct updates, deletions, type reconciliation, and idempotence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->