### PR TITLE
fix(v3/windows): revalidate WebView2 surface on cross-GPU monitor change (#5705)

### DIFF
--- a/v3/UNRELEASED_CHANGELOG.md
+++ b/v3/UNRELEASED_CHANGELOG.md
@@ -27,6 +27,7 @@ After processing, the content will be moved to the main changelog and this file 
 
 ## Fixed
 <!-- Bug fixes -->
+- Revalidate the WebView2 surface when the window crosses onto a monitor driven by a different GPU adapter, to address the permanent black screen on dual-GPU laptops (#5705) in [PR](https://github.com/wailsapp/wails/pull/5710) by @taliesin-ai
 
 ## Deprecated
 <!-- Soon-to-be removed features -->

--- a/v3/pkg/application/webview_window_windows.go
+++ b/v3/pkg/application/webview_window_windows.go
@@ -93,6 +93,15 @@ type windowsWebviewWindow struct {
 	// window is repositioned off the monitor it will restore to).
 	lastKnownDPI w32.UINT
 
+	// currentMonitor is the handle of the monitor the window was last seen on
+	// while non-minimised. It is used to detect when the window crosses onto a
+	// different monitor (potentially driven by a different GPU adapter), which
+	// on some systems invalidates the WebView2 composition surface and needs a
+	// manual revalidation (#5705). It is only sampled while non-minimised: while
+	// minimised the window is parked off its restore monitor, so the handle
+	// flips spuriously (same reasoning as lastKnownDPI, #5605).
+	currentMonitor w32.HMONITOR
+
 	// menubarTheme is the theme for the menubar
 	menubarTheme *w32.MenuBarTheme
 
@@ -467,6 +476,11 @@ func (w *windowsWebviewWindow) run() {
 	if dpi, _ := w.DPI(); dpi != 0 {
 		w.lastKnownDPI = dpi
 	}
+
+	// Seed the current monitor so the first genuine monitor crossing (not the
+	// window's initial placement) is what triggers the WebView2 revalidation
+	// in the WM_WINDOWPOSCHANGED handler (#5705).
+	w.currentMonitor = w32.MonitorFromWindow(w.hwnd, w32.MONITOR_DEFAULTTONEAREST)
 
 	// Ensure correct window size in case the scale factor of current screen is different from the initial one.
 	// This could happen when using the default window position and the window launches on a secondary monitor.
@@ -1639,6 +1653,27 @@ func (w *windowsWebviewWindow) WndProc(msg uint32, wparam, lparam uintptr) uintp
 		if windowPos.Flags&w32.SWP_NOZORDER == 0 {
 			w.parent.emit(events.Windows.WindowZOrderChanged)
 		}
+		// Detect the window crossing onto a different monitor. WM_WINDOWPOSCHANGED
+		// fires reliably during a cross-monitor drag (unlike WM_DISPLAYCHANGE,
+		// which is only broadcast on a resolution/topology change, #5705), and
+		// MonitorFromWindow is a cheap syscall, so comparing the handle every
+		// message is fine. Skip while minimised: the parked off-screen window
+		// reports a spurious monitor handle there (same reasoning as the DPI
+		// handling, #5605).
+		if !w.isMinimizing {
+			if monitor := w32.MonitorFromWindow(w.hwnd, w32.MONITOR_DEFAULTTONEAREST); monitor != 0 && monitor != w.currentMonitor {
+				w.currentMonitor = monitor
+				w.revalidateWebviewForNewMonitor()
+			}
+		}
+	case w32.WM_DISPLAYCHANGE:
+		// A display topology / resolution change (e.g. a hybrid-GPU laptop
+		// activating its discrete adapter for an external panel) can invalidate
+		// the WebView2 composition surface just like a cross-monitor move. Run
+		// the same revalidation. Skip while minimised for the reason above.
+		if !w.isMinimizing {
+			w.revalidateWebviewForNewMonitor()
+		}
 	case w32.WM_PAINT:
 		w.parent.emit(events.Windows.WindowPaint)
 	case w32.WM_ERASEBKGND:
@@ -2057,6 +2092,46 @@ func (w *windowsWebviewWindow) resyncWebviewDPIAfterUnminimiseIfDPIChanged() {
 		return
 	}
 	w.resyncWebviewDPIAfterMinimise()
+}
+
+// revalidateWebviewForNewMonitor is run when the window crosses onto a
+// different monitor (WM_WINDOWPOSCHANGED) or the display topology changes
+// (WM_DISPLAYCHANGE). On dual-GPU systems the destination monitor may be driven
+// by a different GPU adapter than the source, which can leave WebView2's
+// composition surface tied to the old adapter: the content goes permanently
+// black and every subsequent ExecuteScript returns
+// RESOURCE_NOT_IN_CORRECT_STATE (#5705). Wails runs WebView2 in raw-pixels
+// bounds mode with ShouldDetectMonitorScaleChanges disabled, so nothing else
+// prompts the controller to rebuild that surface on a same-DPI move — the
+// WM_DPICHANGED recovery (#5677) never fires when both monitors share a DPI.
+//
+// IMPORTANT (unverified): the effective recovery action here could not be
+// tested on real dual-GPU hardware. Re-asserting the *same* bounds is known to
+// be a no-op (WebView2 early-outs when the rect is unchanged), so this nudges
+// the bounds by one pixel and restores them to force a real re-layout / surface
+// revalidation. If that proves insufficient on affected hardware, stronger
+// escalations to try are a visibility toggle (PutIsVisible false->true) or, as
+// a last resort, recreating the controller. See the PR discussion on #5705.
+func (w *windowsWebviewWindow) revalidateWebviewForNewMonitor() {
+	// Tell WebView2 the parent moved (harmless if already sent by WM_MOVE) and
+	// re-assert the rasterization scale for the mixed-DPI case (a no-op at equal
+	// DPI, and self-guarded against an unavailable controller).
+	_ = w.chromium.NotifyParentWindowPositionChanged()
+	w.resyncWebviewRasterizationScale()
+
+	rect := w32.GetClientRect(w.hwnd)
+	if rect == nil {
+		return
+	}
+	// Nudge the bounds by one pixel so WebView2 performs a genuine re-layout
+	// (a same-bounds Resize would early-out), then restore the correct bounds.
+	w.chromium.ResizeWithBounds(&edge.Rect{
+		Left:   rect.Left,
+		Top:    rect.Top,
+		Right:  rect.Right + 1,
+		Bottom: rect.Bottom,
+	})
+	w.chromium.Resize()
 }
 
 // crossPermissionToWebView2Kind maps a cross-platform PermissionType to the


### PR DESCRIPTION
Draft — addresses #5705. **I cannot test this on real dual-GPU hardware, so the behavioural fix is unverified. Details and an explicit ask for verification are below.**

## What the issue reports

On a dual-GPU laptop (Intel iGPU internal panel + NVIDIA dGPU external panel), dragging a Wails v3 window from one monitor to the other turns the WebView2 content permanently black. The Go process survives, but every subsequent `ExecuteScript` returns `RESOURCE_NOT_IN_CORRECT_STATE` ("The group or resource is not in the correct state…"), so the frontend is dead until restart. Dragging back does not recover it.

## Diagnosis

I traced this against the existing DPI-transition handling and I think the issue is a genuine **gap**, not a regression of the recent fixes:

- Wails runs WebView2 in raw-pixels bounds mode with `PutShouldDetectMonitorScaleChanges(false)` (`webview2/pkg/edge/chromium.go`), which makes Wails responsible for reacting to monitor transitions.
- The recent mixed-DPI work (#5544, #5605, #5677) handles the case where the DPI *changes* across the move: `WM_DPICHANGED` fires, the rasterization scale is re-asserted, and the bounds are re-asserted so content re-lays-out.
- **But the reporter's two monitors are both at 100% (96 DPI).** With no DPI change, `WM_DPICHANGED` never fires and `resyncWebviewRasterizationScale()` is a no-op — so there is currently **no** code path that reacts to the window changing monitors at equal DPI. That is exactly the scenario where the composition surface, tied to the *source* monitor's GPU adapter, is left invalid.

Two honest caveats on the diagnosis:

1. A commenter reports the opposite (crash only with a DPI *mismatch*, fine at equal DPI). I read that as evidence the underlying trigger is **GPU-adapter surface loss**, which is largely orthogonal to DPI — so I've deliberately *not* framed this as "mixed-DPI is already solved". Both triggers plausibly share the same adapter-change root cause.
2. This may ultimately be a WebView2 **runtime** device-loss bug (dual-GPU black screens are a known class in the WebView2 backlog). A Wails-side workaround may only partially recover it.

## On the issue's suggested fix

The issue proposes a `WM_DISPLAYCHANGE` handler. `WM_DISPLAYCHANGE` is only broadcast on a resolution/topology change — it does **not** reliably fire when a window is *dragged* between monitors. So the robust detector for the drag case is tracking the window's `HMONITOR` across `WM_WINDOWPOSCHANGED` (which does fire during the drag). I've implemented that as the primary path, and *also* kept a `WM_DISPLAYCHANGE` handler because on some hybrid-GPU laptops activating the dGPU for the external panel does cause a topology change.

## What this PR does

1. Track the window's current monitor handle; seed it at creation so only genuine crossings trigger work.
2. On `WM_WINDOWPOSCHANGED`, when the handle changes (skipped while minimised, matching the #5605 reasoning), run a revalidation. Also run it on `WM_DISPLAYCHANGE`.
3. The revalidation: `NotifyParentWindowPositionChanged` + rasterization-scale resync (no-op at equal DPI) + a **bounds re-assert that actually produces a delta**.

## The part I most want review on

The revalidation **action** is the discriminating variable I can't test. Re-asserting the *same* bounds is a no-op (WebView2 early-outs on an unchanged rect — this is also why #5677 only re-asserts bounds *after* a scale change made layout stale). So I nudge the bounds by 1px and restore them to force a real re-layout / surface revalidation. That's the least-risky action that might actually do something, but I genuinely don't know whether it's enough to rebuild a composition surface stranded on a dead adapter.

Escalations, in increasing order of effectiveness **and** regression risk, that a hardware owner could try by editing `revalidateWebviewForNewMonitor`:

- **(this PR)** 1px bounds nudge + restore — invisible, may not force a device rebuild.
- **Visibility toggle** — `controller.PutIsVisible(false)` then `true`. More likely to force the compositor to re-attach, but risks a visible flash on *every* monitor crossing for *all* users.
- **Controller recreation** — near-certain to recover, but heavy and loses page state.

## Testing

- Cross-compiles clean for `windows/amd64` and `windows/arm64`; `go vet` shows only pre-existing `unsafe.Pointer` notes. **Behaviour is unverified — I have no dual-GPU Windows machine.**

## Ask

@lirt (#5705 reporter) and @qq540491950 — could you build this branch and confirm whether the 1px-nudge recovery clears the black screen on your hardware? If it doesn't, trying the visibility toggle (one-line change, noted in the code comment) would tell us whether a stronger surface reset is required. Maintainers: happy to reshape the recovery action or gate the visibility toggle behind an opt-in if that's the direction preferred.
