### PR TITLE
fix(v2): align generic pointer TypeScript names

### DIFF
--- a/v2/internal/binding/binding_test/binding_generic_pointer_test.go
+++ b/v2/internal/binding/binding_test/binding_generic_pointer_test.go
@@ -1,0 +1,59 @@
+package binding_test
+
+import (
+	"io/fs"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/wailsapp/wails/v2/internal/binding"
+	"github.com/wailsapp/wails/v2/internal/logger"
+)
+
+type GenericPointerBindings struct{}
+
+type Message[T any] struct {
+	Value T `json:"value"`
+}
+
+func (h *GenericPointerBindings) RoundTrip(input Message[*string]) Message[*string] {
+	return input
+}
+
+func TestGenericPointerBindingsUseSameTypeName(t *testing.T) {
+	generationDir := t.TempDir()
+
+	testLogger := &logger.Logger{}
+	b := binding.NewBindings(testLogger, []interface{}{&GenericPointerBindings{}}, []interface{}{}, false, []interface{}{})
+
+	err := b.GenerateGoBindings(generationDir)
+	if err != nil {
+		t.Fatalf("could not generate the Go bindings: %v", err)
+	}
+
+	rawGeneratedBindings, err := fs.ReadFile(os.DirFS(generationDir), "binding_test/GenericPointerBindings.d.ts")
+	if err != nil {
+		t.Fatalf("could not read the generated bindings: %v", err)
+	}
+	generatedBindings := string(rawGeneratedBindings)
+
+	if !strings.Contains(generatedBindings, "binding_test.Message_string_") {
+		t.Fatalf("generated bindings should reference Message_string_, got:\n%s", generatedBindings)
+	}
+	if strings.Contains(generatedBindings, "Message__string_") {
+		t.Fatalf("generated bindings should not reference Message__string_, got:\n%s", generatedBindings)
+	}
+
+	rawGeneratedModels, err := fs.ReadFile(os.DirFS(generationDir), "models.ts")
+	if err != nil {
+		t.Fatalf("could not read the generated models: %v", err)
+	}
+	generatedModels := string(rawGeneratedModels)
+
+	if !strings.Contains(generatedModels, "export class Message_string_") {
+		t.Fatalf("generated models should define Message_string_, got:\n%s", generatedModels)
+	}
+	if strings.Contains(generatedModels, "Message__string_") {
+		t.Fatalf("generated models should not define Message__string_, got:\n%s", generatedModels)
+	}
+}

--- a/v2/internal/binding/binding_test/binding_generics_test.go
+++ b/v2/internal/binding/binding_test/binding_generics_test.go
@@ -59,42 +59,6 @@ var Generics2Test = BindingTest{
 	want: `
 export namespace binding_test {
         
-                export class ListData__github_com_wailsapp_wails_v2_internal_binding_binding_test_binding_test_import_float_package_SomeStruct_ {
-                    Total: number;
-                    TotalPage: number;
-                    PageNum: number;
-                    List?: float_package.SomeStruct[];
-        
-                    static createFrom(source: any = {}) {
-                        return new ListData__github_com_wailsapp_wails_v2_internal_binding_binding_test_binding_test_import_float_package_SomeStruct_(source);
-                    }
-        
-                    constructor(source: any = {}) {
-                        if ('string' === typeof source) source = JSON.parse(source);
-                        this.Total = source["Total"];
-                        this.TotalPage = source["TotalPage"];
-                        this.PageNum = source["PageNum"];
-                        this.List = this.convertValues(source["List"], float_package.SomeStruct);
-                    }
-        
-                        convertValues(a: any, classs: any, asMap: boolean = false): any {
-                            if (!a) {
-                                return a;
-                            }
-                            if (a.slice && a.map) {
-                                return (a as any[]).map(elem => this.convertValues(elem, classs));
-                            } else if ("object" === typeof a) {
-                                if (asMap) {
-                                    for (const key of Object.keys(a)) {
-                                        a[key] = new classs(a[key]);
-                                    }
-                                    return a;
-                                }
-                                return new classs(a);
-                            }
-                            return a;
-                        }
-                }
                 export class ListData_github_com_wailsapp_wails_v2_internal_binding_binding_test_binding_test_import_float_package_SomeStruct_ {
                     Total: number;
                     TotalPage: number;

--- a/v2/internal/typescriptify/typescriptify.go
+++ b/v2/internal/typescriptify/typescriptify.go
@@ -45,7 +45,7 @@ const (
 var jsVariableUnsafeChars = regexp.MustCompile(`[^A-Za-z0-9_]`)
 
 func nameTypeOf(typeOf reflect.Type) string {
-	tname := typeOf.Name()
+	tname := strings.ReplaceAll(typeOf.Name(), "*", "")
 	gidx := strings.IndexRune(tname, '[')
 	if gidx > 0 { // its a generic type
 		rem := strings.SplitN(tname, "[", 2)
@@ -114,7 +114,8 @@ type TypeScriptify struct {
 	fieldTypeOptions map[reflect.Type]TypeOptions
 
 	// throwaway, used when converting
-	alreadyConverted map[string]bool
+	alreadyConverted     map[string]bool
+	alreadyConvertedName map[string]bool
 
 	Namespace    string
 	KnownStructs *slicer.StringSlicer
@@ -392,6 +393,7 @@ func (t *TypeScriptify) AddEnumValues(typeOf reflect.Type, values interface{}) *
 
 func (t *TypeScriptify) Convert(customCode map[string]string) (string, error) {
 	t.alreadyConverted = make(map[string]bool)
+	t.alreadyConvertedName = make(map[string]bool)
 	depth := 0
 
 	result := ""
@@ -534,9 +536,14 @@ func (t *TypeScriptify) convertEnum(depth int, typeOf reflect.Type, elements []e
 	if _, found := t.alreadyConverted[typeOf.String()]; found { // Already converted
 		return "", nil
 	}
-	t.alreadyConverted[typeOf.String()] = true
 
 	entityName := t.Prefix + nameTypeOf(typeOf) + t.Suffix
+	if _, found := t.alreadyConvertedName[entityName]; found { // Already converted
+		return "", nil
+	}
+	t.alreadyConverted[typeOf.String()] = true
+	t.alreadyConvertedName[entityName] = true
+
 	result := "enum " + entityName + " {\n"
 
 	for _, val := range elements {
@@ -634,6 +641,10 @@ func (t *TypeScriptify) convertType(depth int, typeOf reflect.Type, customCode m
 	if _, found := t.alreadyConverted[typeOf.String()]; found { // Already converted
 		return "", nil
 	}
+	entityName := t.Prefix + nameTypeOf(typeOf) + t.Suffix
+	if _, found := t.alreadyConvertedName[entityName]; found { // Already converted
+		return "", nil
+	}
 	fields := t.deepFields(typeOf)
 	t.logf(depth, "Converting type %s", typeOf.String())
 	if differentNamespaces(t.Namespace, typeOf) {
@@ -641,8 +652,7 @@ func (t *TypeScriptify) convertType(depth int, typeOf reflect.Type, customCode m
 	}
 
 	t.alreadyConverted[typeOf.String()] = true
-
-	entityName := t.Prefix + nameTypeOf(typeOf) + t.Suffix
+	t.alreadyConvertedName[entityName] = true
 
 	if typeClashWithReservedKeyword(entityName) {
 		warnAboutTypesClash(entityName)

--- a/website/src/pages/changelog.mdx
+++ b/website/src/pages/changelog.mdx
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed nil pointer crash in `application.Quit` when called before `Run` or after `Run` returned early [#5452](https://github.com/wailsapp/wails/issues/5452) by @c-tonneslan
+- Fixed v2 TypeScript model names for generic pointer type arguments so generated `App.d.ts` references match `models.ts` [#5160](https://github.com/wailsapp/wails/issues/5160) by @sjh9714
 
 ## v2.12.0 - 2026-03-26
 


### PR DESCRIPTION
# Description

Fixes #5160.

The v2 binding generator already strips `*` from generic type arguments when writing `App.d.ts`, but `models.ts` kept the `*` while deriving model class names. This made `Message[*string]` generate a binding reference to `Message_string_` while the model was emitted as `Message__string_`.

This mirrors the same `*` stripping in `nameTypeOf()` and also deduplicates emitted models by generated TypeScript name so pointer and non-pointer generic instantiations do not produce duplicate class declarations after normalisation.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [ ] Windows
- [x] macOS
- [ ] Linux

Commands run:

- `GOWORK=off go test ./internal/binding/binding_test -run TestGenericPointerBindingsUseSameTypeName`
- `GOWORK=off go test ./internal/binding/...`
- `GOWORK=off go test ./...`
- `GOWORK=off go run ./cmd/wails doctor`

I also attempted the repo-local `coderabbit --plain` check, but the `coderabbit` executable is not installed in this environment.

## Test Configuration

```text
# Wails
Version | v2.12.0

# System
OS           | MacOS
Version      | 26.3.1
ID           | 25D2128
Go Version   | go1.26.3
Platform     | darwin
Architecture | arm64
CPU          | Apple M4
Memory       | 16GB

# Dependencies
Xcode command line tools | Installed | 2416
Nodejs                   | Installed | 22.22.0
npm                      | Installed | 10.9.4

# Diagnosis
SUCCESS Your system is ready for Wails development!
```

# Checklist:

- [x] (v2 only) I have updated `website/src/pages/changelog.mdx` with details of this PR (v3 changelog entries are added automatically)
- [x] My code follows the general coding style of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

Note: I used Codex while preparing this change, and I reviewed the final diff and ran the listed checks locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed incorrect TypeScript type naming for generic pointer bindings. Generated names now consistently match across binding declarations and model files, resolving type mismatches.

* **Tests**
  * Added test suite validating generic pointer binding type name generation produces consistent results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->