### PR TITLE
fix windows minimize crash/flash

### DIFF
--- a/v3/pkg/application/webview_window_windows.go
+++ b/v3/pkg/application/webview_window_windows.go
@@ -1706,6 +1706,9 @@ func (w *windowsWebviewWindow) WndProc(msg uint32, wparam, lparam uintptr) uintp
 			bounds := &edge.Rect{Left: 0, Top: 0, Right: width, Bottom: height}
 			InvokeSync(func() {
 				time.Sleep(1 * time.Nanosecond)
+				if w.chromium == nil || !w.chromium.IsReady() {
+					return
+				}
 				w.chromium.ResizeWithBounds(bounds)
 				w.parent.emit(events.Windows.WindowDidResize)
 			})
@@ -1936,6 +1939,9 @@ func (w *windowsWebviewWindow) resyncWebviewRasterizationScale() bool {
 // unchanged — the page keeps reporting sizes computed with the stale scale
 // until the bounds are re-asserted (#5544, reporter verification round 2).
 func (w *windowsWebviewWindow) resyncWebviewDPIAfterMinimise() {
+	if w.chromium == nil || !w.chromium.IsReady() {
+		return
+	}
 	if w.resyncWebviewRasterizationScale() {
 		w.chromium.Resize()
 	}


### PR DESCRIPTION
This pull request adds additional safety checks to the Windows webview window handling code to prevent operations on an uninitialized or not-ready `chromium` instance. These checks help avoid potential runtime errors during window resizing and DPI resynchronization.

**Stability improvements:**

* Added a guard in the `WndProc` method to ensure `w.chromium` is not `nil` and is ready before calling `ResizeWithBounds`.
* Added a guard in the `resyncWebviewDPIAfterMinimise` method to ensure `w.chromium` is not `nil` and is ready before proceeding with DPI resynchronization logic.

** UNTESTED **

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced Windows WebView window stability during resize and DPI synchronization operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->