### PR TITLE
fix(webview2): recover from transient runtime COM errors instead of exiting

### DIFF
--- a/webview2/pkg/edge/chromium.go
+++ b/webview2/pkg/edge/chromium.go
@@ -246,7 +246,10 @@ func (e *Chromium) Resize() {
 
 	bounds, err := w32.GetClientRect(e.hwnd)
 	if err != nil {
-		e.errorCallback(err)
+		// GetClientRect can fail transiently while the window is being torn
+		// down or reconfigured during DPI churn. Skipping a resize frame is
+		// recoverable; killing the process (errorCallback) is not.
+		log.Printf("[WebView2] Resize failed to get client rect: %v", err)
 		return
 	}
 
@@ -256,21 +259,23 @@ func (e *Chromium) Resize() {
 func (e *Chromium) Navigate(url string) {
 	err := e.webview.Navigate(url)
 	if err != nil {
-		e.errorCallback(err)
+		// A failed navigation is recoverable (the previous content stays
+		// visible); killing the process is not.
+		log.Printf("[WebView2] Navigate failed: %v", err)
 	}
 }
 
 func (e *Chromium) NavigateToString(content string) {
 	err := e.webview.NavigateToString(content)
 	if err != nil {
-		e.errorCallback(err)
+		log.Printf("[WebView2] NavigateToString failed: %v", err)
 	}
 }
 
 func (e *Chromium) Init(script string) {
 	err := e.webview.AddScriptToExecuteOnDocumentCreated(script, nil)
 	if err != nil {
-		e.errorCallback(err)
+		log.Printf("[WebView2] Init script registration failed: %v", err)
 	}
 }
 
@@ -407,13 +412,20 @@ func (e *Chromium) ContainsFullScreenElementChanged(sender *ICoreWebView2, args 
 func (e *Chromium) MessageReceived(sender *ICoreWebView2, args *ICoreWebView2WebMessageReceivedEventArgs) uintptr {
 	message, err := args.TryGetWebMessageAsString()
 	if err != nil {
-		e.errorCallback(err)
+		// The web message originates from (potentially untrusted) page
+		// content. A malformed message must never be able to take the whole
+		// process down — drop it and keep running.
+		log.Printf("[WebView2] dropping malformed web message: %v", err)
+		return 0
 	}
 
 	if HasCapability(e.webview2RuntimeVersion, GetAdditionalObjects) {
 		obj, err := args.GetAdditionalObjects()
 		if err != nil {
-			e.errorCallback(err)
+			// Fall back to delivering the plain string message below rather
+			// than killing the process.
+			log.Printf("[WebView2] failed to read additional objects, delivering message without them: %v", err)
+			obj = nil
 		}
 
 		if obj != nil && e.MessageWithAdditionalObjectsCallback != nil {
@@ -428,7 +440,7 @@ func (e *Chromium) MessageReceived(sender *ICoreWebView2, args *ICoreWebView2Web
 
 	err = sender.PostWebMessageAsString(message)
 	if err != nil && !errors.Is(err, windows.ERROR_IO_PENDING) {
-		e.errorCallback(err)
+		log.Printf("[WebView2] PostWebMessageAsString failed: %v", err)
 	}
 	return 0
 }
@@ -609,14 +621,14 @@ func (e *Chromium) Focus() {
 func (e *Chromium) PutZoomFactor(zoomFactor float64) {
 	err := e.controller.PutZoomFactor(zoomFactor)
 	if err != nil {
-		e.errorCallback(err)
+		log.Printf("[WebView2] PutZoomFactor failed: %v", err)
 	}
 }
 
 func (e *Chromium) OpenDevToolsWindow() {
 	err := e.webview.OpenDevToolsWindow()
 	if err != nil {
-		e.errorCallback(err)
+		log.Printf("[WebView2] OpenDevToolsWindow failed: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

`Chromium.errorCallback` logs and then calls `os.Exit(1)`. That is correct while the WebView2 **environment/controller is being created** (the app cannot run without it), but several **runtime** COM paths routed transient post-startup failures through the same callback — so a recoverable hiccup killed the whole application.

Per the audit in #5580, this single pattern has caused multiple independent crash reports (#5446, #4158, and the mixed-DPI monitor-crossing crashes #5544 / #5650). `Focus()` and `Eval()` were already converted to log-and-recover on a previous PR; this completes the audit for the remaining runtime sites.

## Changes (webview2 module)

Converted from `errorCallback` (→ `os.Exit`) to **log-and-recover**, following the existing `Focus`/`Eval` precedent:

| Site | New behaviour |
|------|---------------|
| `Resize` / `GetClientRect` | log + skip the resize frame |
| `Navigate` / `NavigateToString` | log (previous content stays visible) |
| `Init` (AddScriptToExecuteOnDocumentCreated) | log |
| `MessageReceived` → `TryGetWebMessageAsString` | **drop the malformed message (log + return)** instead of taking the process down |
| `MessageReceived` → `GetAdditionalObjects` | log + fall back to delivering the plain string message |
| `MessageReceived` → `PostWebMessageAsString` | log |

**Security note:** the `MessageReceived` web message originates from (potentially untrusted) page content. Previously a malformed message was a process-level DoS — `TryGetWebMessageAsString` failure → `errorCallback` → `os.Exit`. It is now dropped and the app keeps running.

### Beyond the audit table
Two further **user-triggered** runtime ops were also converted (please confirm you're happy with these): `PutZoomFactor`, `OpenDevToolsWindow`.

### Intentionally left fatal
All ~20 init / controller-creation sites (`Embed`, environment/controller creation callbacks, controller setup) remain fatal as specified in the audit.

### Not touched (flagging for a follow-up decision)
These are also runtime event-handler sites that still hard-exit and may warrant the same treatment, but were outside the audit's enumerated table — left as-is to keep this PR scoped:
- `PermissionRequested` (GetPermissionKind / PutState)
- `AcceleratorKeyPressed`
- `SetBackgroundColour`
- `WebResourceRequested` — note this one uses `log.Fatal` directly

## Testing
- `gofmt` clean; `go vet` clean (the two pre-existing `unsafe.Pointer` warnings are in unrelated files).
- Built **natively on Windows** (Go 1.26) via the workspace: `v3/pkg/application` and the `examples/window` app compile and link against the patched module; the app initialises WebView2 successfully at runtime (confirmed from logs).
- The transient-COM failure modes (mixed-DPI monitor drag, tray restore) can't be reproduced over a headless SSH session (no interactive desktop — the example dies earlier on `GetCursorPos`). The change itself is a direct, auditable swap of `os.Exit` for `log`, matching the already-merged `Focus`/`Eval` pattern.

## Rollout
This is a **webview2-module** change. It needs a `webview2/v1.0.26` tag and a `v3/go.mod` bump to reach released v3.

Refs #5580 #5544 #5650


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Error handling improved: several error conditions now log and allow graceful continuation instead of terminating the application.
  * Enhanced resilience for window resizing, navigation, and web message processing.
  * Developer tools and zoom functionality now recover gracefully on failure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->