### PR TITLE
example(mobile): default divide example divisor to 2

### DIFF
--- a/v3/examples/mobile/frontend/index.html
+++ b/v3/examples/mobile/frontend/index.html
@@ -46,7 +46,7 @@
             <div class="row">
                 <input id="divA" type="number" value="10" inputmode="decimal"/>
                 <span class="op">÷</span>
-                <input id="divB" type="number" value="0" inputmode="decimal"/>
+                <input id="divB" type="number" value="2" inputmode="decimal"/>
                 <button class="btn" id="btnDivide">Divide</button>
             </div>
             <pre id="bindingsOut" class="output">Results appear here…</pre>


### PR DESCRIPTION
Small tweak to the mobile kitchen-sink example: the Divide row's second input defaulted to `0`, so the example showed a divide-by-zero error on first tap. Default it to `2` so `10 ÷ 2 = 5` works out of the box.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed division by zero error in mobile example by updating the default division operand value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->