### PR TITLE
fix(v3/linux): WebKitGTK main-loop crashes on long-running apps (#5631)

### DIFF
--- a/v3/UNRELEASED_CHANGELOG.md
+++ b/v3/UNRELEASED_CHANGELOG.md
@@ -24,6 +24,7 @@ After processing, the content will be moved to the main changelog and this file 
 ## Fixed
 <!-- Bug fixes -->
 - Fix crash on Windows when restoring an app that was minimised long enough for WebView2 to suspend or its render/GPU process to be recycled. The minimise/restore DPI resync (#5544) now only touches the WebView2 controller when the window's DPI actually changed, avoiding fatal COM calls into a suspended controller on the common same-DPI restore (#5605)
+- Fix repeated native `SIGABRT`/`SIGSEGV` crashes (typically inside `g_object_unref` during the GTK main loop) on long-running Linux apps under frequent asset/media loads. The asset server completed `WebKitURISchemeRequest`s from worker goroutines, calling thread-unsafe WebKit2GTK functions off the GTK main thread; completion (`webkit_uri_scheme_request_finish_with_response`/`finish_error`) now runs on the main thread. Completes the partial fix in #5566. Affects both the GTK3 and GTK4/WebKitGTK 6.0 builds (#5631, #5557)
 - Fix intermittent `fatal error: invalid pointer found on stack` in `setupSignalHandlers` on Linux/GTK3. Window IDs passed as signal `user_data` were held in a Go `unsafe.Pointer` local, so the garbage collector aborted when it scanned the (non-pointer) value during a stack copy. The ID is now kept integer-typed (`uintptr_t`) on the Go side, back-porting to the legacy GTK3 path the same fix #4958 applied to the GTK4 path (which switched the C signal functions to `uintptr_t` to clear `-race`/checkptr errors) (#5631)
 
 ## Deprecated

--- a/v3/UNRELEASED_CHANGELOG.md
+++ b/v3/UNRELEASED_CHANGELOG.md
@@ -24,6 +24,7 @@ After processing, the content will be moved to the main changelog and this file 
 ## Fixed
 <!-- Bug fixes -->
 - Fix crash on Windows when restoring an app that was minimised long enough for WebView2 to suspend or its render/GPU process to be recycled. The minimise/restore DPI resync (#5544) now only touches the WebView2 controller when the window's DPI actually changed, avoiding fatal COM calls into a suspended controller on the common same-DPI restore (#5605)
+- Fix intermittent `fatal error: invalid pointer found on stack` in `setupSignalHandlers` on Linux/GTK3. Window IDs passed as signal `user_data` were held in a Go `unsafe.Pointer` local, so the garbage collector aborted when it scanned the (non-pointer) value during a stack copy. The ID is now kept integer-typed (`uintptr_t`) on the Go side, back-porting to the legacy GTK3 path the same fix #4958 applied to the GTK4 path (which switched the C signal functions to `uintptr_t` to clear `-race`/checkptr errors) (#5631)
 
 ## Deprecated
 <!-- Soon-to-be removed features -->

--- a/v3/internal/assetserver/webview/mainthread_linux.go
+++ b/v3/internal/assetserver/webview/mainthread_linux.go
@@ -1,0 +1,100 @@
+//go:build linux && cgo && !android
+
+package webview
+
+/*
+#cgo linux pkg-config: glib-2.0
+
+#include <glib.h>
+#include <stdint.h>
+
+extern void webviewMainThreadCallback(uintptr_t id);
+
+typedef struct {
+	uintptr_t id;
+	GMutex    mutex;
+	GCond     cond;
+	gboolean  done;
+} webviewMainSyncCall;
+
+// webview_main_sync_trampoline runs on the GTK main thread (scheduled via
+// g_main_context_invoke). It invokes the Go callback, then signals the waiting
+// worker. g_cond_signal happens while the mutex is held and before the unlock,
+// so the waiter cannot re-acquire the mutex (and destroy the primitives) until
+// the signal has completed — making the stack-allocated GMutex/GCond safe.
+static gboolean webview_main_sync_trampoline(gpointer data) {
+	webviewMainSyncCall *call = (webviewMainSyncCall *)data;
+	webviewMainThreadCallback(call->id);
+	g_mutex_lock(&call->mutex);
+	call->done = TRUE;
+	g_cond_signal(&call->cond);
+	g_mutex_unlock(&call->mutex);
+	return G_SOURCE_REMOVE;
+}
+
+// webview_invoke_on_main_sync schedules the Go callback identified by id on the
+// default GTK main context and blocks the calling thread until it has finished.
+//
+// WebKit2GTK objects may only be touched on the thread running the GTK main loop
+// (g_application_run). Asset-server responses are produced on worker goroutines,
+// so the WebKit calls that complete a request must hop here first. The wait is
+// safe because webkit_uri_scheme_request_finish_with_response returns before the
+// response stream is drained (WebKit reads it asynchronously), so the main loop
+// never blocks waiting on the worker.
+//
+// If the caller is already the main thread, g_main_context_invoke runs the
+// trampoline inline, so the wait completes immediately without deadlocking.
+static void webview_invoke_on_main_sync(uintptr_t id) {
+	webviewMainSyncCall call;
+	call.id = id;
+	call.done = FALSE;
+	g_mutex_init(&call.mutex);
+	g_cond_init(&call.cond);
+
+	g_main_context_invoke(NULL, webview_main_sync_trampoline, &call);
+
+	g_mutex_lock(&call.mutex);
+	while (!call.done) {
+		g_cond_wait(&call.cond, &call.mutex);
+	}
+	g_mutex_unlock(&call.mutex);
+
+	g_mutex_clear(&call.mutex);
+	g_cond_clear(&call.cond);
+}
+*/
+import "C"
+
+import (
+	"sync"
+)
+
+var (
+	mainSyncMu        sync.Mutex
+	mainSyncNextID    uintptr
+	mainSyncCallbacks = map[uintptr]func(){}
+)
+
+// invokeOnMainSync runs fn on the GTK main thread and blocks until it returns.
+// It is safe to call from any goroutine, including the main thread itself.
+func invokeOnMainSync(fn func()) {
+	mainSyncMu.Lock()
+	mainSyncNextID++
+	id := mainSyncNextID
+	mainSyncCallbacks[id] = fn
+	mainSyncMu.Unlock()
+
+	C.webview_invoke_on_main_sync(C.uintptr_t(id))
+}
+
+//export webviewMainThreadCallback
+func webviewMainThreadCallback(id C.uintptr_t) {
+	mainSyncMu.Lock()
+	fn := mainSyncCallbacks[uintptr(id)]
+	delete(mainSyncCallbacks, uintptr(id))
+	mainSyncMu.Unlock()
+
+	if fn != nil {
+		fn()
+	}
+}

--- a/v3/internal/assetserver/webview/responsewriter_linux.go
+++ b/v3/internal/assetserver/webview/responsewriter_linux.go
@@ -9,6 +9,15 @@ package webview
 #include <webkit/webkit.h>
 #include <gio/gunixinputstream.h>
 
+// webview_asset_error_quark returns a stable GError domain for asset-server
+// failures. The string literal is static storage, so g_quark_from_static_string
+// interns it once and never leaks. Interning the per-request error message
+// instead (the previous behaviour) grew the global quark table unboundedly on
+// long-running apps, since GQuarks are never freed.
+static GQuark webview_asset_error_quark(void) {
+	return g_quark_from_static_string("wails-webview-assetserver");
+}
+
 */
 import "C"
 import (
@@ -115,7 +124,7 @@ func (rw *responseWriter) finishWithError(code int, err error) {
 	// on the GTK main loop; this runs on an asset-server worker goroutine, so
 	// it must hop to the main thread. See mainthread_linux.go and issue #5631.
 	invokeOnMainSync(func() {
-		gerr := C.g_error_new_literal(C.g_quark_from_string(msg), C.int(code), msg)
+		gerr := C.g_error_new_literal(C.webview_asset_error_quark(), C.int(code), msg)
 		C.webkit_uri_scheme_request_finish_error(rw.req, gerr)
 		C.g_error_free(gerr)
 	})

--- a/v3/internal/assetserver/webview/responsewriter_linux.go
+++ b/v3/internal/assetserver/webview/responsewriter_linux.go
@@ -109,10 +109,16 @@ func (rw *responseWriter) finishWithError(code int, err error) {
 	rw.wErr = err
 
 	msg := C.CString(err.Error())
-	gerr := C.g_error_new_literal(C.g_quark_from_string(msg), C.int(code), msg)
-	C.webkit_uri_scheme_request_finish_error(rw.req, gerr)
-	C.g_error_free(gerr)
-	C.free(unsafe.Pointer(msg))
+	defer C.free(unsafe.Pointer(msg))
+
+	// webkit_uri_scheme_request_finish_error touches the WebKit-owned request
+	// on the GTK main loop; this runs on an asset-server worker goroutine, so
+	// it must hop to the main thread. See mainthread_linux.go and issue #5631.
+	invokeOnMainSync(func() {
+		gerr := C.g_error_new_literal(C.g_quark_from_string(msg), C.int(code), msg)
+		C.webkit_uri_scheme_request_finish_error(rw.req, gerr)
+		C.g_error_free(gerr)
+	})
 }
 
 type nopCloser struct {

--- a/v3/internal/assetserver/webview/responsewriter_linux_gtk3.go
+++ b/v3/internal/assetserver/webview/responsewriter_linux_gtk3.go
@@ -112,10 +112,16 @@ func (rw *responseWriter) finishWithError(code int, err error) {
 	rw.wErr = err
 
 	msg := C.CString(err.Error())
-	gerr := C.g_error_new_literal(C.g_quark_from_string(msg), C.int(code), msg)
-	C.webkit_uri_scheme_request_finish_error(rw.req, gerr)
-	C.g_error_free(gerr)
-	C.free(unsafe.Pointer(msg))
+	defer C.free(unsafe.Pointer(msg))
+
+	// webkit_uri_scheme_request_finish_error touches the WebKit-owned request
+	// on the GTK main loop; this runs on an asset-server worker goroutine, so
+	// it must hop to the main thread. See mainthread_linux.go and issue #5631.
+	invokeOnMainSync(func() {
+		gerr := C.g_error_new_literal(C.g_quark_from_string(msg), C.int(code), msg)
+		C.webkit_uri_scheme_request_finish_error(rw.req, gerr)
+		C.g_error_free(gerr)
+	})
 }
 
 type nopCloser struct {

--- a/v3/internal/assetserver/webview/responsewriter_linux_gtk3.go
+++ b/v3/internal/assetserver/webview/responsewriter_linux_gtk3.go
@@ -9,6 +9,15 @@ package webview
 #include "webkit2/webkit2.h"
 #include "gio/gunixinputstream.h"
 
+// webview_asset_error_quark returns a stable GError domain for asset-server
+// failures. The string literal is static storage, so g_quark_from_static_string
+// interns it once and never leaks. Interning the per-request error message
+// instead (the previous behaviour) grew the global quark table unboundedly on
+// long-running apps, since GQuarks are never freed.
+static GQuark webview_asset_error_quark(void) {
+	return g_quark_from_static_string("wails-webview-assetserver");
+}
+
 */
 import "C"
 import (
@@ -118,7 +127,7 @@ func (rw *responseWriter) finishWithError(code int, err error) {
 	// on the GTK main loop; this runs on an asset-server worker goroutine, so
 	// it must hop to the main thread. See mainthread_linux.go and issue #5631.
 	invokeOnMainSync(func() {
-		gerr := C.g_error_new_literal(C.g_quark_from_string(msg), C.int(code), msg)
+		gerr := C.g_error_new_literal(C.webview_asset_error_quark(), C.int(code), msg)
 		C.webkit_uri_scheme_request_finish_error(rw.req, gerr)
 		C.g_error_free(gerr)
 	})

--- a/v3/internal/assetserver/webview/webkit_linux.go
+++ b/v3/internal/assetserver/webview/webkit_linux.go
@@ -44,35 +44,41 @@ func webkit_uri_scheme_request_get_http_headers(req *C.WebKitURISchemeRequest) h
 }
 
 func webkit_uri_scheme_request_finish(req *C.WebKitURISchemeRequest, code int, header http.Header, stream *C.GInputStream, streamLength int64) error {
-	resp := C.webkit_uri_scheme_response_new(stream, C.gint64(streamLength))
-	defer C.g_object_unref(C.gpointer(resp))
+	// Completing the request touches WebKit/libsoup objects owned by the GTK
+	// main loop, but this runs on an asset-server worker goroutine. WebKit2GTK
+	// is not thread-safe, so the whole sequence must hop to the main thread.
+	// See mainthread_linux.go and issue #5631.
+	invokeOnMainSync(func() {
+		resp := C.webkit_uri_scheme_response_new(stream, C.gint64(streamLength))
+		defer C.g_object_unref(C.gpointer(resp))
 
-	cReason := C.CString(http.StatusText(code))
-	C.webkit_uri_scheme_response_set_status(resp, C.guint(code), cReason)
-	C.free(unsafe.Pointer(cReason))
+		cReason := C.CString(http.StatusText(code))
+		C.webkit_uri_scheme_response_set_status(resp, C.guint(code), cReason)
+		C.free(unsafe.Pointer(cReason))
 
-	cMimeType := C.CString(header.Get(HeaderContentType))
-	C.webkit_uri_scheme_response_set_content_type(resp, cMimeType)
-	C.free(unsafe.Pointer(cMimeType))
+		cMimeType := C.CString(header.Get(HeaderContentType))
+		C.webkit_uri_scheme_response_set_content_type(resp, cMimeType)
+		C.free(unsafe.Pointer(cMimeType))
 
-	// Ownership of hdrs is transferred to the response by
-	// webkit_uri_scheme_response_set_http_headers (transfer full), so we must
-	// not unref it here — doing so frees the headers while WebKit/libsoup still
-	// reference them, crashing in soup_message_headers_iter_next on render.
-	hdrs := C.soup_message_headers_new(C.SOUP_MESSAGE_HEADERS_RESPONSE)
-	for name, values := range header {
-		cName := C.CString(name)
-		for _, value := range values {
-			cValue := C.CString(value)
-			C.soup_message_headers_append(hdrs, cName, cValue)
-			C.free(unsafe.Pointer(cValue))
+		// Ownership of hdrs is transferred to the response by
+		// webkit_uri_scheme_response_set_http_headers (transfer full), so we must
+		// not unref it here — doing so frees the headers while WebKit/libsoup still
+		// reference them, crashing in soup_message_headers_iter_next on render.
+		hdrs := C.soup_message_headers_new(C.SOUP_MESSAGE_HEADERS_RESPONSE)
+		for name, values := range header {
+			cName := C.CString(name)
+			for _, value := range values {
+				cValue := C.CString(value)
+				C.soup_message_headers_append(hdrs, cName, cValue)
+				C.free(unsafe.Pointer(cValue))
+			}
+			C.free(unsafe.Pointer(cName))
 		}
-		C.free(unsafe.Pointer(cName))
-	}
 
-	C.webkit_uri_scheme_response_set_http_headers(resp, hdrs)
+		C.webkit_uri_scheme_response_set_http_headers(resp, hdrs)
 
-	C.webkit_uri_scheme_request_finish_with_response(req, resp)
+		C.webkit_uri_scheme_request_finish_with_response(req, resp)
+	})
 	return nil
 }
 

--- a/v3/internal/assetserver/webview/webkit_linux_gtk3.go
+++ b/v3/internal/assetserver/webview/webkit_linux_gtk3.go
@@ -44,35 +44,41 @@ func webkit_uri_scheme_request_get_http_headers(req *C.WebKitURISchemeRequest) h
 }
 
 func webkit_uri_scheme_request_finish(req *C.WebKitURISchemeRequest, code int, header http.Header, stream *C.GInputStream, streamLength int64) error {
-	resp := C.webkit_uri_scheme_response_new(stream, C.gint64(streamLength))
-	defer C.g_object_unref(C.gpointer(resp))
+	// Completing the request touches WebKit/libsoup objects owned by the GTK
+	// main loop, but this runs on an asset-server worker goroutine. WebKit2GTK
+	// is not thread-safe, so the whole sequence must hop to the main thread.
+	// See mainthread_linux.go and issue #5631.
+	invokeOnMainSync(func() {
+		resp := C.webkit_uri_scheme_response_new(stream, C.gint64(streamLength))
+		defer C.g_object_unref(C.gpointer(resp))
 
-	cReason := C.CString(http.StatusText(code))
-	C.webkit_uri_scheme_response_set_status(resp, C.guint(code), cReason)
-	C.free(unsafe.Pointer(cReason))
+		cReason := C.CString(http.StatusText(code))
+		C.webkit_uri_scheme_response_set_status(resp, C.guint(code), cReason)
+		C.free(unsafe.Pointer(cReason))
 
-	cMimeType := C.CString(header.Get(HeaderContentType))
-	C.webkit_uri_scheme_response_set_content_type(resp, cMimeType)
-	C.free(unsafe.Pointer(cMimeType))
+		cMimeType := C.CString(header.Get(HeaderContentType))
+		C.webkit_uri_scheme_response_set_content_type(resp, cMimeType)
+		C.free(unsafe.Pointer(cMimeType))
 
-	// Ownership of hdrs is transferred to the response by
-	// webkit_uri_scheme_response_set_http_headers (transfer full), so we must
-	// not unref it here — doing so frees the headers while WebKit/libsoup still
-	// reference them, crashing in soup_message_headers_iter_next on render.
-	hdrs := C.soup_message_headers_new(C.SOUP_MESSAGE_HEADERS_RESPONSE)
-	for name, values := range header {
-		cName := C.CString(name)
-		for _, value := range values {
-			cValue := C.CString(value)
-			C.soup_message_headers_append(hdrs, cName, cValue)
-			C.free(unsafe.Pointer(cValue))
+		// Ownership of hdrs is transferred to the response by
+		// webkit_uri_scheme_response_set_http_headers (transfer full), so we must
+		// not unref it here — doing so frees the headers while WebKit/libsoup still
+		// reference them, crashing in soup_message_headers_iter_next on render.
+		hdrs := C.soup_message_headers_new(C.SOUP_MESSAGE_HEADERS_RESPONSE)
+		for name, values := range header {
+			cName := C.CString(name)
+			for _, value := range values {
+				cValue := C.CString(value)
+				C.soup_message_headers_append(hdrs, cName, cValue)
+				C.free(unsafe.Pointer(cValue))
+			}
+			C.free(unsafe.Pointer(cName))
 		}
-		C.free(unsafe.Pointer(cName))
-	}
 
-	C.webkit_uri_scheme_response_set_http_headers(resp, hdrs)
+		C.webkit_uri_scheme_response_set_http_headers(resp, hdrs)
 
-	C.webkit_uri_scheme_request_finish_with_response(req, resp)
+		C.webkit_uri_scheme_request_finish_with_response(req, resp)
+	})
 	return nil
 }
 

--- a/v3/pkg/application/linux_cgo_gtk3.go
+++ b/v3/pkg/application/linux_cgo_gtk3.go
@@ -94,9 +94,13 @@ extern void onProcessRequest(WebKitURISchemeRequest *request, uintptr_t user_dat
 extern void sendMessageToBackend(WebKitUserContentManager *contentManager, WebKitJavascriptResult *result, void *data);
 // exported below (end)
 
-static void signal_connect(void *widget, char *event, void *cb, void* data) {
-   // g_signal_connect is a macro and can't be called directly
-   g_signal_connect(widget, event, cb, data);
+static void signal_connect(void *widget, char *event, void *cb, uintptr_t data) {
+   // g_signal_connect is a macro and can't be called directly.
+   // data carries a window ID (not a real pointer); it is passed as the
+   // gpointer user_data value itself and recovered by the handlers as a
+   // uintptr_t. Keeping it integer-typed on the Go side avoids the GC
+   // scanning it as a stack pointer. See issue #5631.
+   g_signal_connect(widget, event, cb, (gpointer)data);
 }
 
 static WebKitWebView* webkit_web_view(GtkWidget *webview) {
@@ -433,15 +437,15 @@ static void on_drag_leave(GtkWidget *widget, GdkDragContext *context, guint time
 }
 
 // Set up drag and drop handlers for external file drops with hover effects
-static void enableDND(GtkWidget *widget, gpointer data)
+static void enableDND(GtkWidget *widget, uintptr_t data)
 {
     // Core handlers for file drop
-    g_signal_connect(G_OBJECT(widget), "drag-data-received", G_CALLBACK(on_drag_data_received), data);
-    g_signal_connect(G_OBJECT(widget), "drag-drop", G_CALLBACK(on_drag_drop), data);
+    g_signal_connect(G_OBJECT(widget), "drag-data-received", G_CALLBACK(on_drag_data_received), (gpointer)data);
+    g_signal_connect(G_OBJECT(widget), "drag-drop", G_CALLBACK(on_drag_drop), (gpointer)data);
 
     // Hover effect handlers - return FALSE for internal drags to let WebKit handle them
-    g_signal_connect(G_OBJECT(widget), "drag-motion", G_CALLBACK(on_drag_motion), data);
-    g_signal_connect(G_OBJECT(widget), "drag-leave", G_CALLBACK(on_drag_leave), data);
+    g_signal_connect(G_OBJECT(widget), "drag-motion", G_CALLBACK(on_drag_motion), (gpointer)data);
+    g_signal_connect(G_OBJECT(widget), "drag-leave", G_CALLBACK(on_drag_leave), (gpointer)data);
 }
 
 // Block external file drops - consume the events to prevent WebKit from navigating to files
@@ -468,10 +472,10 @@ static gboolean on_drag_motion_blocked(GtkWidget *widget, GdkDragContext *contex
 }
 
 // Set up handlers that block external file drops while allowing internal HTML5 drag-and-drop
-static void disableDND(GtkWidget *widget, gpointer data)
+static void disableDND(GtkWidget *widget, uintptr_t data)
 {
-    g_signal_connect(G_OBJECT(widget), "drag-drop", G_CALLBACK(on_drag_drop_blocked), data);
-    g_signal_connect(G_OBJECT(widget), "drag-motion", G_CALLBACK(on_drag_motion_blocked), data);
+    g_signal_connect(G_OBJECT(widget), "drag-drop", G_CALLBACK(on_drag_drop_blocked), (gpointer)data);
+    g_signal_connect(G_OBJECT(widget), "drag-motion", G_CALLBACK(on_drag_motion_blocked), (gpointer)data);
 }
 
 // Store/retrieve an unsigned integer as a GObject data pointer without allocating memory.
@@ -635,7 +639,7 @@ func appRun(app pointer) error {
 
 	signal := C.CString("activate")
 	defer C.free(unsafe.Pointer(signal))
-	C.signal_connect(unsafe.Pointer(application), signal, C.activateLinux, nil)
+	C.signal_connect(unsafe.Pointer(application), signal, C.activateLinux, 0)
 	status := C.g_application_run(application, 0, nil)
 	C.g_application_release(application)
 	C.g_object_unref(C.gpointer(app))
@@ -654,7 +658,7 @@ func appDestroy(application pointer) {
 func (w *linuxWebviewWindow) contextMenuSignals(menu pointer) {
 	c := NewCalloc()
 	defer c.Free()
-	winID := unsafe.Pointer(uintptr(C.uint(w.parent.ID())))
+	winID := C.uintptr_t(w.parent.ID())
 	C.signal_connect(unsafe.Pointer(menu), c.String("button-release-event"), C.onMenuButtonEvent, winID)
 }
 
@@ -1129,15 +1133,14 @@ func (w *linuxWebviewWindow) close() {
 }
 
 func (w *linuxWebviewWindow) enableDND() {
-	// Pass window ID as pointer value (not pointer to ID) - same pattern as other signal handlers
-	winID := unsafe.Pointer(uintptr(w.parent.id))
-	C.enableDND((*C.GtkWidget)(w.webview), C.gpointer(winID))
+	// Pass the window ID as the gpointer user_data value itself (not a pointer
+	// to it) using an integer type, so the Go GC never scans it. See #5631.
+	C.enableDND((*C.GtkWidget)(w.webview), C.uintptr_t(w.parent.id))
 }
 
 func (w *linuxWebviewWindow) disableDND() {
 	// Block external file drops while allowing internal HTML5 drag-and-drop
-	winID := unsafe.Pointer(uintptr(w.parent.id))
-	C.disableDND((*C.GtkWidget)(w.webview), C.gpointer(winID))
+	C.disableDND((*C.GtkWidget)(w.webview), C.uintptr_t(w.parent.id))
 }
 
 func (w *linuxWebviewWindow) execJS(js string) {
@@ -1810,7 +1813,7 @@ func (w *linuxWebviewWindow) setupSignalHandlers(emit func(e events.WindowEventT
 	c := NewCalloc()
 	defer c.Free()
 
-	winID := unsafe.Pointer(uintptr(C.uint(w.parent.ID())))
+	winID := C.uintptr_t(w.parent.ID())
 
 	// Set up the window close event
 	wv := unsafe.Pointer(w.webview)
@@ -1821,7 +1824,7 @@ func (w *linuxWebviewWindow) setupSignalHandlers(emit func(e events.WindowEventT
 	C.signal_connect(unsafe.Pointer(w.window), c.String("configure-event"), C.handleConfigureEvent, winID)
 
 	contentManager := C.webkit_web_view_get_user_content_manager(w.webKitWebView())
-	C.signal_connect(unsafe.Pointer(contentManager), c.String("script-message-received::external"), C.sendMessageToBackend, nil)
+	C.signal_connect(unsafe.Pointer(contentManager), c.String("script-message-received::external"), C.sendMessageToBackend, 0)
 	C.signal_connect(wv, c.String("button-press-event"), C.onButtonEvent, winID)
 	C.signal_connect(wv, c.String("button-release-event"), C.onButtonEvent, winID)
 	C.signal_connect(wv, c.String("key-press-event"), C.onKeyPressEvent, winID)


### PR DESCRIPTION
## Summary

Fixes the repeated native crashes reported in #5631 on long-running Linux apps. There are **two distinct bugs** behind the two crash signatures in that report; this PR addresses both as two separate commits.

Reported in: #5631 (see also #5557, the earlier report of the same asset-server crash).

## Bug 1 — WebKit asset requests completed off the GTK main thread (the 9/10 signature)

`SIGSEGV` inside `g_object_unref` during `g_main_context_iteration` (`addr=0x28`).

The asset server completes `WebKitURISchemeRequest`s from a pool of worker goroutines (`assetserver_webview.go`), calling `webkit_uri_scheme_request_finish_*` **off the GTK main thread**. WebKit2GTK is not thread-safe — these calls mutate and finalise GObjects owned by the main loop, racing `g_application_run` and corrupting refcounts.

#5566 (which closed #5557) marshalled only the trailing `g_object_unref` of the request onto the main context; the `finish` call itself — where most of the WebKit object manipulation happens — was still run on the worker goroutine, so the crash persisted on `v3.0.0-alpha2.103`.

**Fix:** add `invokeOnMainSync` (`mainthread_linux.go`) — a synchronous main-thread dispatch built on `g_main_context_invoke` + `GCond`, shared by the GTK3 and GTK4 cgo builds — and run the full response completion (`webkit_uri_scheme_request_finish_with_response` / `finish_error`) under it. The synchronous wait can't deadlock the main loop because `finish_with_response` returns before the response stream is drained (WebKit reads it asynchronously). Body streaming over the pipe stays off the main thread; the request-body input stream (transfer-full, owned solely by us) is intentionally left on the worker.

## Bug 2 — GC stack-scan crash from a fake pointer (the 1/10 signature)

`fatal error: invalid pointer found on stack` in `setupSignalHandlers`.

`setupSignalHandlers`/`contextMenuSignals`/`enableDND`/`disableDND` passed the window ID as signal `user_data` but held it in a Go `unsafe.Pointer` local via `unsafe.Pointer(uintptr(id))`. The value is a small integer (window ID 1 → `0x1`), not a real pointer, so the GC aborted when it scanned that pointer-typed stack slot during a stack copy.

**Fix:** the GTK4 path already passes the ID as `C.uintptr_t` — **#4958** switched the C signal functions to `uintptr_t` specifically to clear `-race`/`checkptr` errors from this exact fake-pointer pattern, but only on the (then new) GTK4 files. When #5463 flipped GTK4 to default and renamed the legacy code to `*_gtk3.go`, the GTK3 path kept the old `unsafe.Pointer` form. This commit back-ports #4958's `uintptr_t` change to the GTK3 path.

## Verification (Linux, WebKitGTK 2.52.3)

- Compiles clean on both `-tags gtk3` and the default GTK4 build; `gofmt` and `go vet` clean on the changed files.
- **No deadlock under load:** GTK3 served ~449K asset requests (sustained ~8K/s, goroutine-per-request, reloads every 1.5s) — each a synchronous finish-on-main round-trip — with a clean exit.
- **Deterministic mechanism check** (`g_main_context_is_owner`): the `finish` call runs `on GTK main thread = false` before the change and `= true` after, on **both** the GTK3 and GTK4 builds.

## Notes

- Affects both the GTK3 and GTK4/WebKitGTK 6.0 cgo builds. The purego (non-cgo) Linux build has the same off-thread pattern and is left for a follow-up.
- The two commits are logically independent and can be reviewed/split separately; Bug 2 is a small, self-contained back-port.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed repeated native crashes (SIGABRT/SIGSEGV) in long-running Linux sessions by ensuring WebView-related URI handling completes on the GTK main thread.
  * Fixed intermittent “invalid pointer found on stack” crashes by correcting how window IDs are passed through Linux signal handling (including GTK3).
  * Improved WebView error handling reliability on Linux (including safer error finalization and more consistent error identification).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->