### PR TITLE
fix(v3/linux): make Menu.Update() rebuild the native menu (GTK4)

### DIFF
--- a/v3/pkg/application/linux_cgo.go
+++ b/v3/pkg/application/linux_cgo.go
@@ -347,6 +347,24 @@ func menuAppend(parent *Menu, menu *MenuItem, hidden bool) {
 	}
 }
 
+// menuClear removes every item from the menu's native GMenu so that it can be
+// rebuilt from scratch on Menu.Update() (#5464). The per-menu append counter is
+// reset too, so rebuilt items get fresh 0-based positions (menuIndex is used by
+// menu_remove_item for hide/show). This mirrors the GTK3/purego menuClear.
+func menuClear(menu *Menu) {
+	if menu.impl == nil {
+		return
+	}
+	impl := menu.impl.(*linuxMenu)
+	if impl.native == nil {
+		return
+	}
+	C.g_menu_remove_all((*C.GMenu)(impl.native))
+	menuItemCountersLock.Lock()
+	delete(menuItemCounters, impl.native)
+	menuItemCountersLock.Unlock()
+}
+
 func menuBarNew() pointer {
 	gmenu := C.g_menu_new()
 	C.set_app_menu_model(gmenu)

--- a/v3/pkg/application/menu_linux.go
+++ b/v3/pkg/application/menu_linux.go
@@ -36,8 +36,11 @@ func (m *linuxMenu) processMenu(menu *Menu) {
 
 	impl := menu.impl.(*linuxMenu)
 	if impl.processed {
-		// Menu already processed, skip re-processing to avoid duplicates
-		return
+		// On re-process (Menu.Update()), clear the existing native menu and
+		// rebuild from scratch so that added/removed items are reflected
+		// (#5464). The previous one-way guard skipped re-processing to avoid
+		// appending duplicates, which made Menu.Update() a silent no-op.
+		menuClear(menu)
 	}
 	impl.processed = true
 


### PR DESCRIPTION
## Summary

`Menu.Update()` is a silent no-op on the **default GTK4 build**. `processMenu` used a one-way `processed` guard that returned early on every call after the first:

```go
if impl.processed {
    return // skip re-processing to avoid duplicates
}
impl.processed = true
```

So adding/removing items, rebuilding after `Clear()`, or any runtime mutation never reached the native menu (#5464).

## Fix

Replace the early-return with a **clear-and-rebuild** on re-process — the same approach the **GTK3** path (`menu_linux_gtk3.go`) already uses (it calls `menuClear()` before rebuilding). The GTK4 GMenu model was simply missing its `menuClear()`:

- Add `menuClear()` in `linux_cgo.go` using `g_menu_remove_all` on the native `GMenu`, and reset the per-menu append counter (`menuItemCounters`) so rebuilt items get fresh 0-based positions (the index is used by `menu_remove_item` for hide/show).
- In `processMenu`, call `menuClear(menu)` instead of returning when already processed.

Because the rebuild clears first and then re-appends, re-running `Update()` is idempotent and cannot duplicate items (the original guard's concern).

## Scope

Only the default **GTK4 cgo** path (`menu_linux.go` + `linux_cgo.go`) was affected:
- The **GTK3** path (`menu_linux_gtk3.go`) already calls `menuClear()` and works.
- The **purego** target does not currently compile on `master` at all (`undefined: linuxApp`, `fatalHandler`, `newPlatformApp`, … — unrelated to menus), so it is out of scope here; this change neither fixes nor breaks it (verified: identical build errors before and after).

## Testing

Verified on **Linux / GTK4 under Xvfb** (real app, runtime menu mutation): a submenu built with one item, then a second item added and `Menu.Update()` called at runtime — the native `GMenu`'s item count goes **1 → 2** (the added item appears). Before the fix the early-return left it at 1. `pkg/application` builds clean on GTK4 cgo; `gofmt` clean.

(No CI unit test: menu construction dispatches to the main thread via `InvokeSync`, so it needs a running application/GTK main loop and can't run in a standalone `go test` — the verification above used a real app under Xvfb.)

## Known follow-up (not in this PR)
Rebuilt items register fresh `GAction`s; the previous actions linger in the action map. Bounded by `Update()` frequency, not a correctness/crash issue — can be cleaned up separately.

Fixes #5464


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed menu updates not properly reflecting changes. Menu items can now be correctly added or removed when a menu is refreshed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->