### PR TITLE
ci(npm): publish @wailsio/runtime via Trusted Publishing (OIDC)

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -57,6 +57,7 @@ jobs:
       contents: write
       actions: read
       pull-requests: read
+      id-token: write # Required for npm Trusted Publishing (OIDC) + provenance
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -81,6 +82,12 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: "20"
+
+      - name: Upgrade npm for Trusted Publishing
+        # Trusted Publishing (OIDC) requires npm >= 11.5.1.
+        run: |
+          npm install -g npm@latest
+          npm --version
 
       - name: Install dependencies
         working-directory: v3/internal/runtime/desktop/@wailsio/runtime
@@ -114,9 +121,10 @@ jobs:
           git commit -m "[skip ci] Publish @wailsio/runtime ${{ steps.bump-version.outputs.version }}"
           git push
 
-      - name: Publish npm package
-        uses: JS-DevTools/npm-publish@v3
-        with:
-          package: v3/internal/runtime/desktop/@wailsio/runtime
-          access: public
-          token: ${{ secrets.NPM_TOKEN }}
+      - name: Publish npm package (Trusted Publishing / OIDC)
+        # No NODE_AUTH_TOKEN/NPM_TOKEN: npm exchanges the GitHub OIDC token for a
+        # short-lived publish credential. Provenance is attached automatically.
+        # Requires a Trusted Publisher to be configured for @wailsio/runtime on
+        # npmjs.com (repo: wailsapp/wails, workflow: publish-npm.yml).
+        working-directory: v3/internal/runtime/desktop/@wailsio/runtime
+        run: npm publish --access public


### PR DESCRIPTION
## Problem

`publish-npm.yml` has **failed at the `Publish npm package` step on every run since ~Feb 2026**. The earlier steps (build → bump → commit → push) succeed, so master's runtime version climbed to **alpha.90** while **npm stayed frozen at alpha.79** (last good publish 2026-01-25).

The failure is npm **E404 on `PUT https://registry.npmjs.org/@wailsio%2fruntime`** — npm's disguised authorization failure (404 not 403 to avoid leaking package existence). I.e. `secrets.NPM_TOKEN` is no longer authorized to publish the `@wailsio` scope.

**Impact:** alpha.79 predates the Android runtime bridge (`window.wails.invokeAsync`), so JS↔Go bindings are broken for every stock `wails3 init` **Android** app — the runtime falls back to `fetch('/wails/runtime')`, whose POST body the Android WebView drops → HTTP 422 `missing object value`.

## Fix

Migrate to npm **Trusted Publishing (OIDC)** — no long-lived token to rot:
- add `id-token: write` for the OIDC token + automatic provenance
- upgrade npm to ≥ 11.5.1 (required for trusted publishing)
- replace `JS-DevTools/npm-publish` + `NPM_TOKEN` with plain `npm publish --access public`

## Required out-of-band step (done)

A Trusted Publisher is configured for `@wailsio/runtime` on npmjs.com: org `wailsapp`, repo `wails`, workflow `publish-npm.yml`, empty environment.

## Effect

One successful run ships **alpha.91** (master already has the bridge); templates pin `"latest"`, so all stock Android users are fixed.

Validated with `actionlint` (clean) + YAML parse. End-to-end publish only testable in CI after merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the npm package publishing workflow to use GitHub Trusted Publishing for enhanced security and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->