### PR TITLE
Revert "docs(v3): update README — replace 'v3 Alpha' with Beta scope statement"

### DIFF
--- a/v3/README.md
+++ b/v3/README.md
@@ -1,33 +1,9 @@
-# Wails v3 Beta
+# v3 Alpha
 
-Welcome to Wails v3! This is the beta release of the next major version of Wails.
-
-## What Beta means
-
-The v3 API in `v3/pkg/application` and related packages is stable. We will not make breaking changes without a deprecation cycle and clear migration guidance.
+Thanks for wanting to help out with testing/developing Wails v3! This guide will help you get started.
 
 ## Getting Started
 
-Full documentation is available at [v3.wails.io](https://v3.wails.io).
+All the instructions for getting started are in the v3 documentation directory: `mkdocs-website`. 
+Please read the README.md file in that directory for more information.
 
-To get started with a new project:
-```bash
-go install github.com/wailsapp/wails/v3/cmd/wails3@latest
-wails3 init -n myapp
-```
-
-## Beta scope — what's deferred
-
-The following areas are still under active development and are **not** covered by the v3 stability guarantee:
-
-- **iOS / Android**: Not production-ready in v3 beta; deferred to a future release.
-- **GTK4 Linux backend**: Now the default on Linux but still in active stabilisation. Some rendering edge cases may remain.
-- **Some niche AppKit APIs**: A small number of macOS-specific window APIs are still being finalised.
-
-The items listed above may have breaking changes without a deprecation cycle.
-
-## Giving feedback
-
-- **Bug reports**: [github.com/wailsapp/wails/issues](https://github.com/wailsapp/wails/issues)
-- **Discussions**: [github.com/wailsapp/wails/discussions](https://github.com/wailsapp/wails/discussions)
-- **Discord**: [wails.io/discord](https://wails.io/discord)


### PR DESCRIPTION
Reverts wailsapp/wails#5490

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the v3 README to reflect an Alpha kickoff instead of a Beta release guide.
  * Removed outdated beta-specific details such as stability promises, scope notes, and feedback guidance.
  * Added a pointer to the v3 documentation for full getting-started instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->