### PR TITLE
fix(wake): expand precondition templates before running them

### DIFF
--- a/v3/internal/wake/exec/exec.go
+++ b/v3/internal/wake/exec/exec.go
@@ -205,7 +205,12 @@ func (e *Executor) runTask(ctx context.Context, task *ast.Task, depVars map[stri
 		return nil
 	}
 
-	if err := checkPreconditions(task); err != nil {
+	mergedVars := e.mergeVars(task, depVars)
+
+	// Preconditions are templated against the task's resolved vars, so this
+	// must run after mergeVars (their `sh:` guards reference vars like
+	// .OBFUSCATED) and before the up-to-date short-circuit below.
+	if err := checkPreconditions(task, mergedVars); err != nil {
 		return err
 	}
 
@@ -214,8 +219,6 @@ func (e *Executor) runTask(ctx context.Context, task *ast.Task, depVars map[stri
 		e.reportPrunedCached(task)
 		return nil
 	}
-
-	mergedVars := e.mergeVars(task, depVars)
 
 	// depRuns is shared across goroutines once the parallel dep fanout is
 	// in flight, so take e.mu for both the lazy-init and every read/write.

--- a/v3/internal/wake/exec/runner.go
+++ b/v3/internal/wake/exec/runner.go
@@ -3,10 +3,12 @@ package exec
 import (
 	"fmt"
 	"os"
+	"strings"
 	"sync"
 	"time"
 
 	"github.com/wailsapp/wails/v3/internal/wake/ast"
+	"github.com/wailsapp/wails/v3/internal/wake/parse"
 	"github.com/wailsapp/wails/v3/internal/wake/platform"
 )
 
@@ -19,16 +21,22 @@ var cache = &runCache{
 	lastRuns: make(map[string]time.Time),
 }
 
-func checkPreconditions(task *ast.Task) error {
+func checkPreconditions(task *ast.Task, vars map[string]*ast.Var) error {
 	for _, pc := range task.Precondition {
-		if pc.Sh == "" {
+		// Precondition `sh:` strings are Go templates just like cmds. They must
+		// be expanded against the task's resolved vars before running; otherwise
+		// a guard like `{{if eq .OBFUSCATED "true"}}command -v garble{{else}}true{{end}}`
+		// reaches the shell verbatim, fails to parse as a command, and surfaces
+		// the precondition's `msg:` as a spurious failure on every build.
+		sh := parse.ExpandTemplates(pc.Sh, vars)
+		if strings.TrimSpace(sh) == "" {
 			continue
 		}
-		c := platform.ShellCommand(pc.Sh)
+		c := platform.ShellCommand(sh)
 		if err := c.Run(); err != nil {
 			msg := pc.Msg
 			if msg == "" {
-				msg = fmt.Sprintf("precondition failed: %q", pc.Sh)
+				msg = fmt.Sprintf("precondition failed: %q", sh)
 			}
 			return fmt.Errorf("wake: %s", msg)
 		}

--- a/v3/internal/wake/exec/runner_test.go
+++ b/v3/internal/wake/exec/runner_test.go
@@ -1,0 +1,56 @@
+package exec
+
+import (
+	"testing"
+
+	"github.com/wailsapp/wails/v3/internal/wake/ast"
+)
+
+// Precondition `sh:` strings are Go templates and must be expanded against the
+// task's resolved vars before being run as shell commands. The build Taskfiles
+// guard the garble check with `{{if eq .OBFUSCATED "true"}}...{{else}}true{{end}}`;
+// without expansion the raw template reaches the shell, fails to parse, and the
+// precondition's `msg:` surfaces as a spurious "garble is required" error on
+// every build. See the obfuscation false-positive regression.
+func TestCheckPreconditionsExpandsTemplates(t *testing.T) {
+	const guard = `{{if eq .OBFUSCATED "true"}}command -v definitely-not-a-real-binary >/dev/null 2>&1{{else}}true{{end}}`
+
+	newTask := func() *ast.Task {
+		return &ast.Task{
+			Precondition: []*ast.Precondition{{Sh: guard, Msg: "garble is required for obfuscated builds"}},
+		}
+	}
+
+	t.Run("unset var resolves to true and passes", func(t *testing.T) {
+		if err := checkPreconditions(newTask(), map[string]*ast.Var{}); err != nil {
+			t.Fatalf("expected precondition to pass when OBFUSCATED is unset, got: %v", err)
+		}
+	})
+
+	t.Run("non-true var resolves to true and passes", func(t *testing.T) {
+		vars := map[string]*ast.Var{"OBFUSCATED": {Value: "false"}}
+		if err := checkPreconditions(newTask(), vars); err != nil {
+			t.Fatalf("expected precondition to pass when OBFUSCATED is false, got: %v", err)
+		}
+	})
+
+	t.Run("true var runs the guard and reports msg on failure", func(t *testing.T) {
+		vars := map[string]*ast.Var{"OBFUSCATED": {Value: "true"}}
+		err := checkPreconditions(newTask(), vars)
+		if err == nil {
+			t.Fatal("expected precondition to fail when OBFUSCATED is true and the tool is missing")
+		}
+		if got := err.Error(); got == "" || !contains(got, "garble is required") {
+			t.Fatalf("expected garble msg, got: %v", err)
+		}
+	})
+}
+
+func contains(s, sub string) bool {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}

--- a/website/src/pages/changelog.mdx
+++ b/website/src/pages/changelog.mdx
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed wake (experimental `WAILS_USE_WAKE=true` build runner) running precondition `sh:` strings without template expansion, causing a spurious "garble is required for obfuscated builds" error on every build by @leaanthony
 - Fixed nil pointer crash in `application.Quit` when called before `Run` or after `Run` returned early [#5452](https://github.com/wailsapp/wails/issues/5452) by @c-tonneslan
 
 ## v2.12.0 - 2026-03-26


### PR DESCRIPTION
## Description

Wake (the experimental Go-native build runner, opt-in via `WAILS_USE_WAKE=true`) ran each task's precondition `sh:` string **directly as a shell command without expanding its Go template first**.

The generated build Taskfiles guard the garble/obfuscation check like this:

```yaml
preconditions:
  - sh: '{{if eq .OBFUSCATED "true"}}command -v garble >/dev/null 2>&1{{else}}true{{end}}'
    msg: "garble is required for obfuscated builds. Install it with: go install mvdan.cc/garble@v0.16.0 ..."
```

The intent: only check for `garble` when `OBFUSCATED=true`; otherwise the precondition is the literal command `true`, which always passes. The `task` CLI templates the `sh:` string, so on a normal build it renders to `true` and stays quiet.

Wake never templated preconditions, so the raw `{{if eq .OBFUSCATED "true"}}...{{else}}true{{end}}` text reached the shell, failed to parse as a command (e.g. `ambiguous redirect`), and the precondition's `msg:` surfaced as a **spurious "garble is required for obfuscated builds" error on every `WAILS_USE_WAKE=true wails3 build`** — even when obfuscation was never requested.

### Root cause

- `parse/parse.go` stores the precondition `sh:` value verbatim.
- `exec/runner.go` `checkPreconditions` ran `platform.ShellCommand(pc.Sh)` with no expansion.
- `parse.ExpandTemplates` is applied to cmds, deps, env, dir, label and vars — but never preconditions.
- `checkPreconditions` was also called *before* `mergeVars`, so the task's resolved vars weren't even available yet.

### Fix

- `checkPreconditions` now expands `pc.Sh` via `parse.ExpandTemplates` against the task's merged vars before running it, and skips empty results.
- Moved the precondition check to run **after** `mergeVars` (so vars like `.OBFUSCATED` are resolvable) and still **before** the up-to-date short-circuit.
- Added a regression test (`runner_test.go`) covering unset / non-`true` / `true` values of the guard variable.

## Testing

- `go test ./internal/wake/...` — all pass, including the new regression test.
- Verified end-to-end: `WAILS_USE_WAKE=true wails3 build` no longer emits the garble precondition error and now proceeds past the precondition.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
- Fixed precondition evaluation in the build runner when using WAILS_USE_WAKE to properly expand and check conditions, eliminating spurious build errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->