### PR TITLE
ci: replace cache-apt-pkgs-action with plain apt-get installs

### DIFF
--- a/.github/workflows/build-and-test-v3.yml
+++ b/.github/workflows/build-and-test-v3.yml
@@ -109,18 +109,16 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install linux dependencies (GTK4 default)
-        uses: awalsh128/cache-apt-pkgs-action@latest
         if: matrix.os == 'ubuntu-latest'
-        with:
-          packages: libgtk-4-dev libwebkitgtk-6.0-dev libwayland-dev build-essential pkg-config xvfb x11-xserver-utils at-spi2-core xdg-desktop-portal-gtk
-          version: 1.0
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends libgtk-4-dev libwebkitgtk-6.0-dev libwayland-dev build-essential pkg-config xvfb x11-xserver-utils at-spi2-core xdg-desktop-portal-gtk
 
       - name: Install linux dependencies (GTK3 legacy)
-        uses: awalsh128/cache-apt-pkgs-action@latest
         if: matrix.os == 'ubuntu-latest'
-        with:
-          packages: libgtk-3-dev libwebkit2gtk-4.1-dev
-          version: 1.0
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends libgtk-3-dev libwebkit2gtk-4.1-dev
 
       - name: Setup Go
         uses: actions/setup-go@v5
@@ -223,18 +221,16 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install linux dependencies (GTK4 default)
-        uses: awalsh128/cache-apt-pkgs-action@latest
         if: matrix.os == 'ubuntu-latest'
-        with:
-          packages: libgtk-4-dev libwebkitgtk-6.0-dev libwayland-dev build-essential pkg-config
-          version: 1.0
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends libgtk-4-dev libwebkitgtk-6.0-dev libwayland-dev build-essential pkg-config
 
       - name: Install linux dependencies (GTK3 legacy)
-        uses: awalsh128/cache-apt-pkgs-action@latest
         if: matrix.os == 'ubuntu-latest'
-        with:
-          packages: libgtk-3-dev libwebkit2gtk-4.1-dev
-          version: 1.0
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends libgtk-3-dev libwebkit2gtk-4.1-dev
 
       - name: Setup Go
         uses: actions/setup-go@v5

--- a/.github/workflows/build-and-test-v3.yml
+++ b/.github/workflows/build-and-test-v3.yml
@@ -117,7 +117,6 @@ jobs:
       - name: Install linux dependencies (GTK3 legacy)
         if: matrix.os == 'ubuntu-latest'
         run: |
-          sudo apt-get update -qq
           sudo apt-get install -y --no-install-recommends libgtk-3-dev libwebkit2gtk-4.1-dev
 
       - name: Setup Go
@@ -229,7 +228,6 @@ jobs:
       - name: Install linux dependencies (GTK3 legacy)
         if: matrix.os == 'ubuntu-latest'
         run: |
-          sudo apt-get update -qq
           sudo apt-get install -y --no-install-recommends libgtk-3-dev libwebkit2gtk-4.1-dev
 
       - name: Setup Go

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -24,17 +24,17 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - uses: awalsh128/cache-apt-pkgs-action@latest
+      - name: Install apt packages
         if: matrix.os == 'ubuntu-22.04'
-        with:
-          packages: libgtk-3-dev libwebkit2gtk-4.0-dev build-essential pkg-config
-          version: 1.0
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends libgtk-3-dev libwebkit2gtk-4.0-dev build-essential pkg-config
 
-      - uses: awalsh128/cache-apt-pkgs-action@latest
+      - name: Install apt packages
         if: matrix.os == 'ubuntu-24.04'
-        with:
-          packages: libgtk-3-dev libwebkit2gtk-4.1-dev build-essential pkg-config libegl1
-          version: 1.0
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends libgtk-3-dev libwebkit2gtk-4.1-dev build-essential pkg-config libegl1
 
       - name: Setup Go
         uses: actions/setup-go@v4
@@ -127,21 +127,21 @@ jobs:
           go install
           wails -help
 
-      - uses: awalsh128/cache-apt-pkgs-action@latest
+      - name: Install apt packages
         if: matrix.os == 'ubuntu-22.04'
-        with:
-          packages: libgtk-3-dev libwebkit2gtk-4.0-dev build-essential pkg-config
-          version: 1.0
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends libgtk-3-dev libwebkit2gtk-4.0-dev build-essential pkg-config
 
 #      - name: Install linux dependencies ( 22.04 )
 #        if: matrix.os == 'ubuntu-22.04'
 #        run: sudo apt-get update -y && sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.0-dev build-essential pkg-config
 
-      - uses: awalsh128/cache-apt-pkgs-action@latest
+      - name: Install apt packages
         if: matrix.os == 'ubuntu-24.04'
-        with:
-          packages: libgtk-3-dev libwebkit2gtk-4.1-dev build-essential pkg-config libegl1
-          version: 1.0
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends libgtk-3-dev libwebkit2gtk-4.1-dev build-essential pkg-config libegl1
 
 #      - name: Install linux dependencies ( 24.04 )
 #        if: matrix.os == 'ubuntu-24.04'

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -24,13 +24,13 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Install apt packages
+      - name: Install apt packages (ubuntu-22.04)
         if: matrix.os == 'ubuntu-22.04'
         run: |
           sudo apt-get update -qq
           sudo apt-get install -y --no-install-recommends libgtk-3-dev libwebkit2gtk-4.0-dev build-essential pkg-config
 
-      - name: Install apt packages
+      - name: Install apt packages (ubuntu-24.04)
         if: matrix.os == 'ubuntu-24.04'
         run: |
           sudo apt-get update -qq
@@ -127,7 +127,7 @@ jobs:
           go install
           wails -help
 
-      - name: Install apt packages
+      - name: Install apt packages (ubuntu-22.04)
         if: matrix.os == 'ubuntu-22.04'
         run: |
           sudo apt-get update -qq
@@ -137,7 +137,7 @@ jobs:
 #        if: matrix.os == 'ubuntu-22.04'
 #        run: sudo apt-get update -y && sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.0-dev build-essential pkg-config
 
-      - name: Install apt packages
+      - name: Install apt packages (ubuntu-24.04)
         if: matrix.os == 'ubuntu-24.04'
         run: |
           sudo apt-get update -qq

--- a/.github/workflows/cross-compile-test-v3.yml
+++ b/.github/workflows/cross-compile-test-v3.yml
@@ -92,10 +92,9 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Linux dependencies
-        uses: awalsh128/cache-apt-pkgs-action@latest
-        with:
-          packages: libgtk-4-dev libwebkitgtk-6.0-dev libgtk-3-dev libwebkit2gtk-4.1-dev libwayland-dev build-essential pkg-config
-          version: 1.0
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends libgtk-4-dev libwebkitgtk-6.0-dev libgtk-3-dev libwebkit2gtk-4.1-dev libwayland-dev build-essential pkg-config
 
       - name: Install Wails3 CLI
         working-directory: v3

--- a/.github/workflows/pr-master.yml
+++ b/.github/workflows/pr-master.yml
@@ -66,18 +66,16 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install linux dependencies (22.04)
-        uses: awalsh128/cache-apt-pkgs-action@latest
         if: matrix.os == 'ubuntu-22.04'
-        with:
-          packages: libgtk-3-dev libwebkit2gtk-4.0-dev build-essential pkg-config
-          version: 1.0
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends libgtk-3-dev libwebkit2gtk-4.0-dev build-essential pkg-config
 
       - name: Install linux dependencies (24.04)
-        uses: awalsh128/cache-apt-pkgs-action@latest
         if: matrix.os == 'ubuntu-24.04'
-        with:
-          packages: libgtk-3-dev libwebkit2gtk-4.1-dev build-essential pkg-config
-          version: 1.0
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends libgtk-3-dev libwebkit2gtk-4.1-dev build-essential pkg-config
 
       - name: Setup Go
         uses: actions/setup-go@v5


### PR DESCRIPTION
All Linux CI jobs on every PR are currently red: the `awalsh128/cache-apt-pkgs-action@latest` steps restore a cache miss without actually installing the packages, so cgo builds fail with `Package gtk+-3.0 was not found` (v2 test jobs) and `Package gtk4 / webkitgtk-6.0 was not found` (v3 cross-compile). Examples: the current check runs on #5741, #5742, #5743, #5703.

This replaces all 11 usages across the four workflows with plain `apt-get update -qq && apt-get install -y --no-install-recommends <same package lists>`. A few seconds slower per job, always correct, and removes a mutable `@latest` action from the critical path.

This PR's own checks exercise the changed workflows directly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI workflows to install Linux GTK/WebKit build dependencies using direct `apt-get update` and `apt-get install` commands instead of cached apt package actions.
  * Preserved the existing dependency sets for Ubuntu GTK4 (default) and GTK3 (legacy), including the relevant WebKit package variants per Ubuntu version.
  * Applied the same approach across Go tests, template tests, and cross-compile dependency setup while leaving the test logic unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->