### PR TITLE
fix(v3/ios): empty string from a bound method no longer crashes the app

### DIFF
--- a/v3/UNRELEASED_CHANGELOG.md
+++ b/v3/UNRELEASED_CHANGELOG.md
@@ -23,6 +23,7 @@ After processing, the content will be moved to the main changelog and this file 
 
 ## Fixed
 <!-- Bug fixes -->
+- Fix an iOS crash (SIGABRT) when a bound Go service method returns an empty string. The iOS asset response writer guarded the body pointer with `buf != nil` instead of its length, so a zero-length body made `&buf[0]` panic; it now guards on length, matching the desktop writers
 
 ## Deprecated
 <!-- Soon-to-be removed features -->

--- a/v3/internal/assetserver/webview/responsewriter_ios.go
+++ b/v3/internal/assetserver/webview/responsewriter_ios.go
@@ -103,7 +103,11 @@ func (rw *responseWriter) Write(buf []byte) (int, error) {
 
 	var content unsafe.Pointer
 	var contentLen int
-	if buf != nil {
+	// Guard on length, not just nil: a non-nil but empty slice (e.g. the body of
+	// a bound method that returned "") would make &buf[0] panic with an
+	// index-out-of-range, aborting the Go runtime. An empty body is valid — pass
+	// a nil pointer with length 0, which yields an empty NSData on the C side.
+	if len(buf) != 0 {
 		content = unsafe.Pointer(&buf[0])
 		contentLen = len(buf)
 	}


### PR DESCRIPTION
## Problem

On iOS, a bound Go service method that returns an **empty string** immediately crashes the app (SIGABRT / abort trap).

## Root cause

The iOS asset response writer (`internal/assetserver/webview/responsewriter_ios.go`) guarded the response-body pointer with `if buf != nil`:

```go
if buf != nil {
    content = unsafe.Pointer(&buf[0])   // panics on a non-nil, zero-length slice
    contentLen = len(buf)
}
```

A bound method returning `""` produces a zero-length **but non-nil** response body, which passes the `!= nil` check — then `&buf[0]` panics with index-out-of-range, and the unrecovered panic aborts the Go runtime (SIGABRT). The desktop (darwin) writer already guards correctly with `buf != nil && len(buf) > 0`, which is why this was iOS-only.

## Fix

Guard on **length** instead of nil (matching the desktop writers). An empty body passes a nil pointer + length 0, which is a valid empty `NSData` on the C side.

## Verification

Reproduced on the iOS simulator: before the fix, a service method returning `""` crashed to the home screen (SIGABRT confirmed in the crash report, faulting thread inside the Go runtime). After the fix, the call returns `""` correctly (`typeof string`) and the app runs normally. Non-empty responses are byte-for-byte unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an iOS crash that occurred when a bound Go service method returns an empty string.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->