### PR TITLE
docs: clarify v3 changelog is auto-generated in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ Thanks for your interest in contributing! Wails has two active tracks. Pick the 
 - Source: the `v3/` directory on the `master` branch.
 - Docs: [v3.wails.io](https://v3.wails.io/).
 - Detailed contributor guide: [v3.wails.io/contributing](https://v3.wails.io/contributing/).
-- Changelog: update `v3/UNRELEASED_CHANGELOG.md`.
+- Changelog: v3 entries are added automatically from your PR on merge. To control the wording, add your own entry to `v3/UNRELEASED_CHANGELOG.md` and the automation will use it instead.
 - **Enhancements require prior discussion** on [Discord](https://discord.gg/JDdSxwjhGf) — see the [feedback guide](https://v3.wails.io/getting-started/feedback/).
 
 ## Pull request checklist


### PR DESCRIPTION
# Description

`CONTRIBUTING.md` tells v3 contributors to update `v3/UNRELEASED_CHANGELOG.md`, but that contradicts the PR template, which says v3 changelog entries are added automatically.

The template is the accurate one. `.github/workflows/auto-changelog-v3.yml` runs on PR merge and auto-generates a v3 changelog entry; it only skips the auto-fill when the PR already touched `v3/UNRELEASED_CHANGELOG.md`. So a v3 entry is never required from the contributor — at most it's an optional way to control the wording.

This updates the `CONTRIBUTING.md` v3 line to match that behaviour: entries are added automatically, with a manual entry as an optional override. No change to the PR template, which was already correct.

Fixes #5623

## Type of change

- [x] This change requires a documentation update

# How Has This Been Tested?

Documentation-only change to `CONTRIBUTING.md`. No code paths are affected, so there is nothing to run on a specific OS. Verified the new wording matches the actual `auto-changelog-v3.yml` behaviour and the existing PR template statement.

- [ ] Windows
- [ ] macOS
- [ ] Linux

## Test Configuration

N/A — documentation-only change, `wails doctor` not applicable.

# Checklist:

- [ ] (v2 only) I have updated `website/src/pages/changelog.mdx` with details of this PR (v3 changelog entries are added automatically)
- [x] My code follows the general coding style of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated v3 (alpha) contribution guidelines to clarify that changelog entries are generated automatically on merge, and how to control the wording for your changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->