### PR TITLE
ci(release): skip internal commits and link webview2 notes in release notes

### DIFF
--- a/.github/workflows/auto-changelog-v3.yml
+++ b/.github/workflows/auto-changelog-v3.yml
@@ -83,5 +83,11 @@ jobs:
         git config user.name "github-actions[bot]"
         git config user.email "github-actions[bot]@users.noreply.github.com"
         git add v3/UNRELEASED_CHANGELOG.md
+        # The auto-fill step intentionally writes nothing for internal-only PRs
+        # (ci/chore/build/test/style). Skip cleanly so the merge doesn't go red.
+        if git diff --cached --quiet; then
+          echo "ℹ️ No changelog entry to commit (internal PR or no change) — skipping."
+          exit 0
+        fi
         git commit -m "chore(changelog): auto-add entry for PR #${PR_NUMBER} — ${PR_TITLE}"
         git push https://x-access-token:${{ secrets.WAILS_REPO_TOKEN || secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git master

--- a/.github/workflows/nightly-release-v3.yml
+++ b/.github/workflows/nightly-release-v3.yml
@@ -59,12 +59,10 @@ jobs:
     - name: Sync webview2 to latest release
       # Ensure v3 always releases against the newest released webview2 module.
       # Reads the latest webview2/v* tag; if v3/go.mod is behind, bumps it and
-      # folds the webview2 release notes into the v3 unreleased changelog (so
-      # they appear in the v3 release notes). Best-effort: a failure here must
-      # never block the v3 release — it just proceeds on the current version.
+      # adds a v3 changelog entry linking to the webview2 release notes (so they
+      # appear in the v3 release notes). Best-effort: a failure here must never
+      # block the v3 release — it just proceeds on the current version.
       id: webview2_sync
-      env:
-        GH_TOKEN: ${{ secrets.WAILS_REPO_TOKEN || github.token }}
       run: |
         set -e
         LATEST_TAG=$(git tag -l "webview2/v*" | sort -V | tail -n 1)
@@ -85,15 +83,14 @@ jobs:
           git checkout -- v3/go.mod v3/go.sum 2>/dev/null || true
           exit 0
         fi
-        # Fold the webview2 release notes into the v3 unreleased changelog.
-        NOTES=$(gh release view "webview2/${LATEST}" --repo "${{ github.repository }}" --json body -q .body 2>/dev/null || true)
-        ENTRY="- Bump \`webview2\` to ${LATEST}."
-        if [ -n "$NOTES" ]; then
-          BODY=$(printf '%s\n' "$NOTES" | sed '1{/^## /d;}' | sed '/^[[:space:]]*$/d' | sed 's/^/  /')
-          INSERT="${ENTRY}"$'\n'"${BODY}"
-        else
-          INSERT="${ENTRY}"
-        fi
+        # Reference the webview2 release notes by link rather than embedding
+        # them. Each webview2 release body uses its own heading style (some are
+        # hand-written with "### Fixes", others are flat auto-generated bullet
+        # lists), so inlining produced inconsistent, messy changelog entries. A
+        # single link is uniform and always points at the authoritative notes.
+        # The tag contains a slash ("webview2/vX.Y.Z"), so URL-encode it as %2F.
+        RELEASE_URL="https://github.com/${{ github.repository }}/releases/tag/webview2%2F${LATEST}"
+        INSERT="- Bump \`webview2\` to ${LATEST} ([release notes](${RELEASE_URL}))."
         # Insert the notes under "## Changed". If that anchor is ever missing,
         # append the section so the notes are never silently dropped.
         if grep -q '^## Changed' v3/UNRELEASED_CHANGELOG.md; then

--- a/.github/workflows/release-webview2.yml
+++ b/.github/workflows/release-webview2.yml
@@ -118,15 +118,28 @@ jobs:
         run: |
           LAST_TAG="${{ steps.changes.outputs.last_tag }}"
           VERSION="${{ steps.version.outputs.version }}"
+          # Drop internal-only commits (pipeline, chores, build/test plumbing)
+          # from the user-facing notes. The conventional-commit type is matched
+          # case-insensitively, tolerating an optional "(scope)" and breaking
+          # "!". Keep this set in sync with internalTypes in
+          # v3/scripts/auto-changelog.go. `|| true` so pipefail doesn't kill the
+          # step when grep filters everything out (no match -> exit 1).
+          INTERNAL_RE='^(ci|chore|build|test|style)(\([^)]*\))?!?:'
+          if [ -n "$LAST_TAG" ]; then
+            RANGE="${LAST_TAG}..HEAD"
+          else
+            RANGE="HEAD"
+          fi
+          NOTES=$(git log --no-merges --pretty='%s' $RANGE -- webview2/ \
+            | grep -viE "$INTERNAL_RE" | sed 's/^/- /' | head -n 50 || true)
+          [ -z "$NOTES" ] && NOTES="- Maintenance release (no user-facing changes)."
           {
             echo "## webview2 ${VERSION}"
             echo ""
+            echo "$NOTES"
             if [ -n "$LAST_TAG" ]; then
-              git log --no-merges --pretty='- %s' "$LAST_TAG"..HEAD -- webview2/
               echo ""
               echo "**Full diff:** https://github.com/${{ github.repository }}/compare/${LAST_TAG}...webview2/${VERSION}"
-            else
-              git log --no-merges --pretty='- %s' HEAD -- webview2/ | head -n 50
             fi
           } > release-notes.md
           echo "----- generated release notes -----"

--- a/v3/scripts/auto-changelog.go
+++ b/v3/scripts/auto-changelog.go
@@ -42,6 +42,18 @@ func main() {
 		os.Exit(1)
 	}
 
+	// Internal-only PRs (CI, chores, build/test plumbing, secrets) are not
+	// user-facing and must not appear in the release notes. Detect them from
+	// the conventional-commit type in the PR title and skip — successfully, so
+	// the merge doesn't go red. A maintainer who *does* want an internal-typed
+	// PR in the changelog can add the entry to UNRELEASED_CHANGELOG.md in the PR
+	// itself; the workflow's "Check if changelog was updated" step then leaves
+	// it untouched, so this skip is never a silent data-loss trap.
+	if isInternalChange(pr.Title) {
+		fmt.Printf("ℹ️  PR title %q is an internal change — skipping changelog entry.\n", pr.Title)
+		return
+	}
+
 	context, err := fetchCodeRabbitSummary(repo, prNumber, githubToken)
 	if err != nil {
 		fmt.Printf("⚠️  Could not fetch CodeRabbit summary: %v — falling back to PR title\n", err)
@@ -132,6 +144,31 @@ func githubGet(url, token string) ([]byte, error) {
 		return nil, fmt.Errorf("GitHub API %s returned %d", url, resp.StatusCode)
 	}
 	return io.ReadAll(resp.Body)
+}
+
+// internalTypes are the conventional-commit types treated as internal: pipeline
+// changes, chores (incl. secret rotations and dependency bumps), and build/test
+// plumbing. These never reach the user-facing release notes. Keep this set in
+// sync with the skip filter in .github/workflows/release-webview2.yml.
+var internalTypes = map[string]bool{
+	"ci": true, "chore": true, "build": true, "test": true, "style": true,
+}
+
+// internalTitleRe captures the conventional-commit type from a PR title, e.g.
+// "ci(webview2): ..." -> "ci", "chore!: ..." -> "chore". Matching is anchored,
+// case-insensitive, and tolerant of an optional "(scope)" and breaking "!".
+var internalTitleRe = regexp.MustCompile(`^(?i)([a-z]+)(\([^)]*\))?!?:`)
+
+// isInternalChange reports whether a PR title denotes an internal-only change.
+// It fails open: a title without a recognised conventional-commit prefix (or
+// with a user-facing type like feat/fix/docs/perf/refactor) is NOT internal, so
+// we never drop a genuine change just because its title wasn't conventional.
+func isInternalChange(title string) bool {
+	m := internalTitleRe.FindStringSubmatch(strings.TrimSpace(title))
+	if m == nil {
+		return false
+	}
+	return internalTypes[strings.ToLower(m[1])]
 }
 
 func generateEntry(context, apiKey string) (string, string, error) {


### PR DESCRIPTION
## What

Cleans up the v3 release notes in two ways:

1. **Keep internal-only changes out** — pipeline/CI changes, chores (incl. secret rotations and dependency bumps), and build/test/style plumbing.
2. **Link to webview2 release notes instead of embedding them** — avoids inconsistent, messy folded-in entries.

Prompted by `v3.0.0-alpha2.106`, whose notes picked up internal CI entries (e.g. *"Fix release-webview2 workflow… (#5671)"*, *"Update auto-changelog OpenRouter model (#5670)"*) **and** showed inconsistent embedded webview2 headings (`### Fixes` from the hand-written v1.0.26 body vs flat bullets from the auto-generated v1.0.27 body).

## 1. Skip internal commits/PRs

Release notes are assembled from two ingestion points (by the time `release.go` runs, entries are LLM-rewritten prose with no type prefix, so filtering must happen at ingestion):

- **`auto-changelog.go`**: detect the conventional-commit type from the PR title; skip internal types (`ci`/`chore`/`build`/`test`/`style`) before the LLM call. **Fails open** — a non-conventional title is treated as user-facing and never dropped.
- **`auto-changelog-v3.yml`**: guard the commit step so an internal PR (which now writes no entry) doesn't fail at `git commit` with "nothing to commit".
- **`release-webview2.yml`**: filter the same internal types out of the git-log notes — pipefail-safe, with a *"Maintenance release (no user-facing changes)"* fallback when nothing user-facing remains.

The skip-set is kept identical between the Go predicate (`internalTypes`) and the shell filter (`INTERNAL_RE`), with cross-referencing comments.

**Escape hatch:** a maintainer who *does* want an internal-typed PR in the notes can add the entry to `UNRELEASED_CHANGELOG.md` in the PR itself — the existing "Check if changelog was updated" step then leaves it untouched. So the skip is never silent data loss.

## 2. Link to webview2 notes

**`nightly-release-v3.yml`**: the webview2-sync step previously inlined the full release body under the bump bullet, inheriting whatever heading style each release happened to use. It now emits a single bullet linking to the release page:

> - Bump `webview2` to v1.0.27 ([release notes](https://github.com/wailsapp/wails/releases/tag/webview2%2Fv1.0.27)).

(The tag contains a slash, URL-encoded as `%2F`.) Also drops the now-unused `gh release view` call and its `GH_TOKEN` env.

## Testing

- Table-test of the predicate against real subjects: skips `ci(webview2): … #5671/#5672`, `ci(changelog): … #5670`, `chore`/`build`/`test`/`style` (case-insensitive, scoped, breaking `!`); keeps `fix`/`feat`/`docs`/`perf`/`refactor` and fails open on no-prefix titles. ✅
- Exercised the webview2 shell filter on real `v1.0.25..master` (drops the `ci(webview2):` commit, keeps the `fix(webview2):` one) and on an all-internal input (hits the fallback under `set -o pipefail`, exit 0). ✅
- Verified the link bullet renders correctly. ✅
- `gofmt` clean; script compiles; `actionlint` adds no new findings across all three workflows.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Avoids creating empty changelog commits when no changelog changes were generated.
  * Improves release note generation by filtering out internal maintenance-only commit messages and using a cleaner, capped list of user-facing updates.
  * Adds a clearer fallback message when no release-note-worthy changes are found.
* **Chores**
  * Updates nightly changelog handling for webview2 to insert a consistent link to the authoritative release notes instead of embedding transformed content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->