### PR TITLE
fix: preserve executable modes when extracting templates

### DIFF
--- a/v3/UNRELEASED_CHANGELOG.md
+++ b/v3/UNRELEASED_CHANGELOG.md
@@ -23,7 +23,6 @@ After processing, the content will be moved to the main changelog and this file 
 
 ## Fixed
 <!-- Bug fixes -->
-- Preserve executable permissions when extracting v3 template assets, fixing generated Android `gradlew` scripts (#5606).
 
 ## Deprecated
 <!-- Soon-to-be removed features -->

--- a/v3/UNRELEASED_CHANGELOG.md
+++ b/v3/UNRELEASED_CHANGELOG.md
@@ -23,6 +23,7 @@ After processing, the content will be moved to the main changelog and this file 
 
 ## Fixed
 <!-- Bug fixes -->
+- Preserve executable permissions when extracting v3 template assets, fixing generated Android `gradlew` scripts (#5606).
 
 ## Deprecated
 <!-- Soon-to-be removed features -->

--- a/v3/internal/commands/gradlew_exec_test.go
+++ b/v3/internal/commands/gradlew_exec_test.go
@@ -1,0 +1,48 @@
+package commands
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/wailsapp/wails/v3/internal/gosod"
+)
+
+// TestEmbeddedGradlewExtractsExecutable guards against regressing #5606. The
+// Android gradlew wrapper ships inside the embedded build_assets FS, where
+// go:embed reports it as 0444 (no exec bit). Extracting it must still produce an
+// executable file so `wails3 task android:package` can run ./gradlew. A test that
+// only exercises a fstest.MapFS with a 0755 source would not catch this, because
+// such a source never occurs in the real embedded path.
+func TestEmbeddedGradlewExtractsExecutable(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("executable bits are not represented in file modes on Windows")
+	}
+
+	// Sanity-check the premise: the embedded source really is non-executable.
+	if info, err := fs.Stat(buildAssets, "build_assets/android/gradlew"); err != nil {
+		t.Fatalf("stat embedded gradlew: %v", err)
+	} else if info.Mode().Perm()&0111 != 0 {
+		t.Fatalf("expected embedded gradlew to report a non-exec mode, got %v", info.Mode().Perm())
+	}
+
+	// The android subtree has no .tmpl files, so it extracts with nil data.
+	androidFS, err := fs.Sub(buildAssets, "build_assets/android")
+	if err != nil {
+		t.Fatal(err)
+	}
+	dir := t.TempDir()
+	if err := gosod.New(androidFS).Extract(dir, nil); err != nil {
+		t.Fatalf("extract android build assets: %v", err)
+	}
+
+	info, err := os.Stat(filepath.Join(dir, "gradlew"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm()&0111 == 0 {
+		t.Fatalf("expected extracted gradlew to be executable, got mode %v", info.Mode().Perm())
+	}
+}

--- a/v3/internal/gosod/gosod.go
+++ b/v3/internal/gosod/gosod.go
@@ -193,11 +193,7 @@ func (t *TemplateDir) copyFile(src, dst string) error {
 			log.Println("gosod: close source:", err)
 		}
 	}()
-	mode := fs.FileMode(0644)
-	if info, err := s.Stat(); err == nil {
-		mode = info.Mode().Perm()
-	}
-	d, err := os.OpenFile(dst, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, mode)
+	d, err := os.OpenFile(dst, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0666)
 	if err != nil {
 		return err
 	}
@@ -205,5 +201,20 @@ func (t *TemplateDir) copyFile(src, dst string) error {
 		_ = d.Close()
 		return err
 	}
-	return d.Close()
+	if err := d.Close(); err != nil {
+		return err
+	}
+	// Preserve the source's executable bits (e.g. Android's gradlew) without
+	// inheriting the read-only modes that embedded filesystems often report.
+	// Creating with 0666 lets the umask apply; we then add only the exec bits.
+	if info, err := s.Stat(); err == nil {
+		if execBits := info.Mode().Perm() & 0111; execBits != 0 {
+			if dstInfo, err := os.Stat(dst); err == nil {
+				if err := os.Chmod(dst, dstInfo.Mode().Perm()|execBits); err != nil {
+					return err
+				}
+			}
+		}
+	}
+	return nil
 }

--- a/v3/internal/gosod/gosod.go
+++ b/v3/internal/gosod/gosod.go
@@ -165,6 +165,12 @@ func (t *TemplateDir) processTemplates(targetDir string, data interface{}) error
 		if err := w.Close(); err != nil {
 			return err
 		}
+		// Rendered scripts (e.g. the iOS build.sh.tmpl) lose any source mode the
+		// same way embedded standard files do, so recover executability from the
+		// rendered content's shebang.
+		if err := makeExecutableIfNeeded(target, 0); err != nil {
+			return err
+		}
 	}
 	return nil
 }
@@ -204,17 +210,64 @@ func (t *TemplateDir) copyFile(src, dst string) error {
 	if err := d.Close(); err != nil {
 		return err
 	}
-	// Preserve the source's executable bits (e.g. Android's gradlew) without
-	// inheriting the read-only modes that embedded filesystems often report.
-	// Creating with 0666 lets the umask apply; we then add only the exec bits.
+	var srcMode fs.FileMode
 	if info, err := s.Stat(); err == nil {
-		if execBits := info.Mode().Perm() & 0111; execBits != 0 {
-			if dstInfo, err := os.Stat(dst); err == nil {
-				if err := os.Chmod(dst, dstInfo.Mode().Perm()|execBits); err != nil {
-					return err
-				}
-			}
-		}
+		srcMode = info.Mode()
 	}
-	return nil
+	return makeExecutableIfNeeded(dst, srcMode)
+}
+
+// makeExecutableIfNeeded sets the executable bits on a freshly written file when
+// it is meant to be runnable. Two signals are used:
+//
+//   - the source FileMode already carries an exec bit (true for disk-based
+//     local/remote templates), or
+//   - the file content begins with a shebang ("#!").
+//
+// The shebang check is what actually restores executability for embedded scripts
+// such as Android's gradlew wrapper (#5606): go:embed reports every file as 0444,
+// so the source mode alone can never tell us the file was meant to be executable.
+// Exec bits are added only where a read bit is already present, so a restrictive
+// umask is still respected.
+func makeExecutableIfNeeded(path string, srcMode fs.FileMode) error {
+	executable := srcMode&0o111 != 0
+	if !executable {
+		hasShebang, err := startsWithShebang(path)
+		if err != nil {
+			return err
+		}
+		executable = hasShebang
+	}
+	if !executable {
+		return nil
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		return err
+	}
+	mode := info.Mode().Perm()
+	mode |= (mode & 0o444) >> 2 // mirror each read bit into the matching exec bit
+	return os.Chmod(path, mode)
+}
+
+// startsWithShebang reports whether the file at path begins with "#!".
+func startsWithShebang(path string) (bool, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return false, err
+	}
+	defer func() {
+		if err := f.Close(); err != nil {
+			log.Println("gosod: close for shebang check:", err)
+		}
+	}()
+	buf := make([]byte, 2)
+	n, err := io.ReadFull(f, buf)
+	if err == io.EOF || err == io.ErrUnexpectedEOF {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	return n == 2 && buf[0] == '#' && buf[1] == '!', nil
 }

--- a/v3/internal/gosod/gosod.go
+++ b/v3/internal/gosod/gosod.go
@@ -193,7 +193,11 @@ func (t *TemplateDir) copyFile(src, dst string) error {
 			log.Println("gosod: close source:", err)
 		}
 	}()
-	d, err := os.Create(dst)
+	mode := fs.FileMode(0644)
+	if info, err := s.Stat(); err == nil {
+		mode = info.Mode().Perm()
+	}
+	d, err := os.OpenFile(dst, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, mode)
 	if err != nil {
 		return err
 	}

--- a/v3/internal/gosod/gosod_test.go
+++ b/v3/internal/gosod/gosod_test.go
@@ -39,12 +39,15 @@ func TestExtract_StandardFile(t *testing.T) {
 	}
 }
 
-func TestExtract_StandardFilePreservesMode(t *testing.T) {
+func TestExtract_ShebangScriptBecomesExecutable(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("executable bits are not represented in file modes on Windows")
 	}
+	// Model the embedded reality that broke #5606: go:embed reports every file
+	// as 0444, so a script like gradlew arrives without an exec bit. Its
+	// executability has to be recovered from the shebang, not the source mode.
 	fsys := fstest.MapFS{
-		"gradlew": {Data: []byte("#!/bin/sh\n"), Mode: 0755},
+		"gradlew": {Data: []byte("#!/usr/bin/env sh\nexit 0\n"), Mode: 0444},
 	}
 	td := New(fsys)
 	dir := t.TempDir()
@@ -58,7 +61,30 @@ func TestExtract_StandardFilePreservesMode(t *testing.T) {
 	// Assert on the executable bits rather than an exact mode: the umask can
 	// legitimately mask other permission bits, so 0755 is not guaranteed.
 	if info.Mode().Perm()&0111 == 0 {
-		t.Fatalf("expected extracted file to be executable, got mode %v", info.Mode().Perm())
+		t.Fatalf("expected shebang script to be executable, got mode %v", info.Mode().Perm())
+	}
+}
+
+func TestExtract_SourceExecBitPreserved(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("executable bits are not represented in file modes on Windows")
+	}
+	// Disk-based local/remote templates keep their real modes, so an executable
+	// binary without a shebang must stay executable after extraction.
+	fsys := fstest.MapFS{
+		"tool": {Data: []byte("\x7fELF not a script\n"), Mode: 0755},
+	}
+	td := New(fsys)
+	dir := t.TempDir()
+	if err := td.Extract(dir, nil); err != nil {
+		t.Fatal(err)
+	}
+	info, err := os.Stat(filepath.Join(dir, "tool"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm()&0111 == 0 {
+		t.Fatalf("expected executable source to stay executable, got mode %v", info.Mode().Perm())
 	}
 }
 

--- a/v3/internal/gosod/gosod_test.go
+++ b/v3/internal/gosod/gosod_test.go
@@ -38,6 +38,24 @@ func TestExtract_StandardFile(t *testing.T) {
 	}
 }
 
+func TestExtract_StandardFilePreservesMode(t *testing.T) {
+	fsys := fstest.MapFS{
+		"gradlew": {Data: []byte("#!/bin/sh\n"), Mode: 0755},
+	}
+	td := New(fsys)
+	dir := t.TempDir()
+	if err := td.Extract(dir, nil); err != nil {
+		t.Fatal(err)
+	}
+	info, err := os.Stat(filepath.Join(dir, "gradlew"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := info.Mode().Perm(); got != 0755 {
+		t.Fatalf("expected extracted mode 0755, got %v", got)
+	}
+}
+
 // ---- Template file (.tmpl suffix removed, content rendered) ----
 
 func TestExtract_TemplateFile(t *testing.T) {
@@ -404,7 +422,6 @@ func TestExtract_CopyFileCloseFails(t *testing.T) {
 	}
 }
 
-
 // ---- resolveTarget: template parse error returns original path ----
 
 func TestResolveTarget_TemplateParseError(t *testing.T) {
@@ -527,12 +544,12 @@ func (d *callbackErrDir) ReadDir(n int) ([]fs.DirEntry, error) {
 
 type callbackErrFileInfo struct{}
 
-func (i *callbackErrFileInfo) Name() string      { return "." }
-func (i *callbackErrFileInfo) Size() int64       { return 0 }
-func (i *callbackErrFileInfo) Mode() fs.FileMode { return fs.ModeDir | 0755 }
+func (i *callbackErrFileInfo) Name() string       { return "." }
+func (i *callbackErrFileInfo) Size() int64        { return 0 }
+func (i *callbackErrFileInfo) Mode() fs.FileMode  { return fs.ModeDir | 0755 }
 func (i *callbackErrFileInfo) ModTime() time.Time { return time.Time{} }
-func (i *callbackErrFileInfo) IsDir() bool       { return true }
-func (i *callbackErrFileInfo) Sys() interface{}  { return nil }
+func (i *callbackErrFileInfo) IsDir() bool        { return true }
+func (i *callbackErrFileInfo) Sys() interface{}   { return nil }
 
 type callbackErrEntry struct{}
 

--- a/v3/internal/gosod/gosod_test.go
+++ b/v3/internal/gosod/gosod_test.go
@@ -5,6 +5,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 	"testing/fstest"
 	"time"
@@ -39,6 +40,9 @@ func TestExtract_StandardFile(t *testing.T) {
 }
 
 func TestExtract_StandardFilePreservesMode(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("executable bits are not represented in file modes on Windows")
+	}
 	fsys := fstest.MapFS{
 		"gradlew": {Data: []byte("#!/bin/sh\n"), Mode: 0755},
 	}
@@ -51,8 +55,37 @@ func TestExtract_StandardFilePreservesMode(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got := info.Mode().Perm(); got != 0755 {
-		t.Fatalf("expected extracted mode 0755, got %v", got)
+	// Assert on the executable bits rather than an exact mode: the umask can
+	// legitimately mask other permission bits, so 0755 is not guaranteed.
+	if info.Mode().Perm()&0111 == 0 {
+		t.Fatalf("expected extracted file to be executable, got mode %v", info.Mode().Perm())
+	}
+}
+
+func TestExtract_ReadOnlySourceModeStaysWritable(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("executable bits are not represented in file modes on Windows")
+	}
+	// Embedded filesystems frequently report read-only modes (e.g. 0444). The
+	// extracted file should still be writable (umask applied) and must not
+	// gain executable bits the source does not have.
+	fsys := fstest.MapFS{
+		"config.txt": {Data: []byte("data"), Mode: 0444},
+	}
+	td := New(fsys)
+	dir := t.TempDir()
+	if err := td.Extract(dir, nil); err != nil {
+		t.Fatal(err)
+	}
+	info, err := os.Stat(filepath.Join(dir, "config.txt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm()&0200 == 0 {
+		t.Fatalf("expected extracted file to be writable, got mode %v", info.Mode().Perm())
+	}
+	if info.Mode().Perm()&0111 != 0 {
+		t.Fatalf("expected extracted file to be non-executable, got mode %v", info.Mode().Perm())
 	}
 }
 


### PR DESCRIPTION
# Description

Preserves executable file modes when v3 template assets are extracted. This keeps the generated Android `gradlew` script executable after `wails init`, so `wails3 task android:package` can run it without a manual `chmod`.

Fixes #5606

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [x] Linux

Linux distro: Ubuntu 24.04-based container

- `cd v3 && go test ./internal/gosod -run 'TestExtract_StandardFilePreservesMode|TestExtract_StandardFile$' -count=1`
- `cd v3 && go test ./internal/gosod -count=1`
- `cd v3 && git diff --check`

## Test Configuration

`wails doctor` was not run in this container; the change is covered by focused `internal/gosod` unit tests.

# Checklist:

- [ ] (v2 only) I have updated `website/src/pages/changelog.mdx` with details of this PR (v3 changelog entries are added automatically)
- [x] My code follows the general coding style of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed executable permissions not being preserved when extracting v3 template assets. Executable bits are now correctly restored for extracted files, including generated Android `gradlew` scripts.

* **Tests**
  * Added regression coverage for embedded `gradlew` extraction and new permission-focused checks (shebang-driven executability, executable source preservation, and read-only sources staying writable), skipping Windows where applicable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->