### PR TITLE
fix(android): generate bindings in Android context

### DIFF
--- a/v3/examples/android/build/Taskfile.yml
+++ b/v3/examples/android/build/Taskfile.yml
@@ -36,6 +36,10 @@ tasks:
         vars:
           BUILD_FLAGS:
             ref: .BUILD_FLAGS
+          GOOS:
+            ref: .GOOS
+          CGO_ENABLED:
+            ref: .CGO_ENABLED
     cmds:
       - npm run {{.BUILD_COMMAND}} -q
     env:
@@ -87,6 +91,9 @@ tasks:
       - frontend/bindings/**/*
     cmds:
       - wails3 generate bindings -f '{{.BUILD_FLAGS}}' -clean=true
+    env:
+      GOOS: '{{.GOOS | default OS}}'
+      CGO_ENABLED: '{{.CGO_ENABLED | default ""}}'
 
   generate:icons:
     summary: Generates Windows `.ico` and Mac `.icns` files from an image

--- a/v3/examples/android/build/Taskfile.yml
+++ b/v3/examples/android/build/Taskfile.yml
@@ -22,7 +22,7 @@ tasks:
       - npm install
 
   build:frontend:
-    label: build:frontend (PRODUCTION={{.PRODUCTION}})
+    label: build:frontend (PRODUCTION={{.PRODUCTION}} GOOS={{.GOOS | default OS}} CGO_ENABLED={{.CGO_ENABLED | default ""}})
     summary: Build the frontend project
     dir: frontend
     sources:
@@ -76,7 +76,7 @@ tasks:
         fi
 
   generate:bindings:
-    label: generate:bindings (BUILD_FLAGS={{.BUILD_FLAGS}})
+    label: generate:bindings (BUILD_FLAGS={{.BUILD_FLAGS}} GOOS={{.GOOS | default OS}} CGO_ENABLED={{.CGO_ENABLED | default ""}})
     summary: Generates bindings for the frontend
     deps:
       - task: go:mod:tidy

--- a/v3/examples/android/build/android/Taskfile.yml
+++ b/v3/examples/android/build/android/Taskfile.yml
@@ -32,10 +32,6 @@ tasks:
     summary: Creates a debug build of the application for Android
     deps:
       - task: common:go:mod:tidy
-      - task: generate:android:bindings
-        vars:
-          BUILD_FLAGS:
-            ref: .BUILD_FLAGS
       - task: common:build:frontend
         vars:
           BUILD_FLAGS:
@@ -43,7 +39,7 @@ tasks:
           PRODUCTION:
             ref: .PRODUCTION
           GOOS: android
-          CGO_ENABLED: 0
+          CGO_ENABLED: "0"
       - task: common:generate:icons
     cmds:
       - echo "Building Android app {{.APP_NAME}}..."

--- a/v3/examples/android/build/android/Taskfile.yml
+++ b/v3/examples/android/build/android/Taskfile.yml
@@ -42,6 +42,8 @@ tasks:
             ref: .BUILD_FLAGS
           PRODUCTION:
             ref: .PRODUCTION
+          GOOS: android
+          CGO_ENABLED: 0
       - task: common:generate:icons
     cmds:
       - echo "Building Android app {{.APP_NAME}}..."
@@ -231,23 +233,6 @@ tasks:
         ./gradlew bundleRelease
         cp app/build/outputs/bundle/release/app-release.aab "../../{{.BIN_DIR}}/{{.APP_NAME}}.aab"
         echo "Release AAB created: {{.BIN_DIR}}/{{.APP_NAME}}.aab"
-
-  generate:android:bindings:
-    internal: true
-    summary: Generates bindings for Android
-    sources:
-      - "**/*.go"
-      - go.mod
-      - go.sum
-    generates:
-      - frontend/bindings/**/*
-    cmds:
-      # Bindings are generated from the Go AST; CGO is disabled so the NDK
-      # is not required for this step
-      - wails3 generate bindings -f '-tags android' -clean=true
-    env:
-      GOOS: android
-      CGO_ENABLED: 0
 
   ensure-emulator:
     internal: true

--- a/v3/examples/mobile/build/Taskfile.yml
+++ b/v3/examples/mobile/build/Taskfile.yml
@@ -36,6 +36,10 @@ tasks:
         vars:
           BUILD_FLAGS:
             ref: .BUILD_FLAGS
+          GOOS:
+            ref: .GOOS
+          CGO_ENABLED:
+            ref: .CGO_ENABLED
     cmds:
       - npm run {{.BUILD_COMMAND}} -q
     env:
@@ -87,6 +91,9 @@ tasks:
       - frontend/bindings/**/*
     cmds:
       - wails3 generate bindings -f '{{.BUILD_FLAGS}}' -clean=true
+    env:
+      GOOS: '{{.GOOS | default OS}}'
+      CGO_ENABLED: '{{.CGO_ENABLED | default ""}}'
 
   generate:icons:
     summary: Generates Windows `.ico` and Mac `.icns` files from an image

--- a/v3/examples/mobile/build/Taskfile.yml
+++ b/v3/examples/mobile/build/Taskfile.yml
@@ -22,7 +22,7 @@ tasks:
       - npm install
 
   build:frontend:
-    label: build:frontend (PRODUCTION={{.PRODUCTION}})
+    label: build:frontend (PRODUCTION={{.PRODUCTION}} GOOS={{.GOOS | default OS}} CGO_ENABLED={{.CGO_ENABLED | default ""}})
     summary: Build the frontend project
     dir: frontend
     sources:
@@ -76,7 +76,7 @@ tasks:
         fi
 
   generate:bindings:
-    label: generate:bindings (BUILD_FLAGS={{.BUILD_FLAGS}})
+    label: generate:bindings (BUILD_FLAGS={{.BUILD_FLAGS}} GOOS={{.GOOS | default OS}} CGO_ENABLED={{.CGO_ENABLED | default ""}})
     summary: Generates bindings for the frontend
     deps:
       - task: go:mod:tidy

--- a/v3/examples/mobile/build/android/Taskfile.yml
+++ b/v3/examples/mobile/build/android/Taskfile.yml
@@ -43,7 +43,7 @@ tasks:
           PRODUCTION:
             ref: .PRODUCTION
           GOOS: android
-          CGO_ENABLED: 0
+          CGO_ENABLED: "0"
     cmds:
       - echo "Building Android app {{.APP_NAME}}..."
       - task: compile:go:shared

--- a/v3/examples/mobile/build/android/Taskfile.yml
+++ b/v3/examples/mobile/build/android/Taskfile.yml
@@ -42,6 +42,8 @@ tasks:
             ref: .BUILD_FLAGS
           PRODUCTION:
             ref: .PRODUCTION
+          GOOS: android
+          CGO_ENABLED: 0
     cmds:
       - echo "Building Android app {{.APP_NAME}}..."
       - task: compile:go:shared
@@ -241,23 +243,6 @@ tasks:
       - build/android/gen/main_android.gen.go
     cmds:
       - wails3 android overlay:gen -out build/android/overlay.json -config build/config.yml
-
-  generate:android:bindings:
-    internal: true
-    summary: Generates bindings for Android
-    sources:
-      - "**/*.go"
-      - go.mod
-      - go.sum
-    generates:
-      - frontend/bindings/**/*
-    cmds:
-      # Bindings are generated from the Go AST; CGO is disabled so the NDK
-      # is not required for this step
-      - wails3 generate bindings -f '-tags android' -clean=true
-    env:
-      GOOS: android
-      CGO_ENABLED: 0
 
   ensure-emulator:
     internal: true

--- a/v3/internal/commands/android_taskfile_test.go
+++ b/v3/internal/commands/android_taskfile_test.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -55,11 +56,27 @@ func TestAndroidTaskfileRunDevice(t *testing.T) {
 func TestAndroidTaskfileBuildUsesAndroidBindingContext(t *testing.T) {
 	// Given
 	buildTask := androidTaskYAML(t, "build")
+	var task struct {
+		Deps []struct {
+			Task string         `yaml:"task"`
+			Vars map[string]any `yaml:"vars"`
+		} `yaml:"deps"`
+	}
+	require.NoError(t, yaml.Unmarshal([]byte(buildTask), &task))
 
 	// Then
 	assert.Contains(t, buildTask, "task: common:build:frontend")
 	assert.Contains(t, buildTask, "GOOS: android")
-	assert.Contains(t, buildTask, "CGO_ENABLED: 0")
+	assert.NotContains(t, buildTask, "generate:android:bindings")
+
+	for _, dependency := range task.Deps {
+		if dependency.Task == "common:build:frontend" {
+			require.Equal(t, "android", dependency.Vars["GOOS"])
+			require.Equal(t, "0", dependency.Vars["CGO_ENABLED"])
+			return
+		}
+	}
+	t.Fatal("Android build should depend on common:build:frontend")
 }
 
 func TestCommonTaskfileForwardsBindingContext(t *testing.T) {
@@ -73,6 +90,35 @@ func TestCommonTaskfileForwardsBindingContext(t *testing.T) {
 	assert.Contains(t, taskfile, "ref: .CGO_ENABLED")
 	assert.Contains(t, taskfile, `GOOS: '{{.Opn}}.GOOS | default OS{{.Cls}}'`)
 	assert.Contains(t, taskfile, `CGO_ENABLED: '{{.Opn}}.CGO_ENABLED | default ""{{.Cls}}'`)
+	assert.Contains(t, taskfile, `label: build:frontend (DEV={{.Opn}}.DEV{{.Cls}} RUNNER={{.Opn}}.PACKAGE_MANAGER{{.Cls}} GOOS={{.Opn}}.GOOS | default OS{{.Cls}} CGO_ENABLED={{.Opn}}.CGO_ENABLED | default ""{{.Cls}})`)
+	assert.Contains(t, taskfile, `label: generate:bindings (GOOS={{.Opn}}.GOOS | default OS{{.Cls}} CGO_ENABLED={{.Opn}}.CGO_ENABLED | default ""{{.Cls}})`)
+}
+
+func TestAndroidExamplesUseCommonBindingContext(t *testing.T) {
+	for _, path := range []string{
+		"../../examples/android/build/android/Taskfile.yml",
+		"../../examples/mobile/build/android/Taskfile.yml",
+	} {
+		data, err := os.ReadFile(path)
+		require.NoError(t, err)
+		taskfile := string(data)
+
+		assert.NotContains(t, taskfile, "generate:android:bindings", path)
+		assert.Contains(t, taskfile, "task: common:build:frontend", path)
+		assert.Contains(t, taskfile, `CGO_ENABLED: "0"`, path)
+	}
+
+	for _, path := range []string{
+		"../../examples/android/build/Taskfile.yml",
+		"../../examples/mobile/build/Taskfile.yml",
+	} {
+		data, err := os.ReadFile(path)
+		require.NoError(t, err)
+		taskfile := string(data)
+
+		assert.Contains(t, taskfile, `GOOS={{.GOOS | default OS}}`, path)
+		assert.Contains(t, taskfile, `CGO_ENABLED={{.CGO_ENABLED | default ""}}`, path)
+	}
 }
 
 func androidTaskYAML(t *testing.T, name string) string {

--- a/v3/internal/commands/android_taskfile_test.go
+++ b/v3/internal/commands/android_taskfile_test.go
@@ -101,11 +101,32 @@ func TestAndroidExamplesUseCommonBindingContext(t *testing.T) {
 	} {
 		data, err := os.ReadFile(path)
 		require.NoError(t, err)
-		taskfile := string(data)
 
-		assert.NotContains(t, taskfile, "generate:android:bindings", path)
-		assert.Contains(t, taskfile, "task: common:build:frontend", path)
-		assert.Contains(t, taskfile, `CGO_ENABLED: "0"`, path)
+		var taskfile struct {
+			Tasks map[string]yaml.Node `yaml:"tasks"`
+		}
+		require.NoError(t, yaml.Unmarshal(data, &taskfile), path)
+		buildNode, ok := taskfile.Tasks["build"]
+		require.True(t, ok, "%s should include a build task", path)
+		var buildTask struct {
+			Deps []struct {
+				Task string         `yaml:"task"`
+				Vars map[string]any `yaml:"vars"`
+			} `yaml:"deps"`
+		}
+		require.NoError(t, buildNode.Decode(&buildTask), path)
+		assert.NotContains(t, string(data), "generate:android:bindings", path)
+
+		foundFrontendBuild := false
+		for _, dependency := range buildTask.Deps {
+			if dependency.Task != "common:build:frontend" {
+				continue
+			}
+			foundFrontendBuild = true
+			assert.Equal(t, "android", dependency.Vars["GOOS"], path)
+			assert.Equal(t, "0", dependency.Vars["CGO_ENABLED"], path)
+		}
+		assert.True(t, foundFrontendBuild, "%s build task should depend on common:build:frontend", path)
 	}
 
 	for _, path := range []string{

--- a/v3/internal/commands/android_taskfile_test.go
+++ b/v3/internal/commands/android_taskfile_test.go
@@ -52,6 +52,29 @@ func TestAndroidTaskfileRunDevice(t *testing.T) {
 	assert.NotContains(t, runDeviceTask, "ensure-emulator")
 }
 
+func TestAndroidTaskfileBuildUsesAndroidBindingContext(t *testing.T) {
+	// Given
+	buildTask := androidTaskYAML(t, "build")
+
+	// Then
+	assert.Contains(t, buildTask, "task: common:build:frontend")
+	assert.Contains(t, buildTask, "GOOS: android")
+	assert.Contains(t, buildTask, "CGO_ENABLED: 0")
+}
+
+func TestCommonTaskfileForwardsBindingContext(t *testing.T) {
+	// Given
+	data, err := buildAssets.ReadFile("build_assets/Taskfile.tmpl.yml")
+	require.NoError(t, err)
+	taskfile := string(data)
+
+	// Then
+	assert.Contains(t, taskfile, "ref: .GOOS")
+	assert.Contains(t, taskfile, "ref: .CGO_ENABLED")
+	assert.Contains(t, taskfile, `GOOS: '{{.Opn}}.GOOS | default OS{{.Cls}}'`)
+	assert.Contains(t, taskfile, `CGO_ENABLED: '{{.Opn}}.CGO_ENABLED | default ""{{.Cls}}'`)
+}
+
 func androidTaskYAML(t *testing.T, name string) string {
 	t.Helper()
 

--- a/v3/internal/commands/build_assets/Taskfile.tmpl.yml
+++ b/v3/internal/commands/build_assets/Taskfile.tmpl.yml
@@ -70,7 +70,7 @@ tasks:
       - yarn install
 
   build:frontend:
-    label: build:frontend (DEV={{.Opn}}.DEV{{.Cls}} RUNNER={{.Opn}}.PACKAGE_MANAGER{{.Cls}})
+    label: build:frontend (DEV={{.Opn}}.DEV{{.Cls}} RUNNER={{.Opn}}.PACKAGE_MANAGER{{.Cls}} GOOS={{.Opn}}.GOOS | default OS{{.Cls}} CGO_ENABLED={{.Opn}}.CGO_ENABLED | default ""{{.Cls}})
     summary: Build the frontend project
     # darwin:build:universal runs its per-arch builds as parallel deps, each of
     # which depends on this task. Without run:once the two executions race:
@@ -178,6 +178,7 @@ tasks:
 
 
   generate:bindings:
+    label: generate:bindings (GOOS={{.Opn}}.GOOS | default OS{{.Cls}} CGO_ENABLED={{.Opn}}.CGO_ENABLED | default ""{{.Cls}})
     summary: Generates bindings for the frontend
     run: once
     deps:

--- a/v3/internal/commands/build_assets/Taskfile.tmpl.yml
+++ b/v3/internal/commands/build_assets/Taskfile.tmpl.yml
@@ -92,6 +92,10 @@ tasks:
             ref: .BUILD_FLAGS
           OBFUSCATED:
             ref: .OBFUSCATED
+          GOOS:
+            ref: .GOOS
+          CGO_ENABLED:
+            ref: .CGO_ENABLED
     cmds:
       - task: frontend:run
         vars:
@@ -189,6 +193,9 @@ tasks:
       - frontend/bindings/**/*
     cmds:
       - wails3 generate bindings -f '{{.Opn}}.BUILD_FLAGS{{.Cls}}' -clean=true{{if not (and .UseInterfaces .Typescript)}} -time-type=Date{{end}}{{.Opn}}if eq .OBFUSCATED "true"{{.Cls}} -obfuscated{{.Opn}}end{{.Cls}}{{if .Typescript}} -ts{{end}}{{if and .UseInterfaces .Typescript}} -i{{end}}
+    env:
+      GOOS: '{{.Opn}}.GOOS | default OS{{.Cls}}'
+      CGO_ENABLED: '{{.Opn}}.CGO_ENABLED | default ""{{.Cls}}'
 
   generate:icons:
     summary: Generates Windows `.ico` and Mac `.icns` from an image; on macOS, `-iconcomposerinput appicon.icon -macassetdir darwin` also produces `Assets.car` from a `.icon` file (skipped on other platforms).

--- a/v3/internal/commands/build_assets/android/Taskfile.yml
+++ b/v3/internal/commands/build_assets/android/Taskfile.yml
@@ -47,7 +47,7 @@ tasks:
           PRODUCTION:
             ref: .PRODUCTION
           GOOS: android
-          CGO_ENABLED: 0
+          CGO_ENABLED: "0"
     cmds:
       - echo "Building Android app {{.APP_NAME}}..."
       - task: compile:go:shared

--- a/v3/internal/commands/build_assets/android/Taskfile.yml
+++ b/v3/internal/commands/build_assets/android/Taskfile.yml
@@ -46,6 +46,8 @@ tasks:
             ref: .BUILD_FLAGS
           PRODUCTION:
             ref: .PRODUCTION
+          GOOS: android
+          CGO_ENABLED: 0
     cmds:
       - echo "Building Android app {{.APP_NAME}}..."
       - task: compile:go:shared
@@ -249,23 +251,6 @@ tasks:
       - build/android/gen/main_android.gen.go
     cmds:
       - wails3 android overlay:gen -out build/android/overlay.json -config build/config.yml
-
-  generate:android:bindings:
-    internal: true
-    summary: Generates bindings for Android
-    sources:
-      - "**/*.go"
-      - go.mod
-      - go.sum
-    generates:
-      - frontend/bindings/**/*
-    cmds:
-      # Bindings are generated from the Go AST; CGO is disabled so the NDK
-      # is not required for this step
-      - wails3 generate bindings -f '-tags android' -clean=true
-    env:
-      GOOS: android
-      CGO_ENABLED: 0
 
   ensure-emulator:
     internal: true

--- a/v3/internal/generator/load_android_test.go
+++ b/v3/internal/generator/load_android_test.go
@@ -1,0 +1,23 @@
+package generator
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadPackagesAndroidWithoutCGO(t *testing.T) {
+	t.Setenv("GOOS", "android")
+	t.Setenv("CGO_ENABLED", "0")
+
+	packages, err := LoadPackages(
+		[]string{"-tags", "android,debug"},
+		"github.com/wailsapp/wails/v3/pkg/application",
+	)
+	require.NoError(t, err)
+	require.NotEmpty(t, packages, "LoadPackages returned no packages")
+
+	for _, pkg := range packages {
+		require.Empty(t, pkg.Errors, "package %s has loading errors", pkg.PkgPath)
+	}
+}

--- a/v3/pkg/application/application_android_nocgo.go
+++ b/v3/pkg/application/application_android_nocgo.go
@@ -45,6 +45,12 @@ func androidBridgeString(method string) (string, bool) {
 	return "", false
 }
 
+func androidBridgeStringString(method string, arg string) (string, bool) {
+	return "", false
+}
+
+func androidBridgeVoid(method string) {}
+
 func androidBridgeVoidString(method string, arg string) {}
 
 func androidBridgeVoidInt(method string, v int) {}


### PR DESCRIPTION
# Description

Android builds passed the `android` build tag to the common binding generator
without changing its Go target from the host OS. On macOS, package loading
therefore selected both Darwin files and explicitly tagged Android files,
producing 98 analyzer warnings even though the later Android compilation
succeeded.

This change:

- forwards `GOOS` and `CGO_ENABLED` through the common frontend/binding task;
- generates Android bindings with `GOOS=android` and `CGO_ENABLED=0`, so this
  step still does not require the NDK;
- adds the two Android no-CGO bridge stubs exposed by the correct target
  context;
- removes the unused duplicate Android binding task; and
- keeps the checked-in Android/mobile examples in sync with the template.

Fixes #5810

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [ ] Windows
- [x] macOS
- [ ] Linux

Before the fix, the stock `v3/examples/mobile` project emitted 98 warnings:

```sh
GOWORK=off wails3 generate bindings -dry -clean=false -f "-tags android,debug"
```

With the fixed CLI and Android task context, the same example processed 229
packages with no analyzer warnings:

```sh
GOWORK=off GOOS=android CGO_ENABLED=0 \
  wails3 generate bindings -dry -clean=false -f "-tags android,debug"
```

The complete Android task path also succeeds without binding warnings:

```sh
GOWORK=off wails3 task android:build -f
```

Regression and full test suites:

```sh
go test ./internal/commands ./internal/generator ./pkg/application
go test ./...
```

Desktop binding generation was also checked with the default host context and
completed without warnings.

## Test Configuration

```text
Wails CLI: v3.0.0-dev (built from this branch)
Go: go1.26.5
OS: macOS 26.5.2 (arm64, Apple Silicon)
Android SDK: installed
Android NDK: 28.2.13676358
Java: OpenJDK 17.0.19
```

# Checklist:

- [x] (v2 only) I have updated `website/src/pages/changelog.mdx` with details of this PR (not applicable; this is a v3 change and v3 changelog entries are added automatically)
- [x] My code follows the general coding style of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (not applicable; this fixes build task behavior without changing the user-facing API)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Android and mobile build workflows by consistently propagating platform (`GOOS`) and `CGO_ENABLED` settings into frontend builds and binding generation.
  - Binding generation now works correctly for Android builds without CGO.
  - Added safe JNI bridge fallbacks for Android when CGO is disabled.
- **Tests**
  - Added/expanded automated checks to verify generated build Taskfiles correctly include `GOOS`/`CGO_ENABLED` forwarding and that Android no-CGO package loading succeeds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->