### PR TITLE
docs(mcp): link MCP Server feedback discussion

### DIFF
--- a/docs/src/content/docs/guides/mcp-service.mdx
+++ b/docs/src/content/docs/guides/mcp-service.mdx
@@ -281,3 +281,11 @@ go run -tags mcp .
 
 Then connect Claude Code or any MCP client to `http://127.0.0.1:9099/mcp` and ask it to
 exercise the UI.
+
+## Feedback
+
+The built-in MCP server is an experiment, and your feedback decides where it goes.
+If you try it, we'd love to hear which client and tools you used, what you expected
+and what actually happened, and whether letting an agent drive your app was useful —
+the most useful reports say exactly what you ran. Tell us in the
+[MCP Server feedback discussion](https://github.com/wailsapp/wails/discussions/5692).


### PR DESCRIPTION
Adds a **Feedback** section to the MCP Server docs page (`guides/mcp-service.mdx`) pointing readers to the [MCP Server feedback discussion #5692](https://github.com/wailsapp/wails/discussions/5692).

Mirrors the existing pattern on the [Wake experimental docs page](https://v3.wails.io/experimental/wake/), which links its own feedback discussion the same way. Docs-only change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new “Feedback” section to the MCP service guide.
  * Clarified that the built-in MCP server is experimental and invited readers to share their experience.
  * Included prompts for reporting the client and tools used, expected behavior, actual behavior, and a link to the feedback discussion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->