### PR TITLE
Fix/V3/Windows: blank content and crash when restoring minimized window (introduced by #5572)

### DIFF
--- a/v3/pkg/application/webview_window_windows.go
+++ b/v3/pkg/application/webview_window_windows.go
@@ -76,6 +76,14 @@ type windowsWebviewWindow struct {
 	// Used to prevent unnecessary redraws during minimize/restore operations
 	isMinimizing bool
 
+	// dpiBeforeMinimise records the window's DPI immediately before it entered
+	// the minimised state, so that on restore we can tell whether the DPI
+	// genuinely changed while the window was parked (the cross-monitor #5544
+	// scenario), as opposed to unconditionally touching WebView2's Controller3
+	// rasterization-scale APIs on every single minimise/restore cycle, even on
+	// a single-monitor, single-DPI setup where nothing needs correcting.
+	dpiBeforeMinimise w32.UINT
+
 	// lastSizeWParam is the wParam from the most-recent WM_SIZE message.
 	// Gate the dark-menubar force-repaint on a state transition so it does not fire
 	// on every SIZE_RESTORED during live drag-resize. WM_ENTERSIZEMOVE/WM_EXITSIZEMOVE
@@ -1500,6 +1508,8 @@ func (w *windowsWebviewWindow) isActive() bool {
 	return w32.GetForegroundWindow() == w.hwnd
 }
 
+var resizePending atomic.Int32
+
 func (w *windowsWebviewWindow) WndProc(msg uint32, wparam, lparam uintptr) uintptr {
 
 	// Use the original implementation that works perfectly for maximized
@@ -1606,14 +1616,20 @@ func (w *windowsWebviewWindow) WndProc(msg uint32, wparam, lparam uintptr) uintp
 		w.parent.emit(events.Windows.WindowBackgroundErase)
 		// Paint the background with the configured colour so that areas not yet
 		// covered by WebView2 during a resize show the correct colour instead of white.
+		// GetClientRect can legitimately return nil for a window in a transient
+		// state (the same nil case already guarded against in
+		// convertWindowToWebviewCoordinates above), which minimise/restore
+		// transitions are especially prone to triggering; FillRect with a nil
+		// rect crashes, so this must be checked before painting.
 		if w.parent.options.BackgroundType == BackgroundTypeSolid {
-			col := w.parent.options.BackgroundColour
-			hdc := w32.HDC(wparam)
-			rc := w32.GetClientRect(w.hwnd)
-			colorRef := w32.COLORREF(uint32(col.Red) | uint32(col.Green)<<8 | uint32(col.Blue)<<16)
-			hbrush := w32.CreateSolidBrush(colorRef)
-			w32.FillRect(hdc, rc, hbrush)
-			w32.DeleteObject(w32.HGDIOBJ(hbrush))
+			if rc := w32.GetClientRect(w.hwnd); rc != nil {
+				col := w.parent.options.BackgroundColour
+				hdc := w32.HDC(wparam)
+				colorRef := w32.COLORREF(uint32(col.Red) | uint32(col.Green)<<8 | uint32(col.Blue)<<16)
+				hbrush := w32.CreateSolidBrush(colorRef)
+				w32.FillRect(hdc, rc, hbrush)
+				w32.DeleteObject(w32.HGDIOBJ(hbrush))
+			}
 		}
 		return 1
 	// WM_UAHDRAWMENUITEM is handled by MenuBarWndProc at the top of this function
@@ -1654,9 +1670,6 @@ func (w *windowsWebviewWindow) WndProc(msg uint32, wparam, lparam uintptr) uintp
 		switch wparam {
 		case w32.SIZE_MAXIMIZED:
 			if w.isMinimizing {
-				// A maximised window leaving the minimised state arrives
-				// here (not at SIZE_RESTORED), and needs the same DPI
-				// resync as the restore path below (#5544).
 				w.resyncWebviewDPIAfterMinimise()
 				w.parent.emit(events.Windows.WindowUnMinimise)
 			}
@@ -1668,47 +1681,50 @@ func (w *windowsWebviewWindow) WndProc(msg uint32, wparam, lparam uintptr) uintp
 		case w32.SIZE_RESTORED:
 			restoredFromMaximised := w.lastSizeWParam == w32.SIZE_MAXIMIZED
 			if restoredFromMaximised {
-				// Native caption drag from a maximised frameless window bypasses UnMaximise(),
-				// so we need to restore the saved constraints here before the next resize.
 				w.parent.restoreSavedSizeConstraintOptions()
 			}
 			if w.isMinimizing {
-				// While minimised the window is parked at (-32000,-32000),
-				// which on mixed-DPI systems can re-associate it with another
-				// monitor's DPI. Nothing corrects WebView2's rasterization
-				// scale on restore, so window.devicePixelRatio keeps the
-				// wrong monitor's value until a manual resize (#5544).
+				if w.dpiBeforeMinimise == 0 {
+					w.dpiBeforeMinimise, _ = w.DPI()
+				}
 				w.resyncWebviewDPIAfterMinimise()
 				w.parent.emit(events.Windows.WindowUnMinimise)
 			}
 			w.isMinimizing = false
 			w.parent.emit(events.Windows.WindowRestore)
-			// Repaint the dark menubar only when leaving a maximized/snapped state.
-			// SIZE_RESTORED fires on every WM_SIZE during live drag-resize; gating on the
-			// previous state avoids per-frame invalidations and the associated flicker.
-			// WM_ENTERSIZEMOVE/WM_EXITSIZEMOVE cannot guard this because keyboard snap
-			// (Win+Left) bypasses those messages entirely.
 			if restoredFromMaximised && w.menu != nil && w.menubarTheme != nil {
 				w32.RedrawWindow(w.hwnd, nil, 0, w32.RDW_FRAME|w32.RDW_INVALIDATE)
 			}
 		case w32.SIZE_MINIMIZED:
+			if !w.isMinimizing {
+				w.dpiBeforeMinimise, _ = w.DPI()
+			}
 			w.isMinimizing = true
 			w.parent.emit(events.Windows.WindowMinimise)
 		}
 		w.lastSizeWParam = wparam
 
-		if !(w.parent.options.Frameless && wparam == w32.SIZE_MINIMIZED) {
-			// If the window is frameless and minimizing, suppress the WebView2 resize.
-			// Without this, restoring has wrong dimensions during the animation.
-			// See https://github.com/MicrosoftEdge/WebView2Feedback/issues/2549
+		doResize := func() {
 			width := int32(lparam & 0xFFFF)
 			height := int32((lparam >> 16) & 0xFFFF)
-			bounds := &edge.Rect{Left: 0, Top: 0, Right: width, Bottom: height}
+			bounds := &edge.Rect{
+				Left:   0,
+				Top:    0,
+				Right:  width,
+				Bottom: height,
+			}
 			InvokeSync(func() {
 				time.Sleep(1 * time.Nanosecond)
 				w.chromium.ResizeWithBounds(bounds)
+				resizePending.Store(0)
 				w.parent.emit(events.Windows.WindowDidResize)
 			})
+		}
+
+		if w.parent.options.Frameless && wparam == w32.SIZE_MINIMIZED {
+			// suppress WebView2 resize while minimizing
+		} else if resizePending.CompareAndSwap(0, 1) {
+			doResize()
 		}
 		return 0
 
@@ -1769,9 +1785,17 @@ func (w *windowsWebviewWindow) WndProc(msg uint32, wparam, lparam uintptr) uintp
 				w32.SetLayeredWindowAttributes(w.hwnd, 0, 255, w32.LWA_ALPHA)
 			}
 		}
-		// ShouldDetectMonitorScaleChanges is disabled (raw-pixels bounds
-		// mode), so the rasterization scale must follow DPI changes manually.
-		w.resyncWebviewRasterizationScale()
+		// ShouldDetectMonitorScaleChanges is disabled (raw-pixels bounds mode), so
+		// the rasterization scale must follow DPI changes manually. Skip this while
+		// minimised, same reasoning as the SetWindowPos guard above: the DPI
+		// reported here belongs to whatever monitor the parked (-32000,-32000)
+		// position maps to, not the window's real monitor. A correct
+		// WM_DPICHANGED for the real monitor still arrives on restore if one is
+		// actually needed, and resyncWebviewDPIAfterMinimise() already handles
+		// that case explicitly.
+		if !w.isMinimizing {
+			w.resyncWebviewRasterizationScale()
+		}
 		w.parent.emit(events.Windows.WindowDPIChanged)
 	}
 
@@ -1930,12 +1954,26 @@ func (w *windowsWebviewWindow) resyncWebviewRasterizationScale() bool {
 }
 
 // resyncWebviewDPIAfterMinimise runs when the window leaves the minimised
-// state (whether it comes back as restored or maximised). If the rasterization
-// scale had drifted while the window was parked at (-32000,-32000), a scale
-// re-put alone does not make WebView2 re-lay out content whose bounds are
-// unchanged — the page keeps reporting sizes computed with the stale scale
-// until the bounds are re-asserted (#5544, reporter verification round 2).
+// state (whether it comes back as restored or maximised). It only touches
+// WebView2's rasterization scale when the DPI captured right before
+// minimising and the DPI on restore actually differ — e.g. the window was
+// minimised on one monitor and got remapped to a different one while
+// parked (#5544). For the overwhelmingly common case of minimising and
+// restoring on the same monitor/DPI, this must be a complete no-op: it
+// must not unconditionally call into WebView2's Controller3 APIs on every
+// single minimise/restore cycle, since that is what regressed ordinary
+// minimise/restore (content area staying blank behind the native frame,
+// sometimes crashing outright) even when DPI never changed.
 func (w *windowsWebviewWindow) resyncWebviewDPIAfterMinimise() {
+	if w.dpiBeforeMinimise == 0 {
+		return
+	}
+
+	dpiNow, _ := w.DPI()
+	if dpiNow == 0 || dpiNow == w.dpiBeforeMinimise {
+		return
+	}
+
 	if w.resyncWebviewRasterizationScale() {
 		w.chromium.Resize()
 	}


### PR DESCRIPTION
Fix a Windows regression introduced by #5572 where restoring a minimized window could leave the content area blank,
and in some cases crash the app.

This regression was introduced in v3.0.0-alpha.102 and has been reproducible in all subsequent alpha releases tested (v3.0.0-alpha.103 and v3.0.0-alpha.104).
The last known working version is v3.0.0-alpha.101, where minimizing to tray and restoring worked correctly without blank content or crashes.

On Windows, 52b352994 (#5572) unconditionally resynced WebView2 rasterization scale in the minimize/restore path. That caused even normal same-DPI minimize/restore cycles to enter the WebView2 reconfiguration path and race with ResizeWithBounds() during restore, which could leave the content area blank and, in some cases, crash the app.

This change records the DPI before minimizing and only resyncs WebView2 rasterization scale when the DPI after restore actually differs from the pre-minimize DPI. It keeps the cross-monitor DPI fix needed for #5544 while avoiding unnecessary Controller3 updates during ordinary minimize/restore cycles.

- Record the window DPI before minimizing.
- Only resync WebView2 rasterization scale when the restore DPI actually differs from the pre-minimize DPI.
- Keep the fix for cross-monitor DPI changes, so #5544 remains covered.
- Make the normal minimize/restore path a no-op for WebView2 DPI sync, avoiding unneces


<!--

*********************************************************************
*               PLEASE READ BEFORE SUBMITTING YOUR PR               *
*     YOUR PR MAY BE REJECTED IF IT DOES NOT FOLLOW THESE STEPS     *
*********************************************************************

- *DO NOT* submit bugs for a source install of v3, ONLY tagged versions, e.g. v3.0.0-alpha.11
- *DO NOT* submit PRs for v3 alpha enhancements, unless you have opened a post on the discord channel.
  All enhancements must be discussed first.
  The feedback guide for v3 is here: https://v3.wails.io/feedback/

- Before submitting your PR, please ensure you have created and linked the PR to an issue.
- If a relevant issue already exists, please reference it in your PR by including `Fixes #<issue number>` in your PR description.
- Please fill in the checklists.

-->

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change
  
Please select the option that is relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
  
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration using `wails doctor`.

- [x] Windows
- [ ] macOS
- [ ] Linux
      
If you checked Linux, please specify the distro and version.
  
## Test Configuration

Please paste the output of `wails doctor`. If you are unable to run this command, please describe your environment in as much detail as possible.

# Checklist:

- [ ] (v2 only) I have updated `website/src/pages/changelog.mdx` with details of this PR (v3 changelog entries are added automatically)
- [x] My code follows the general coding style of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved stability when minimizing, restoring, and maximizing windows
  * Fixed potential crashes in background rendering
  * Enhanced DPI scaling accuracy across monitor configurations during window state transitions
  * Optimized resize operations to improve performance and prevent redundant calls

<!-- end of auto-generated comment: release notes by coderabbit.ai -->