### PR TITLE
fix(linux): fix 8 defects in the cgo GTK4 backend found during the purego port

### DIFF
--- a/v3/pkg/application/linux_cgo.c
+++ b/v3/pkg/application/linux_cgo.c
@@ -789,7 +789,10 @@ static gboolean on_message_dialog_close(GtkWindow *window, gpointer user_data) {
     int result = (data->cancel_button >= 0) ? data->cancel_button : -1;
     alertDialogCallback(data->request_id, result);
     message_dialog_cleanup(data);
-    return TRUE;
+    // FALSE lets GTK's default close-request handler destroy the window.
+    // Returning TRUE means "handled, don't close": the dialog would stay on
+    // screen forever with its buttons wired to the freed MessageDialogData.
+    return FALSE;
 }
 
 static gboolean on_message_dialog_key_pressed(GtkEventControllerKey *controller,
@@ -921,38 +924,44 @@ void show_message_dialog(GtkWindow *parent, const char *heading, const char *bod
 // Clipboard (async API for GTK4)
 // ============================================================================
 
-static char *clipboard_sync_result = NULL;
-static gboolean clipboard_sync_done = FALSE;
+// Per-call state: the nested g_main_context_iteration loop below can dispatch
+// arbitrary main-loop sources, including another clipboard_get_text_sync call.
+// With static globals the two calls would clobber each other's result/done
+// flags; with stack-allocated state each call completes independently.
+typedef struct {
+    char *result;
+    gboolean done;
+} ClipboardSyncData;
 
 static void on_clipboard_sync_finish(GObject *source, GAsyncResult *result, gpointer user_data) {
+    ClipboardSyncData *data = (ClipboardSyncData *)user_data;
     GdkClipboard *clipboard = GDK_CLIPBOARD(source);
     GError *error = NULL;
 
-    clipboard_sync_result = gdk_clipboard_read_text_finish(clipboard, result, &error);
+    data->result = gdk_clipboard_read_text_finish(clipboard, result, &error);
 
     if (error != NULL) {
         DEBUG_LOG("clipboard read error: %s", error->message);
         g_error_free(error);
-        clipboard_sync_result = NULL;
+        data->result = NULL;
     }
-    clipboard_sync_done = TRUE;
+    data->done = TRUE;
 }
 
 char* clipboard_get_text_sync(void) {
     GdkDisplay *display = gdk_display_get_default();
     GdkClipboard *clipboard = gdk_display_get_clipboard(display);
-    
-    clipboard_sync_done = FALSE;
-    clipboard_sync_result = NULL;
-    
-    gdk_clipboard_read_text_async(clipboard, NULL, on_clipboard_sync_finish, NULL);
-    
+
+    ClipboardSyncData data = { NULL, FALSE };
+
+    gdk_clipboard_read_text_async(clipboard, NULL, on_clipboard_sync_finish, &data);
+
     GMainContext *ctx = g_main_context_default();
-    while (!clipboard_sync_done) {
+    while (!data.done) {
         g_main_context_iteration(ctx, TRUE);
     }
-    
-    return clipboard_sync_result;
+
+    return data.result;
 }
 
 void clipboard_free_text(char *text) {

--- a/v3/pkg/application/linux_cgo.go
+++ b/v3/pkg/application/linux_cgo.go
@@ -77,8 +77,12 @@ var (
 )
 
 var (
-	gtkSignalToMenuItem map[uint]*MenuItem
-	mainThreadId        *C.GThread
+	// gtkSignalToMenuItem is written by attachMenuHandler from whichever
+	// goroutine builds the menu and read by menuActionActivated on the GTK
+	// main thread, so it must be lock-protected.
+	gtkSignalToMenuItem     map[uint]*MenuItem
+	gtkSignalToMenuItemLock sync.RWMutex
+	mainThreadId            *C.GThread
 )
 
 var (
@@ -127,8 +131,12 @@ func isOnMainThread() bool {
 
 // implementation below
 func appName() string {
+	// The returned string is owned by GLib (it must not be modified or freed)
+	// and may be NULL if no application name has been set.
 	name := C.g_get_application_name()
-	defer C.free(unsafe.Pointer(name))
+	if name == nil {
+		return ""
+	}
 	return C.GoString(name)
 }
 
@@ -206,14 +214,12 @@ func (a *linuxApp) getCurrentWindowID() uint {
 
 func (a *linuxApp) getWindows() []pointer {
 	result := []pointer{}
+	// gtk_application_get_windows returns NULL when there are no windows.
 	windows := C.gtk_application_get_windows((*C.GtkApplication)(a.application))
-	for {
+	for ; windows != nil; windows = windows.next {
 		result = append(result, pointer(windows.data))
-		windows = windows.next
-		if windows == nil {
-			return result
-		}
 	}
+	return result
 }
 
 func (a *linuxApp) hideAllWindows() {
@@ -254,21 +260,36 @@ func clipboardSet(text string) {
 
 // Menu - GTK4 uses GMenu/GAction instead of GtkMenu
 
+// menuItemActions is written during menu construction (any goroutine) and read
+// from API goroutines (setChecked/setDisabled/accelerators), so it shares a
+// lock with its counter.
 var menuItemActionCounter uint32 = 0
 var menuItemActions = make(map[uint]string)
+var menuItemActionsLock sync.RWMutex
 var menuItemIds = make(map[pointer]uint)
 var menuItemIdsMutex sync.RWMutex
 
 func generateActionName(itemId uint) string {
+	menuItemActionsLock.Lock()
+	defer menuItemActionsLock.Unlock()
 	menuItemActionCounter++
 	name := fmt.Sprintf("action_%d", menuItemActionCounter)
 	menuItemActions[itemId] = name
 	return name
 }
 
+func lookupActionName(itemId uint) (string, bool) {
+	menuItemActionsLock.RLock()
+	defer menuItemActionsLock.RUnlock()
+	name, ok := menuItemActions[itemId]
+	return name, ok
+}
+
 //export menuActionActivated
 func menuActionActivated(id C.guint) {
+	gtkSignalToMenuItemLock.RLock()
 	item, ok := gtkSignalToMenuItem[uint(id)]
+	gtkSignalToMenuItemLock.RUnlock()
 	if !ok {
 		return
 	}
@@ -403,7 +424,9 @@ func handleClick(idPtr unsafe.Pointer) {
 }
 
 func attachMenuHandler(item *MenuItem) uint {
+	gtkSignalToMenuItemLock.Lock()
 	gtkSignalToMenuItem[item.id] = item
+	gtkSignalToMenuItemLock.Unlock()
 	return item.id
 }
 
@@ -417,7 +440,7 @@ func menuItemChecked(widget pointer) bool {
 	if !exists {
 		return false
 	}
-	actionName, ok := menuItemActions[itemId]
+	actionName, ok := lookupActionName(itemId)
 	if !ok {
 		return false
 	}
@@ -503,7 +526,7 @@ func menuItemSetChecked(widget pointer, checked bool) {
 	if !exists {
 		return
 	}
-	actionName, ok := menuItemActions[itemId]
+	actionName, ok := lookupActionName(itemId)
 	if !ok {
 		return
 	}
@@ -526,7 +549,7 @@ func menuItemSetDisabled(widget pointer, disabled bool) {
 	if !exists {
 		return
 	}
-	actionName, ok := menuItemActions[itemId]
+	actionName, ok := lookupActionName(itemId)
 	if !ok {
 		return
 	}
@@ -714,7 +737,7 @@ func setMenuItemAccelerator(itemId uint, accel *accelerator) {
 	}
 
 	// Look up the action name for this menu item
-	actionName, ok := menuItemActions[itemId]
+	actionName, ok := lookupActionName(itemId)
 	if !ok {
 		return
 	}
@@ -1782,15 +1805,26 @@ func fileDialogCallback(requestID C.uint, files **C.char, count C.int, cancelled
 		return
 	}
 
+	// Copy the C strings before this callback returns: the caller frees them.
+	var paths []string
 	if count > 0 && files != nil {
 		slice := unsafe.Slice(files, int(count))
 		for _, cstr := range slice {
 			if cstr != nil {
-				ch <- C.GoString(cstr)
+				paths = append(paths, C.GoString(cstr))
 			}
 		}
 	}
-	close(ch)
+
+	// Deliver from a goroutine: this callback runs on the GTK main thread and
+	// the result channel has a fixed buffer, so sending inline would block the
+	// main loop (deadlocking the app) once a selection exceeds the buffer.
+	go func() {
+		for _, path := range paths {
+			ch <- path
+		}
+		close(ch)
+	}()
 }
 
 //export alertDialogCallback

--- a/v3/pkg/application/systemtray_linux.go
+++ b/v3/pkg/application/systemtray_linux.go
@@ -6,7 +6,6 @@ Portions of this code are derived from the project:
 */
 package application
 
-import "C"
 import (
 	"fmt"
 	"os"


### PR DESCRIPTION
## Description

The CGO-free Linux backend port (#5715) translated `linux_cgo.go`/`linux_cgo.c` line by line, and that close reading surfaced 8 defects in the cgo GTK4 backend. They were fixed (not copied) in the purego backend and catalogued in [`BUGS_FOUND.md`](https://github.com/wailsapp/wails/blob/worktree-linux-purego/v3/pkg/application/BUGS_FOUND.md); this PR applies the same fixes to the cgo backend itself.

## Fixes

| # | Defect | Fix |
|---|--------|-----|
| 1 | `appName()` freed the GLib-owned string from `g_get_application_name()` (UB — GLib returns the same pointer on the next call) and could pass NULL to `GoString` | Copy the string, never free, nil-check |
| 2 | `getWindows()` dereferenced the `GList` head before the nil check — crash via `App.Hide()`/`Show()`/`isVisible()` with zero windows | Nil-checked loop |
| 3 | `clipboard_get_text_sync()` used static globals while spinning a nested `g_main_context_iteration` loop; a reentrant read clobbered the first call's flags (wrong text or infinite spin) | Per-call stack-allocated state |
| 4 | `gtkSignalToMenuItem` written from menu-building goroutines, read on the GTK main thread, unsynchronised (fatal concurrent map access) | RWMutex |
| 5 | `menuItemActions`/`menuItemActionCounter` same race between `generateActionName` and setChecked/setDisabled/accelerator reads | RWMutex + `lookupActionName` helper |
| 6 | `fileDialogCallback` runs on the GTK main thread and sent paths into a channel with a fixed buffer of 100 — selecting >100 files deadlocked the main loop | Copy paths, deliver from a goroutine |
| 7 | `systemtray_linux.go` carried a vestigial `import "C"` (zero `C.` usages), silently making the pure-Go dbus tray cgo-only | Remove the import |
| 8 | `on_message_dialog_close` returned `TRUE` from `close-request` after freeing `MessageDialogData` — GTK4 treats TRUE as "don't close", leaving a zombie dialog whose buttons pointed at freed memory (UAF) | Return `FALSE` so GTK's default handler destroys the window |

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

On Ubuntu 26.04 (GTK 4.22.2 / WebKitGTK 2.52.3):
- `go build ./...` — passes (only pre-existing unrelated `build_assets/ios` failure)
- `go test ./pkg/application` — passes
- `go vet ./pkg/application` — only the pre-existing `unsafe.Pointer` idiom notices in `dialogs_linux.go`
- `go build -tags gtk3 ./pkg/application` — passes (shares `systemtray_linux.go`)
- Headless smoke run of `examples/window` (menus exercise the new locks) — starts and runs cleanly

## Checklist:

- [x] My code follows the general coding style of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability when closing dialog windows, preventing rare crashes or lingering dialogs.
  * Fixed clipboard text retrieval issues so repeated copy/paste actions work more reliably.
  * Made menu actions and keyboard shortcuts more dependable under fast or concurrent use.
  * Improved file dialog behavior so selecting multiple files is less likely to hang or deadlock.
  * Minor window-listing and app-name handling improvements for smoother Linux behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->