### PR TITLE
docs: add Web Permissions guide and options reference (missing from #5567)

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -188,7 +188,7 @@ export default defineConfig({
               items: [
                 { label: "Window Basics", link: "/features/windows/basics" },
                 { label: "Window Options", link: "/features/windows/options" },
-                { label: "Web Permissions", link: "/features/windows/permissions" },
+                { label: "Permissions", link: "/features/windows/permissions" },
                 { label: "Multiple Windows", link: "/features/windows/multiple" },
                 { label: "Frameless Windows", link: "/features/windows/frameless" },
                 { label: "Window Events", link: "/features/windows/events" },

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -188,6 +188,7 @@ export default defineConfig({
               items: [
                 { label: "Window Basics", link: "/features/windows/basics" },
                 { label: "Window Options", link: "/features/windows/options" },
+                { label: "Web Permissions", link: "/features/windows/permissions" },
                 { label: "Multiple Windows", link: "/features/windows/multiple" },
                 { label: "Frameless Windows", link: "/features/windows/frameless" },
                 { label: "Window Events", link: "/features/windows/events" },

--- a/docs/src/content/docs/features/windows/options.mdx
+++ b/docs/src/content/docs/features/windows/options.mdx
@@ -703,7 +703,7 @@ Permissions: map[application.PermissionType]application.Permission{
 
 **Important — Windows:** Before this option existed, Wails silently granted all WebView2 capabilities. Now, setting any entry in `Permissions` disables that blanket grant. Capabilities not listed will show WebView2's native prompt rather than being auto-allowed. List every capability your app needs explicitly.
 
-**See [Web Permissions](/features/windows/permissions) for the full guide, platform matrix, and examples.**
+**See [Permissions](/features/windows/permissions) for the full guide, platform matrix, and examples.**
 
 ## Window Lifecycle Events
 

--- a/docs/src/content/docs/features/windows/options.mdx
+++ b/docs/src/content/docs/features/windows/options.mdx
@@ -59,6 +59,9 @@ type WebviewWindowOptions struct {
     ContentProtectionEnabled    bool
     KeyBindings                 map[string]func(window *WebviewWindow)
 
+    // Permissions
+    Permissions map[PermissionType]Permission
+
     // Window-control button states
     MinimiseButtonState ButtonState
     MaximiseButtonState ButtonState
@@ -675,6 +678,32 @@ window := app.Window.NewWithOptions(application.WebviewWindowOptions{
 // Toggle at runtime
 window.SetContentProtection(true)
 ```
+
+### Permissions
+
+**Type:** `map[PermissionType]Permission`  
+**Default:** `nil` (platform default handling)  
+**Platform:** Linux, Windows (macOS defers to TCC)
+
+```go
+Permissions: map[application.PermissionType]application.Permission{
+    application.PermissionMicrophone: application.PermissionAllow,
+    application.PermissionCamera:     application.PermissionAllow,
+},
+```
+
+**Purpose:** Declaratively control how capability requests (camera, microphone, geolocation, notifications, clipboard read) from the window's web content are handled, without platform-specific code.
+
+**PermissionType values:** `PermissionMicrophone`, `PermissionCamera`, `PermissionGeolocation`, `PermissionNotifications`, `PermissionClipboardRead`
+
+**Permission values:**
+- `PermissionDefault` (0) — platform's native handling: OS/WebView2 prompt on macOS/Windows; media capture allowed, others denied on Linux
+- `PermissionAllow` (1) — grant without prompting
+- `PermissionDeny` (2) — deny without prompting
+
+**Important — Windows:** Before this option existed, Wails silently granted all WebView2 capabilities. Now, setting any entry in `Permissions` disables that blanket grant. Capabilities not listed will show WebView2's native prompt rather than being auto-allowed. List every capability your app needs explicitly.
+
+**See [Web Permissions](/features/windows/permissions) for the full guide, platform matrix, and examples.**
 
 ## Window Lifecycle Events
 

--- a/docs/src/content/docs/features/windows/options.mdx
+++ b/docs/src/content/docs/features/windows/options.mdx
@@ -697,8 +697,8 @@ Permissions: map[application.PermissionType]application.Permission{
 **PermissionType values:** `PermissionMicrophone`, `PermissionCamera`, `PermissionGeolocation`, `PermissionNotifications`, `PermissionClipboardRead`
 
 **Permission values:**
-- `PermissionDefault` (0) — platform's native handling: OS/WebView2 prompt on macOS/Windows; media capture allowed, others denied on Linux
-- `PermissionAllow` (1) — grant without prompting
+- `PermissionDefault` (0) — platform's native handling: OS/WebView2 prompt on macOS/Windows; on Linux, camera/microphone are allowed, everything else is denied
+- `PermissionAllow` (1) — grant without prompting (Linux: only camera/microphone are implemented; other types remain denied)
 - `PermissionDeny` (2) — deny without prompting
 
 **Important — Windows:** Before this option existed, Wails silently granted all WebView2 capabilities. Now, setting any entry in `Permissions` disables that blanket grant. Capabilities not listed will show WebView2's native prompt rather than being auto-allowed. List every capability your app needs explicitly.

--- a/docs/src/content/docs/features/windows/permissions.mdx
+++ b/docs/src/content/docs/features/windows/permissions.mdx
@@ -5,7 +5,7 @@ sidebar:
   order: 3
 ---
 
-import { Tabs, TabItem, Aside } from "@astrojs/starlight/components";
+import { Aside } from "@astrojs/starlight/components";
 
 Web content that calls `navigator.mediaDevices.getUserMedia()`, the Geolocation API, or the Notifications API needs the host application to grant or deny those requests. Wails exposes a cross-platform `Permissions` map on `WebviewWindowOptions` that lets you control this declaratively — no platform-specific code required.
 
@@ -81,13 +81,18 @@ This means if you configure `Permissions` at all on Windows, any capability you 
 
 ### macOS (TCC)
 
-macOS manages camera, microphone, geolocation, and notification access through the system privacy framework (TCC). The OS prompt appears automatically when web content requests a capability, and the user's choice is remembered per-app.
+macOS manages camera, microphone, geolocation, and notification access through its system privacy framework. The OS prompt appears automatically the first time web content requests a capability, and the user's choice is remembered per-app in System Settings → Privacy & Security.
 
-The `Permissions` map **has no effect on macOS** — all requests defer to TCC regardless of what you set. Include the appropriate `NSMicrophoneUsageDescription`, `NSCameraUsageDescription`, etc. keys in your `Info.plist`.
+This works correctly without any `Permissions` configuration. The map is **currently ignored on macOS** — all requests go through TCC regardless of what you set. The practical gap is that `PermissionDeny` has no effect on macOS: you cannot block a webview from using a capability that TCC has already granted at the system level.
 
-<Aside type="note">
-Wiring the `WKUIDelegate` to the `Permissions` map on macOS is a planned follow-up. For now, macOS permission behaviour is unchanged.
-</Aside>
+Ensure your `Info.plist` includes the appropriate usage description keys:
+
+```xml
+<key>NSMicrophoneUsageDescription</key>
+<string>Used for voice input</string>
+<key>NSCameraUsageDescription</key>
+<string>Used for video calls</string>
+```
 
 ## Common Patterns
 

--- a/docs/src/content/docs/features/windows/permissions.mdx
+++ b/docs/src/content/docs/features/windows/permissions.mdx
@@ -1,5 +1,5 @@
 ---
-title: Web Permissions
+title: Permissions
 description: Control camera, microphone, geolocation and other capability requests from web content
 sidebar:
   order: 3

--- a/docs/src/content/docs/features/windows/permissions.mdx
+++ b/docs/src/content/docs/features/windows/permissions.mdx
@@ -21,7 +21,7 @@ window := app.Window.NewWithOptions(application.WebviewWindowOptions{
 })
 ```
 
-That's all. Camera and microphone requests from that window's web content are granted without a browser prompt.
+Camera and microphone requests from that window's web content are granted without a browser prompt.
 
 ## Permission Types
 
@@ -55,19 +55,17 @@ Each platform handles `PermissionDefault` differently because their underlying w
 
 WebKitGTK has **no native permission prompt**. Without a handler attached, it silently denies every request — which is why `getUserMedia` always returned `NotAllowedError` before this feature was added.
 
-With the `Permissions` map wired in:
+Currently Wails handles **camera and microphone** requests on Linux. Geolocation, notifications, and clipboard read are not yet wired up and remain denied regardless of the policy you set.
 
-| Policy | Media capture (camera/mic) | Other capabilities |
+| Policy | Camera / Microphone | Geolocation, Notifications, Clipboard |
 |---|---|---|
-| `PermissionDefault` | **Allowed** (restores getUserMedia) | Denied |
-| `PermissionAllow` | Allowed | Allowed |
-| `PermissionDeny` | Denied | Denied |
-
-The asymmetry is intentional: allowing media capture by default means existing apps using `getUserMedia` keep working without any code change. Other capabilities (geolocation, notifications, clipboard) remain denied by default because those carry more risk for embedded web content.
+| `PermissionDefault` | **Allowed** (restores getUserMedia) | Always denied |
+| `PermissionAllow` | Allowed | Always denied (not yet implemented) |
+| `PermissionDeny` | Denied | Always denied |
 
 ### Windows (WebView2)
 
-WebView2 has a native permission prompt and a per-kind permission API.
+WebView2 has a native permission prompt and a per-kind permission API. All five capability types are fully supported.
 
 | Policy | Behaviour |
 |---|---|
@@ -96,9 +94,9 @@ Ensure your `Info.plist` includes the appropriate usage description keys:
 
 ## Common Patterns
 
-### Media capture app (all platforms)
+### Media capture app
 
-Grant camera and microphone, prompt for everything else:
+Grant camera and microphone across all platforms:
 
 ```go
 Permissions: map[application.PermissionType]application.Permission{
@@ -107,19 +105,18 @@ Permissions: map[application.PermissionType]application.Permission{
 },
 ```
 
-On **Linux** this explicitly allows both devices.  
-On **Windows** this allows both; other capabilities show a prompt.  
-On **macOS** this has no effect; TCC handles it.
+On **Linux** this explicitly allows both devices; other capabilities remain denied.  
+On **Windows** this allows both; any other capability you don't list will show a native prompt.  
+On **macOS** this has no effect; TCC handles everything.
 
-### Deny everything (kiosk / locked-down app)
+### Deny media capture on Linux
+
+Linux allows camera and microphone by default. To opt out:
 
 ```go
 Permissions: map[application.PermissionType]application.Permission{
-    application.PermissionMicrophone:   application.PermissionDeny,
-    application.PermissionCamera:       application.PermissionDeny,
-    application.PermissionGeolocation:  application.PermissionDeny,
-    application.PermissionNotifications: application.PermissionDeny,
-    application.PermissionClipboardRead: application.PermissionDeny,
+    application.PermissionMicrophone: application.PermissionDeny,
+    application.PermissionCamera:     application.PermissionDeny,
 },
 ```
 
@@ -157,15 +154,12 @@ settingsWindow := app.Window.NewWithOptions(application.WebviewWindowOptions{
     // No Permissions entry — uses platform defaults
 })
 
-// Embedded content window — locked down
+// Embedded content window — deny media capture
 embeddedWindow := app.Window.NewWithOptions(application.WebviewWindowOptions{
     Title: "Embedded",
     Permissions: map[application.PermissionType]application.Permission{
-        application.PermissionMicrophone:    application.PermissionDeny,
-        application.PermissionCamera:        application.PermissionDeny,
-        application.PermissionGeolocation:   application.PermissionDeny,
-        application.PermissionNotifications: application.PermissionDeny,
-        application.PermissionClipboardRead: application.PermissionDeny,
+        application.PermissionMicrophone: application.PermissionDeny,
+        application.PermissionCamera:     application.PermissionDeny,
     },
 })
 ```
@@ -193,9 +187,9 @@ The evaluation order on Windows is:
 |---|---|---|---|
 | Microphone | ✅ | ✅ | TCC only |
 | Camera | ✅ | ✅ | TCC only |
-| Geolocation | ✅ | ✅ | TCC only |
-| Notifications | ✅ | ✅ | TCC only |
-| Clipboard Read | ✅ | ✅ | TCC only |
+| Geolocation | ❌ not yet | ✅ | TCC only |
+| Notifications | ❌ not yet | ✅ | TCC only |
+| Clipboard Read | ❌ not yet | ✅ | TCC only |
 
 ## Troubleshooting
 
@@ -210,3 +204,7 @@ Once any entry is present in `Permissions`, Wails no longer sets the blanket `Al
 **macOS permissions aren't working**
 
 The `Permissions` map has no effect on macOS. Ensure your `Info.plist` includes the correct usage description keys (`NSMicrophoneUsageDescription`, `NSCameraUsageDescription`, etc.) and that the user has granted access in System Settings → Privacy & Security.
+
+**Geolocation/notifications/clipboard have no effect on Linux**
+
+Only camera and microphone are currently handled on Linux. Support for other capability types is not yet implemented — they remain denied regardless of the policy you set.

--- a/docs/src/content/docs/features/windows/permissions.mdx
+++ b/docs/src/content/docs/features/windows/permissions.mdx
@@ -123,9 +123,9 @@ Permissions: map[application.PermissionType]application.Permission{
 },
 ```
 
-### Restore the pre-5567 Windows behaviour (allow all)
+### Allow all capabilities on Windows
 
-Before PR #5567, Windows silently granted all capabilities. To preserve that:
+To grant every capability without prompting:
 
 ```go
 Permissions: map[application.PermissionType]application.Permission{

--- a/docs/src/content/docs/features/windows/permissions.mdx
+++ b/docs/src/content/docs/features/windows/permissions.mdx
@@ -1,0 +1,207 @@
+---
+title: Web Permissions
+description: Control camera, microphone, geolocation and other capability requests from web content
+sidebar:
+  order: 3
+---
+
+import { Tabs, TabItem, Aside } from "@astrojs/starlight/components";
+
+Web content that calls `navigator.mediaDevices.getUserMedia()`, the Geolocation API, or the Notifications API needs the host application to grant or deny those requests. Wails exposes a cross-platform `Permissions` map on `WebviewWindowOptions` that lets you control this declaratively — no platform-specific code required.
+
+## Quick Start
+
+```go
+window := app.Window.NewWithOptions(application.WebviewWindowOptions{
+    Title: "My App",
+    Permissions: map[application.PermissionType]application.Permission{
+        application.PermissionMicrophone: application.PermissionAllow,
+        application.PermissionCamera:     application.PermissionAllow,
+    },
+})
+```
+
+That's all. Camera and microphone requests from that window's web content are granted without a browser prompt.
+
+## Permission Types
+
+`PermissionType` (uint8) identifies a capability that web content can request.
+
+| Constant | Capability |
+|---|---|
+| `PermissionMicrophone` | `getUserMedia({audio: true})` |
+| `PermissionCamera` | `getUserMedia({video: true})` |
+| `PermissionGeolocation` | `navigator.geolocation` |
+| `PermissionNotifications` | `Notification.requestPermission()` |
+| `PermissionClipboardRead` | `navigator.clipboard.readText()` |
+
+## Permission Values
+
+`Permission` (uint8) is the policy applied to a given type.
+
+| Constant | Value | Meaning |
+|---|---|---|
+| `PermissionDefault` | 0 | Use the platform's native handling (see below) |
+| `PermissionAllow` | 1 | Grant without prompting |
+| `PermissionDeny` | 2 | Deny without prompting |
+
+`PermissionDefault` is the zero value, so unset entries in the map behave as default.
+
+## Platform Behaviour
+
+Each platform handles `PermissionDefault` differently because their underlying webviews have different native behaviour.
+
+### Linux (WebKitGTK)
+
+WebKitGTK has **no native permission prompt**. Without a handler attached, it silently denies every request — which is why `getUserMedia` always returned `NotAllowedError` before this feature was added.
+
+With the `Permissions` map wired in:
+
+| Policy | Media capture (camera/mic) | Other capabilities |
+|---|---|---|
+| `PermissionDefault` | **Allowed** (restores getUserMedia) | Denied |
+| `PermissionAllow` | Allowed | Allowed |
+| `PermissionDeny` | Denied | Denied |
+
+The asymmetry is intentional: allowing media capture by default means existing apps using `getUserMedia` keep working without any code change. Other capabilities (geolocation, notifications, clipboard) remain denied by default because those carry more risk for embedded web content.
+
+### Windows (WebView2)
+
+WebView2 has a native permission prompt and a per-kind permission API.
+
+| Policy | Behaviour |
+|---|---|
+| `PermissionDefault` | WebView2 shows its native OS/browser permission prompt |
+| `PermissionAllow` | Granted silently |
+| `PermissionDeny` | Denied silently |
+
+**Important:** Before this feature existed, Wails called `SetGlobalPermission(Allow)` unconditionally — silently granting all capabilities. Now, when any entry is present in `Permissions`, that blanket grant is **not** set. Unset capabilities fall through to WebView2's native prompt instead of being auto-granted.
+
+This means if you configure `Permissions` at all on Windows, any capability you don't explicitly list will show a prompt rather than being silently allowed. Set the capabilities you need explicitly.
+
+### macOS (TCC)
+
+macOS manages camera, microphone, geolocation, and notification access through the system privacy framework (TCC). The OS prompt appears automatically when web content requests a capability, and the user's choice is remembered per-app.
+
+The `Permissions` map **has no effect on macOS** — all requests defer to TCC regardless of what you set. Include the appropriate `NSMicrophoneUsageDescription`, `NSCameraUsageDescription`, etc. keys in your `Info.plist`.
+
+<Aside type="note">
+Wiring the `WKUIDelegate` to the `Permissions` map on macOS is a planned follow-up. For now, macOS permission behaviour is unchanged.
+</Aside>
+
+## Common Patterns
+
+### Media capture app (all platforms)
+
+Grant camera and microphone, prompt for everything else:
+
+```go
+Permissions: map[application.PermissionType]application.Permission{
+    application.PermissionMicrophone: application.PermissionAllow,
+    application.PermissionCamera:     application.PermissionAllow,
+},
+```
+
+On **Linux** this explicitly allows both devices.  
+On **Windows** this allows both; other capabilities show a prompt.  
+On **macOS** this has no effect; TCC handles it.
+
+### Deny everything (kiosk / locked-down app)
+
+```go
+Permissions: map[application.PermissionType]application.Permission{
+    application.PermissionMicrophone:   application.PermissionDeny,
+    application.PermissionCamera:       application.PermissionDeny,
+    application.PermissionGeolocation:  application.PermissionDeny,
+    application.PermissionNotifications: application.PermissionDeny,
+    application.PermissionClipboardRead: application.PermissionDeny,
+},
+```
+
+### Restore the pre-5567 Windows behaviour (allow all)
+
+Before PR #5567, Windows silently granted all capabilities. To preserve that:
+
+```go
+Permissions: map[application.PermissionType]application.Permission{
+    application.PermissionMicrophone:    application.PermissionAllow,
+    application.PermissionCamera:        application.PermissionAllow,
+    application.PermissionGeolocation:   application.PermissionAllow,
+    application.PermissionNotifications: application.PermissionAllow,
+    application.PermissionClipboardRead: application.PermissionAllow,
+},
+```
+
+### Per-window policies
+
+Different windows can have different policies:
+
+```go
+// Main app window — full media access
+mainWindow := app.Window.NewWithOptions(application.WebviewWindowOptions{
+    Title: "App",
+    Permissions: map[application.PermissionType]application.Permission{
+        application.PermissionMicrophone: application.PermissionAllow,
+        application.PermissionCamera:     application.PermissionAllow,
+    },
+})
+
+// Settings window — no special capabilities
+settingsWindow := app.Window.NewWithOptions(application.WebviewWindowOptions{
+    Title: "Settings",
+    // No Permissions entry — uses platform defaults
+})
+
+// Embedded content window — locked down
+embeddedWindow := app.Window.NewWithOptions(application.WebviewWindowOptions{
+    Title: "Embedded",
+    Permissions: map[application.PermissionType]application.Permission{
+        application.PermissionMicrophone:    application.PermissionDeny,
+        application.PermissionCamera:        application.PermissionDeny,
+        application.PermissionGeolocation:   application.PermissionDeny,
+        application.PermissionNotifications: application.PermissionDeny,
+        application.PermissionClipboardRead: application.PermissionDeny,
+    },
+})
+```
+
+## Windows-Specific Override
+
+The per-window `Windows.Permissions` field (`map[CoreWebView2PermissionKind]CoreWebView2PermissionState`) still works and can override individual capabilities after the cross-platform map is applied. Use it when you need access to WebView2 permission kinds that have no cross-platform equivalent (e.g. `CoreWebView2PermissionKindOtherSensors`).
+
+```go
+Windows: application.WindowsWindow{
+    Permissions: map[application.CoreWebView2PermissionKind]application.CoreWebView2PermissionState{
+        application.CoreWebView2PermissionKindOtherSensors: application.CoreWebView2PermissionStateAllow,
+    },
+},
+```
+
+The evaluation order on Windows is:
+1. Cross-platform `Permissions` map (sets per-kind state via `SetPermission`)
+2. `Windows.Permissions` map (overrides individual kinds)
+3. For any kind not covered by either map: WebView2's native prompt (when a policy is configured) or auto-allow (when no policy is configured — the legacy behaviour)
+
+## Platform Support Matrix
+
+| Capability | Linux | Windows | macOS |
+|---|---|---|---|
+| Microphone | ✅ | ✅ | TCC only |
+| Camera | ✅ | ✅ | TCC only |
+| Geolocation | ✅ | ✅ | TCC only |
+| Notifications | ✅ | ✅ | TCC only |
+| Clipboard Read | ✅ | ✅ | TCC only |
+
+## Troubleshooting
+
+**`getUserMedia` still fails on Linux after upgrading**
+
+Check that you have not explicitly set `PermissionMicrophone: PermissionDeny` or `PermissionCamera: PermissionDeny`. The default (unset) allows media capture on Linux.
+
+**Windows is prompting for permissions I didn't configure**
+
+Once any entry is present in `Permissions`, Wails no longer sets the blanket `Allow` grant. Capabilities you don't list will show WebView2's native prompt. Add explicit `PermissionAllow` entries for every capability your app uses.
+
+**macOS permissions aren't working**
+
+The `Permissions` map has no effect on macOS. Ensure your `Info.plist` includes the correct usage description keys (`NSMicrophoneUsageDescription`, `NSCameraUsageDescription`, etc.) and that the user has granted access in System Settings → Privacy & Security.


### PR DESCRIPTION
## What's missing

PR #5567 shipped a cross-platform `Permissions` map for controlling camera, microphone, geolocation, notifications, and clipboard-read access from web content. No documentation was included.

## What this adds

### New page: [Web Permissions](/features/windows/permissions)

Full developer guide covering:
- Quick-start example
- `PermissionType` reference table (Microphone, Camera, Geolocation, Notifications, ClipboardRead)  
- `Permission` reference table (Default, Allow, Deny)
- **Per-platform behaviour** — the critical stuff:
  - Linux/WebKitGTK: no native prompt, `PermissionDefault` allows media capture (the getUserMedia fix), denies other capabilities
  - Windows/WebView2: `PermissionDefault` shows native prompt; **breaking change** — when any `Permissions` entry is set, the old blanket `SetGlobalPermission(Allow)` is no longer applied
  - macOS/TCC: map has no effect, defers to system privacy framework
- Common patterns: media app, deny-all kiosk, per-window policies, restoring pre-#5567 Windows behaviour
- Windows-specific `WindowsWindow.Permissions` override and evaluation order
- Platform support matrix
- Troubleshooting section

### Updated: Window Options reference

- `Permissions` field added to the `WebviewWindowOptions` struct summary
- Dedicated `### Permissions` section with type reference, platform callouts, and link to the full guide

### Updated: Sidebar

Web Permissions entry added between Window Options and Multiple Windows.

Closes the documentation gap for #5567.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added per-window webview permission controls for microphone, camera, geolocation, notifications, and clipboard with platform-aware behavior and explicit Windows evaluation order.

* **Documentation**
  * New comprehensive permissions guide with examples, platform behavior notes (Linux, Windows, macOS), troubleshooting tips, and a platform support matrix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->