### PR TITLE
docs: update landing page tagline to 'Five platforms'

### DIFF
--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -6,7 +6,7 @@ banner:
         Wails v3 is in ALPHA. <a href="https://wails.io">v2 docs</a>
 template: splash
 hero:
-  tagline: Build beautiful, performant applications using Go and modern web technologies. One codebase. Three platforms. No browsers.*
+  tagline: Build beautiful, performant applications using Go and modern web technologies. One codebase. Five platforms. No browsers.*
   image:
     dark: ../../assets/wails-logo-dark.svg
     light: ../../assets/wails-logo-light.svg


### PR DESCRIPTION
Updates the landing page hero tagline to reflect the actual number of supported platforms (Windows, macOS, Linux, iOS, Android → five platforms).

Supersedes the same change that was lost when #5601 was squash-merged before this commit landed on the branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated homepage messaging to reflect the expansion from three to five supported platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->