### PR TITLE
fix(v2): sort generated enums in enum-only packages

### DIFF
--- a/v2/internal/binding/binding.go
+++ b/v2/internal/binding/binding.go
@@ -164,7 +164,15 @@ func (b *Bindings) GenerateModels() ([]byte, error) {
 		w.Namespace = packageName
 		w.WithBackupDir("")
 
-		for enumName, enum := range enumsToGenerate {
+		// Sort the enum names first to make the output deterministic
+		sortedEnumNames := make([]string, 0, len(enumsToGenerate))
+		for enumName := range enumsToGenerate {
+			sortedEnumNames = append(sortedEnumNames, enumName)
+		}
+		sort.Strings(sortedEnumNames)
+
+		for _, enumName := range sortedEnumNames {
+			enum := enumsToGenerate[enumName]
 			fqemumname := packageName + "." + enumName
 			if seen.Contains(fqemumname) {
 				continue

--- a/v2/internal/binding/binding.go
+++ b/v2/internal/binding/binding.go
@@ -87,6 +87,24 @@ func (b *Bindings) ToJSON() (string, error) {
 	return b.db.ToJSON()
 }
 
+// addEnumsToGenerator adds unseen enums in name order for deterministic output.
+func addEnumsToGenerator(w *typescriptify.TypeScriptify, packageName string, enums map[string]interface{}, seen *slicer.StringSlicer) {
+	sortedEnumNames := make([]string, 0, len(enums))
+	for enumName := range enums {
+		sortedEnumNames = append(sortedEnumNames, enumName)
+	}
+	sort.Strings(sortedEnumNames)
+
+	for _, enumName := range sortedEnumNames {
+		enum := enums[enumName]
+		fqemumname := packageName + "." + enumName
+		if seen.Contains(fqemumname) {
+			continue
+		}
+		w.AddEnum(enum)
+	}
+}
+
 func (b *Bindings) GenerateModels() ([]byte, error) {
 	models := map[string]string{}
 	var seen slicer.StringSlicer
@@ -123,21 +141,7 @@ func (b *Bindings) GenerateModels() ([]byte, error) {
 		// if we have enums for this package, add them as well
 		var enums, enumsExist = b.enumsToGenerateTS[packageName]
 		if enumsExist {
-			// Sort the enum names first to make the output deterministic
-			sortedEnumNames := make([]string, 0, len(enums))
-			for enumName := range enums {
-				sortedEnumNames = append(sortedEnumNames, enumName)
-			}
-			sort.Strings(sortedEnumNames)
-
-			for _, enumName := range sortedEnumNames {
-				enum := enums[enumName]
-				fqemumname := packageName + "." + enumName
-				if seen.Contains(fqemumname) {
-					continue
-				}
-				w.AddEnum(enum)
-			}
+			addEnumsToGenerator(w, packageName, enums, &seen)
 			seenEnumsPackages.Add(packageName)
 		}
 
@@ -164,21 +168,7 @@ func (b *Bindings) GenerateModels() ([]byte, error) {
 		w.Namespace = packageName
 		w.WithBackupDir("")
 
-		// Sort the enum names first to make the output deterministic
-		sortedEnumNames := make([]string, 0, len(enumsToGenerate))
-		for enumName := range enumsToGenerate {
-			sortedEnumNames = append(sortedEnumNames, enumName)
-		}
-		sort.Strings(sortedEnumNames)
-
-		for _, enumName := range sortedEnumNames {
-			enum := enumsToGenerate[enumName]
-			fqemumname := packageName + "." + enumName
-			if seen.Contains(fqemumname) {
-				continue
-			}
-			w.AddEnum(enum)
-		}
+		addEnumsToGenerator(w, packageName, enumsToGenerate, &seen)
 		str, err := w.Convert(nil)
 		if err != nil {
 			return nil, err

--- a/v2/internal/binding/binding_test/binding_enum_ordering_test.go
+++ b/v2/internal/binding/binding_test/binding_enum_ordering_test.go
@@ -120,6 +120,42 @@ var EnumOrderingTest = BindingTest{
 `,
 }
 
+// OutstandingEnumOrderingTest tests that enums in a package without generated
+// structs are also output in alphabetical order by enum name.
+var OutstandingEnumOrderingTest = BindingTest{
+	name:    "OutstandingEnumOrderingTest",
+	structs: nil,
+	enums: []interface{}{
+		// Intentionally add enums in non-alphabetical order
+		AllZFirstEnumValues,
+		AllASecondEnumValues,
+		AllMMiddleEnumValues,
+	},
+	exemptions:  nil,
+	shouldError: false,
+	TsGenerationOptionsTest: TsGenerationOptionsTest{
+		TsPrefix: "",
+		TsSuffix: "",
+	},
+	want: `export namespace binding_test {
+
+	export enum ASecondEnum {
+	    AValue1 = 0,
+	    AValue2 = 1,
+	}
+	export enum MMiddleEnum {
+	    MValue1 = 0,
+	    MValue2 = 1,
+	}
+	export enum ZFirstEnum {
+	    ZValue1 = 0,
+	    ZValue2 = 1,
+	}
+
+}
+`,
+}
+
 // EnumElementOrderingEnum tests sorting of enum elements by TSName
 type EnumElementOrderingEnum string
 

--- a/v2/internal/binding/binding_test/binding_test.go
+++ b/v2/internal/binding/binding_test/binding_test.go
@@ -57,6 +57,7 @@ func TestBindings_GenerateModels(t *testing.T) {
 		DeepElementsTest,
 		// PR #4664: Enum ordering tests
 		EnumOrderingTest,
+		OutstandingEnumOrderingTest,
 		EnumElementOrderingTest,
 		TSNameEnumElementOrderingTest,
 	}

--- a/website/src/pages/changelog.mdx
+++ b/website/src/pages/changelog.mdx
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Fixed nondeterministic generated enum ordering for enum-only packages in [#5786](https://github.com/wailsapp/wails/pull/5786) by [@Saramanda9988](https://github.com/Saramanda9988).
+
 ## v2.13.0 - 2026-07-06
 ### Added
 


### PR DESCRIPTION
<!--

*********************************************************************
*               PLEASE READ BEFORE SUBMITTING YOUR PR               *
*     YOUR PR MAY BE REJECTED IF IT DOES NOT FOLLOW THESE STEPS     *
*********************************************************************

- *DO NOT* submit bugs for a source install of v3, ONLY tagged versions, e.g. v3.0.0-alpha.11
- *DO NOT* submit PRs for v3 alpha enhancements, unless you have opened a post on the discord channel.
  All enhancements must be discussed first.
  The feedback guide for v3 is here: https://v3.wails.io/feedback/

- Before submitting your PR, please ensure you have created and linked the PR to an issue.
- If a relevant issue already exists, please reference it in your PR by including `Fixes #<issue number>` in your PR description.
- Please fill in the checklists.

-->

# Description

Wails v2.13.0 sorts generated enums when their Go package also contains structs that need TypeScript model generation. However, enum-only packages are handled by a separate "outstanding enums" path that still iterates over a Go map directly.

Because Go map iteration order is unspecified, running binding generation multiple times can reorder otherwise unchanged enum declarations in `models.ts`, producing noisy source control diffs. Such as [modals.ts](https://github.com/Saramanda9988/LunaBox/commit/aaebfae9e9c5fdd23c768340185464799fb8c794#diff-3ae06b81def60098ee962d3ad564dc31130e42c81ed7af638bbc4cf8684f65c4)

This change:

- Sorts enum names before generating enums from enum-only packages.
- Extracts the shared enum sorting and generation logic into `addEnumsToGenerator`, so packages with structs and enum-only packages use the same deterministic path.
- Adds a regression test covering a package with enums but no generated structs.

This is a follow-up to #4664, which fixed enum ordering for packages that also contain generated structs.

## Type of change
  
Please select the option that is relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
  
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration using `wails doctor`.

- [x] Windows
- [ ] macOS
- [ ] Linux
  
## Test Configuration

```text
# Wails
┌───────────────────┐
| Version | v2.13.0 |
└───────────────────┘

# System
┌──────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
| OS           | Windows 10 Home China   |
| Version      | 2009 (Build: 22631)   |
| ID           | 23H2   |
| Branding     | Windows 11 家庭中文版   |
| Go Version   | go1.25.7   |
| Platform     | windows   |
| Architecture | amd64   |
| CPU          | 13th Gen Intel(R) Core(TM) i7-13650HX   |
| GPU 1        | Virtual Display Driver (MikeTheTech) -Driver: 23.40.36.27   |
| GPU 2        | OrayIddDriver Device (Shanghai Best Oray Information Technology Co., Ltd.) - Driver: 17.50.19.949 |
| GPU 3        | NVIDIA GeForce RTX 4060 Laptop GPU (NVIDIA) - Driver: 32.0.15.9186   |
| Memory       | 32GB   |
└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘

# Dependencies
┌───────────────────────────────────────────────────────┐
| Dependency | Package Name | Status    | Version|
| WebView2   | N/A          | Installed | 150.0.4078.65|
| Nodejs     | N/A          | Installed | 22.18.0|
| npm        | N/A          | Installed | 11.4.2|
| *upx       | N/A          | Available ||
| *nsis      | N/A          | Installed | v3.11|
||
└─────────────── * - Optional Dependency ───────────────┘

# Diagnosis
Optional package(s) installation details: 
  - upx : Available at https://upx.github.io/
  
```

# Checklist:

- [x] (v2 only) I have updated `website/src/pages/changelog.mdx` with details of this PR (v3 changelog entries are added automatically)
- [x] My code follows the general coding style of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed generated enum ordering for packages containing only enums.
  - Enum declarations now appear in consistent alphabetical order across generated TypeScript output.

- **Tests**
  - Added coverage to verify deterministic ordering and enum member generation.

- **Documentation**
  - Updated the changelog with the enum ordering fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->