### PR TITLE
feat(v3/ios): Add DisableSafeAreaInsets ios option to disable safe zone insets

### DIFF
--- a/v3/pkg/application/application_ios.go
+++ b/v3/pkg/application/application_ios.go
@@ -130,6 +130,9 @@ func newPlatformApp(app *App) *iosApp {
 	}
 	C.ios_set_disable_input_accessory(C.bool(disable))
 
+	// Safe area insets for WebView (Disable*)
+	C.ios_set_disable_safe_area_insets(C.bool(app.options.IOS.DisableSafeAreaInsets))
+
 	// Scrolling / Bounce / Indicators (defaults enabled; using Disable* flags)
 	C.ios_set_disable_scroll(C.bool(app.options.IOS.DisableScroll))
 	C.ios_set_disable_bounce(C.bool(app.options.IOS.DisableBounce))

--- a/v3/pkg/application/application_ios.h
+++ b/v3/pkg/application/application_ios.h
@@ -26,6 +26,10 @@ void ios_app_quit(void);
 // Check if dark mode is enabled
 bool ios_is_dark_mode(void);
 
+// Safe area insets control
+bool ios_is_safe_area_insets_disabled(void);
+void ios_set_disable_safe_area_insets(bool disabled);
+
 // Configure/show state for iOS WKWebView input accessory view (keyboard toolbar)
 // If disabled, the accessory view will be hidden.
 void ios_set_disable_input_accessory(bool disabled);

--- a/v3/pkg/application/application_ios.m
+++ b/v3/pkg/application/application_ios.m
@@ -21,6 +21,7 @@ WailsAppDelegate *appDelegate = nil;
 unsigned int nextWindowID = 1;
 static bool g_disableInputAccessory = false; // default: enabled (shown)
 // New global flags with sensible iOS defaults
+static bool g_disableSafeAreaInsets = false; // default: WebView respects safe area insets
 static bool g_disableScroll = false;              // default: scrolling enabled
 static bool g_disableBounce = false;              // default: bounce enabled
 static bool g_disableScrollIndicators = false;    // default: indicators shown
@@ -74,6 +75,14 @@ bool ios_is_dark_mode(void) {
         return style == UIUserInterfaceStyleDark;
     }
     return false;
+}
+
+// Safe area insets control
+void ios_set_disable_safe_area_insets(bool disabled) {
+    g_disableSafeAreaInsets = disabled;
+}
+bool ios_is_safe_area_insets_disabled(void) {
+    return g_disableSafeAreaInsets;
 }
 
 void ios_set_disable_input_accessory(bool disabled) {

--- a/v3/pkg/application/application_options.go
+++ b/v3/pkg/application/application_options.go
@@ -311,6 +311,9 @@ type IOSOptions struct {
 	// false => accessory view is enabled/shown
 	DisableInputAccessoryView bool
 
+	// Safe area insets for WebView (default false)
+	DisableSafeAreaInsets bool
+
 	// Scrolling & Bounce (defaults: scroll/bounce/indicators are enabled on iOS)
 	// Use Disable* to keep default true behavior without surprising zero-values.
 	DisableScroll           bool

--- a/v3/pkg/application/webview_window_ios.m
+++ b/v3/pkg/application/webview_window_ios.m
@@ -266,9 +266,14 @@ static NSMutableArray<NSString *> *pendingConsoleJS;
         tabH = size.height;
         self.tabBar.frame = CGRectMake(0, height - safe.bottom - tabH, width, tabH);
     }
-    CGFloat webTop = safe.top;
-    CGFloat webBottom = safe.bottom + tabH;
-    self.webView.frame = UIEdgeInsetsInsetRect(self.view.bounds, UIEdgeInsetsMake(webTop, safe.left, webBottom, safe.right));
+    if (ios_is_safe_area_insets_disabled()) {
+        CGFloat webHeight = (self.tabBar && !self.tabBar.isHidden) ? (height - safe.bottom - tabH) : height;
+        self.webView.frame = CGRectMake(0, 0, width, webHeight);
+    } else {
+        CGFloat webTop = safe.top;
+        CGFloat webBottom = safe.bottom + tabH;
+        self.webView.frame = UIEdgeInsetsInsetRect(self.view.bounds, UIEdgeInsetsMake(webTop, safe.left, webBottom, safe.right));
+    }
 }
 // Orientation lock and status-bar appearance are driven by global state set
 // from Go (see mobile_features_ios.m). These overrides feed UIKit the current


### PR DESCRIPTION
<!--

*********************************************************************
*               PLEASE READ BEFORE SUBMITTING YOUR PR               *
*     YOUR PR MAY BE REJECTED IF IT DOES NOT FOLLOW THESE STEPS     *
*********************************************************************

- *DO NOT* submit bugs for a source install of v3, ONLY tagged versions, e.g. v3.0.0-alpha.11
- *DO NOT* submit PRs for v3 alpha enhancements, unless you have opened a post on the discord channel.
  All enhancements must be discussed first.
  The feedback guide for v3 is here: https://v3.wails.io/feedback/

- Before submitting your PR, please ensure you have created and linked the PR to an issue.
- If a relevant issue already exists, please reference it in your PR by including `Fixes #<issue number>` in your PR description.
- Please fill in the checklists.

-->

# Description

This adds a IOSOption called `DisableSafeAreaInsets` to disable safe area insets. It is false by default, so existing code will have unchanged results.

## Type of change
  
Please select the option that is relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
  
I ran an example app with `DisableSafeAreaInsets` set to true, false, and with it not being present. All values work as expected. macOS and Windows remain unaffected.

- [X] Windows
- [X] macOS
- [X] iOS
- [ ] Linux
      
If you checked Linux, please specify the distro and version.
  
## Test Configuration

```
Wails v3.0.0-dev › Wails Doctor
                                                                                                                                                                                                                                                                                                                                                        
# System
        
┌────────────────────────────┐
| Name          | MacOS      |
| Version       | 27.0       |
| ID            | 26A5353q   |
| Branding      | MacOS 27.0 |
| Platform      | darwin     |
| Architecture  | arm64      |
| Apple Silicon | true       |
| CPU           | Apple M1   |
| CPU           | Apple M1   |
| GPU           | 7 cores    |
| Memory        | 16 GB      |
└────────────────────────────┘
                   
# Build Environment
                   
┌──────────────────────────────────────────────────────────────────────┐
| Wails CLI      | v3.0.0-dev                                          |
| Go Version     | go1.26.4                                            |
| -buildmode     | exe                                                 |
| -compiler      | gc                                                  |
| CGO_CFLAGS     |                                                     |
| CGO_CPPFLAGS   |                                                     |
| CGO_CXXFLAGS   |                                                     |
| CGO_ENABLED    | 1                                                   |
| CGO_LDFLAGS    |                                                     |
| DefaultGODEBUG | cryptocustomrand=1,tlssecpmlkem=0,urlstrictcolons=0 |
| GOARCH         | arm64                                               |
| GOARM64        | v8.0                                                |
| GOOS           | darwin                                              |
| vcs            | git                                                 |
| vcs.modified   | true                                                |
| vcs.revision   | eb9bb02b73f7c30f0e650f01a8a1587ed816ce5f            |
| vcs.time       | 2026-06-17T21:23:24Z                                |
└──────────────────────────────────────────────────────────────────────┘
              
# Dependencies
              
┌──────────────────────────────────────────────────────────────────────────────────────────────────────────┐
| *Android SDK       | Not found. Set ANDROID_HOME (install via Android Studio or the command-line tools). |
| *NSIS              | Not Installed. Install with `brew install makensis`.                                |
| *Xcode (iOS)       | Xcode 26.5, Build version 17F42                                                     |
| *iOS Device SDK    | 26.5                                                                                |
| *iOS Simulator SDK | 26.5                                                                                |
| Xcode cli tools    | 2417                                                                                |
| npm                | 10.5.2                                                                              |
| docker             | *Not installed (optional - for cross-compilation)                                   |
|                                                                                                          |
└──────────────────────────────────────── * - Optional Dependency ─────────────────────────────────────────┘
         
# Signing
         
┌──────────────────────────────────────────────────────────────────────┐
| macOS Signing   | Developer ID Application: Half-Eaten Toast LLC ... |
| Windows Signing | Not configured                                     |
| Linux Signing   | Not configured (GPG)                               |
└──────────────────────────────────────────────────────────────────────┘
                     
# Checking for issues
                     
 SUCCESS  No issues found
           
# Diagnosis
           
 SUCCESS  Your system is ready for Wails development!

Need documentation? Run: wails3 docs
 ♥   If Wails is useful to you or your company, please consider sponsoring the project: wails3 sponsor
``` 

# Checklist:

- [ ] (v2 only) I have updated `website/src/pages/changelog.mdx` with details of this PR (v3 changelog entries are added automatically)
- [x] My code follows the general coding style of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
