### PR TITLE
Add retract statement for v3.0.0-alpha.98-tui

### DIFF
--- a/v3/go.mod
+++ b/v3/go.mod
@@ -162,3 +162,5 @@ require (
 	modernc.org/memory v1.11.0 // indirect
 	mvdan.cc/sh/v3 v3.12.0 // indirect
 )
+
+retract v3.0.0-alpha.98-tui


### PR DESCRIPTION
This pull request makes a minor update to the `go.mod` file by retracting a specific pre-release version. This helps prevent accidental use of an unstable or deprecated version in downstream dependencies.

* Retracted the `v3.0.0-alpha.98-tui` version in `go.mod` to avoid its usage.

I made a mistake :(

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Retracted module version v3.0.0-alpha.98-tui to prevent accidental selection during dependency resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->