### PR TITLE
docs: state the terms contributions are accepted under

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,3 +23,18 @@ Thanks for your interest in contributing! Wails has two active tracks. Pick the 
 - Update the relevant changelog file (see above).
 - Follow the existing coding style in the area you're touching.
 - Add tests where it makes sense.
+
+## Licence and provenance
+
+Wails is released under the [MIT Licence](LICENSE), and contributions come in
+under the same terms. By opening a pull request you confirm that:
+
+- You wrote the contribution yourself, or you have the right to submit it.
+- You are licensing it to the project under the MIT Licence.
+- Any third-party code included in it is compatibly licensed, and its origin
+  and licence are stated in the pull request.
+
+There is no CLA to sign and no sign-off trailer to add. If you are unsure
+whether something you want to include is safe to contribute, ask in the pull
+request before merging rather than after: sorting out the provenance of code
+that has already shipped is considerably harder than sorting it out up front.


### PR DESCRIPTION
`CONTRIBUTING.md` never said what licence contributions come in under, whether a CLA applies, or whether a sign-off trailer is required. That is a routine question for anyone contributing from inside a company, and leaving it implicit means each of them has to ask or guess.

This states the position that already applies rather than introducing a new one: MIT in, MIT out, no CLA, no DCO trailer, and third-party code disclosed in the pull request.

Found while auditing release readiness for the beta: "contribution terms documented" is a standard legal gate for a major release, and it was the only one of that group failing.

If you would rather require DCO sign-off, that is a different and larger change (it needs a bot and it affects every contributor), so I have not assumed it here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance on licensing and contribution provenance.
  * Clarified MIT licensing expectations for contributions and third-party code.
  * Noted that no contributor license agreement or sign-off trailer is required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->