### PR TITLE
fix(v3): guard nil AllowDarkModeForWindow to avoid panic on Windows Server 2019

### DIFF
--- a/v3/UNRELEASED_CHANGELOG.md
+++ b/v3/UNRELEASED_CHANGELOG.md
@@ -23,6 +23,7 @@ After processing, the content will be moved to the main changelog and this file 
 
 ## Fixed
 <!-- Bug fixes -->
+- Fix nil pointer panic on startup when a window uses a Dark (or system-dark) title bar on Windows builds without the dark-mode uxtheme APIs, such as Windows Server 2019 (build 17763). The unguarded `AllowDarkModeForWindow` calls in the window's theme setup now match the nil guard used elsewhere in `w32`.
 
 ## Deprecated
 <!-- Soon-to-be removed features -->

--- a/v3/pkg/application/webview_window_windows.go
+++ b/v3/pkg/application/webview_window_windows.go
@@ -563,7 +563,10 @@ func (w *windowsWebviewWindow) run() {
 	switch options.Windows.Theme {
 	case SystemDefault:
 		isDark := w32.IsCurrentlyDarkMode()
-		if isDark {
+		// AllowDarkModeForWindow is only loaded on Windows builds that expose the
+		// dark-mode uxtheme APIs; it is nil on older builds (e.g. Windows Server
+		// 2019 / build 17763). Guard the call as done elsewhere in w32.
+		if isDark && w32.AllowDarkModeForWindow != nil {
 			w32.AllowDarkModeForWindow(w.hwnd, true)
 		}
 		w.updateTheme(isDark)
@@ -577,7 +580,11 @@ func (w *windowsWebviewWindow) run() {
 	case Light:
 		w.updateTheme(false)
 	case Dark:
-		w32.AllowDarkModeForWindow(w.hwnd, true)
+		// Nil on Windows builds without the dark-mode uxtheme APIs (e.g. Server
+		// 2019 / build 17763); calling it there panics. Guard as done elsewhere.
+		if w32.AllowDarkModeForWindow != nil {
+			w32.AllowDarkModeForWindow(w.hwnd, true)
+		}
 		w.updateTheme(true)
 		// Don't initialize default dark theme here if custom theme might be set
 		// The updateTheme call above will handle custom themes


### PR DESCRIPTION
## Description

A Wails v3 app crashes on startup with a nil-pointer panic on Windows builds that predate the dark-mode uxtheme APIs — most notably **Windows Server 2019 (build 17763)** — when a window requests a `Dark` (or system-dark) title bar. The window never renders.

```
panic: runtime error: invalid memory address or nil pointer dereference
  github.com/wailsapp/wails/v3/pkg/application.(*windowsWebviewWindow).run
    v3/pkg/application/webview_window_windows.go:580
  ...application.(*App).Run
```

## Root cause

`pkg/w32/theme.go` `init()` only loads the undocumented dark-mode uxtheme procs (including `AllowDarkModeForWindow`, ordinal 133) when `IsWindowsVersionAtLeast(10, 0, 18334)`. On older builds — e.g. Server 2019 / 1809 (17763) — the package-level `w32.AllowDarkModeForWindow` stays **nil**.

`(*windowsWebviewWindow).run` then calls it **unguarded** in the theme switch:
- `case Dark:` — always
- `case SystemDefault:` — when the OS is currently in dark mode

So a window with `Windows.Theme == Dark` (or `SystemDefault` while the OS is set to dark) dereferences a nil function value and panics before the window is shown.

Notably, `pkg/w32/theme.go` already guards the **identical** call in `SetMenuTheme`:
```go
if AllowDarkModeForWindow != nil {
    AllowDarkModeForWindow(HWND(hwnd), useDarkMode)
}
```
These two call sites just missed the same guard.

## Fix

Guard both call sites with `if w32.AllowDarkModeForWindow != nil`, matching the existing pattern. On supported builds behaviour is unchanged; on unsupported builds the window falls back gracefully (native title bar stays default) instead of crashing.

## Reproduction

Windows Server 2019 (build 17763), a window with `Windows: application.WindowsWindow{ Theme: application.Dark }` → panic on startup. With this change the window opens normally.

## Notes

- Pure defensive guard; no behaviour change on builds ≥ 18334.
- Out of scope here (happy to follow up if wanted): the `>= 18334` gate is broader than the window-level API requires — `AllowDarkModeForWindow`/`ShouldAppsUseDarkMode` (ordinals 133/132) actually exist from 17763; only `SetPreferredAppMode` (ordinal 135, new signature) needs 1903+. Splitting that gate could enable a dark title bar on 1809/Server 2019, but that also needs the legacy pre-1903 code path, so I kept this PR to the crash fix.
- No test added: this exercises undocumented Windows APIs whose presence depends on the OS build, which isn't practical to unit-test.

Changelog entry added to `v3/UNRELEASED_CHANGELOG.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a startup crash on Windows Server 2019 and other systems without dark-mode support.
  * Improved reliability when applying dark themes to application windows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->