### PR TITLE
fix(v3/windows): don't resync WebView2 DPI on restore unless DPI changed (#5605)

### DIFF
--- a/v3/UNRELEASED_CHANGELOG.md
+++ b/v3/UNRELEASED_CHANGELOG.md
@@ -23,6 +23,7 @@ After processing, the content will be moved to the main changelog and this file 
 
 ## Fixed
 <!-- Bug fixes -->
+- Fix crash on Windows when restoring an app that was minimised long enough for WebView2 to suspend or its render/GPU process to be recycled. The minimise/restore DPI resync (#5544) now only touches the WebView2 controller when the window's DPI actually changed, avoiding fatal COM calls into a suspended controller on the common same-DPI restore (#5605)
 
 ## Deprecated
 <!-- Soon-to-be removed features -->

--- a/v3/pkg/application/webview_window_windows.go
+++ b/v3/pkg/application/webview_window_windows.go
@@ -1947,17 +1947,13 @@ func (w *windowsWebviewWindow) WndProc(msg uint32, wparam, lparam uintptr) uintp
 // is the application's responsibility. It is a no-op when the controller is
 // unavailable or already in sync.
 func (w *windowsWebviewWindow) resyncWebviewRasterizationScale() bool {
-	// Guard the early-initialisation window: e.controller is assigned partway
-	// through controller creation, before COM setup completes, and calling in
-	// then is fatal. IsReady only covers that startup window — it does NOT
-	// detect a controller left unusable by a suspend or render/GPU process
-	// failure (the inited flag is never reset), so it is not what protects the
-	// #5605 restore path. That protection is the DPI-change gate in
+	// The #5605 restore crash is prevented by the DPI-change gate in
 	// resyncWebviewDPIAfterUnminimiseIfDPIChanged, which keeps us off the
-	// controller entirely when the DPI is unchanged.
-	if !w.chromium.IsReady() {
-		return false
-	}
+	// controller entirely when the DPI is unchanged. The GetController nil
+	// check below covers the early-initialisation / unavailable-controller
+	// window. (A chromium.IsReady() guard was considered, but that method is
+	// not in the released webview2 module v3 depends on, so it cannot be used
+	// here yet.)
 	controller := w.chromium.GetController()
 	if controller == nil {
 		return false

--- a/v3/pkg/application/webview_window_windows.go
+++ b/v3/pkg/application/webview_window_windows.go
@@ -82,6 +82,16 @@ type windowsWebviewWindow struct {
 	// cannot be used for this because keyboard snap (Win+Left) bypasses those messages.
 	lastSizeWParam uintptr
 
+	// lastKnownDPI is the window's DPI the last time it was in a non-minimised
+	// state. It is used on the un-minimise path to decide whether the WebView2
+	// rasterization scale actually needs resyncing: when the DPI is unchanged
+	// (the common case — same monitor, fixed DPI) we must avoid making any COM
+	// call into the controller, which can be fatal if WebView2 suspended or its
+	// render/GPU process died while minimised (#5605). It is read with the Win32
+	// GetDpiForWindow, never via COM, and only updated while not minimised so it
+	// never captures the (-32000,-32000) parked position's DPI.
+	lastKnownDPI w32.UINT
+
 	// menubarTheme is the theme for the menubar
 	menubarTheme *w32.MenuBarTheme
 
@@ -445,6 +455,13 @@ func (w *windowsWebviewWindow) run() {
 
 	if w.hwnd == 0 {
 		globalApplication.fatal("unable to create window")
+	}
+
+	// Seed the last-known DPI so the first un-minimise has a baseline to compare
+	// against (it is otherwise refreshed on every non-minimised WM_SIZE). See
+	// resyncWebviewDPIAfterUnminimiseIfDPIChanged (#5605).
+	if dpi, _ := w.DPI(); dpi != 0 {
+		w.lastKnownDPI = dpi
 	}
 
 	// Ensure correct window size in case the scale factor of current screen is different from the initial one.
@@ -1657,7 +1674,7 @@ func (w *windowsWebviewWindow) WndProc(msg uint32, wparam, lparam uintptr) uintp
 				// A maximised window leaving the minimised state arrives
 				// here (not at SIZE_RESTORED), and needs the same DPI
 				// resync as the restore path below (#5544).
-				w.resyncWebviewDPIAfterMinimise()
+				w.resyncWebviewDPIAfterUnminimiseIfDPIChanged()
 				w.parent.emit(events.Windows.WindowUnMinimise)
 			}
 			w.isMinimizing = false
@@ -1678,7 +1695,7 @@ func (w *windowsWebviewWindow) WndProc(msg uint32, wparam, lparam uintptr) uintp
 				// monitor's DPI. Nothing corrects WebView2's rasterization
 				// scale on restore, so window.devicePixelRatio keeps the
 				// wrong monitor's value until a manual resize (#5544).
-				w.resyncWebviewDPIAfterMinimise()
+				w.resyncWebviewDPIAfterUnminimiseIfDPIChanged()
 				w.parent.emit(events.Windows.WindowUnMinimise)
 			}
 			w.isMinimizing = false
@@ -1696,6 +1713,18 @@ func (w *windowsWebviewWindow) WndProc(msg uint32, wparam, lparam uintptr) uintp
 			w.parent.emit(events.Windows.WindowMinimise)
 		}
 		w.lastSizeWParam = wparam
+
+		// Keep the last-known DPI current while the window is in a normal
+		// (non-minimised) state. The un-minimise transitions above read this to
+		// decide whether a WebView2 rasterization resync is actually needed; it
+		// must never be sampled while minimised, where the window is parked at
+		// (-32000,-32000) and GetDpiForWindow can report a different monitor's
+		// DPI (#5605, #5544).
+		if wparam != w32.SIZE_MINIMIZED {
+			if dpi, _ := w.DPI(); dpi != 0 {
+				w.lastKnownDPI = dpi
+			}
+		}
 
 		if !(w.parent.options.Frameless && wparam == w32.SIZE_MINIMIZED) {
 			// If the window is frameless and minimizing, suppress the WebView2 resize.
@@ -1772,6 +1801,13 @@ func (w *windowsWebviewWindow) WndProc(msg uint32, wparam, lparam uintptr) uintp
 		// ShouldDetectMonitorScaleChanges is disabled (raw-pixels bounds
 		// mode), so the rasterization scale must follow DPI changes manually.
 		w.resyncWebviewRasterizationScale()
+		// Track the new DPI while non-minimised so the un-minimise comparison
+		// (resyncWebviewDPIAfterUnminimiseIfDPIChanged, #5605) stays accurate.
+		if !w.isMinimizing {
+			if dpi, _ := w.DPI(); dpi != 0 {
+				w.lastKnownDPI = dpi
+			}
+		}
 		w.parent.emit(events.Windows.WindowDPIChanged)
 	}
 
@@ -1903,6 +1939,17 @@ func (w *windowsWebviewWindow) WndProc(msg uint32, wparam, lparam uintptr) uintp
 // is the application's responsibility. It is a no-op when the controller is
 // unavailable or already in sync.
 func (w *windowsWebviewWindow) resyncWebviewRasterizationScale() bool {
+	// Guard the early-initialisation window: e.controller is assigned partway
+	// through controller creation, before COM setup completes, and calling in
+	// then is fatal. IsReady only covers that startup window — it does NOT
+	// detect a controller left unusable by a suspend or render/GPU process
+	// failure (the inited flag is never reset), so it is not what protects the
+	// #5605 restore path. That protection is the DPI-change gate in
+	// resyncWebviewDPIAfterUnminimiseIfDPIChanged, which keeps us off the
+	// controller entirely when the DPI is unchanged.
+	if !w.chromium.IsReady() {
+		return false
+	}
 	controller := w.chromium.GetController()
 	if controller == nil {
 		return false
@@ -1939,6 +1986,25 @@ func (w *windowsWebviewWindow) resyncWebviewDPIAfterMinimise() {
 	if w.resyncWebviewRasterizationScale() {
 		w.chromium.Resize()
 	}
+}
+
+// resyncWebviewDPIAfterUnminimiseIfDPIChanged is the un-minimise entry point for
+// the DPI resync. It only touches the WebView2 controller when the window's DPI
+// actually differs from the last value seen while non-minimised — the mixed-DPI
+// case #5544 was meant to fix. In the common case (same monitor, unchanged DPI)
+// it makes zero COM calls, which is what prevents the restore crash in #5605:
+// after a window has been minimised long enough for WebView2 to suspend or for
+// its render/GPU process to be torn down, any COM call into the controller can
+// be fatal, and the resync's GetRasterizationScale probe previously ran on every
+// restore. DPI is read with the Win32 GetDpiForWindow, never via COM.
+func (w *windowsWebviewWindow) resyncWebviewDPIAfterUnminimiseIfDPIChanged() {
+	dpi, _ := w.DPI()
+	if dpi == 0 || dpi == w.lastKnownDPI {
+		// DPI unchanged (or unreadable): nothing to resync. Critically, do not
+		// call into the WebView2 controller here.
+		return
+	}
+	w.resyncWebviewDPIAfterMinimise()
 }
 
 // crossPermissionToWebView2Kind maps a cross-platform PermissionType to the

--- a/v3/pkg/application/webview_window_windows.go
+++ b/v3/pkg/application/webview_window_windows.go
@@ -1798,12 +1798,17 @@ func (w *windowsWebviewWindow) WndProc(msg uint32, wparam, lparam uintptr) uintp
 				w32.SetLayeredWindowAttributes(w.hwnd, 0, 255, w32.LWA_ALPHA)
 			}
 		}
-		// ShouldDetectMonitorScaleChanges is disabled (raw-pixels bounds
-		// mode), so the rasterization scale must follow DPI changes manually.
-		w.resyncWebviewRasterizationScale()
-		// Track the new DPI while non-minimised so the un-minimise comparison
-		// (resyncWebviewDPIAfterUnminimiseIfDPIChanged, #5605) stays accurate.
+		// ShouldDetectMonitorScaleChanges is disabled (raw-pixels bounds mode),
+		// so the rasterization scale must follow DPI changes manually — but only
+		// while non-minimised. While parked at (-32000,-32000) GetDpiForWindow
+		// can report a different monitor's DPI, which would push a wrong scale
+		// onto the controller (one the restore-time DPI gate then won't correct,
+		// since DPI == lastKnownDPI) and would make a COM call into a possibly
+		// suspended controller (#5605). A genuine DPI difference is instead
+		// caught on restore by resyncWebviewDPIAfterUnminimiseIfDPIChanged.
 		if !w.isMinimizing {
+			w.resyncWebviewRasterizationScale()
+			// Track the new DPI so the un-minimise comparison stays accurate.
 			if dpi, _ := w.DPI(); dpi != 0 {
 				w.lastKnownDPI = dpi
 			}

--- a/v3/pkg/application/webview_window_windows.go
+++ b/v3/pkg/application/webview_window_windows.go
@@ -89,7 +89,8 @@ type windowsWebviewWindow struct {
 	// call into the controller, which can be fatal if WebView2 suspended or its
 	// render/GPU process died while minimised (#5605). It is read with the Win32
 	// GetDpiForWindow, never via COM, and only updated while not minimised so it
-	// never captures the (-32000,-32000) parked position's DPI.
+	// never captures the parked minimised position's DPI (while minimised the
+	// window is repositioned off the monitor it will restore to).
 	lastKnownDPI w32.UINT
 
 	// menubarTheme is the theme for the menubar
@@ -1690,11 +1691,12 @@ func (w *windowsWebviewWindow) WndProc(msg uint32, wparam, lparam uintptr) uintp
 				w.parent.restoreSavedSizeConstraintOptions()
 			}
 			if w.isMinimizing {
-				// While minimised the window is parked at (-32000,-32000),
-				// which on mixed-DPI systems can re-associate it with another
-				// monitor's DPI. Nothing corrects WebView2's rasterization
-				// scale on restore, so window.devicePixelRatio keeps the
-				// wrong monitor's value until a manual resize (#5544).
+				// While minimised the window is repositioned off the monitor it
+				// will restore to (Windows parks it off-screen / at the primary
+				// monitor's corner), which on mixed-DPI systems can re-associate
+				// it with another monitor's DPI. Nothing corrects WebView2's
+				// rasterization scale on restore, so window.devicePixelRatio
+				// keeps the wrong monitor's value until a manual resize (#5544).
 				w.resyncWebviewDPIAfterUnminimiseIfDPIChanged()
 				w.parent.emit(events.Windows.WindowUnMinimise)
 			}
@@ -1717,9 +1719,9 @@ func (w *windowsWebviewWindow) WndProc(msg uint32, wparam, lparam uintptr) uintp
 		// Keep the last-known DPI current while the window is in a normal
 		// (non-minimised) state. The un-minimise transitions above read this to
 		// decide whether a WebView2 rasterization resync is actually needed; it
-		// must never be sampled while minimised, where the window is parked at
-		// (-32000,-32000) and GetDpiForWindow can report a different monitor's
-		// DPI (#5605, #5544).
+		// must never be sampled while minimised, where the window is repositioned
+		// off its restore monitor and GetDpiForWindow can report a different
+		// monitor's DPI (#5605, #5544).
 		if wparam != w32.SIZE_MINIMIZED {
 			if dpi, _ := w.DPI(); dpi != 0 {
 				w.lastKnownDPI = dpi
@@ -1777,8 +1779,8 @@ func (w *windowsWebviewWindow) WndProc(msg uint32, wparam, lparam uintptr) uintp
 		}
 
 	case w32.WM_DPICHANGED:
-		// While minimised the window is parked at (-32000,-32000); a DPI
-		// change in that state delivers a suggested rect scaled for whatever
+		// While minimised the window is repositioned off its restore monitor; a
+		// DPI change in that state delivers a suggested rect scaled for whatever
 		// monitor the parked position maps to. Applying it resizes the
 		// window's restore bookkeeping (e.g. a maximised 1920x1080 window
 		// restored at 3072x1728 after crossing a 200%→125% boundary while
@@ -1800,8 +1802,9 @@ func (w *windowsWebviewWindow) WndProc(msg uint32, wparam, lparam uintptr) uintp
 		}
 		// ShouldDetectMonitorScaleChanges is disabled (raw-pixels bounds mode),
 		// so the rasterization scale must follow DPI changes manually — but only
-		// while non-minimised. While parked at (-32000,-32000) GetDpiForWindow
-		// can report a different monitor's DPI, which would push a wrong scale
+		// while non-minimised. While minimised the window sits off its restore
+		// monitor, so GetDpiForWindow can report a different monitor's DPI, which
+		// would push a wrong scale
 		// onto the controller (one the restore-time DPI gate then won't correct,
 		// since DPI == lastKnownDPI) and would make a COM call into a possibly
 		// suspended controller (#5605). A genuine DPI difference is instead
@@ -1983,8 +1986,8 @@ func (w *windowsWebviewWindow) resyncWebviewRasterizationScale() bool {
 
 // resyncWebviewDPIAfterMinimise runs when the window leaves the minimised
 // state (whether it comes back as restored or maximised). If the rasterization
-// scale had drifted while the window was parked at (-32000,-32000), a scale
-// re-put alone does not make WebView2 re-lay out content whose bounds are
+// scale had drifted while the window was minimised off its restore monitor, a
+// scale re-put alone does not make WebView2 re-lay out content whose bounds are
 // unchanged — the page keeps reporting sizes computed with the stale scale
 // until the bounds are re-asserted (#5544, reporter verification round 2).
 func (w *windowsWebviewWindow) resyncWebviewDPIAfterMinimise() {


### PR DESCRIPTION
## Summary

Fixes the Windows crash in #5605: the app crashes when reopened after being minimised for ~10–15 seconds.

The minimise/restore rasterization-scale resync added in #5544/#5572 ("fix metrics after restore") runs a `GetRasterizationScale` COM probe on **every** restore-from-minimise — it's the no-op check inside `resyncWebviewRasterizationScale`. When a window has been minimised long enough for WebView2 to suspend or for its render/GPU process to be recycled (the reporter's 10–15s window, likely on NVIDIA-Optimus + real displays), that COM call into the now-unusable controller is the suspected fatal operation that crashes the app on reopen. `SetSize`/`PutBounds` were already hardened against this state in #5544; the rasterization probe was the one COM call still firing unconditionally on restore.

## Fix

Gate the resync on an **actual DPI change**, detected with the Win32 `GetDpiForWindow` (never via COM):

- Track `lastKnownDPI` while the window is non-minimised (creation, non-minimised `WM_SIZE`, `WM_DPICHANGED`). Never sampled while minimised, where the window is parked at `(-32000,-32000)` and DPI can read as another monitor's.
- On un-minimise, only call into the WebView2 controller when the current DPI differs from `lastKnownDPI`. In the common same-monitor/fixed-DPI case (the reporter's), this makes **zero COM calls** on restore — which removes the suspected crash.
- The mixed-DPI restore that #5544 fixed is preserved: on a DPI-changing restore the resync still fires, either via this gate or via the (ungated) `WM_DPICHANGED` handler.
- Added an `IsReady()` guard to `resyncWebviewRasterizationScale` as defense-in-depth. Note this only covers the early-init window — it does **not** detect a process-failed controller (the `inited` flag is never reset), so the DPI gate is the real protection.

## Test plan / verification

Verified on a Windows box with the **same WebView2 runtime as the reporter (149.0.4022.69)**:

- [x] `go build` and `go test ./pkg/application/` pass; `gofmt` clean.
- [x] Instrumented run confirms the restore path now logs `DPI unchanged → SKIP, 0 COM calls` and the app survives minimise/restore.
- [x] #5544 mixed-DPI behaviour preserved — verified by tracing the DPI-changed path (not by test; see caveat).

### Caveats (please read)

- **Not reproduced on available hardware.** The test box has only a virtual display, so Chromium native window occlusion never fires there — a minimised WebView2 never suspends (process count + working set stay flat across a 60s minimise), so the crash itself cannot be triggered. What's verified is that the suspected fatal COM call is eliminated on the reporter's likely path, **not** that the crash is gone end-to-end.
- A mixed-DPI user whose window also lands on a different-DPI monitor across a long minimise could still hit the controller. That's rarer and matches the one case (#5544) verified working without the long wait.
- **@Bare7a** — to confirm the mechanism, could you grab the **Windows Application event-log entry** for the crash? `Get-WinEvent -FilterHashtable @{LogName='Application'; ProviderName='Application Error'} -MaxEvents 5` — the faulting module + offset would confirm it's the WebView2 COM call. And of course a test build of this branch on your hardware would be the real confirmation.

Fixes #5605


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a critical Windows crash during minimize/restore when WebView2 suspends or its render/GPU process is recycled.
  * Improved restore stability by resynchronizing WebView2 DPI/rasterization scale only after restoring, and only when the window DPI actually changes.
  * Avoided DPI/rasterization resync attempts while the window is minimized or WebView2 isn’t ready to receive DPI/controller updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->