### PR TITLE
Fix TypeScript interface generation missing `| null` for slice/map fields

### DIFF
--- a/.github/workflows/auto-changelog-v3.yml
+++ b/.github/workflows/auto-changelog-v3.yml
@@ -22,7 +22,7 @@ jobs:
       contents: write
 
     steps:
-    - name: Checkout master
+    - name: Checkout v3-alpha
       uses: actions/checkout@v4
       with:
         ref: master

--- a/.github/workflows/build-and-test-v3.yml
+++ b/.github/workflows/build-and-test-v3.yml
@@ -7,9 +7,6 @@ on:
       - master
     paths:
       - 'v3/**'
-      - 'webview2/**'
-      - 'go.work'
-      - 'go.work.sum'
       - '.github/workflows/build-and-test-v3.yml'
   pull_request_review:
     types: [submitted]
@@ -98,6 +95,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     if: github.base_ref == 'master'
     timeout-minutes: 25
+    env:
+      GOWORK: "off"
     strategy:
       fail-fast: false
       matrix:
@@ -127,10 +126,7 @@ jobs:
         with:
           go-version: ${{ matrix.go-version }}
           cache: true
-          cache-dependency-path: |
-            v3/go.sum
-            webview2/go.sum
-            go.work.sum
+          cache-dependency-path: "v3/go.sum"
 
       - name: Install Task
         uses: arduino/setup-task@v2
@@ -204,6 +200,8 @@ jobs:
     needs: [test_js, test_go]
     runs-on: ${{ matrix.os }}
     if: github.base_ref == 'master'
+    env:
+      GOWORK: "off"
     strategy:
       fail-fast: false
       matrix:
@@ -245,10 +243,7 @@ jobs:
         with:
           go-version: ${{ matrix.go-version }}
           cache: true
-          cache-dependency-path: |
-            v3/go.sum
-            webview2/go.sum
-            go.work.sum
+          cache-dependency-path: "v3/go.sum"
 
       - name: Install Task
         uses: arduino/setup-task@v2
@@ -284,9 +279,6 @@ jobs:
           # Replace @wailsio/runtime version with local tarball
           npm pkg set dependencies.@wailsio/runtime="file://$RUNTIME_TGZ"
           cd ..
-          # Register the generated project in the workspace so Go 1.25 workspace
-          # mode does not reject packages in a module not listed in go.work.
-          go work use .
           wails3 build
 
       # GTK3 legacy template builds are covered by the Go example compilation tests above.

--- a/.github/workflows/build-cross-image.yml
+++ b/.github/workflows/build-cross-image.yml
@@ -30,9 +30,6 @@ on:
     paths:
       - 'v3/internal/commands/build_assets/docker/Dockerfile.cross'
 
-permissions:
-  contents: read
-
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: wailsapp/wails-cross
@@ -40,11 +37,11 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      GOWORK: "off"
     permissions:
       contents: read
       packages: write
-    env:
-      GOWORK: "off"
     outputs:
       image_tag: ${{ steps.vars.outputs.image_version }}
 
@@ -117,9 +114,6 @@ jobs:
     runs-on: ubuntu-latest
     env:
       GOWORK: "off"
-    permissions:
-      contents: read
-      packages: read
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/changelog-v3.yml
+++ b/.github/workflows/changelog-v3.yml
@@ -30,9 +30,9 @@ jobs:
         fetch-depth: 0
         token: ${{ secrets.GITHUB_TOKEN || github.token }}
         
-    - name: Get validation script from master
+    - name: Get REAL validation script from v3-alpha
       run: |
-        echo "Fetching the validation script from master branch..."
+        echo "Fetching the REAL validation script from v3-alpha branch..."
         git fetch origin master
         git checkout origin/master -- v3/scripts/validate-changelog.go
         
@@ -121,9 +121,9 @@ jobs:
             echo "🔍 PR source branch: $BRANCH_NAME"
             echo "🔍 Head repository: $HEAD_REPO"
             
-            # Don't push if this is from a fork or if branch is master (main branch)
+            # Don't push if this is from a fork or if branch is v3-alpha (main branch)
             if [ "$HEAD_REPO" != "wails" ] || [ "$BRANCH_NAME" = "master" ]; then
-              echo "⚠️ Cannot push - either fork or master branch. Manual fix required."
+              echo "⚠️ Cannot push - either fork or direct v3-alpha branch. Manual fix required."
               echo "committed=false" >> $GITHUB_OUTPUT
               exit 0
             fi

--- a/.github/workflows/cross-compile-test-v3.yml
+++ b/.github/workflows/cross-compile-test-v3.yml
@@ -7,9 +7,6 @@ on:
       - master
     paths:
       - 'v3/**'
-      - 'webview2/**'
-      - 'go.work'
-      - 'go.work.sum'
       - '.github/workflows/cross-compile-test-v3.yml'
   workflow_dispatch:
     inputs:
@@ -80,10 +77,7 @@ jobs:
         with:
           go-version: '1.25'
           cache: true
-          cache-dependency-path: |
-            v3/go.sum
-            webview2/go.sum
-            go.work.sum
+          cache-dependency-path: "v3/go.sum"
 
       - name: Install Task
         uses: arduino/setup-task@v2

--- a/.github/workflows/nightly-release-v3.yml
+++ b/.github/workflows/nightly-release-v3.yml
@@ -117,11 +117,8 @@ jobs:
             echo "should_continue=true" >> $GITHUB_OUTPUT
           fi
         else
-          # No current tag, check against latest release.
-          # Only consider the active "alpha2.*" series: it outranks the legacy
-          # "alpha.*" tags in semver, and on the very first run (no alpha2 tag
-          # yet) the empty result correctly forces the inaugural alpha2 release.
-          LATEST_TAG=$(git tag --list "v3.0.0-alpha2.*" | sort -V | tail -1)
+          # No current tag, check against latest release
+          LATEST_TAG=$(git tag --list "v3.0.0-alpha.*" | sort -V | tail -1)
           if [ -z "$LATEST_TAG" ]; then
             echo "No previous release found, proceeding with release"
             echo "has_changes=true" >> $GITHUB_OUTPUT
@@ -174,13 +171,8 @@ jobs:
         steps.quick_check.outputs.should_continue == 'true' || 
         github.event.inputs.force_release == 'true'
       env:
-        # Keep these DISTINCT: the release script validates WAILS_REPO_TOKEN
-        # against the API before pushing anything and falls back to
-        # GITHUB_TOKEN if the PAT is expired/revoked. Passing the same value
-        # for both (as before) made the fallback meaningless and an expired
-        # PAT produced a half-release: tag pushed, no GitHub release.
-        WAILS_REPO_TOKEN: ${{ secrets.WAILS_REPO_TOKEN }}
-        GITHUB_TOKEN: ${{ github.token }}
+        WAILS_REPO_TOKEN: ${{ secrets.WAILS_REPO_TOKEN || github.token }}
+        GITHUB_TOKEN: ${{ secrets.WAILS_REPO_TOKEN || github.token }}
       run: |
         cd v3/tasks/release
         ARGS=()

--- a/v2/internal/binding/binding_test/binding_deepelements_test.go
+++ b/v2/internal/binding/binding_test/binding_deepelements_test.go
@@ -124,3 +124,44 @@ export namespace binding_test {
             }
 `,
 }
+
+var DeepElementsInterfacesTest = BindingTest{
+	name: "DeepElementsAsInterfaces",
+	structs: []interface{}{
+		&DeepElements{},
+	},
+	exemptions:  nil,
+	shouldError: false,
+	TsGenerationOptionsTest: TsGenerationOptionsTest{
+		TsOutputType: "interfaces",
+	},
+	want: `
+export namespace binding_test {
+            
+                export interface DeepMessage {
+                    Msg: string;
+                }
+                export interface DeepElements {
+                    Single: number[] | null;
+                    Double: string[][] | null;
+                    FourDouble: number[][] | null;
+                    DoubleFour: number[][] | null;
+                    Triple: number[][][] | null;
+                    SingleMap: Record<string, number> | null;
+                    SliceMap: Record<string, Array<number>> | null;
+                    DoubleSliceMap: Record<string, Array<Array<number>>> | null;
+                    ArrayMap: Record<string, Array<number>> | null;
+                    DoubleArrayMap1: Record<string, Array<Array<number>>> | null;
+                    DoubleArrayMap2: Record<string, Array<Array<number>>> | null;
+                    DoubleArrayMap3: Record<string, Array<Array<number>>> | null;
+                    OneStructs: DeepMessage[] | null;
+                    TwoStructs: DeepMessage[][] | null;
+                    ThreeStructs: DeepMessage[][][] | null;
+                    MapStructs: Record<string, Array<DeepMessage>> | null;
+                    MapTwoStructs: Record<string, Array<Array<DeepMessage>>> | null;
+                    MapThreeStructs: Record<string, Array<Array<Array<DeepMessage>>>> | null;
+                }
+            
+            }
+`,
+}

--- a/v2/internal/binding/binding_test/binding_test.go
+++ b/v2/internal/binding/binding_test/binding_test.go
@@ -55,6 +55,7 @@ func TestBindings_GenerateModels(t *testing.T) {
 		Generics2Test,
 		IgnoredTest,
 		DeepElementsTest,
+		DeepElementsInterfacesTest,
 		// PR #4664: Enum ordering tests
 		EnumOrderingTest,
 		EnumElementOrderingTest,

--- a/v2/internal/typescriptify/typescriptify.go
+++ b/v2/internal/typescriptify/typescriptify.go
@@ -327,7 +327,11 @@ func (t *typeScriptClassBuilder) AddMapField(fieldName string, field reflect.Str
 			fieldName = fmt.Sprintf(`"%s"?`, strippedFieldName)
 		}
 	}
-	t.fields = append(t.fields, fmt.Sprintf("%s%s: Record<%s, %s>;", t.indent, fieldName, keyTypeStr, valueTypePrefix+valueTypeName+valueTypeSuffix))
+	fieldType := fmt.Sprintf("Record<%s, %s>", keyTypeStr, valueTypePrefix+valueTypeName+valueTypeSuffix)
+	if t.createInterface {
+		fieldType += " | null"
+	}
+	t.fields = append(t.fields, fmt.Sprintf("%s%s: %s;", t.indent, fieldName, fieldType))
 	if valueType.Kind() == reflect.Struct {
 		t.constructorBody = append(t.constructorBody, fmt.Sprintf("%s%sthis%s = this.convertValues(source[\"%s\"], %s, true);",
 			t.indent, t.indent, dotField, strippedFieldName, t.prefix+valueTypePrefix+valueTypeName+valueTypeSuffix+t.suffix))
@@ -658,11 +662,12 @@ func (t *TypeScriptify) convertType(depth int, typeOf reflect.Type, customCode m
 		result = "export " + result
 	}
 	builder := typeScriptClassBuilder{
-		types:     t.kinds,
-		indent:    t.Indent,
-		prefix:    t.Prefix,
-		suffix:    t.Suffix,
-		namespace: t.Namespace,
+		types:           t.kinds,
+		indent:          t.Indent,
+		prefix:          t.Prefix,
+		suffix:          t.Suffix,
+		namespace:       t.Namespace,
+		createInterface: t.CreateInterface,
 	}
 
 	for _, field := range fields {
@@ -846,6 +851,7 @@ type typeScriptClassBuilder struct {
 	constructorBody      []string
 	prefix, suffix       string
 	namespace            string
+	createInterface      bool
 }
 
 func (t *typeScriptClassBuilder) AddSimpleArrayField(fieldName string, field reflect.StructField, arrayDepth int, opts TypeOptions) error {
@@ -863,7 +869,11 @@ func (t *typeScriptClassBuilder) AddSimpleArrayField(fieldName string, field ref
 			t.addInitializerFieldLine(strippedFieldName, fmt.Sprintf("source[\"%s\"]", strippedFieldName))
 			return nil
 		} else if len(typeScriptType) > 0 {
-			t.addField(fieldName, fmt.Sprint(typeScriptType, strings.Repeat("[]", arrayDepth)), false)
+			typ := fmt.Sprint(typeScriptType, strings.Repeat("[]", arrayDepth))
+			if t.createInterface {
+				typ += " | null"
+			}
+			t.addField(fieldName, typ, false)
 			t.addInitializerFieldLine(strippedFieldName, fmt.Sprintf("source[\"%s\"]", strippedFieldName))
 			return nil
 		}
@@ -936,7 +946,11 @@ func (t *typeScriptClassBuilder) AddArrayOfStructsField(fieldName string, field 
 		fieldType = field.Type.Elem().String()
 	}
 	strippedFieldName := strings.ReplaceAll(fieldName, "?", "")
-	t.addField(fieldName, fmt.Sprint(t.prefix+fieldType+t.suffix, strings.Repeat("[]", arrayDepth)), false)
+	typ := fmt.Sprint(t.prefix+fieldType+t.suffix, strings.Repeat("[]", arrayDepth))
+	if t.createInterface {
+		typ += " | null"
+	}
+	t.addField(fieldName, typ, false)
 	t.addInitializerFieldLine(strippedFieldName, fmt.Sprintf("this.convertValues(source[\"%s\"], %s)", strippedFieldName, t.prefix+fieldType+t.suffix))
 }
 

--- a/website/src/pages/changelog.mdx
+++ b/website/src/pages/changelog.mdx
@@ -16,8 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fixed wake (experimental `WAILS_USE_WAKE=true` build runner) running precondition `sh:` strings without template expansion, causing a spurious "garble is required for obfuscated builds" error on every build by @leaanthony
 - Fixed nil pointer crash in `application.Quit` when called before `Run` or after `Run` returned early [#5452](https://github.com/wailsapp/wails/issues/5452) by @c-tonneslan
+- Fixed TypeScript interface generation missing `| null` for slice and map fields. [#3588](https://github.com/wailsapp/wails/issues/3588)
 
 ## v2.12.0 - 2026-03-26
 


### PR DESCRIPTION
## Description

When `bindings.ts_generation.outputType` is set to `"interfaces"` in `wails.json`, the generated TypeScript interfaces do not include `| null` for Go slice and map fields. Go slices and maps can be `nil`, which serializes to `null` in JSON. This causes issues for TypeScript projects using `strictNullChecks`, since the interface claims the field can never be `null`.

This PR adds `| null` to slice, array, and map field types when generating TypeScript interfaces.

## Changes

- Added `createInterface` flag to `typeScriptClassBuilder` struct
- In `AddSimpleArrayField`, append `| null` to the generated type when in interface mode
- In `AddArrayOfStructsField`, append `| null` to the generated type when in interface mode
- In `AddMapField`, append `| null` to the generated type when in interface mode
- Added test case `DeepElementsAsInterfaces` verifying the fix
- Updated changelog under `[Unreleased]`

## Before

```typescript
export interface TestStruct {
    test_slice: number[];
    test_map: Record<string, string>;
    test_structs: ChildEntity[];
}
```

## After

```typescript
export interface TestStruct {
    test_slice: number[] | null;
    test_map: Record<string, string> | null;
    test_structs: ChildEntity[] | null;
}
```

## Verification

All existing tests pass, and the new `DeepElementsAsInterfaces` test case passes:
```
--- PASS: TestBindings_GenerateModels/DeepElements (0.00s)
--- PASS: TestBindings_GenerateModels/DeepElementsAsInterfaces (0.00s)
...
PASS
ok  	github.com/wailsapp/wails/v2/internal/binding/binding_test	0.010s
```

Fixes #3588

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed TypeScript interface generation to correctly include `| null` for array and map (collection) fields.
* **Tests**
  * Added coverage to verify model generation emits `export interface` types with nullable collection fields.
* **Documentation**
  * Updated the changelog entry to reflect the corrected `| null` behavior for slice and map fields in TypeScript interfaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->