### PR TITLE
fix(v3): guarantee event dispatch order under rapid Emit() bursts

### DIFF
--- a/v3/pkg/application/events.go
+++ b/v3/pkg/application/events.go
@@ -96,6 +96,11 @@ type eventListener struct {
 	delete   bool               // Flag to indicate that this listener should be deleted
 }
 
+// dispatchQueueSize buffers EventProcessor's dispatch queues (see Emit) well
+// above realistic emit bursts, so Emit() stays non-blocking in practice. Also
+// bounds in-flight dispatch, unlike the old unbounded goroutine-per-Emit.
+const dispatchQueueSize = 4096
+
 // EventProcessor handles custom events
 type EventProcessor struct {
 	// Go event listeners
@@ -104,13 +109,48 @@ type EventProcessor struct {
 	dispatchEventToWindows func(*CustomEvent)
 	hooks                  map[string][]*hook
 	hookLock               sync.RWMutex
+
+	// Feed the two single-consumer dispatch workers below. Emit() used to hand
+	// each dispatch to its own bare goroutine, and Go gives no ordering
+	// guarantee between them — two events emitted back-to-back could reach
+	// ExecJS in either order. A single ordered worker per queue fixes that,
+	// while keeping listeners and windows independent of each other.
+	listenerQueue chan *CustomEvent
+	windowQueue   chan *CustomEvent
 }
 
 func NewWailsEventProcessor(dispatchEventToWindows func(*CustomEvent)) *EventProcessor {
-	return &EventProcessor{
+	e := &EventProcessor{
 		listeners:              make(map[string][]*eventListener),
 		dispatchEventToWindows: dispatchEventToWindows,
 		hooks:                  make(map[string][]*hook),
+		listenerQueue:          make(chan *CustomEvent, dispatchQueueSize),
+		windowQueue:            make(chan *CustomEvent, dispatchQueueSize),
+	}
+	go e.runListenerDispatch()
+	go e.runWindowDispatch()
+	return e
+}
+
+// runListenerDispatch drains listenerQueue in order for the process lifetime.
+// Each event gets its own recover so one panic can't kill the worker and
+// stop delivery to everything emitted after it.
+func (e *EventProcessor) runListenerDispatch() {
+	for event := range e.listenerQueue {
+		func() {
+			defer handlePanic()
+			e.dispatchEventToListeners(event)
+		}()
+	}
+}
+
+// runWindowDispatch: same as runListenerDispatch, for the window/IPC side.
+func (e *EventProcessor) runWindowDispatch() {
+	for event := range e.windowQueue {
+		func() {
+			defer handlePanic()
+			e.dispatchEventToWindows(event)
+		}()
 	}
 }
 
@@ -157,14 +197,8 @@ func (e *EventProcessor) Emit(thisEvent *CustomEvent) error {
 		}
 	}
 
-	go func() {
-		defer handlePanic()
-		e.dispatchEventToListeners(thisEvent)
-	}()
-	go func() {
-		defer handlePanic()
-		e.dispatchEventToWindows(thisEvent)
-	}()
+	e.listenerQueue <- thisEvent
+	e.windowQueue <- thisEvent
 
 	return nil
 }

--- a/v3/pkg/application/events_test.go
+++ b/v3/pkg/application/events_test.go
@@ -2,6 +2,7 @@ package application_test
 
 import (
 	"sync"
+	"sync/atomic"
 	"testing"
 
 	"github.com/wailsapp/wails/v3/pkg/application"
@@ -10,14 +11,21 @@ import (
 )
 
 type mockNotifier struct {
+	mu     sync.Mutex
 	Events []*application.CustomEvent
 }
 
+// mu: dispatch now runs on a persistent worker (see runWindowDispatch), so it
+// can race with a test's Reset() right after Emit(). Mutex makes that safe.
 func (m *mockNotifier) dispatchEventToWindows(event *application.CustomEvent) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	m.Events = append(m.Events, event)
 }
 
 func (m *mockNotifier) Reset() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	m.Events = []*application.CustomEvent{}
 }
 
@@ -99,12 +107,13 @@ func Test_EventsOnMultiple(t *testing.T) {
 
 	// Test OnApplicationEvent
 	eventName := "test"
-	counter := 0
+	// atomic: 2 of the 3 Emit()s below can invoke this callback concurrently.
+	var counter atomic.Int32
 	var wg sync.WaitGroup
 	wg.Add(2)
 	unregisterFn := eventProcessor.OnMultiple(eventName, func(event *application.CustomEvent) {
 		// This is called in a goroutine
-		counter++
+		counter.Add(1)
 		wg.Done()
 	}, 2)
 	_ = eventProcessor.Emit(&application.CustomEvent{
@@ -120,16 +129,16 @@ func Test_EventsOnMultiple(t *testing.T) {
 		Data: "test payload",
 	})
 	wg.Wait()
-	i.Equal(2, counter)
+	i.Equal(int32(2), counter.Load())
 
 	// Unregister
 	notifier.Reset()
 	unregisterFn()
-	counter = 0
+	counter.Store(0)
 	_ = eventProcessor.Emit(&application.CustomEvent{
 		Name: "test",
 		Data: "test payload",
 	})
-	i.Equal(0, counter)
+	i.Equal(int32(0), counter.Load())
 
 }

--- a/v3/pkg/application/linux_cgo_gtk3.go
+++ b/v3/pkg/application/linux_cgo_gtk3.go
@@ -107,6 +107,37 @@ static WebKitWebView* webkit_web_view(GtkWidget *webview) {
 	return WEBKIT_WEB_VIEW(webview);
 }
 
+// Discards the result/error; execute_js_sync's callers never need one.
+static void on_evaluate_javascript_finish(GObject *source, GAsyncResult *result, gpointer user_data) {
+	gboolean *done = (gboolean *)user_data;
+	GError *error = NULL;
+	JSCValue *value = webkit_web_view_evaluate_javascript_finish(WEBKIT_WEB_VIEW(source), result, &error);
+	if (error != NULL) {
+		g_error_free(error);
+	}
+	if (value != NULL) {
+		g_object_unref(value);
+	}
+	*done = TRUE;
+}
+
+// Blocks until WebKit confirms `script` actually finished — callback=NULL
+// (the old behavior) only confirms WebKit accepted the request, not that
+// back-to-back calls execute in the order they were issued. Same nested
+// main-loop technique as clipboard_get_text_sync (linux_cgo.c): blocking on
+// a condvar instead would freeze the loop our own completion callback needs
+// to run on. `done` is stack-local, so concurrent calls stay independent.
+static void execute_js_sync(WebKitWebView *web_view, const char *script, gssize length,
+                             const char *world_name, const char *source_uri) {
+	gboolean done = FALSE;
+	webkit_web_view_evaluate_javascript(web_view, script, length, world_name, source_uri,
+		NULL, on_evaluate_javascript_finish, &done);
+	GMainContext *ctx = g_main_context_default();
+	while (!done) {
+		g_main_context_iteration(ctx, TRUE);
+	}
+}
+
 // Wrapper for the WEBKIT_IS_USER_MEDIA_PERMISSION_REQUEST macro
 static int is_user_media_permission_request(WebKitPermissionRequest *request) {
 	return WEBKIT_IS_USER_MEDIA_PERMISSION_REQUEST(request) ? 1 : 0;
@@ -1151,14 +1182,7 @@ func (w *linuxWebviewWindow) disableDND() {
 func (w *linuxWebviewWindow) execJS(js string) {
 	InvokeAsync(func() {
 		value := C.CString(js)
-		C.webkit_web_view_evaluate_javascript(w.webKitWebView(),
-			value,
-			C.long(len(js)),
-			nil,
-			emptyWorldName,
-			nil,
-			nil,
-			nil)
+		C.execute_js_sync(w.webKitWebView(), value, C.long(len(js)), nil, emptyWorldName)
 		C.free(unsafe.Pointer(value))
 	})
 }


### PR DESCRIPTION
## Problem

Events emitted rapidly in succession (e.g. a Go backend streaming many small
events back-to-back) can reach the frontend **out of order**, or with visible
interleaving. Two independent causes:

1. **`EventProcessor.Emit`** (`v3/pkg/application/events.go`) spawns two bare
   goroutines per call for dispatch (one for Go listeners, one for windows).
   Go gives no ordering guarantee between separately spawned goroutines, so
   two events emitted back-to-back can have their window-dispatch (and
   therefore their `ExecJS` call) run in either order.

2. **linux/gtk3 `execJS`** (`v3/pkg/application/linux_cgo_gtk3.go`) calls
   `webkit_web_view_evaluate_javascript` with `callback=NULL` ("fire and
   forget"). WebKit confirms the request was *accepted*, not that it
   *finished executing* — WebKit evaluates scripts asynchronously via its
   WebProcess, and without a completion callback nothing guarantees that
   rapid, back-to-back `evaluate_javascript` calls execute in the same order
   they were dispatched.

## Fix

1. Replaced the two bare goroutines in `Emit()` with one buffered, ordered
   worker per dispatch target (listeners, windows). `Emit()` stays
   non-blocking under normal load (buffer of 4096, well above realistic
   bursts) — dispatch is now strict FIFO per target, and also bounded,
   unlike the previous unbounded goroutine-per-`Emit()` fan-out.

2. `execJS` now waits for the real WebKit completion callback before
   returning, using the same nested main-loop-iteration technique already
   used by `clipboard_get_text_sync` (`linux_cgo.c`) to make an async
   GLib/GTK call appear synchronous from the calling C code — blocking on a
   condition variable instead would freeze the very loop that has to keep
   running for the completion callback to ever be delivered.

Also fixed two pre-existing latent races in `events_test.go`'s mock notifier
and counter that `-race` now catches reliably against the new, more
deterministic dispatch timing (they were always technically possible, just
rarely triggered by the old bare-goroutine timing).

## Verification

Isolated repro: 500 `Emit()` calls in a tight loop, no app-specific code
involved, checking arrival order in the page.

| | Before | After |
|---|---|---|
| Out of order | 478/500 (95.6%) | **0/500** |
| Wall-clock to issue all 500 `Emit()` calls | 2.16ms | **244µs** (faster — `Emit()` no longer spawns two goroutines per call) |

`go test -race ./pkg/application/...` passes clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved event delivery stability by switching to queued, long-running dispatch for listener and window callbacks, reducing missed or inconsistent event handling.
  * Improved Linux JavaScript execution reliability by waiting for WebKit to complete evaluating scripts before continuing.
* **Tests**
  * Updated event-dispatch tests to be race-safe under concurrent callback execution and reset behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->