### PR TITLE
fix(ios): document required privacy usage-description keys in Info.plist

### DIFF
--- a/v3/internal/commands/updatable_build_assets/ios/Info.plist.tmpl
+++ b/v3/internal/commands/updatable_build_assets/ios/Info.plist.tmpl
@@ -61,5 +61,26 @@
     <key>CFBundleGetInfoString</key>
     <string>{{.ProductComments}}</string>
     {{end}}
+    <!--
+      Privacy usage descriptions. iOS hard-crashes (and the App Store rejects the
+      build) the moment a permission-gated API is called without the matching
+      key. The Wails runtime exposes camera, microphone, photo library, location,
+      motion and biometric APIs; uncomment the key for each feature your app
+      actually uses and replace the string with a real, user-facing reason. Only
+      ship keys for features you use — unused keys draw App Store review scrutiny.
+
+    <key>NSCameraUsageDescription</key>
+    <string>This app uses the camera to capture photos and videos.</string>
+    <key>NSMicrophoneUsageDescription</key>
+    <string>This app uses the microphone when recording video.</string>
+    <key>NSPhotoLibraryUsageDescription</key>
+    <string>This app accesses your photo library to select images.</string>
+    <key>NSLocationWhenInUseUsageDescription</key>
+    <string>This app uses your location while you are using it.</string>
+    <key>NSMotionUsageDescription</key>
+    <string>This app uses motion data from device sensors.</string>
+    <key>NSFaceIDUsageDescription</key>
+    <string>This app uses Face ID to authenticate you.</string>
+    -->
 </dict>
 </plist>


### PR DESCRIPTION
# Description

The iOS `Info.plist` template ships **no** `NS*UsageDescription` keys, yet the Wails runtime exposes permission-gated iOS APIs — camera (`AVCaptureDevice`), microphone (video recording), photo library (`UIImagePickerController`), location (`CLLocationManager`), motion (`CoreMotion`) and biometrics (`LAContext`). On iOS, calling any of these **without** the matching usage-description key is an instant hard crash, and the App Store rejects builds that use the API without the key. Nothing in the template hints at the requirement, so an app that uses e.g. the camera or Face ID crashes the first time the feature is exercised.

This adds a **commented** block to the `Info.plist` template listing the six keys that map to the runtime's permission-gated APIs, each with a placeholder justification string, plus a header explaining that the developer must uncomment the ones their app uses. The keys are shipped commented rather than active so that apps don't declare usage descriptions for features they don't use (which itself draws App Store review scrutiny). This turns a silent, undocumented crash into a discoverable one-line opt-in.

The six keys were chosen by auditing which permission-gated APIs the runtime feature layer actually calls (`mobile_features_ios.m`): `NSCameraUsageDescription`, `NSMicrophoneUsageDescription`, `NSPhotoLibraryUsageDescription`, `NSLocationWhenInUseUsageDescription`, `NSMotionUsageDescription`, `NSFaceIDUsageDescription`.

_No pre-existing issue — this fixes a crash discovered during app development. Happy to file a tracking issue if preferred._

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- Rendered the template with empty optionals and confirmed the result parses as a valid `plist` (the commented block is inert XML).
- Ran the host-side command/template test suite (`go test ./internal/commands/...`) — passes.
- Cross-checked each key against the actual permission-gated API calls in the runtime's iOS feature layer.

Honest caveat: this is a template/manifest change; I have not exercised the crash-then-fix loop on a physical device.

- [ ] Windows
- [ ] macOS
- [x] Linux

Linux: Ubuntu 24.04.4 LTS (build/test host; the change targets iOS).

## Test Configuration

- Wails CLI: v3.0.0-alpha2.117
- Go: go1.26.5
- OS: Ubuntu 24.04.4 LTS (Noble), amd64

# Checklist:

- [ ] (v2 only) I have updated `website/src/pages/changelog.mdx` with details of this PR (v3 changelog entries are added automatically) — n/a (v3)
- [x] My code follows the general coding style of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

Notes on the unchecked boxes (in the interest of an honest checklist):

- **Documentation:** the change is self-documenting (an inline commented block with instructions in the template). No separate website docs added.
- **Tests:** the keys are shipped commented, so there is no active behaviour to assert beyond "the template still renders valid XML," which is covered by the existing host template tests. No standalone test was added.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance for configuring iOS privacy usage descriptions.
  * Documented standard permission keys for camera, microphone, photos, location, motion, and Face ID without enabling them by default.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->