### PR TITLE
ci: skip release/publish/changelog automation on forks

### DIFF
--- a/.github/workflows/auto-changelog-v3.yml
+++ b/.github/workflows/auto-changelog-v3.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   auto-changelog:
-    if: github.event.pull_request.merged == true || github.event_name == 'workflow_dispatch'
+    if: github.repository == 'wailsapp/wails' && (github.event.pull_request.merged == true || github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-latest
     env:
       GOWORK: "off"

--- a/.github/workflows/changelog-v3.yml
+++ b/.github/workflows/changelog-v3.yml
@@ -15,6 +15,7 @@ on:
 jobs:
   validate:
     runs-on: ubuntu-latest
+    if: github.repository == 'wailsapp/wails'
     env:
       GOWORK: "off"
     permissions:

--- a/.github/workflows/nightly-release-v3.yml
+++ b/.github/workflows/nightly-release-v3.yml
@@ -19,6 +19,7 @@ on:
 jobs:
   nightly-release:
     runs-on: ubuntu-latest
+    if: github.repository == 'wailsapp/wails'
     env:
       GOWORK: "off"
     

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -13,7 +13,7 @@ concurrency:
 jobs:
   detect:
     name: Detect committed changes
-    if: github.event_name != 'workflow_dispatch'
+    if: github.repository == 'wailsapp/wails' && github.event_name != 'workflow_dispatch'
     outputs:
       changed: ${{ steps.package-json-changes.outputs.any_modified == 'true' || steps.source-changes.outputs.any_modified == 'true' }}
     runs-on: ubuntu-latest
@@ -50,7 +50,8 @@ jobs:
     name: Rebuild and publish
     needs: [detect]
     if: >-
-      !failure() && !cancelled()
+      github.repository == 'wailsapp/wails'
+      && !failure() && !cancelled()
       && (github.event_name == 'workflow_dispatch' || needs.detect.outputs.changed == 'true')
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## Why

`nightly-release-v3.yml`, `publish-npm.yml`, `auto-changelog-v3.yml` and `changelog-v3.yml` have no repository guard, so any fork with Actions enabled runs them against its own default branch.

This is actively biting #5462: the PR head is the author's fork `master`, and the fork's Actions keep committing straight into the open PR — a nightly-minted `v3.0.0-alpha2.114` release bump that collides with the real one, `@wailsio/runtime` version bumps, and 90+ regenerated typedoc files whose source links point at the fork instead of `wailsapp/wails`.

## What

Add the same job-level guard the repo already uses in `weekly-release-v2.yml` and `generate-sponsor-image.yml`:

```yaml
if: github.repository == 'wailsapp/wails'
```

composed with the existing conditions where a job already had an `if`. For `pull_request`/`pull_request_target` events `github.repository` is the **base** repo, so fork-authored PRs against upstream still run these normally — only runs inside a fork are skipped.

Because push-triggered runs use the workflow file at the pushed commit and cron runs use the fork's default-branch copy, merging this and then updating #5462's branch from master disarms the fork automation without needing any settings change on the fork.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Tightened automation checks so release, changelog, and publishing jobs run only in the intended repository.
  * Improved control over when manual and merged-PR workflows trigger, reducing accidental execution in other contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->