### PR TITLE
fix(android): default to singleTask launchMode to prevent duplicate A…

### DIFF
--- a/v3/examples/android/build/android/app/src/main/AndroidManifest.xml
+++ b/v3/examples/android/build/android/app/src/main/AndroidManifest.xml
@@ -18,6 +18,7 @@
         <activity
             android:name=".MainActivity"
             android:exported="true"
+            android:launchMode="singleTask"
             android:configChanges="orientation|screenSize|keyboardHidden"
             android:windowSoftInputMode="adjustResize">
             <intent-filter>

--- a/v3/examples/mobile/build/android/app/src/main/AndroidManifest.xml
+++ b/v3/examples/mobile/build/android/app/src/main/AndroidManifest.xml
@@ -45,6 +45,7 @@
         <activity
             android:name=".MainActivity"
             android:exported="true"
+            android:launchMode="singleTask"
             android:configChanges="orientation|screenSize|keyboardHidden|uiMode"
             android:windowSoftInputMode="adjustResize">
             <intent-filter>

--- a/v3/internal/commands/build_assets/android/app/src/main/AndroidManifest.xml
+++ b/v3/internal/commands/build_assets/android/app/src/main/AndroidManifest.xml
@@ -36,6 +36,7 @@
         <activity
             android:name=".MainActivity"
             android:exported="true"
+            android:launchMode="singleTask"
             android:configChanges="orientation|screenSize|keyboardHidden|uiMode"
             android:windowSoftInputMode="adjustResize">
             <intent-filter>


### PR DESCRIPTION
# Description

The Android manifest template has no explicit `launchMode`, defaulting to `"standard"`. Any incoming intent — deep link, notification tap, or foreground service return via `getLaunchIntentForPackage()` — spawns a **second** `MainActivity`: a second WebView and a second attempt to initialise the Go bridge against process-global state (`g_bridge`, `g_jvm`, `globalApp`).

Set `launchMode="singleTask"` so there is always exactly one Activity instance. New intents are delivered via `onNewIntent()` instead of creating duplicates. This is the standard approach for single-activity WebView shells (Capacitor, Cordova, etc.).

The existing `WailsForegroundService.java` already uses `getLaunchIntentForPackage()` to return to the app — under the current `standard` default, that intent creates a duplicate Activity instead of resuming the existing one.

Affects the scaffold template and both Android examples (`examples/android`, `examples/mobile`).

Fixes #5725

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Template-only change (XML attribute). Verified by building and deploying a Wails Android app on emulator, confirming:
1. App launches normally
2. Tapping the foreground service notification returns to the existing Activity instead of spawning a duplicate
3. `adb shell am start -a android.intent.action.VIEW -d "https://example.com"` routes through `onNewIntent()` instead of creating a second instance

- [ ] Windows
- [ ] macOS
- [x] Linux

Linux: Ubuntu 22.04.5 LTS, Android emulator Pixel 7 API 34 (x86_64)

## Test Configuration
Wails v3.0.0-alpha2.111
Go 1.26.4
Ubuntu 22.04.5 LTS
Android SDK 34, NDK 26.3.11579264


# Checklist:

- [ ] (v2 only) I have updated `website/src/pages/changelog.mdx` with details of this PR (v3 changelog entries are added automatically)
- [x] My code follows the general coding style of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes*
* Some tests fail on my machine out of the box, but no new tests related to the change fails

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Android app navigation by reusing a single main activity instance when the app is relaunched.
  - Prevented duplicate activity instances during launches and repeated navigation, reducing unintended screen resets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->