### PR TITLE
ci(v3): keep @wailsio/runtime in lockstep with the CLI version

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -6,6 +6,9 @@ on:
       # Self-heal: if bundle bytes ever change on master without a matching
       # source change, this rebuild overwrites them with source-derived output.
       - 'v3/internal/assetserver/bundledassets/**'
+      # The runtime version is derived from this file, so a release that moves
+      # it must trigger a publish.
+      - 'v3/internal/version/version.txt'
       - '.github/workflows/publish-npm.yml'
   workflow_dispatch:
 
@@ -47,6 +50,7 @@ jobs:
             v3/internal/runtime/desktop/@wailsio/runtime/tsconfig.json
             v3/internal/runtime/desktop/@wailsio/runtime/src/**
             v3/internal/assetserver/bundledassets/**
+            v3/internal/version/version.txt
             v3/pkg/events/events.txt
             v3/tasks/events/**
 
@@ -135,11 +139,46 @@ jobs:
           done
           echo "All expected runtime artifacts were generated."
 
-      - name: Bump version
+      - name: Set version from the CLI version file
         id: bump-version
-        working-directory: v3/internal/runtime/desktop/@wailsio/runtime
+        # The npm package version is taken from v3/internal/version/version.txt,
+        # the same file go:embed puts into the CLI, so the runtime and the CLI
+        # always report the same version.
+        #
+        # This replaces `npm version prerelease`, which incremented the trailing
+        # numeric identifier with no knowledge of the release channel. That is
+        # how the two version series drifted apart: the CLI moved alpha ->
+        # alpha2 -> beta while npm kept counting alpha.N, so a beta CLI shipped
+        # next to an "alpha" runtime and every upgrading user had to be told
+        # that the mismatch was expected.
         run: |
-          echo "version=$(npm --no-git-tag-version --force version prerelease)" >> "$GITHUB_OUTPUT"
+          set -euo pipefail
+          VERSION="$(tr -d '[:space:]' < v3/internal/version/version.txt)"
+          VERSION="${VERSION#v}"
+          if [[ -z "$VERSION" ]]; then
+            echo "::error::v3/internal/version/version.txt is empty"
+            exit 1
+          fi
+          cd v3/internal/runtime/desktop/@wailsio/runtime
+          npm --no-git-tag-version --allow-same-version version "$VERSION"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Runtime version set to $VERSION (from version.txt)"
+
+      - name: Skip publish if this version is already on npm
+        id: already-published
+        # Lockstep means the version only moves when version.txt moves, so a run
+        # triggered by a runtime source change between releases would otherwise
+        # try to republish an existing version and fail. Regenerated assets are
+        # still committed below; only the publish is skipped.
+        run: |
+          set -euo pipefail
+          VERSION="${{ steps.bump-version.outputs.version }}"
+          if npm view "@wailsio/runtime@${VERSION}" version >/dev/null 2>&1; then
+            echo "published=true" >> "$GITHUB_OUTPUT"
+            echo "::notice::@wailsio/runtime@${VERSION} is already on npm; skipping publish. It will publish when version.txt next moves."
+          else
+            echo "published=false" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Commit regenerated runtime + version bump
         # Commit ALL regenerated tracked files back to master, not just the
@@ -172,8 +211,9 @@ jobs:
         # short-lived publish credential. Provenance is attached automatically.
         # Requires a Trusted Publisher to be configured for @wailsio/runtime on
         # npmjs.com (repo: wailsapp/wails, workflow: publish-npm.yml).
+        if: steps.already-published.outputs.published != 'true'
         working-directory: v3/internal/runtime/desktop/@wailsio/runtime
-        # --tag latest: v3 ships prerelease (alpha.N) as the default dist-tag,
-        # matching the templates' "@wailsio/runtime": "latest" pin. npm >= 11
-        # requires an explicit --tag to publish a prerelease as latest.
+        # --tag latest: v3 ships prereleases as the default dist-tag, matching
+        # the templates' "@wailsio/runtime": "latest" pin. npm >= 11 requires an
+        # explicit --tag to publish a prerelease as latest.
         run: npm publish --access public --tag latest


### PR DESCRIPTION
## The problem

`publish-npm.yml` bumped the package with:

```
npm --no-git-tag-version --force version prerelease
```

That increments the trailing numeric identifier and knows nothing about the release channel. It is exactly why the two version series drifted apart: the CLI moved `alpha` → `alpha2` → `beta` while npm carried on counting `alpha.N`.

Today the CLI reports `v3.0.0-alpha2.117` and npm's latest is `3.0.0-alpha.97`. At beta that becomes user-visible: a `v3.0.0-beta.0` CLI sitting next to an `@wailsio/runtime` that still says `alpha`, and every upgrading user has to be told the mismatch is fine.

## The change

The runtime version now comes from `v3/internal/version/version.txt` — the same file `go:embed` puts into the CLI — so the two always agree.

Two consequences handled:

- **Republish.** The version now only moves when `version.txt` moves, so a run triggered by a runtime source change between releases would try to republish an existing version and fail. Those runs now skip the publish step while still committing regenerated assets, with a notice explaining why.
- **Trigger.** `version.txt` is added to both the trigger paths and the detect job's file list, so a release that moves it does publish.

## Merging this publishes nothing

A workflow-file-only change does not match the detect job's file lists, so the publish job will not run on merge. I deliberately did **not** bump `package.json` in this PR for that reason.

The next publish happens when `version.txt` next moves, and it will be `3.0.0-alpha2.117` rather than `3.0.0-alpha.98`. That sorts higher under semver, so `latest` resolution and every downstream pin behave correctly. It is a visible jump in the npm series, which is the one-off cost of ending the drift.

## Verification

- `actionlint` clean.
- Version derivation exercised against the real `version.txt` (`v3.0.0-alpha2.117` → `3.0.0-alpha2.117`) and against the beta branch value (`v3.0.0-beta.0` → `3.0.0-beta.0`).
- The already-published guard exercised against the live registry: correctly reports `3.0.0-alpha.97` as present (would skip) and `3.0.0-beta.0` as absent (would publish).

Once this is in, the alpha-to-beta upgrade page on the beta branch loses its "the runtime version will not match your CLI" caveat, which is a better outcome than documenting the confusion.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Runtime releases now use the exact version specified for the release.
  * Publishing automatically skips versions already available on npm while continuing related release updates.
  * Release publishing now applies the appropriate npm `latest` tag behavior.
* **Bug Fixes**
  * Changes to the release version now reliably trigger the publishing workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->