### PR TITLE
fix: repair vue-ts template script block

### DIFF
--- a/v2/pkg/templates/generate/assets/vue-ts/frontend/src/App.vue
+++ b/v2/pkg/templates/generate/assets/vue-ts/frontend/src/App.vue
@@ -1,5 +1,6 @@
 <script lang="ts" setup>
-import HelloWorld from './components/HelloWorld.vue'</script>
+import HelloWorld from './components/HelloWorld.vue'
+</script>
 
 <template>
   <img id="logo" alt="Wails logo" src="./assets/images/logo-universal.png"/>

--- a/v2/pkg/templates/templates/vue-ts/frontend/src/App.vue
+++ b/v2/pkg/templates/templates/vue-ts/frontend/src/App.vue
@@ -1,5 +1,6 @@
 <script lang="ts" setup>
-import HelloWorld from './components/HelloWorld.vue'</script>
+import HelloWorld from './components/HelloWorld.vue'
+</script>
 
 <template>
   <img id="logo" alt="Wails logo" src="./assets/images/logo-universal.png"/>

--- a/v2/pkg/templates/templates_test.go
+++ b/v2/pkg/templates/templates_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/matryer/is"
@@ -51,6 +52,33 @@ func TestInstall(t *testing.T) {
 	_, _, err = Install(options)
 	is2.NoErr(err)
 
+}
+
+func TestVueTSTemplateAppScriptBlock(t *testing.T) {
+	paths := []string{
+		"templates/vue-ts/frontend/src/App.vue",
+		"generate/assets/vue-ts/frontend/src/App.vue",
+	}
+	const scriptBlock = `<script lang="ts" setup>
+import HelloWorld from './components/HelloWorld.vue'
+</script>`
+
+	var canonical string
+	for _, path := range paths {
+		contents, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read %s: %v", path, err)
+		}
+
+		if !strings.Contains(string(contents), scriptBlock) {
+			t.Errorf("%s does not contain a valid App script block", path)
+		}
+		if canonical == "" {
+			canonical = string(contents)
+		} else if string(contents) != canonical {
+			t.Errorf("%s has drifted from %s", path, paths[0])
+		}
+	}
 }
 
 func TestInstallFailsInNonEmptyDirectory(t *testing.T) {

--- a/website/src/pages/changelog.mdx
+++ b/website/src/pages/changelog.mdx
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed generated Vue TypeScript apps failing to compile due to a malformed script block [`#5802`](https://github.com/wailsapp/wails/issues/5802) by `@cyphercodes`
+
 ## v2.13.0 - 2026-07-06
 ### Added
 


### PR DESCRIPTION
# Description

Moves the Vue TypeScript template's closing `</script>` tag onto its own line so generated `App.vue` files compile correctly. The regression test covers both the shipped template and its generator asset copy, and also guards against drift between them.

Fixes #5802

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [ ] Windows
- [ ] macOS
- [x] Linux

Linux distro: Ubuntu 24.04

- `GOWORK=off go test ./pkg/templates -run TestVueTSTemplateAppScriptBlock -count=1`
- `GOWORK=off go test ./pkg/templates -count=1`
- `GOWORK=off go vet ./pkg/templates`
- Generated a `vue-ts` project with `templates.Install`, then ran `npm install --no-package-lock` and `npm run build` in its frontend
- `git diff --check`

## Test Configuration

`wails doctor` was not run because the CLI is not installed in this isolated checkout. Test environment: Ubuntu 24.04 (linux/amd64), Go 1.25.0, Node.js 22.22.2, npm 10.9.7.

# Checklist:

- [x] (v2 only) I have updated `website/src/pages/changelog.mdx` with details of this PR (v3 changelog entries are added automatically)
- [x] My code follows the general coding style of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Vue TypeScript app compilation failures caused by a malformed script block in generated templates.

* **Documentation**
  * Added the fix to the unreleased changelog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->