### PR TITLE
docs(changelog): credit #5734's co-contributors

### DIFF
--- a/docs/src/content/docs/changelog.mdx
+++ b/docs/src/content/docs/changelog.mdx
@@ -31,6 +31,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 */
 ## [Unreleased]
 
+
+### Fixed
+
+- Re-enable WebView2 monitor-scale detection and gate host resync on DPI change in [PR](https://github.com/wailsapp/wails/pull/5734) by @taliesin-ai, based on the fix validated by @randalmurphal, with root-cause verification by @eleclin and hardware testing by @qq540491950
 ## v3.0.0-alpha2.113 - 2026-07-04
 
 ## Added
@@ -49,7 +53,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix Android AVD auto-creation picking the wrong system image or cmdline-tools version due to lexicographic version sorting in [PR](https://github.com/wailsapp/wails/pull/5730) by @taliesin-ai
 - Fix the setup wizard suggesting an outdated Android NDK version (now 26.3.11579264, matching the documented requirement) in [PR](https://github.com/wailsapp/wails/pull/5730) by @taliesin-ai
 - Update French documentation for SvelteKit and options in [PR](https://github.com/wailsapp/wails/pull/5744) by @leaanthony
-- Re-enable WebView2 monitor-scale detection and gate host resync on DPI change in [PR](https://github.com/wailsapp/wails/pull/5734) by @taliesin-ai, based on the fix validated by @randalmurphal, with root-cause verification by @eleclin and hardware testing by @qq540491950
 - Fix SIGSEGV on macOS screen enumeration during display changes in [PR](https://github.com/wailsapp/wails/pull/5516) by @flofreud
 
 ## v3.0.0-alpha2.112 - 2026-07-03

--- a/docs/src/content/docs/changelog.mdx
+++ b/docs/src/content/docs/changelog.mdx
@@ -49,7 +49,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix Android AVD auto-creation picking the wrong system image or cmdline-tools version due to lexicographic version sorting in [PR](https://github.com/wailsapp/wails/pull/5730) by @taliesin-ai
 - Fix the setup wizard suggesting an outdated Android NDK version (now 26.3.11579264, matching the documented requirement) in [PR](https://github.com/wailsapp/wails/pull/5730) by @taliesin-ai
 - Update French documentation for SvelteKit and options in [PR](https://github.com/wailsapp/wails/pull/5744) by @leaanthony
-- Re-enable WebView2 monitor-scale detection and gate host resync on DPI change in [PR](https://github.com/wailsapp/wails/pull/5734) by @taliesin-ai
+- Re-enable WebView2 monitor-scale detection and gate host resync on DPI change in [PR](https://github.com/wailsapp/wails/pull/5734) by @taliesin-ai, based on the fix validated by @randalmurphal, with root-cause verification by @eleclin and hardware testing by @qq540491950
 - Fix SIGSEGV on macOS screen enumeration during display changes in [PR](https://github.com/wailsapp/wails/pull/5516) by @flofreud
 
 ## v3.0.0-alpha2.112 - 2026-07-03


### PR DESCRIPTION
The #5734 squash merge dropped @randalmurphal's git authorship (his validated app-layer fix was cherry-picked onto the branch with authorship preserved, but squashing collapsed it without a `Co-authored-by` trailer), and the changelog entry credits only @taliesin-ai. @eleclin (independent root-cause verification on #5701) and @qq540491950 (hardware testing that pinned down #5705) also deserve a mention. One-line changelog amendment; no marker or structure changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the unreleased changelog to note a WebView2-related fix for monitor-scale detection and DPI-based host resync.
  * Adjusted the order of related fixed items in the changelog for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->