### PR TITLE
fix(website): repair French MDX corrupted by translation sync, unblocking the v2 site build

### DIFF
--- a/website/i18n/fr/docusaurus-plugin-content-docs/current/guides/sveltekit.mdx
+++ b/website/i18n/fr/docusaurus-plugin-content-docs/current/guides/sveltekit.mdx
@@ -108,7 +108,7 @@ wails dev
 
 ##### Le runtime Wails se décharge avec des pages de navigation complètes !
 
-- Tout ce qui provoque la navigation de page complète : \`window.location.href = '/<some>/<page>' ou le menu contextuel se recharge lorsque vous utilisez wails dev.  Cela signifie que vous pouvez finir par perdre la possibilité d'appeler n'importe quel runtime cassant l'application. Il y a deux façons de contourner ce problème.
+- Tout ce qui provoque la navigation de page complète : `window.location.href = '/<some>/<page>'` ou le menu contextuel se recharge lorsque vous utilisez wails dev.  Cela signifie que vous pouvez finir par perdre la possibilité d'appeler n'importe quel runtime cassant l'application. Il y a deux façons de contourner ce problème.
 - Utilisez `import { goto } de '$app/navigation'` puis appelez `goto('/<some>/<page>')` dans votre +page.svelte. Cela empêchera la navigation de la page complète.
 - Si la navigation de la page complète ne peut pas être empêchée, le runtime Wails peut être ajouté à toutes les pages en ajoutant ce qui suit dans le `<head>` de myapp/frontend/src/app.html
 

--- a/website/i18n/fr/docusaurus-plugin-content-docs/current/reference/options.mdx
+++ b/website/i18n/fr/docusaurus-plugin-content-docs/current/reference/options.mdx
@@ -961,4 +961,4 @@ Définir cette option à `true` ouvrira l'inspecteur Web au démarrage de l'appl
 Nom: OpenInspectorOnStartup<br/> Type: `bool`
 
 [^1]: Cela nécessite la prise en charge de WebKit2GTK 2.36+ et votre application doit être construite avec la balise de compilation `webkit2_36` pour activer le support de cette fonctionnalité. Cela augmente aussi la version minnimale de WebKit2GTK à 2.36 pour votre application.
-[^2]: Cela nécessite la prise en charge de WebKit2GTK 2.40+ et votre application doit être construite avec la balise de compilation `webkit2_40` pour activer le support de cette fonctionnalité. Cela augmente aussi la version minnimale de WebKit2GTK à 2.40 pour votre application.&#160;[ [    &#8617;](#fnref2:2){.footnote-backref} &#8617;](#fnref:2){.footnote-backref}
+[^2]: Cela nécessite la prise en charge de WebKit2GTK 2.40+ et votre application doit être construite avec la balise de compilation `webkit2_40` pour activer le support de cette fonctionnalité. Cela augmente aussi la version minnimale de WebKit2GTK à 2.40 pour votre application.


### PR DESCRIPTION
## The story

**wails.io has not deployed since 2026-04-06.** Every Cloudflare Pages build of the v2 site (project `wails`) since then has failed — the live site is a frozen snapshot of the 2026-04-06 content. That's why https://wails.io/img/sponsors.svg still serves the old sponsorskit image and `contributors.svg` 404s, which in turn is why the credits pages (including https://v3.wails.io/credits/, which hotlinks those images) show old graphics even though #5719 and #5724 are merged.

## Root cause

The `docs: sync translations` commit 8224d7036 (2026-04-06) introduced two MDX syntax errors into the French docs:

1. **`reference/options.mdx`** — a footnote gained literal `{.footnote-backref}` attribute syntax; MDX parses `{...}` as a JS expression and acorn fails ("Could not parse expression with acorn").
2. **`guides/sveltekit.mdx`** — a code span lost its backticks (opening one escaped as `\``, closing one dropped), leaving a bare `<page>` that MDX treats as an unclosed JSX tag ("Expected a closing tag for `<page>`").

Docusaurus aborts on the first error, so only one showed per build.

## Fix

Two one-line repairs restoring the structure of the English source. Verified locally: `npm run build` in `website/` (Node 22) now completes successfully for **all locales and versions**.

## Notes

- Merging this should let the next Cloudflare Pages build of `wails` succeed and republish three months of pending content, including the new `sponsors.svg` / `contributors.svg`.
- The nightly sponsor-image commit uses `[skip ci]`, which Cloudflare also honours — image-only refreshes will ride along with the next regular commit to master, same as before.
- Worth considering as a follow-up: a CI job that runs `npm run build` (or at least MDX-compiles) on PRs/pushes touching `website/`, so a bad translation sync can't silently freeze the site again; and checking whether the Crowdin source still contains the corrupt strings, in which case the next sync could reintroduce them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved French docs formatting for an inline code example in the SvelteKit guide.
  * Cleaned up a footnote rendering issue in the options reference so the note displays more cleanly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->