### PR TITLE
docs(changelog): credit contributors whose fixes landed via parallel PRs

### DIFF
--- a/v3/UNRELEASED_CHANGELOG.md
+++ b/v3/UNRELEASED_CHANGELOG.md
@@ -24,6 +24,7 @@ After processing, the content will be moved to the main changelog and this file 
 ## Fixed
 <!-- Bug fixes -->
 - Fix `Menu.Update()` not rebuilding the native menu on GTK4 Linux (#5659, independently diagnosed and fixed by @puneetdixit200 in #5539)
+- Fix crash enumerating macOS screens on display change by copying screen id/name strings and snapshotting the count (#5565, independently diagnosed and fixed by @x-haose in #5584)
 
 ## Deprecated
 <!-- Soon-to-be removed features -->

--- a/v3/UNRELEASED_CHANGELOG.md
+++ b/v3/UNRELEASED_CHANGELOG.md
@@ -23,6 +23,7 @@ After processing, the content will be moved to the main changelog and this file 
 
 ## Fixed
 <!-- Bug fixes -->
+- Fix `Menu.Update()` not rebuilding the native menu on GTK4 Linux (#5659, independently diagnosed and fixed by @puneetdixit200 in #5539)
 
 ## Deprecated
 <!-- Soon-to-be removed features -->


### PR DESCRIPTION
Collects release-note credit for external contributors whose PRs we're closing as duplicates of already-merged work — so they're acknowledged in the changelog even though their PR wasn't the one merged.

One commit per contributor for clean attribution. Will be updated as PR triage continues.

- @puneetdixit200 — GTK4 `Menu.Update()` fix (#5539), landed in parallel via #5659

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue on GTK4 Linux where menus could fail to rebuild correctly after updates, improving menu reliability.
  * Fixed a macOS crash that could occur when enumerating screens after display changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->