### PR TITLE
fix(v3/ci): quote pipe in 'wails3 tool has gcc|clang' Taskfile command

### DIFF
--- a/.github/workflows/build-and-test-v3.yml
+++ b/.github/workflows/build-and-test-v3.yml
@@ -284,6 +284,9 @@ jobs:
           # Replace @wailsio/runtime version with local tarball
           npm pkg set dependencies.@wailsio/runtime="file://$RUNTIME_TGZ"
           cd ..
+          # Register the generated project in the workspace so Go 1.25 workspace
+          # mode does not reject packages in a module not listed in go.work.
+          go work use .
           wails3 build
 
       # GTK3 legacy template builds are covered by the Go example compilation tests above.

--- a/v3/internal/commands/build_assets/linux/Taskfile.yml
+++ b/v3/internal/commands/build_assets/linux/Taskfile.yml
@@ -36,7 +36,7 @@ tasks:
       TARGET_ARCH: '{{.ARCH | default ARCH}}'
       # Check if a C compiler is available (gcc or clang) — cross-platform via wails3 tool
       HAS_CC:
-        sh: 'wails3 tool has gcc|clang'
+        sh: 'wails3 tool has "gcc|clang"'
 
   build:native:
     summary: Builds the application natively on Linux

--- a/v3/internal/generator/load.go
+++ b/v3/internal/generator/load.go
@@ -4,6 +4,7 @@ import (
 	"go/ast"
 	"go/parser"
 	"go/token"
+	"os"
 
 	"github.com/wailsapp/wails/v3/internal/generator/config"
 	"golang.org/x/tools/go/packages"
@@ -67,6 +68,7 @@ func ResolvePatterns(buildFlags []string, patterns ...string) (paths []string, e
 	pkgs, err := packages.Load(&packages.Config{
 		Mode:       packages.NeedName,
 		BuildFlags: buildFlags,
+		Env:        append(os.Environ(), "GOWORK=off"),
 	}, rewrittenPatterns...)
 
 	for _, pkg := range pkgs {
@@ -105,6 +107,10 @@ func LoadPackages(buildFlags []string, patterns ...string) (pkgs []*packages.Pac
 		Mode:       packages.LoadAllSyntax,
 		BuildFlags: buildFlags,
 		Fset:       fset,
+		// Disable workspace mode: if the project lives inside a Go workspace but is
+		// not listed as a workspace module, Go 1.25 emits package errors that leave
+		// TypesInfo incomplete, causing the generator to find zero services.
+		Env: append(os.Environ(), "GOWORK=off"),
 		ParseFile: func(fset *token.FileSet, filename string, src []byte) (file *ast.File, err error) {
 			file, err = parser.ParseFile(fset, filename, src, parser.ParseComments|parser.SkipObjectResolution)
 			return

--- a/v3/internal/generator/load.go
+++ b/v3/internal/generator/load.go
@@ -4,7 +4,6 @@ import (
 	"go/ast"
 	"go/parser"
 	"go/token"
-	"os"
 
 	"github.com/wailsapp/wails/v3/internal/generator/config"
 	"golang.org/x/tools/go/packages"
@@ -68,7 +67,6 @@ func ResolvePatterns(buildFlags []string, patterns ...string) (paths []string, e
 	pkgs, err := packages.Load(&packages.Config{
 		Mode:       packages.NeedName,
 		BuildFlags: buildFlags,
-		Env:        append(os.Environ(), "GOWORK=off"),
 	}, rewrittenPatterns...)
 
 	for _, pkg := range pkgs {
@@ -107,10 +105,6 @@ func LoadPackages(buildFlags []string, patterns ...string) (pkgs []*packages.Pac
 		Mode:       packages.LoadAllSyntax,
 		BuildFlags: buildFlags,
 		Fset:       fset,
-		// Disable workspace mode: if the project lives inside a Go workspace but is
-		// not listed as a workspace module, Go 1.25 emits package errors that leave
-		// TypesInfo incomplete, causing the generator to find zero services.
-		Env: append(os.Environ(), "GOWORK=off"),
 		ParseFile: func(fset *token.FileSet, filename string, src []byte) (file *ast.File, err error) {
 			file, err = parser.ParseFile(fset, filename, src, parser.ParseComments|parser.SkipObjectResolution)
 			return


### PR DESCRIPTION
## Root cause

Commit #5533 (`0464978ce`) changed the Linux build Taskfile from:
\`\`\`yaml
sh: 'wails3 tool has-cc'
\`\`\`
to:
\`\`\`yaml
sh: 'wails3 tool has gcc|clang'
\`\`\`

When Task runs a `sh:` value, it passes it to `/bin/sh -c`. The shell interprets the bare `|` as a **pipe**, running:
- `wails3 tool has gcc` → outputs "true" or "false"
- piped into `clang` (the C compiler)

`clang` receives stdin with no C source files, prints `clang: error: no input files`, and exits 1 — failing every Linux template build in CI.

## Fix

Wrap the argument in shell double-quotes so `|` is passed literally to the Go process, which then splits on it to check each tool:

\`\`\`yaml
sh: 'wails3 tool has "gcc|clang"'
\`\`\`

The outer YAML single-quotes preserve the double-quotes verbatim; the shell then sees `wails3 tool has "gcc|clang"` and passes `gcc|clang` as a single argument.

## Fixes

Unblocks all `Test Templates (ubuntu-latest, *, 1.25)` failures in CI (e.g. PR #5597).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed Linux build system parameter handling to improve tool detection reliability.

* **Chores**
  * Enhanced template generation validation to ensure compatibility with Go 1.25 workspace mode.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->