### PR TITLE
test(v3/icons): assert .ico is small, not an exact byte size

### DIFF
--- a/v3/internal/commands/icons_test.go
+++ b/v3/internal/commands/icons_test.go
@@ -280,15 +280,17 @@ func TestGenerateIcon(t *testing.T) {
 						panic(err)
 					}
 				}()
-				// The size of the file should be 571 bytes
-				if f.Size() != 571 {
-					return fmt.Errorf("appicon.ico is not the correct size. Got %d", f.Size())
-				}
+				// A single 16px icon yields a small .ico. The exact byte count
+				// depends on the source image (which changes over time), so assert
+				// the file is small and non-empty rather than an exact size.
 				if f.IsDir() {
 					return fmt.Errorf("appicon.ico is a directory")
 				}
 				if f.Size() == 0 {
 					return fmt.Errorf("appicon.ico is empty")
+				}
+				if f.Size() > 5000 {
+					return fmt.Errorf("appicon.ico is larger than expected for a single 16px icon. Got %d", f.Size())
 				}
 				return nil
 			},
@@ -357,14 +359,17 @@ func TestGenerateIcon(t *testing.T) {
 						panic(err)
 					}
 				}()
-				if f.Size() != 571 {
-					return fmt.Errorf("appicon.ico is not the correct size. Got %d", f.Size())
-				}
+				// Sizes "0,16" should drop the 0 and behave like a single 16px
+				// icon: a small, non-empty .ico (exact byte count varies with the
+				// source image).
 				if f.IsDir() {
 					return fmt.Errorf("appicon.ico is a directory")
 				}
 				if f.Size() == 0 {
 					return fmt.Errorf("appicon.ico is empty")
+				}
+				if f.Size() > 5000 {
+					return fmt.Errorf("appicon.ico is larger than expected for a single 16px icon. Got %d", f.Size())
 				}
 				return nil
 			},


### PR DESCRIPTION
TestGenerateIcon hard-asserted the generated `.ico` was exactly **571 bytes**. After the default icons were updated in #5610, the single-16px `.ico` is **481 bytes**, so the test has been failing on `master` (macOS + Windows Go Tests v3).

The exact byte count depends on the source image, so this replaces the exact-size assertions (two test cases) with a check that the file is **small (<5000 bytes) and non-empty** — the test's actual intent (a single 16px icon) — which won't re-break when icons change again.

Verified `go test -run TestGenerateIcon ./internal/commands/` passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated icon-generation test validation to use flexible range-based assertions instead of strict byte-size checks, improving test robustness and accommodating expected variations in generated output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->