### PR TITLE
fix(v3/windows): guard WM_ERASEBKGND paint against nil GetClientRect

### DIFF
--- a/v3/UNRELEASED_CHANGELOG.md
+++ b/v3/UNRELEASED_CHANGELOG.md
@@ -23,6 +23,7 @@ After processing, the content will be moved to the main changelog and this file 
 
 ## Fixed
 <!-- Bug fixes -->
+- Fix crash on Windows when erasing the background during a minimise/restore transition: `GetClientRect` can return nil for a window in a transient state, and the solid-background paint passed it straight into `FillRect`. Now guarded, matching the existing nil-check in `convertWindowToWebviewCoordinates` (salvaged from #5635)
 
 ## Deprecated
 <!-- Soon-to-be removed features -->

--- a/v3/pkg/application/webview_window_windows.go
+++ b/v3/pkg/application/webview_window_windows.go
@@ -1607,13 +1607,18 @@ func (w *windowsWebviewWindow) WndProc(msg uint32, wparam, lparam uintptr) uintp
 		// Paint the background with the configured colour so that areas not yet
 		// covered by WebView2 during a resize show the correct colour instead of white.
 		if w.parent.options.BackgroundType == BackgroundTypeSolid {
-			col := w.parent.options.BackgroundColour
-			hdc := w32.HDC(wparam)
-			rc := w32.GetClientRect(w.hwnd)
-			colorRef := w32.COLORREF(uint32(col.Red) | uint32(col.Green)<<8 | uint32(col.Blue)<<16)
-			hbrush := w32.CreateSolidBrush(colorRef)
-			w32.FillRect(hdc, rc, hbrush)
-			w32.DeleteObject(w32.HGDIOBJ(hbrush))
+			// GetClientRect returns nil for a window in a transient state (the
+			// same nil case already guarded in convertWindowToWebviewCoordinates),
+			// which minimise/restore transitions are especially prone to trigger.
+			// FillRect with a nil rect crashes, so guard before painting.
+			if rc := w32.GetClientRect(w.hwnd); rc != nil {
+				col := w.parent.options.BackgroundColour
+				hdc := w32.HDC(wparam)
+				colorRef := w32.COLORREF(uint32(col.Red) | uint32(col.Green)<<8 | uint32(col.Blue)<<16)
+				hbrush := w32.CreateSolidBrush(colorRef)
+				w32.FillRect(hdc, rc, hbrush)
+				w32.DeleteObject(w32.HGDIOBJ(hbrush))
+			}
 		}
 		return 1
 	// WM_UAHDRAWMENUITEM is handled by MenuBarWndProc at the top of this function


### PR DESCRIPTION
## Summary

On Windows, the `WM_ERASEBKGND` solid-background paint passes the result of `GetClientRect` straight into `FillRect`. `GetClientRect` can return `nil` for a window in a transient state (the same nil case already guarded in `convertWindowToWebviewCoordinates`), which minimise/restore transitions are especially prone to trigger — and `FillRect` with a nil rect crashes. This adds the missing nil check before painting.

## Test

- Cross-compiles for windows/amd64 and windows/arm64.
- Built and run on a Windows 11 box (WebView2 149): solid-background window survives repeated minimise → wait → restore cycles, no crash and no blank content.

This fix was salvaged from the equivalent change in #5635; credit to @sinspired via the `Co-authored-by` trailer.

## Changelog

`v3/UNRELEASED_CHANGELOG.md` updated under Fixed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a crash on Windows that occurred when minimizing or restoring windows with solid background colors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->