### PR TITLE
feat(mobile): deliver deep links as ApplicationLaunchedWithUrl on Android and iOS

### DIFF
--- a/v3/internal/commands/build_assets/android/app/src/main/AndroidManifest.xml
+++ b/v3/internal/commands/build_assets/android/app/src/main/AndroidManifest.xml
@@ -42,6 +42,31 @@
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
+
+            <!--
+              Deep linking (Android App Links). Uncomment and set your own host to
+              receive HTTPS links (OAuth/OIDC callbacks, email verification, shared
+              content, …) in Go via the common:ApplicationLaunchedWithUrl event.
+
+              The URL is delivered to MainActivity's onCreate (cold start) /
+              onNewIntent (warm start) and forwarded to Go. For reliable warm-start
+              delivery, also set android:launchMode="singleTask" on this <activity>
+              so a new intent reuses the running instance instead of spawning a copy.
+
+              android:autoVerify="true" enables verified App Links; you must host
+              https://<your-host>/.well-known/assetlinks.json containing this app's
+              signing certificate SHA-256 fingerprint for the OS to open links
+              directly in the app (without it, the OS shows a chooser).
+
+            <intent-filter android:autoVerify="true">
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="https"
+                      android:host="your-app.example.com"
+                      android:pathPrefix="/auth" />
+            </intent-filter>
+            -->
         </activity>
 
         <provider

--- a/v3/internal/commands/build_assets/android/app/src/main/java/com/wails/app/MainActivity.java
+++ b/v3/internal/commands/build_assets/android/app/src/main/java/com/wails/app/MainActivity.java
@@ -94,6 +94,10 @@ public class MainActivity extends AppCompatActivity {
 
         // Load the application
         loadApplication();
+
+        // If a deep link (App Link / custom scheme) cold-started the app, deliver
+        // it now. onNewIntent handles the warm-start case while already running.
+        handleDeepLinkIntent(getIntent());
     }
 
     @SuppressLint("SetJavaScriptEnabled")
@@ -442,6 +446,33 @@ public class MainActivity extends AppCompatActivity {
             pendingFilePickerCallbackID = -1;
             bridge.filePickerDone(callbackID);
         }
+    }
+
+    @Override
+    protected void onNewIntent(Intent intent) {
+        super.onNewIntent(intent);
+        // Keep getIntent() in sync so later reads see the latest intent.
+        setIntent(intent);
+        handleDeepLinkIntent(intent);
+    }
+
+    /**
+     * Extract a deep link URL from an ACTION_VIEW intent and forward it to Go as
+     * the cross-platform common:ApplicationLaunchedWithUrl event. No-op for
+     * intents that carry no data URI (e.g. the normal launcher intent).
+     */
+    private void handleDeepLinkIntent(@Nullable Intent intent) {
+        if (intent == null || bridge == null) {
+            return;
+        }
+        if (!Intent.ACTION_VIEW.equals(intent.getAction())) {
+            return;
+        }
+        Uri data = intent.getData();
+        if (data == null) {
+            return;
+        }
+        bridge.onDeepLink(data.toString());
     }
 
     @Override

--- a/v3/internal/commands/build_assets/android/app/src/main/java/com/wails/app/WailsBridge.java
+++ b/v3/internal/commands/build_assets/android/app/src/main/java/com/wails/app/WailsBridge.java
@@ -119,6 +119,7 @@ public class WailsBridge {
     private static native void nativeMainThreadCallback(int callbackID);
     private static native void nativeEmitSystemEvent(String name, String json);
     private static native void nativeEmitEvent(String name, String json);
+    private static native void nativeOnDeepLink(String url);
 
     public WailsBridge(Activity activity) {
         this.activity = activity;
@@ -192,6 +193,15 @@ public class WailsBridge {
      */
     public void onPageFinished(String url) {
         if (initialized) nativeOnPageFinished(url);
+    }
+
+    /**
+     * Deliver a deep link (App Link or custom-scheme URL) to Go. Surfaces as the
+     * cross-platform common:ApplicationLaunchedWithUrl application event.
+     * Called by MainActivity from onCreate (cold start) and onNewIntent (warm).
+     */
+    public void onDeepLink(String url) {
+        if (initialized && url != null && !url.isEmpty()) nativeOnDeepLink(url);
     }
 
     /**

--- a/v3/internal/commands/updatable_build_assets/ios/Info.plist.tmpl
+++ b/v3/internal/commands/updatable_build_assets/ios/Info.plist.tmpl
@@ -61,5 +61,21 @@
     <key>CFBundleGetInfoString</key>
     <string>{{.ProductComments}}</string>
     {{end}}
+    <!-- Deep linking via a custom URL scheme (e.g. myapp://callback). Uncomment
+         and set your scheme to receive these URLs in Go via the
+         common:ApplicationLaunchedWithUrl event. For HTTPS Universal Links use
+         the associated-domains entitlement instead (see entitlements.plist).
+    <key>CFBundleURLTypes</key>
+    <array>
+        <dict>
+            <key>CFBundleURLName</key>
+            <string>{{.ProductIdentifier}}</string>
+            <key>CFBundleURLSchemes</key>
+            <array>
+                <string>myapp</string>
+            </array>
+        </dict>
+    </array>
+    -->
 </dict>
 </plist>

--- a/v3/internal/commands/updatable_build_assets/ios/entitlements.plist.tmpl
+++ b/v3/internal/commands/updatable_build_assets/ios/entitlements.plist.tmpl
@@ -7,5 +7,15 @@
          (e.g. aps-environment) as your app needs them. -->
     <key>get-task-allow</key>
     <true/>
+    <!-- Universal Links (HTTPS deep linking). Uncomment and set your own domain
+         to receive verified https://<domain>/... links in Go via the
+         common:ApplicationLaunchedWithUrl event. You must also host
+         https://<domain>/.well-known/apple-app-site-association pointing at this
+         app's <TeamID>.<CFBundleIdentifier>.
+    <key>com.apple.developer.associated-domains</key>
+    <array>
+        <string>applinks:your-app.example.com</string>
+    </array>
+    -->
 </dict>
 </plist>

--- a/v3/pkg/application/application_android.go
+++ b/v3/pkg/application/application_android.go
@@ -487,6 +487,10 @@ func (a *App) platformRun() {
 	// startup races.
 	applicationEvents <- newApplicationEvent(events.Android.ActivityCreated)
 
+	// Flush any deep links that arrived before the app was ready (cold start).
+	// This runs AFTER the launch event so listeners are wired first.
+	flushAndroidPendingDeepLinks()
+
 	// Block forever - Android manages the app lifecycle via JNI callbacks
 	select {}
 }
@@ -675,6 +679,54 @@ func emitAndroidApplicationEventWithData(event events.ApplicationEventType, json
 	applicationEvents <- evt
 }
 
+// Android deep-link buffering. On cold start, the Java side calls
+// nativeOnDeepLink before the Go app is initialized (globalApp is nil). URLs
+// received in this window are buffered and flushed once the app starts.
+var (
+	androidDeepLinkLock     sync.Mutex
+	androidDeepLinkReady    bool
+	androidPendingDeepLinks []string
+)
+
+// emitAndroidDeepLink forwards a deep link (App Link / custom scheme) URL to the
+// event loop as the cross-platform common:ApplicationLaunchedWithUrl event, so
+// the same Go listener works on desktop and Android. Empty URLs are ignored.
+// If the Go app is not yet initialized, the URL is buffered.
+func emitAndroidDeepLink(url string) {
+	if url == "" {
+		return
+	}
+	androidDeepLinkLock.Lock()
+	if !androidDeepLinkReady {
+		androidPendingDeepLinks = append(androidPendingDeepLinks, url)
+		androidDeepLinkLock.Unlock()
+		return
+	}
+	androidDeepLinkLock.Unlock()
+
+	evt := newApplicationEvent(events.Common.ApplicationLaunchedWithUrl)
+	evt.Context().setURL(url)
+	applicationEvents <- evt
+}
+
+// flushAndroidPendingDeepLinks emits any URLs that arrived before the Go app
+// was initialized, then marks delivery as ready. Pending URLs are emitted
+// before setting ready to preserve FIFO ordering with concurrent calls.
+func flushAndroidPendingDeepLinks() {
+	androidDeepLinkLock.Lock()
+	pending := androidPendingDeepLinks
+	androidPendingDeepLinks = nil
+	// Emit all buffered URLs BEFORE setting ready, so a concurrent
+	// emitAndroidDeepLink cannot overtake the buffered ones.
+	for _, url := range pending {
+		evt := newApplicationEvent(events.Common.ApplicationLaunchedWithUrl)
+		evt.Context().setURL(url)
+		applicationEvents <- evt
+	}
+	androidDeepLinkReady = true
+	androidDeepLinkLock.Unlock()
+}
+
 // JNI Export Functions - Called from Java
 
 //export Java_com_wails_app_WailsBridge_nativeInit
@@ -781,6 +833,20 @@ func Java_com_wails_app_WailsBridge_nativeEmitEvent(env *C.JNIEnv, obj C.jobject
 	C.releaseJString(env, jjson, cJSON)
 
 	emitNativeEventToJS(name, jsonStr)
+}
+
+// Java_com_wails_app_WailsBridge_nativeOnDeepLink is the funnel MainActivity
+// calls when the Activity is launched or resumed via a deep link (App Link or
+// custom-scheme intent). It delivers the URL as the cross-platform
+// common:ApplicationLaunchedWithUrl application event.
+//
+//export Java_com_wails_app_WailsBridge_nativeOnDeepLink
+func Java_com_wails_app_WailsBridge_nativeOnDeepLink(env *C.JNIEnv, obj C.jobject, jurl C.jstring) {
+	cUrl := C.jstringToC(env, jurl)
+	url := C.GoString(cUrl)
+	C.releaseJString(env, jurl, cUrl)
+
+	emitAndroidDeepLink(url)
 }
 
 //export Java_com_wails_app_WailsBridge_nativeOnPageFinished

--- a/v3/pkg/application/application_ios.go
+++ b/v3/pkg/application/application_ios.go
@@ -214,6 +214,10 @@ func (a *iosApp) run() error {
 
 		// Emit the launch event now that listeners are wired and UIKit is up.
 		applicationEvents <- newApplicationEvent(events.IOS.ApplicationDidFinishLaunching)
+
+		// Deep-link listeners are now wired; deliver any URL that arrived during
+		// cold launch and allow subsequent deep links to emit immediately.
+		flushIOSPendingDeepLinks()
 	}()
 
 	// Hand the main thread to UIKit. platformRun calls UIApplicationMain and does
@@ -422,6 +426,56 @@ func processApplicationEvent(eventID C.uint, data unsafe.Pointer) {
 
 	// Send to the applicationEvents channel for processing
 	applicationEvents <- event
+}
+
+// iOS deep-link (Universal Link / custom scheme) delivery. The delegate's
+// continueUserActivity/openURL callbacks can fire before the Go event listeners
+// are wired (notably on cold launch), so URLs received before the runtime is
+// ready are buffered and flushed once listeners are up (see flushIOSPendingDeepLinks).
+var (
+	iosDeepLinkLock     sync.Mutex
+	iosDeepLinkReady    bool
+	iosPendingDeepLinks []string
+)
+
+func emitIOSDeepLink(url string) {
+	event := newApplicationEvent(events.Common.ApplicationLaunchedWithUrl)
+	event.Context().setURL(url)
+	applicationEvents <- event
+}
+
+// flushIOSPendingDeepLinks marks deep-link delivery ready and emits any URLs
+// that arrived before the event listeners were wired. Called once from the
+// startup goroutine after ApplicationDidFinishLaunching is emitted.
+func flushIOSPendingDeepLinks() {
+	iosDeepLinkLock.Lock()
+	iosDeepLinkReady = true
+	pending := iosPendingDeepLinks
+	iosPendingDeepLinks = nil
+	iosDeepLinkLock.Unlock()
+	for _, url := range pending {
+		emitIOSDeepLink(url)
+	}
+}
+
+// iosHandleDeepLink is called from the Objective-C app delegate when the app is
+// opened via a Universal Link or custom-scheme URL. It delivers the URL as the
+// cross-platform common:ApplicationLaunchedWithUrl application event.
+//
+//export iosHandleDeepLink
+func iosHandleDeepLink(curl *C.char) {
+	url := C.GoString(curl)
+	if url == "" {
+		return
+	}
+	iosDeepLinkLock.Lock()
+	if !iosDeepLinkReady {
+		iosPendingDeepLinks = append(iosPendingDeepLinks, url)
+		iosDeepLinkLock.Unlock()
+		return
+	}
+	iosDeepLinkLock.Unlock()
+	emitIOSDeepLink(url)
 }
 
 //export processWindowEvent

--- a/v3/pkg/application/application_ios.go
+++ b/v3/pkg/application/application_ios.go
@@ -214,6 +214,10 @@ func (a *iosApp) run() error {
 
 		// Emit the launch event now that listeners are wired and UIKit is up.
 		applicationEvents <- newApplicationEvent(events.IOS.ApplicationDidFinishLaunching)
+
+		// Deep-link listeners are now wired; deliver any URL that arrived during
+		// cold launch and allow subsequent deep links to emit immediately.
+		flushIOSPendingDeepLinks()
 	}()
 
 	// Hand the main thread to UIKit. platformRun calls UIApplicationMain and does
@@ -417,6 +421,56 @@ func processApplicationEvent(eventID C.uint, data unsafe.Pointer) {
 
 	// Send to the applicationEvents channel for processing
 	applicationEvents <- event
+}
+
+// iOS deep-link (Universal Link / custom scheme) delivery. The delegate's
+// continueUserActivity/openURL callbacks can fire before the Go event listeners
+// are wired (notably on cold launch), so URLs received before the runtime is
+// ready are buffered and flushed once listeners are up (see flushIOSPendingDeepLinks).
+var (
+	iosDeepLinkLock     sync.Mutex
+	iosDeepLinkReady    bool
+	iosPendingDeepLinks []string
+)
+
+func emitIOSDeepLink(url string) {
+	event := newApplicationEvent(events.Common.ApplicationLaunchedWithUrl)
+	event.Context().setURL(url)
+	applicationEvents <- event
+}
+
+// flushIOSPendingDeepLinks marks deep-link delivery ready and emits any URLs
+// that arrived before the event listeners were wired. Called once from the
+// startup goroutine after ApplicationDidFinishLaunching is emitted.
+func flushIOSPendingDeepLinks() {
+	iosDeepLinkLock.Lock()
+	iosDeepLinkReady = true
+	pending := iosPendingDeepLinks
+	iosPendingDeepLinks = nil
+	iosDeepLinkLock.Unlock()
+	for _, url := range pending {
+		emitIOSDeepLink(url)
+	}
+}
+
+// iosHandleDeepLink is called from the Objective-C app delegate when the app is
+// opened via a Universal Link or custom-scheme URL. It delivers the URL as the
+// cross-platform common:ApplicationLaunchedWithUrl application event.
+//
+//export iosHandleDeepLink
+func iosHandleDeepLink(curl *C.char) {
+	url := C.GoString(curl)
+	if url == "" {
+		return
+	}
+	iosDeepLinkLock.Lock()
+	if !iosDeepLinkReady {
+		iosPendingDeepLinks = append(iosPendingDeepLinks, url)
+		iosDeepLinkLock.Unlock()
+		return
+	}
+	iosDeepLinkLock.Unlock()
+	emitIOSDeepLink(url)
 }
 
 //export processWindowEvent

--- a/v3/pkg/application/application_ios_delegate.m
+++ b/v3/pkg/application/application_ios_delegate.m
@@ -6,6 +6,9 @@ extern void processApplicationEvent(unsigned int, void* data);
 extern void processWindowEvent(unsigned int, unsigned int);
 extern bool hasListeners(unsigned int);
 extern void iosApplicationDidLaunch(void);
+// Delivers a Universal Link / custom-scheme URL to the Go event bus as the
+// cross-platform common:ApplicationLaunchedWithUrl event.
+extern void iosHandleDeepLink(char* url);
 // WailsIOSMain (app's generated main_ios.go) runs the user's main()/app.Run().
 // The delegate starts it AFTER UIKit has launched (see below).
 extern void WailsIOSMain(void);
@@ -66,6 +69,34 @@ extern void ios_notifications_init(void);
         WailsIOSMain();
     });
     return YES;
+}
+
+// Universal Links. On cold launch iOS invokes this after
+// didFinishLaunchingWithOptions returns YES, so it also covers the cold-start
+// case; the Go side buffers URLs that arrive before listeners are wired.
+- (BOOL)application:(UIApplication *)application
+        continueUserActivity:(NSUserActivity *)userActivity
+        restorationHandler:(void (^)(NSArray<id<UIUserActivityRestoring>> *restorableObjects))restorationHandler {
+    if ([userActivity.activityType isEqualToString:NSUserActivityTypeBrowsingWeb]) {
+        NSURL *url = userActivity.webpageURL;
+        if (url != nil) {
+            iosHandleDeepLink((char *)[url.absoluteString UTF8String]);
+            return YES;
+        }
+    }
+    return NO;
+}
+
+// Custom URL schemes (e.g. myapp://callback). Also fires on cold launch after
+// didFinishLaunchingWithOptions.
+- (BOOL)application:(UIApplication *)application
+        openURL:(NSURL *)url
+        options:(NSDictionary<UIApplicationOpenURLOptionsKey, id> *)options {
+    if (url != nil) {
+        iosHandleDeepLink((char *)[url.absoluteString UTF8String]);
+        return YES;
+    }
+    return NO;
 }
 // GENERATED EVENTS START
 - (void)applicationDidBecomeActive:(UIApplication *)application {


### PR DESCRIPTION
# Description

Wires Android App Links and iOS Universal Links / custom URL schemes into the existing cross-platform `common:ApplicationLaunchedWithUrl` application event, so the same Go listener works on desktop and mobile:

```go
app.Event.OnApplicationEvent(events.Common.ApplicationLaunchedWithUrl, func(e *application.ApplicationEvent) {
    url := e.Context().URL()
    // handle OAuth/OIDC callback, email verification, shared content, ...
})
```

**Android**
- `MainActivity` handles `ACTION_VIEW` intents in `onCreate` (cold start) and `onNewIntent` (warm start) and forwards the URL via `WailsBridge.onDeepLink`.
- `WailsBridge` gains `onDeepLink` + a `nativeOnDeepLink` JNI method; `application_android.go` adds the `nativeOnDeepLink` export and an `emitAndroidDeepLink` emitter.
- `AndroidManifest.xml` ships a **commented** App Links `intent-filter` template (developer fills in their own host + `assetlinks.json`).

**iOS**
- `WailsAppDelegate` implements `application:continueUserActivity:` (Universal Links) and `application:openURL:options:` (custom schemes). This replaces the current need for app-owned Objective-C that calls the private `iosEmitNativeEvent` symbol via a category.
- `application_ios.go` adds the `iosHandleDeepLink` export; URLs that arrive before the Go listeners are wired (cold launch) are buffered and flushed after `ApplicationDidFinishLaunching`.
- `Info.plist` ships a commented `CFBundleURLTypes` template; `entitlements.plist` ships a commented `associated-domains` template.

**This is a draft proposal to open the discussion** (per the v3 feedback process — happy to iterate on the event contract / API shape). Feedback especially welcome on: reusing `ApplicationLaunchedWithUrl` vs. a dedicated deep-link event, and whether an opt-in Go registration hook (e.g. `application.IOS.OnDeepLink`) is preferable to the raw export.

**Depends on / pairs with #5727** (`singleTask` launchMode): without it, Android delivers a warm-start deep link by spawning a second Activity instead of calling `onNewIntent`, so reliable warm-start delivery needs that change too.

Fixes # (no pre-existing issue — this draft PR is the proposal)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

**Android — verified end-to-end on an emulator** (Pixel 7, API 35, x86_64, headless), using a throwaway `wails3 init` vanilla project built from this branch, with a custom-scheme `intent-filter` uncommented, `android:launchMode="singleTask"` set (as the template comment recommends), and a Go listener on `ApplicationLaunchedWithUrl` forwarding the URL to the frontend:

- **Warm start** (app already running): `adb shell am start -a android.intent.action.VIEW -d "wailstest://callback?token=warm123"` → the single activity is reused (`LAUNCH_SINGLE_TASK`, no duplicate), `onNewIntent` fires, and the URL reaches the WebView UI.
- **Cold start** (app force-stopped): the same intent cold-launches the app via the intent-filter and the URL reaches the WebView (`...token=cold456`).

This exercises the full chain: `ACTION_VIEW` → `onCreate` / `onNewIntent` → `WailsBridge.onDeepLink` → JNI `nativeOnDeepLink` → `emitAndroidDeepLink` → `common:ApplicationLaunchedWithUrl` → Go listener → frontend.

Also:
- Android host (`pkg/application`) cross-compiled for `android/arm64` against the NDK.
- Desktop build (`go build -tags gtk3 ./pkg/application/`) — unaffected, compiles.
- Host command/template test suite (`go test ./internal/commands/...`) — passes.
- iOS side compile- and link-verified on a `macos-latest` runner against the real iOS SDK (the ObjC delegate + Go bridge build cleanly).

Honest caveat: the **iOS runtime path has not been device-tested** (no Mac/device available here) — it is compile/link-verified only. Verified App Links / Universal Links additionally require a signed build plus a hosted `assetlinks.json` / `apple-app-site-association`; the emulator test above uses a custom scheme, which drives the same delivery code path without the domain-verification step.

- [ ] Windows
- [ ] macOS
- [x] Linux

Linux: Ubuntu 24.04.4 LTS (build/test host; targets are Android + iOS).

## Test Configuration

- Wails CLI: v3.0.0-alpha2.117
- Go: go1.26.5
- OS: Ubuntu 24.04.4 LTS (Noble), amd64
- Android NDK: 26.3.11579264 (android/arm64); iOS compile via macos-latest / Xcode

# Checklist:

- [ ] (v2 only) I have updated `website/src/pages/changelog.mdx` with details of this PR (v3 changelog entries are added automatically) — n/a (v3)
- [x] My code follows the general coding style of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

Notes on the unchecked boxes (in the interest of an honest checklist):

- **Documentation:** flagged as needed above — deep linking warrants a setup guide (manifest intent-filter + `assetlinks.json`; entitlements + `apple-app-site-association`). Not written yet; glad to add it, and would value guidance on where it should live.
- **Tests:** the change is almost entirely build-tagged native code (`//go:build android`/`ios`, `.m`) plus templates, for which the v3 tree has no host-runnable harness (no `//go:build android|ios` tests exist). I could not add a meaningful unit test without new mobile test infrastructure. Existing host tests pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added deep-link support for Android and iOS applications.
  * Links are handled when launching the app or while it is already running.
  * iOS supports Universal Links and custom URL schemes.
  * Android supports HTTPS App Links.
  * Startup links are buffered and delivered after the application is ready.
  * Deep links are delivered through the standard application-launched-with-URL event.
  * Added configuration examples for supported link types; configuration remains inactive until customized.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->