### PR TITLE
fix(windows): DPI Blank Screen + Fix hidden-window input dead zones + Systray Panic

### DIFF
--- a/v3/pkg/application/systemtray_windows.go
+++ b/v3/pkg/application/systemtray_windows.go
@@ -551,7 +551,10 @@ func (s *windowsSystemTray) destroy() {
 	// destroy the notification icon
 	nid := s.newNotifyIconData()
 	if !w32.ShellNotifyIcon(w32.NIM_DELETE, &nid) {
-		globalApplication.debug(syscall.GetLastError().Error())
+		// Pass the error as an arg rather than calling .Error() on it: when the
+		// thread's last-error is 0, syscall.GetLastError() returns a nil error,
+		// and nil.Error() would nil-deref panic (mirrors the updateIcon fix).
+		globalApplication.debug("ShellNotifyIcon NIM_DELETE failed", "error", syscall.GetLastError())
 	}
 
 	// Clean up icon handles

--- a/v3/pkg/application/systemtray_windows.go
+++ b/v3/pkg/application/systemtray_windows.go
@@ -343,7 +343,19 @@ func (s *windowsSystemTray) updateIcon() {
 	}
 
 	if !w32.ShellNotifyIcon(w32.NIM_MODIFY, &nid) {
-		panic(syscall.GetLastError())
+		// The icon isn't currently registered with the shell. This happens
+		// transiently when Explorer / the taskbar restarts and our icon is
+		// dropped before the TaskbarCreated handler (reshowSystrays) re-adds it.
+		// Previously this called panic(syscall.GetLastError()); when the thread's
+		// last-error is 0 that is panic(nil), which on Go 1.21+ surfaces as
+		// "panic called with nil argument" and crashes the host app.
+		//
+		// Match the other NIM_MODIFY callers (Show/Hide/setTooltip): log and
+		// return. Roll back currentIcon so the next updateIcon retries once the
+		// icon is registered again; keep the old handle (do not release it).
+		globalApplication.warning("ShellNotifyIcon NIM_MODIFY failed in updateIcon (icon not registered): %v", syscall.GetLastError())
+		s.currentIcon = oldIcon
+		return
 	}
 
 	// Track ownership of the current icon so we know if we can destroy it later

--- a/v3/pkg/application/webview_window_windows.go
+++ b/v3/pkg/application/webview_window_windows.go
@@ -2548,6 +2548,16 @@ func (w *windowsWebviewWindow) navigationCompleted(
 		}
 		w.update()
 	}
+
+	// The first-paint nudge above ends with the controller IsVisible=true. For a
+	// window created Hidden that is never shown (e.g. a pre-created tray popup),
+	// that leaves a live WINDOW_TO_VISUAL DirectComposition input surface
+	// hit-testing at the window's location — an invisible desktop right-click
+	// "dead zone". Re-hide the controller so a never-shown window has no live
+	// surface; show() re-asserts IsVisible(true) when the window is actually shown.
+	if w.parent.options.Hidden && !w.windowShown && !w.showRequested {
+		_ = w.chromium.Hide()
+	}
 }
 
 func (w *windowsWebviewWindow) processKeyBinding(vkey uint) bool {

--- a/v3/pkg/application/webview_window_windows.go
+++ b/v3/pkg/application/webview_window_windows.go
@@ -1274,6 +1274,14 @@ func (w *windowsWebviewWindow) hide() {
 	w.windowShown = false
 	w.showRequested = false
 
+	// Symmetric with show()'s chromium.Show(): under UseVisualHosting a bare
+	// SW_HIDE leaves the DirectComposition input surface hit-testing where the
+	// window was (a desktop right-click "dead zone"). Restore is always
+	// programmatic via Show() -> show() -> chromium.Show().
+	if w.chromium != nil {
+		_ = w.chromium.Hide()
+	}
+
 	// Cancel any pending visibility timeout
 	if w.visibilityTimeout != nil {
 		w.visibilityTimeout.Stop()
@@ -1694,6 +1702,11 @@ func (w *windowsWebviewWindow) WndProc(msg uint32, wparam, lparam uintptr) uintp
 				// here (not at SIZE_RESTORED), and needs the same DPI
 				// resync as the restore path below (#5544).
 				w.resyncWebviewDPIAfterUnminimiseIfDPIChanged()
+				// Re-assert controller visibility hidden on SIZE_MINIMIZED so the
+				// (visual-hosted) window does not restore blank.
+				if w.chromium != nil {
+					_ = w.chromium.Show()
+				}
 				w.parent.emit(events.Windows.WindowUnMinimise)
 			}
 			w.isMinimizing = false
@@ -1716,6 +1729,11 @@ func (w *windowsWebviewWindow) WndProc(msg uint32, wparam, lparam uintptr) uintp
 				// rasterization scale on restore, so window.devicePixelRatio
 				// keeps the wrong monitor's value until a manual resize (#5544).
 				w.resyncWebviewDPIAfterUnminimiseIfDPIChanged()
+				// Re-assert controller visibility hidden on SIZE_MINIMIZED so the
+				// (visual-hosted) window does not restore blank.
+				if w.chromium != nil {
+					_ = w.chromium.Show()
+				}
 				w.parent.emit(events.Windows.WindowUnMinimise)
 			}
 			w.isMinimizing = false
@@ -1731,6 +1749,15 @@ func (w *windowsWebviewWindow) WndProc(msg uint32, wparam, lparam uintptr) uintp
 		case w32.SIZE_MINIMIZED:
 			w.isMinimizing = true
 			w.parent.emit(events.Windows.WindowMinimise)
+			// Under UseVisualHosting (WINDOW_TO_VISUAL) the WebView2 content is a
+			// DirectComposition visual whose input surface keeps hit-testing at the
+			// window's last on-screen rectangle after a bare SW_MINIMIZE — leaving a
+			// desktop right-click "dead zone". Tell the controller to become
+			// invisible (also the WebView2-recommended action on minimize); the
+			// SIZE_RESTORED/SIZE_MAXIMIZED un-minimize branches re-assert it.
+			if w.chromium != nil {
+				_ = w.chromium.Hide()
+			}
 		}
 		w.lastSizeWParam = wparam
 

--- a/webview2/pkg/edge/ICoreWebView2Controller3.go
+++ b/webview2/pkg/edge/ICoreWebView2Controller3.go
@@ -3,6 +3,8 @@
 package edge
 
 import (
+	"math"
+
 	"golang.org/x/sys/windows"
 	"syscall"
 	"unsafe"
@@ -81,10 +83,18 @@ func (i *ICoreWebView2Controller3) GetRasterizationScale() (float64, error) {
 }
 
 func (i *ICoreWebView2Controller3) PutRasterizationScale(scale float64) error {
-
+	// put_RasterizationScale takes the double BY VALUE. Pass its bit pattern
+	// (Go's runtime mirrors the first four syscall args into XMM0-3, which is
+	// where the x64 ABI makes the callee read a double argument) — the same
+	// pattern as PutZoomFactor. Passing &scale here handed the callee a heap
+	// ADDRESS reinterpreted as a double (a denormal ≈ 0.0), silently setting
+	// the rasterization scale to ~0: blank content, then Chromium CHECK
+	// crashes (0x80000003) — the v200.0.26 blank-screen field defect, and
+	// the likely mechanism behind every earlier "scale-put-adjacent" process
+	// death (wailsapp/wails#5701).
 	hr, _, _ := i.Vtbl.PutRasterizationScale.Call(
 		uintptr(unsafe.Pointer(i)),
-		uintptr(unsafe.Pointer(&scale)),
+		uintptr(math.Float64bits(scale)),
 	)
 	if windows.Handle(hr) != windows.S_OK {
 		return syscall.Errno(hr)

--- a/webview2/pkg/webview2/ICoreWebView2Controller.go
+++ b/webview2/pkg/webview2/ICoreWebView2Controller.go
@@ -3,6 +3,8 @@
 package webview2
 
 import (
+	"math"
+
 	"golang.org/x/sys/windows"
 	"syscall"
 	"unsafe"
@@ -113,10 +115,13 @@ func (i *ICoreWebView2Controller) GetZoomFactor() (float64, error) {
 }
 
 func (i *ICoreWebView2Controller) PutZoomFactor(zoomFactor float64) error {
-
+	// The double parameter is passed BY VALUE: use its bit pattern, not a
+	// pointer (Go mirrors the first four syscall args into XMM0-3, where the
+	// x64 ABI reads double arguments). A pointer here reaches the callee as a
+	// denormal ~0.0 double (wailsapp/wails#5701, v200.0.26 blank screen).
 	hr, _, _ := i.Vtbl.PutZoomFactor.Call(
 		uintptr(unsafe.Pointer(i)),
-		uintptr(unsafe.Pointer(&zoomFactor)),
+		uintptr(math.Float64bits(zoomFactor)),
 	)
 	if windows.Handle(hr) != windows.S_OK {
 		return syscall.Errno(hr)
@@ -153,10 +158,12 @@ func (i *ICoreWebView2Controller) RemoveZoomFactorChanged(token EventRegistratio
 
 func (i *ICoreWebView2Controller) SetBoundsAndZoomFactor(bounds RECT, zoomFactor float64) error {
 
+	// bounds (a >8-byte struct) is correctly passed by reference per the x64
+	// ABI; the double is by value — bit pattern, not pointer (see PutZoomFactor).
 	hr, _, _ := i.Vtbl.SetBoundsAndZoomFactor.Call(
 		uintptr(unsafe.Pointer(i)),
 		uintptr(unsafe.Pointer(&bounds)),
-		uintptr(unsafe.Pointer(&zoomFactor)),
+		uintptr(math.Float64bits(zoomFactor)),
 	)
 	if windows.Handle(hr) != windows.S_OK {
 		return syscall.Errno(hr)

--- a/webview2/pkg/webview2/ICoreWebView2Controller3.go
+++ b/webview2/pkg/webview2/ICoreWebView2Controller3.go
@@ -3,6 +3,8 @@
 package webview2
 
 import (
+	"math"
+
 	"golang.org/x/sys/windows"
 	"syscall"
 	"unsafe"
@@ -56,10 +58,13 @@ func (i *ICoreWebView2Controller3) GetRasterizationScale() (float64, error) {
 }
 
 func (i *ICoreWebView2Controller3) PutRasterizationScale(scale float64) error {
-
+	// The double parameter is passed BY VALUE: use its bit pattern, not a
+	// pointer (Go mirrors the first four syscall args into XMM0-3, where the
+	// x64 ABI reads double arguments). A pointer here reaches the callee as a
+	// denormal ~0.0 double (wailsapp/wails#5701, v200.0.26 blank screen).
 	hr, _, _ := i.Vtbl.PutRasterizationScale.Call(
 		uintptr(unsafe.Pointer(i)),
-		uintptr(unsafe.Pointer(&scale)),
+		uintptr(math.Float64bits(scale)),
 	)
 	if windows.Handle(hr) != windows.S_OK {
 		return syscall.Errno(hr)

--- a/webview2/pkg/webview2/ICoreWebView2Cookie.go
+++ b/webview2/pkg/webview2/ICoreWebView2Cookie.go
@@ -3,6 +3,8 @@
 package webview2
 
 import (
+	"math"
+
 	"golang.org/x/sys/windows"
 	"syscall"
 	"unsafe"
@@ -137,9 +139,13 @@ func (i *ICoreWebView2Cookie) GetExpires() (float64, error) {
 
 func (i *ICoreWebView2Cookie) PutExpires(expires float64) error {
 
+	// The double parameter is passed BY VALUE: use its bit pattern, not a
+	// pointer (Go mirrors the first four syscall args into XMM0-3, where the
+	// x64 ABI reads double arguments). A pointer here reaches the callee as a
+	// denormal ~0.0 double (wailsapp/wails#5701, v200.0.26 blank screen).
 	hr, _, _ := i.Vtbl.PutExpires.Call(
 		uintptr(unsafe.Pointer(i)),
-		uintptr(unsafe.Pointer(&expires)),
+		uintptr(math.Float64bits(expires)),
 	)
 	if windows.Handle(hr) != windows.S_OK {
 		return syscall.Errno(hr)


### PR DESCRIPTION
# Description

## FIX (A) - DPI - WebView Crash on Windows
Fix DPI issues where the content would not render when a window is moved from one screen to the next,
at times this would appear as a blank screen, or the DPI value passed to the window would not be correct,
showing the content at the wrong scale.  Showing content at the wrong scale, and eventually the WebView2 process would crash.

## Fix (B)- Hidden Window masks user input - cannot click on certain regions
When the application is created along with a hidden popout window, from the system tray - the hidden,
window is set as hidden. This masks the user input, where the mouse clicks would not reach windows hidden behind the invisible hidden window.

Application Startup Options:
**Env Var** : `COREWEBVIEW2_FORCED_HOSTING_MODE=WINDOW_TO_VISUAL`
```
Windows: application.WindowsOptions {
      UseVisualHosting: true,
}
```

## Fix (C) - Minimise Webviews to reduce GPU load
Call the chromium minimise, keep the symetry and reduce GPU load, while windows are minimised.

## FIX (D) - Systray Panic
After an Explorer/taskbar restart drops the tray icon mid-session: a failed NIM_MODIFY (icon update) called panic(syscall.GetLastError()), which is panic(nil) when the error code is 0 ("panic called with nil argument"),

**Log example - several of these would surface**
`[stdlib] [WebView2] Eval failed: The group or resource is not in the correct state to perform the requested operation.`

**Log example - this is the final log, where the WebView would crash**
`reason=crashed, exitCode=-2147483645 (0x80000003), `



## Detailed Stack Trace


`
[wails] framework error: WebView2 process failed (kind=gpu-process-exited, reason=crashed, exitCode=-2147483645 (0x80000003), desc="", window=1, runtime=149.0.4022.98) — scheduling recovery (#5701)goroutine 1 [running, locked to thread]:runtime/debug.Stack()	runtime/debug/stack.go:26 +0x5egithub.com/wailsapp/wails/v3/pkg/application.(*windowsWebviewWindow).processFailed(0x247d72b0ed80, 0x7ff618361238?, 0x5c900010d030)	github.com/wailsapp/wails/v3@v3.0.0-alpha2.110/pkg/application/webview_recovery_windows.go:182 +0x3cagithub.com/wailsapp/wails/webview2/pkg/edge.(*Chromium).ProcessFailed(0x0?, 0x247d76432428?, 0x247d764323d8?)	github.com/wailsapp/wails/webview2@v1.0.27/pkg/edge/chromium.go:628 +0x25github.com/wailsapp/wails/webview2/pkg/edge._ICoreWebView2ProcessFailedEventHandlerInvoke(0x247d764323e8?, 0x7ff61835b28c?, 0x0?)	github.com/wailsapp/wails/webview2@v1.0.27/pkg/edge/ICoreWebView2ProcessFailedEventHandler.go:37 +0x1csyscall.syscalln(0x0?, 0x0?, {0x247d763ae1a0?, 0x1f74bb82a88?, 0x1f703043618?})	runtime/syscall_windows.go:431 +0x4esyscall.SyscallN(0x247d763ae1a0?, {0x247d763ae1a0?, 0x0?, 0x0?})	syscall/dll_windows.go:99 +0x1esyscall.(*Proc).Call(0x7ff6182f3165?, {0x247d763ae1a0?, 0x7ff618d1ba60?, 0x1?})	syscall/dll_windows.go:256 +0x1csyscall.(*LazyProc).Call(0x7ff61b9d3ec0, {0x247d763ae1a0, 0x4, 0x4})	syscall/dll_windows.go:376 +0x4agithub.com/wailsapp/wails/v3/pkg/w32.DefWindowProc(...)	github.com/wailsapp/wails/v3@v3.0.0-alpha2.110/pkg/w32/user32.go:477github.com/wailsapp/wails/v3/pkg/application.(*windowsWebviewWindow).WndProc(0x247d72b0ed80, 0x112, 0xf012, 0x1730627)	github.com/wailsapp/wails/v3@v3.0.0-alpha2.110/pkg/application/webview_window_windows.go:2069 +0x241egithub.com/wailsapp/wails/v3/pkg/application.(*windowsApp).wndProc(0x247d72c34960, 0x320a9c, 0x112, 0xf012, 0x1730627)	github.com/wailsapp/wails/v3@v3.0.0-alpha2.110/pkg/application/application_windows.go:310 +0x779syscall.syscalln(0x0?, 0x0?, {0x247d763ae180?, 0x1f74bb82a88?, 0x1f703043618?})	runtime/syscall_windows.go:431 +0x4esyscall.SyscallN(0x247d763ae180?, {0x247d763ae180?, 0x0?, 0x0?})	syscall/dll_windows.go:99 +0x1esyscall.(*Proc).Call(0x7ff6182f3165?, {0x247d763ae180?, 0x7ff618d1ba60?, 0x1?})	syscall/dll_windows.go:256 +0x1csyscall.(*LazyProc).Call(0x7ff61b9d3ec0, {0x247d763ae180, 0x4, 0x4})	syscall/dll_windows.go:376 +0x4agithub.com/wailsapp/wails/v3/pkg/w32.DefWindowProc(...)	github.com/wailsapp/wails/v3@v3.0.0-alpha2.110/pkg/w32/user32.go:477github.com/wailsapp/wails/v3/pkg/application.(*windowsWebviewWindow).WndProc(0x247d72b0ed80, 0xa1, 0x2, 0x1730627)	github.com/wailsapp/wails/v3@v3.0.0-alpha2.110/pkg/application/webview_window_windows.go:2069 +0x241egithub.com/wailsapp/wails/v3/pkg/application.(*windowsApp).wndProc(0x247d72c34960, 0x320a9c, 0xa1, 0x2, 0x1730627)	github.com/wailsapp/wails/v3@v3.0.0-alpha2.110/pkg/application/application_windows.go:310 +0x779syscall.syscalln(0x1f703043618?, 0x247d72a3a005?, {0x247d762697f8?, 0x1f74bb82a88?, 0x1f74a0303e0?})	runtime/syscall_windows.go:431 +0x4esyscall.SyscallN(0x247d762697f0?, {0x247d762697f8?, 0x0?, 0x8?})	syscall/dll_windows.go:99 +0x1esyscall.(*Proc).Call(0x7ff6182f3165?, {0x247d762697f8?, 0x7ff618d1c000?, 0x201?})	syscall/dll_windows.go:256 +0x1csyscall.(*LazyProc).Call(0x7ff61b9d4000, {0x247d762697f8, 0x1, 0x1})	syscall/dll_windows.go:376 +0x4agithub.com/wailsapp/wails/v3/pkg/w32.DispatchMessage(...)	github.com/wailsapp/wails/v3@v3.0.0-alpha2.110/pkg/w32/user32.go:520github.com/wailsapp/wails/v3/pkg/application.(*windowsApp).runMainLoop(0x247d72c34960)	github.com/wailsapp/wails/v3@v3.0.0-alpha2.110/pkg/application/mainthread_windows.go:64 +0x129github.com/wailsapp/wails/v3/pkg/application.(*windowsApp).run(0x247d72c34960)	github.com/wailsapp/wails/v3@v3.0.0-alpha2.110/pkg/application/application_windows.go:190 +0x3a5github.com/wailsapp/wails/v3/pkg/application.(*App).Run(0x247d72cd0c08)	github.com/wailsapp/wails/v3@v3.0.0-alpha2.110/pkg/application/application.go:688 +0x1f7main.main()	nextup/main.go:782 +0x4353
`

## Type of change
  
Please select the option that is relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
  
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration using `wails doctor`.

- [x] Windows
- [ ] macOS
- [ ] Linux
      
If you checked Linux, please specify the distro and version.
  
## Test Configuration

Please paste the output of `wails doctor`. If you are unable to run this command, please describe your environment in as much detail as possible.

# Checklist:

- [ ] (v2 only) I have updated `website/src/pages/changelog.mdx` with details of this PR (v3 changelog entries are added automatically)
- [ ] My code follows the general coding style of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows tray stability during Explorer/taskbar restarts and other shell interruptions.
  * Fixed WebView2 visibility handling so hidden or minimized windows no longer leave interactive content exposed.
  * Resolved several WebView2 rendering and sizing issues that could cause blank displays or crashes on Windows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->