### PR TITLE
fix(ci): validate release token before pushing, fall back to github.token

### DIFF
--- a/.github/workflows/nightly-release-v3.yml
+++ b/.github/workflows/nightly-release-v3.yml
@@ -171,8 +171,13 @@ jobs:
         steps.quick_check.outputs.should_continue == 'true' || 
         github.event.inputs.force_release == 'true'
       env:
-        WAILS_REPO_TOKEN: ${{ secrets.WAILS_REPO_TOKEN || github.token }}
-        GITHUB_TOKEN: ${{ secrets.WAILS_REPO_TOKEN || github.token }}
+        # Keep these DISTINCT: the release script validates WAILS_REPO_TOKEN
+        # against the API before pushing anything and falls back to
+        # GITHUB_TOKEN if the PAT is expired/revoked. Passing the same value
+        # for both (as before) made the fallback meaningless and an expired
+        # PAT produced a half-release: tag pushed, no GitHub release.
+        WAILS_REPO_TOKEN: ${{ secrets.WAILS_REPO_TOKEN }}
+        GITHUB_TOKEN: ${{ github.token }}
       run: |
         cd v3/tasks/release
         ARGS=()

--- a/v3/tasks/release/release.go
+++ b/v3/tasks/release/release.go
@@ -588,12 +588,9 @@ func runRelease(opts releaseOptions) error {
 		return fmt.Errorf("failed to determine repository slug: %w", err)
 	}
 
-	token := strings.TrimSpace(os.Getenv("WAILS_REPO_TOKEN"))
-	if token == "" {
-		token = strings.TrimSpace(os.Getenv("GITHUB_TOKEN"))
-	}
-	if token == "" {
-		return errors.New("WAILS_REPO_TOKEN (or GITHUB_TOKEN) must be set to push and create releases")
+	token, err := selectAPIToken(repoSlug)
+	if err != nil {
+		return err
 	}
 
 	if err := git.push(opts.branch, repoSlug, token); err != nil {
@@ -620,6 +617,80 @@ func runRelease(opts releaseOptions) error {
 	writeGitHubOutput("release_outcome", "success")
 	fmt.Println("🎉 Release completed successfully.")
 	return nil
+}
+
+// selectAPIToken picks the token used for git pushes and the GitHub REST
+// API, validating it against the API BEFORE anything is pushed. Discovering
+// a dead token after the version bump and tag have been pushed leaves a
+// half-released state (a tag with no GitHub release and a reset changelog),
+// which is exactly what happened when WAILS_REPO_TOKEN expired: git
+// operations still succeeded via the checkout step's persisted credentials,
+// then the release API call failed with 401.
+//
+// If WAILS_REPO_TOKEN fails validation and a different GITHUB_TOKEN is
+// available (the workflow passes github.token), it is used as a fallback so
+// the nightly release still ships — with a warning, since github.token
+// cannot trigger downstream workflows.
+func selectAPIToken(repoSlug string) (string, error) {
+	primary := strings.TrimSpace(os.Getenv("WAILS_REPO_TOKEN"))
+	fallback := strings.TrimSpace(os.Getenv("GITHUB_TOKEN"))
+	if primary == "" {
+		primary, fallback = fallback, ""
+	}
+	if primary == "" {
+		return "", errors.New("WAILS_REPO_TOKEN (or GITHUB_TOKEN) must be set to push and create releases")
+	}
+
+	err := validateToken(primary, repoSlug)
+	if err == nil {
+		return primary, nil
+	}
+	if fallback != "" && fallback != primary {
+		fmt.Printf("⚠️  WAILS_REPO_TOKEN failed API validation (%v) — falling back to GITHUB_TOKEN. The token is likely expired and should be rotated.\n", err)
+		if fbErr := validateToken(fallback, repoSlug); fbErr == nil {
+			return fallback, nil
+		} else {
+			return "", fmt.Errorf("WAILS_REPO_TOKEN failed validation (%v) and GITHUB_TOKEN fallback also failed: %w", err, fbErr)
+		}
+	}
+	return "", fmt.Errorf("token failed API validation before any push (nothing was released): %w", err)
+}
+
+// validateToken performs a cheap authenticated read against the repository
+// to prove the token is alive. An expired fine-grained PAT answers 401
+// "Requires authentication" here, the same way the release-creation call
+// would fail later.
+func validateToken(token, repoSlug string) error {
+	apiBase := strings.TrimSpace(os.Getenv("GITHUB_API_URL"))
+	if apiBase == "" {
+		apiBase = githubDefaultAPI
+	}
+	apiBase = strings.TrimSuffix(apiBase, "/")
+
+	endpoint := fmt.Sprintf("%s/repos/%s", apiBase, repoSlug)
+	req, err := http.NewRequest(http.MethodGet, endpoint, nil)
+	if err != nil {
+		return fmt.Errorf("failed to create token validation request: %w", err)
+	}
+	setGitHubHeaders(req, token)
+
+	client := &http.Client{Timeout: 15 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to call GitHub API for token validation: %w", err)
+	}
+	defer resp.Body.Close()
+
+	switch {
+	case resp.StatusCode == http.StatusOK:
+		return nil
+	case resp.StatusCode == http.StatusUnauthorized:
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("GitHub API rejected the token (HTTP 401: %s) — expired or revoked?", strings.TrimSpace(string(body)))
+	default:
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("token validation returned HTTP %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
 }
 
 func applyChangelogUpdates(newVersion, changelogContent string) error {

--- a/v3/tasks/release/release.go
+++ b/v3/tasks/release/release.go
@@ -502,6 +502,23 @@ func runRelease(opts releaseOptions) error {
 		return nil
 	}
 
+	// Resolve the repository and validate the token BEFORE touching any
+	// files: discovering a dead token after the version bump and changelog
+	// reset have been written (and committed) would leave local side effects
+	// even though nothing was pushed — both in CI and when run locally.
+	// Dry runs never push, so they need no token at all.
+	var repoSlug, token string
+	if !opts.dryRun {
+		repoSlug, err = resolveRepoSlug(repoDir)
+		if err != nil {
+			return fmt.Errorf("failed to determine repository slug: %w", err)
+		}
+		token, err = selectAPIToken(repoSlug)
+		if err != nil {
+			return err
+		}
+	}
+
 	originalVersionData, err := os.ReadFile(versionFile)
 	if err != nil {
 		return fmt.Errorf("failed to read version file: %w", err)
@@ -581,16 +598,6 @@ func runRelease(opts releaseOptions) error {
 	commitMessage := fmt.Sprintf("chore(v3): bump to %s and update changelog [skip ci]", newVersion)
 	if err := git.commit(commitMessage); err != nil {
 		return fmt.Errorf("failed to commit release changes: %w", err)
-	}
-
-	repoSlug, err := resolveRepoSlug(repoDir)
-	if err != nil {
-		return fmt.Errorf("failed to determine repository slug: %w", err)
-	}
-
-	token, err := selectAPIToken(repoSlug)
-	if err != nil {
-		return err
 	}
 
 	if err := git.push(opts.branch, repoSlug, token); err != nil {


### PR DESCRIPTION
## Problem

The 2026-06-10 nightly release ([run 27289812021](https://github.com/wailsapp/wails/actions/runs/27289812021)) half-failed:

1. The bump commit (`43309ddc9`) and the `v3.0.0-alpha.99` tag were **pushed successfully** — git auth rode on the checkout step's persisted credentials.
2. The GitHub release API call then returned **401 "Requires authentication"** — the signature of an **expired fine-grained PAT** (`WAILS_REPO_TOKEN`). The workflow had run green daily until June 9; nothing in the workflow or script changed.
3. Result: a tag with no GitHub release and an already-reset `UNRELEASED_CHANGELOG.md` — an unrecoverable half-release.

## Fix

- **`release.go`**: validate the token with a cheap authenticated read against the repo **before any push**. A dead token now fails the run cleanly (nothing pushed, nothing reset) with an `expired or revoked?` error. If `WAILS_REPO_TOKEN` fails validation and a distinct `GITHUB_TOKEN` is available, fall back to it with a warning so the nightly still ships.
- **`nightly-release-v3.yml`**: the step previously set both env vars to the same `secrets.WAILS_REPO_TOKEN || github.token` expression, making any fallback meaningless. It now passes the raw secret and `github.token` distinctly. `github.token` has `contents: write` and can create releases; the only degradation is it can't trigger downstream workflows, which nothing in this pipeline relies on (`publish-npm` is path-triggered).

## Follow-ups (not in this PR)

- **Rotate the `WAILS_REPO_TOKEN` secret** — it appears to have hit its expiry on June 10. With this PR the nightly survives on the fallback either way.
- The `v3.0.0-alpha.99` release object needs creating manually for the existing tag (the changelog entry is already in `docs/src/content/docs/changelog.mdx`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved release pipeline: distinct credentials are now handled and strictly validated before any version, changelog, tag or publish actions. Better fallback and failure handling reduces risk of incomplete releases and ensures release steps will halt early on invalid credentials, resulting in more reliable and predictable deployment outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->