### PR TITLE
docs(v3): contributing and feedback links in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,9 +13,9 @@ Thanks for your interest in contributing! Wails has two active tracks. Pick the 
 
 - Source: the `v3/` directory on the `master` branch.
 - Docs: [v3.wails.io](https://v3.wails.io/).
-- Detailed contributor guide: [v3.wails.io/contributing](https://v3.wails.io/contributing/).
+- Detailed contributor guide: [v3.wails.io/contributing](https://v3.wails.io/contributing/getting-started/).
 - Changelog: v3 entries are added automatically from your PR on merge. To control the wording, add your own entry to `v3/UNRELEASED_CHANGELOG.md` and the automation will use it instead.
-- **Enhancements require prior discussion** on [Discord](https://discord.gg/JDdSxwjhGf) — see the [feedback guide](https://v3.wails.io/getting-started/feedback/).
+- **Enhancements require prior discussion** on [Discord](https://discord.gg/JDdSxwjhGf) — see the [feedback guide](https://v3.wails.io/feedback/).
 
 ## Pull request checklist
 


### PR DESCRIPTION
# Description

Fixes v3 contributing and feedback docs links in CONTRIBUTING.md.

I noticed they were pointing to the wrong place when trying to submit a different PR.

## Type of change
  
Please select the option that is relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?
  
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration using `wails doctor`.

- [ ] Windows
- [ ] macOS
- [ ] Linux
      
If you checked Linux, please specify the distro and version.
  
## Test Configuration

Please paste the output of `wails doctor`. If you are unable to run this command, please describe your environment in as much detail as possible.

# Checklist:

- [ ] (v2 only) I have updated `website/src/pages/changelog.mdx` with details of this PR (v3 changelog entries are added automatically)
- [ ] My code follows the general coding style of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated contributor guide links to the current site paths.
  * Corrected the feedback guidance link so contributors are directed to the right page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->