### PR TITLE
chore(beta): add the release record and comms drafts

### DIFF
--- a/.release/v3.0.0-beta.0/README.md
+++ b/.release/v3.0.0-beta.0/README.md
@@ -41,3 +41,43 @@ Against this branch: 17 checks passing, 0 warnings, 2 blockers.
    tag in the `alpha2.` series before using it for real.
 3. This branch drifts behind master quickly. Re-sync and re-audit immediately
    before tagging; `relman audit` now blocks on it.
+
+## Findings worth acting on after the beta
+
+Noticed while preparing this release. None are release-blocking; all of them
+cost something later if forgotten.
+
+**v3 CI compiles the GTK4 backend against exactly one GTK version.** The v3 test
+matrix is `[windows-latest, ubuntu-latest, macos-latest]`, so `linux_cgo.go` is
+only ever built against whatever GTK ubuntu-latest carries. The single
+`ubuntu-22.04` job in the repository lives in `build-and-test.yml`, which is the
+v2 workflow and never compiles that file. A contributor can therefore use a GTK
+symbol newer than the project's real floor and CI will pass.
+
+In practice the floor is set by `#cgo linux pkg-config: gtk4 webkitgtk-6.0`:
+requiring WebKitGTK 6.0 already excludes the older distributions, which is why
+this has not bitten yet. The cheap mitigation is to state a minimum GTK4 version
+in the installation docs so contributors know what they may use, rather than
+adding a matrix entry for distributions that cannot satisfy the WebKitGTK
+requirement anyway.
+
+**Fork pull requests cannot converge while the changelog bot is active.** Master
+requires branches to be up to date, the changelog bot pushes a commit after a
+merge, and a fork PR brought up to date needs its workflow runs approved by hand
+before any required check reports. Each fork PR therefore needs a roughly
+twenty-minute cycle that anything else merging invalidates. There were 500 runs
+sitting in `action_required` while this release was being prepared. Merging in a
+quiet window works and is what was done here, but it does not scale; the durable
+fixes are settings changes.
+
+**`go build ./...` from `v3/` fails on several `examples/` packages**, equally on
+master and on this branch, so it is not a regression. CI stays green because it
+builds examples through `task test:examples`. It does mean the most obvious
+command a new contributor runs does not work.
+
+**Six diagram placeholders render in the documentation.**
+`contributing/index.mdx`, `contributing/architecture.mdx` and
+`concepts/build-system.mdx` contain literal `**[... Diagram Placeholder]**` text
+where D2 diagrams were removed after MDX parse failures. Contributor-facing
+rather than user-facing, so the diagrams were left alone rather than
+reconstructed speculatively.

--- a/.release/v3.0.0-beta.0/README.md
+++ b/.release/v3.0.0-beta.0/README.md
@@ -1,0 +1,43 @@
+# Release record: v3.0.0-beta.0
+
+Working files for the beta. **Nothing here is published.** The comms drafts are
+drafts: they carry structure, constraints and the facts that are already
+settled, and they leave every claim that needs a human decision blank.
+
+| File | What it is |
+|---|---|
+| `plan.json` | The release plan: schedule, gates, and the audit configuration for this repository. Read and written by `relman`. |
+| `comms/launch-sequence.md` | The ordered launch-day runbook, with the Wails-specific steps and the abort criteria. |
+| `comms/packagers.md` | Heads-up for downstream packagers, plugin and template authors and translators. Facts are filled in, dates are not. |
+| `comms/faq.md` | Objection and question list to answer before the launch thread, not during it. |
+| `comms/announcement.md`, `comms/show-hn.md`, `comms/social-*.md`, `comms/email.md`, `comms/discord-forum.md`, `comms/reddit.md` | Per-channel scaffolds with the length limits and audience notes for each. Copy is deliberately absent. |
+
+## What is deliberately empty
+
+`plan.json` has empty `positioning` and `headlines`, and the channel drafts have
+TODOs where those would be interpolated. That is not an oversight: the one-liner,
+the problem statement, the proof point and the call to action are the release's
+argument for itself, and inventing them would produce copy that reads plausibly
+and says something nobody decided to say.
+
+Fill those five fields and re-run `relman kit -plan .release/v3.0.0-beta.0/plan.json`
+to regenerate every channel draft with real copy.
+
+## Audit state at the time of writing
+
+Against this branch: 17 checks passing, 0 warnings, 2 blockers.
+
+- `changelog-entry` clears at release time, when `release.go` folds
+  `UNRELEASED_CHANGELOG.md` into the changelog.
+- `ci-green` requires the branch name in `plan.json` to match the branch CI runs
+  against.
+
+## Known preconditions before tagging
+
+1. The six `APPLE_*` signing secrets do not exist on the repository. Without them
+   the macOS job stops in preflight with the names listed, or continues unsigned
+   if `allow_unsigned_macos` is set deliberately.
+2. `release-v3.yml` has never run. Rehearse it with `draft: true` on a throwaway
+   tag in the `alpha2.` series before using it for real.
+3. This branch drifts behind master quickly. Re-sync and re-audit immediately
+   before tagging; `relman audit` now blocks on it.

--- a/.release/v3.0.0-beta.0/comms/announcement.md
+++ b/.release/v3.0.0-beta.0/comms/announcement.md
@@ -1,0 +1,40 @@
+<!-- Announcement post (your own blog) | Wails v3.0.0-beta.0 | tier T1 | GA 2026-09-15
+     The canonical artifact every other channel links to. Owned by you,
+     permanent, indexable. Write this first; everything else is an excerpt of it. -->
+
+# Wails v3.0.0-beta.0
+
+TODO: one sentence: what this is, who it is for, why this release matters
+
+## Why this release exists
+
+TODO: the problem users had before this release, in their words
+
+## What is new
+
+- TODO: three to five headline changes, each phrased as a user outcome
+
+Expand each headline into a short section with a code sample or screenshot.
+A reader should be able to tell within one screen whether this release affects them.
+
+## How to upgrade
+
+```sh
+TODO: the exact upgrade command
+```
+
+Docs: TODO: docs URL
+
+## Proof
+
+TODO: benchmark, before/after, or a quote from someone who ran the beta
+
+## Thanks
+
+Name the contributors. `relman notes` prints the list from the commit range.
+
+## What is next
+
+One paragraph on the next milestone, so readers know the project has momentum.
+
+TODO: the single action you want a reader to take

--- a/.release/v3.0.0-beta.0/comms/discord-forum.md
+++ b/.release/v3.0.0-beta.0/comms/discord-forum.md
@@ -1,0 +1,24 @@
+<!-- Community chat (Discord/Slack/Matrix) and forum | Wails v3.0.0-beta.0 | tier T1 | GA 2026-09-15
+     Your existing users. They deserve to hear it here first, or at least at the
+     same time as strangers. Include the upgrade command and the migration link
+     above the fold. -->
+
+## Post 1 (must stand alone)
+
+Wails v3.0.0-beta.0 is out. TODO: one line
+
+## Follow-ups (one per headline, each self-contained)
+
+TODO: fill plan.headlines and re-run `relman kit`
+
+
+## Final post
+
+TODO: call to action
+TODO: link
+
+## Media
+
+- One image or 20-second clip showing the change in use, not a logo
+- Alt text on every image
+- Link in the first post if the platform does not penalise it, otherwise the second

--- a/.release/v3.0.0-beta.0/comms/email.md
+++ b/.release/v3.0.0-beta.0/comms/email.md
@@ -1,0 +1,23 @@
+<!-- Newsletter / release email | Wails v3.0.0-beta.0 | tier T1 | GA 2026-09-15
+     Highest-intent audience. One headline, three bullets, one link. Anything
+     longer gets skimmed to nothing. -->
+
+## Post 1 (must stand alone)
+
+Wails v3.0.0-beta.0 is out. TODO: one line
+
+## Follow-ups (one per headline, each self-contained)
+
+TODO: fill plan.headlines and re-run `relman kit`
+
+
+## Final post
+
+TODO: call to action
+TODO: link
+
+## Media
+
+- One image or 20-second clip showing the change in use, not a logo
+- Alt text on every image
+- Link in the first post if the platform does not penalise it, otherwise the second

--- a/.release/v3.0.0-beta.0/comms/faq.md
+++ b/.release/v3.0.0-beta.0/comms/faq.md
@@ -1,0 +1,55 @@
+<!-- FAQ and objection responses | Wails v3.0.0-beta.0 | tier T1 | GA 2026-09-15
+     Pre-write answers to the five questions you know are coming, including the
+     hostile ones. Copy-paste-ready so whoever is on the thread at 3am sounds
+     like the project, not like a tired person. -->
+
+# Launch FAQ
+
+Write the answer once, agree it with the team, paste it everywhere. Consistency
+under pressure is what makes a project look like it knows what it is doing.
+
+**Do I have to upgrade? What happens if I stay on v3.0.0-alpha2.117?**
+
+TODO
+
+**How long will the previous major version be supported, and what counts as support?**
+
+TODO
+
+**How long does a typical migration take, and what is not automated?**
+
+TODO
+
+**What breaks, exactly? (link the migration guide, then answer anyway)**
+
+TODO
+
+**Is this production ready?**
+
+TODO
+
+**Why did this take so long / why is feature X still missing?**
+
+TODO
+
+**How does this compare to <the obvious alternative>?**
+
+TODO
+
+**Who is behind this and how is it funded?**
+
+TODO
+
+**What is the licence, and did it change?**
+
+TODO
+
+**I found a bug in the first hour. Where do I report it and how fast will you respond?**
+
+TODO
+
+## Hostile-question rules
+
+- Answer the strongest version of the question, not the rudest phrasing of it
+- Concede real limitations immediately and say what you plan to do about them
+- Never delete critical comments; correcting the record in public is worth more

--- a/.release/v3.0.0-beta.0/comms/launch-sequence.md
+++ b/.release/v3.0.0-beta.0/comms/launch-sequence.md
@@ -1,0 +1,59 @@
+# Launch sequence: Wails v3 beta
+
+Publish in this order. The rule behind it: nothing is announced before it is
+installable, and nothing is installable before the docs describing it are live.
+Every step needs one named owner, because a step owned by everyone is owned by
+nobody at 3am.
+
+Owners are blank on purpose. Fill them in before the go/no-go, not on the day.
+
+## Before the day
+
+| # | Step | Owner |
+|---|---|---|
+| 1 | Configure the six Apple secrets (`APPLE_SIGNING_CERT`, `APPLE_CERT_PASSWORD`, `APPLE_SIGNING_IDENTITY`, `APPLE_NOTARIZE_USER`, `APPLE_NOTARIZE_PASSWORD`, `APPLE_TEAM_ID`), or decide to ship unsigned macOS binaries with `allow_unsigned_macos` | |
+| 2 | Rehearse the release: `release-v3.yml` via `workflow_dispatch` with `draft: true` on a throwaway tag. Use a tag in the `alpha2.` series (`v3.0.0-alpha2.999`); a tag like `v3.0.0-test.1` would outrank the real beta and hijack `@latest` | |
+| 3 | Delete the draft release and the throwaway tag once the rehearsal passes | |
+| 4 | Re-sync `releases/v3-beta` with master and re-run the audit. The branch drifted 31 commits, then 6 more within hours; `relman audit` blocks on it now | |
+| 5 | Warn downstream: packagers, template and plugin authors, translators (see `packagers.md`) | |
+
+## Release day
+
+| When | Step | Owner |
+|---|---|---|
+| T-60m | Final `relman gono`; blockers green or waived in writing | |
+| T-45m | Tag from `releases/v3-beta`. `release.go` bumps `version.txt` and folds `UNRELEASED_CHANGELOG.md` into the changelog | |
+| T-40m | The tag push triggers `release-v3.yml`: preflight, three platform builds, sign and notarize, `SHA256SUMS`, provenance attestation | |
+| T-25m | `version.txt` moving triggers `publish-npm.yml`, which publishes `@wailsio/runtime` at the matching version | |
+| T-20m | Verify: download a binary, check it against `SHA256SUMS`, verify the attestation, run `wails3 version` and confirm it reports the beta | |
+| T-15m | Install on a clean machine per platform, from the published channel, not the build directory | |
+| T-10m | Docs deploy (Cloudflare Pages, "wails-v3-site"); confirm the version switcher and every locale | |
+| T-5m | Support rota on duty; hotfix path confirmed | |
+| T+0 | Announcement post live | |
+| T+5m | Community chat and forum: existing users hear it first | |
+| T+10m | Show HN plus the first comment | |
+| T+15m | Social threads, newsletter | |
+| T+30m | Tell packagers the artifacts are live | |
+| T+1h | First sweep: install failures, docs 404s, thread questions | |
+| T+3h | Second sweep; decide on a same-day patch | |
+| T+24h | Summarise, file issues, hand over the rota | |
+
+## Abort criteria
+
+Agreed in advance, while nobody is under pressure:
+
+- Install fails on any supported platform: stop, unpublish, fix
+- Data loss or a security regression: stop, unpublish, advisory
+- Docs site down or the upgrade guide missing: hold the announcement, ship the fix
+- Anything else: continue, log it, decide at the T+3h sweep
+
+## Rollback
+
+The GitHub release can be deleted and the tag removed, but **npm cannot be
+unpublished after 72 hours** and the Go module proxy caches versions
+permanently. In practice, the recovery for anything found after publishing is a
+fast patch release, which is why the hotfix path has to be rehearsed rather than
+assumed.
+
+Write the exact commands here once step 2 has actually been executed, so this
+section describes something that has been done rather than something believed.

--- a/.release/v3.0.0-beta.0/comms/packagers.md
+++ b/.release/v3.0.0-beta.0/comms/packagers.md
@@ -1,0 +1,53 @@
+<!-- Downstream packagers and integrators. Send before the freeze ends, not on
+     launch day: their lag is what users experience as a broken release.
+     Date and version are placeholders until the go/no-go fixes them. -->
+
+# Heads-up: Wails v3 beta
+
+Send to: Homebrew and distro package maintainers, plugin and template authors,
+documentation translators, and anyone whose work breaks when ours changes.
+
+## What is changing
+
+**Version scheme.** The CLI moves from the `v3.0.0-alpha2.N` series to
+`v3.0.0-beta.N`. A beta sorts above every alpha under semantic versioning, so
+`@latest` resolves to it.
+
+**`@wailsio/runtime` now matches the CLI version.** Until now the npm package
+counted its own `alpha.N` series independently, so a CLI and its runtime
+reported unrelated versions. From this release the package version is derived
+from the same file the CLI embeds. If you pin the runtime, expect the version
+string to jump series rather than increment.
+
+**Release artifacts now ship with checksums and provenance.** Each release
+carries a `SHA256SUMS` file generated in the same job that publishes the
+binaries, plus a signed build-provenance attestation. If you verify downloads,
+you can now do so properly.
+
+**Artifact names are unchanged:** `wails3-linux-amd64`, `wails3-linux-arm64`,
+`wails3-windows-amd64.exe`, `wails3-darwin-amd64`, `wails3-darwin-arm64`,
+`wails3-darwin-universal`.
+
+**macOS signing.** Whether the darwin binaries are signed and notarized in this
+release depends on the signing credentials being in place. If they are not, the
+release will say so explicitly rather than shipping silently unsigned binaries.
+
+**The repository no longer ships a `go.work`.** If your build tooling assumed a
+workspace at the repository root, it does not need one now.
+
+## What we need from you
+
+- Test the release candidate against your package before the date below.
+- Tell us if any of the above breaks your build, while there is still time.
+- Note that this is a beta: the API is stable and it receives security fixes,
+  but it is not the stable 3.0.
+
+## Dates
+
+- Release candidate available: TBC
+- Deadline for telling us it broke: TBC
+- Release date: TBC
+
+## Contact
+
+Named contact for release week: TBC

--- a/.release/v3.0.0-beta.0/comms/reddit.md
+++ b/.release/v3.0.0-beta.0/comms/reddit.md
@@ -1,0 +1,24 @@
+<!-- Reddit (relevant subreddits) | Wails v3.0.0-beta.0 | tier T1 | GA 2026-09-15
+     Title limit: 300 characters
+     Read each subreddit's self-promotion rules before posting. Post as a
+     participant, respond to criticism in the thread, never delete-and-repost. -->
+
+## Post 1 (must stand alone)
+
+Wails v3.0.0-beta.0 is out. TODO: one line
+
+## Follow-ups (one per headline, each self-contained)
+
+TODO: fill plan.headlines and re-run `relman kit`
+
+
+## Final post
+
+TODO: call to action
+TODO: link
+
+## Media
+
+- One image or 20-second clip showing the change in use, not a logo
+- Alt text on every image
+- Link in the first post if the platform does not penalise it, otherwise the second

--- a/.release/v3.0.0-beta.0/comms/show-hn.md
+++ b/.release/v3.0.0-beta.0/comms/show-hn.md
@@ -1,0 +1,33 @@
+<!-- Hacker News (Show HN) | Wails v3.0.0-beta.0 | tier T1 | GA 2026-09-15
+     Title limit: 80 characters
+     Technical readers who resent marketing. Title states what it is, plainly, no
+     adjectives. The first comment is yours: why you built it, what it does not
+     do, what you want feedback on. Be present for the first three hours or the
+     thread shapes itself without you. -->
+
+## Title options (aim for under 80 characters, no adjectives)
+
+1. Show HN: Wails v3.0.0-beta.0 – TODO  [37 chars]
+2. TODO: alternative that leads with the capability, not the version
+3. TODO: alternative that names the problem solved
+
+Link to the announcement post or the repo, not to a signup page.
+
+## First comment (post immediately, from the account that submitted)
+
+TODO: why you built this, in the first person, no marketing register
+
+What is new in this release:
+
+- TODO: the changes a technical reader would care about
+
+What it does not do yet: TODO. Naming your own limitations up front is the single
+highest-trust move available on this platform, and it pre-empts the top comment.
+
+What I would like feedback on: TODO.
+
+## Thread duty
+
+- Owner present for the first three hours, then hourly for 24 hours
+- Answer criticism with specifics; never argue with the tone
+- Do not ask for upvotes anywhere; it is detectable and it gets posts penalised

--- a/.release/v3.0.0-beta.0/comms/social-bluesky-mastodon.md
+++ b/.release/v3.0.0-beta.0/comms/social-bluesky-mastodon.md
@@ -1,0 +1,26 @@
+<!-- Bluesky (300) / Mastodon (500) | Wails v3.0.0-beta.0 | tier T1 | GA 2026-09-15
+     Post limit: 300 characters
+     Developer-dense, allergic to growth-hack phrasing. Alt-text on every image;
+     this audience notices when it is missing. -->
+
+## Post 1 (must stand alone)
+
+Wails v3.0.0-beta.0 is out. TODO: one line
+
+[42/300 chars: ok]
+
+## Follow-ups (one per headline, each self-contained)
+
+TODO: fill plan.headlines and re-run `relman kit`
+
+
+## Final post
+
+TODO: call to action
+TODO: link
+
+## Media
+
+- One image or 20-second clip showing the change in use, not a logo
+- Alt text on every image
+- Link in the first post if the platform does not penalise it, otherwise the second

--- a/.release/v3.0.0-beta.0/comms/social-linkedin.md
+++ b/.release/v3.0.0-beta.0/comms/social-linkedin.md
@@ -1,0 +1,26 @@
+<!-- LinkedIn | Wails v3.0.0-beta.0 | tier T1 | GA 2026-09-15
+     Post limit: 3000 characters
+     Reaches decision makers, not just users. Frame in terms of what teams can
+     now do; keep one clear link. -->
+
+## Post 1 (must stand alone)
+
+Wails v3.0.0-beta.0 is out. TODO: one line
+
+[42/3000 chars: ok]
+
+## Follow-ups (one per headline, each self-contained)
+
+TODO: fill plan.headlines and re-run `relman kit`
+
+
+## Final post
+
+TODO: call to action
+TODO: link
+
+## Media
+
+- One image or 20-second clip showing the change in use, not a logo
+- Alt text on every image
+- Link in the first post if the platform does not penalise it, otherwise the second

--- a/.release/v3.0.0-beta.0/comms/social-x.md
+++ b/.release/v3.0.0-beta.0/comms/social-x.md
@@ -1,0 +1,26 @@
+<!-- X / Twitter thread | Wails v3.0.0-beta.0 | tier T1 | GA 2026-09-15
+     Post limit: 280 characters
+     First post must stand alone; most readers see only that. Lead with the
+     user-visible change, not the version number. -->
+
+## Post 1 (must stand alone)
+
+Wails v3.0.0-beta.0 is out. TODO: one line
+
+[42/280 chars: ok]
+
+## Follow-ups (one per headline, each self-contained)
+
+TODO: fill plan.headlines and re-run `relman kit`
+
+
+## Final post
+
+TODO: call to action
+TODO: link
+
+## Media
+
+- One image or 20-second clip showing the change in use, not a logo
+- Alt text on every image
+- Link in the first post if the platform does not penalise it, otherwise the second

--- a/.release/v3.0.0-beta.0/plan.json
+++ b/.release/v3.0.0-beta.0/plan.json
@@ -1,0 +1,513 @@
+{
+  "project": "Wails",
+  "version": "v3.0.0-beta.0",
+  "prevVersion": "v3.0.0-alpha2.117",
+  "tier": "T1",
+  "channel": "beta",
+  "releaseDate": "2026-09-15",
+  "branch": "releases/v3-beta",
+  "repoSlug": "wailsapp/wails",
+  "repoPath": "",
+  "owners": {
+    "release-lead": "",
+    "engineering": "",
+    "docs": "",
+    "comms": "",
+    "support": ""
+  },
+  "positioning": {
+    "oneLiner": "",
+    "problem": "",
+    "proof": "",
+    "cta": "",
+    "audience": ""
+  },
+  "milestones": [
+    {
+      "id": "kickoff",
+      "title": "Kickoff: scope locked, owners named, tier agreed",
+      "phase": "plan",
+      "offset": -42,
+      "date": "2026-08-04"
+    },
+    {
+      "id": "feature-freeze",
+      "title": "Feature freeze: nothing new merges to the release branch",
+      "phase": "stabilise",
+      "offset": -35,
+      "date": "2026-08-11"
+    },
+    {
+      "id": "narrative-lock",
+      "title": "Positioning locked; docs plan and migration guide outlined",
+      "phase": "plan",
+      "offset": -28,
+      "date": "2026-08-18"
+    },
+    {
+      "id": "api-freeze",
+      "title": "API/string freeze; translation and docs handoff",
+      "phase": "stabilise",
+      "offset": -21,
+      "date": "2026-08-25"
+    },
+    {
+      "id": "beta",
+      "title": "Public beta / RC1 cut and announced to early adopters",
+      "phase": "stabilise",
+      "offset": -21,
+      "date": "2026-08-25"
+    },
+    {
+      "id": "code-freeze",
+      "title": "Code freeze: release-blocking fixes only, each with a written justification",
+      "phase": "stabilise",
+      "offset": -14,
+      "date": "2026-09-01"
+    },
+    {
+      "id": "assets-draft",
+      "title": "Release notes, announcement post and social kit drafted",
+      "phase": "comms",
+      "offset": -14,
+      "date": "2026-09-01"
+    },
+    {
+      "id": "legal-security",
+      "title": "Licence/IP review and security review complete; embargoed advisories staged",
+      "phase": "assure",
+      "offset": -10,
+      "date": "2026-09-05"
+    },
+    {
+      "id": "docs-complete",
+      "title": "Docs complete: migration guide, upgrade path, reference regenerated",
+      "phase": "docs",
+      "offset": -7,
+      "date": "2026-09-08"
+    },
+    {
+      "id": "rc-final",
+      "title": "Final RC; support runbook and triage rota published",
+      "phase": "assure",
+      "offset": -7,
+      "date": "2026-09-08"
+    },
+    {
+      "id": "briefings",
+      "title": "Embargoed briefings to press, sponsors, downstream maintainers",
+      "phase": "comms",
+      "offset": -7,
+      "date": "2026-09-08"
+    },
+    {
+      "id": "dry-run",
+      "title": "Full release dry run: build, sign, publish to a staging channel, install from it",
+      "phase": "assure",
+      "offset": -3,
+      "date": "2026-09-12"
+    },
+    {
+      "id": "gono-1",
+      "title": "Go/no-go #1: every blocking gate green or explicitly waived",
+      "phase": "assure",
+      "offset": -3,
+      "date": "2026-09-12"
+    },
+    {
+      "id": "gono-final",
+      "title": "Final go/no-go; artifacts staged, posts queued, rollback rehearsed",
+      "phase": "assure",
+      "offset": -1,
+      "date": "2026-09-14"
+    },
+    {
+      "id": "launch",
+      "title": "Launch day: publish, announce, staff the thread",
+      "phase": "launch",
+      "offset": 0,
+      "date": "2026-09-15"
+    },
+    {
+      "id": "watch",
+      "title": "First 72 hours: triage rota live, hotfix branch ready",
+      "phase": "post",
+      "offset": 1,
+      "date": "2026-09-16"
+    },
+    {
+      "id": "patch",
+      "title": "First patch release window",
+      "phase": "post",
+      "offset": 7,
+      "date": "2026-09-22"
+    },
+    {
+      "id": "retro",
+      "title": "Retro: what broke, what to automate, adoption numbers",
+      "phase": "post",
+      "offset": 14,
+      "date": "2026-09-29"
+    },
+    {
+      "id": "adoption",
+      "title": "Adoption review against the pre-agreed success metrics",
+      "phase": "post",
+      "offset": 30,
+      "date": "2026-10-15"
+    }
+  ],
+  "gates": [
+    {
+      "id": "sw-scope",
+      "title": "Scope locked: shipped feature list matches the plan",
+      "phase": "plan",
+      "track": "software",
+      "blocking": true,
+      "status": "open"
+    },
+    {
+      "id": "sw-version",
+      "title": "Version number matches the change set (major iff breaking)",
+      "phase": "stabilise",
+      "track": "software",
+      "blocking": true,
+      "status": "open"
+    },
+    {
+      "id": "sw-compat",
+      "title": "Compatibility promise stated: supported platforms, runtimes, minimum versions",
+      "phase": "stabilise",
+      "track": "software",
+      "blocking": true,
+      "status": "open"
+    },
+    {
+      "id": "sw-deprecations",
+      "title": "Deprecations announced with a removal version; scheduled removals actually removed",
+      "phase": "stabilise",
+      "track": "software",
+      "blocking": true,
+      "status": "open"
+    },
+    {
+      "id": "sw-upgrade",
+      "title": "Upgrade path tested from the last two releases on real projects",
+      "phase": "assure",
+      "track": "software",
+      "blocking": true,
+      "status": "open"
+    },
+    {
+      "id": "sw-rollback",
+      "title": "Rollback/downgrade path documented and rehearsed",
+      "phase": "assure",
+      "track": "software",
+      "blocking": true,
+      "status": "open"
+    },
+    {
+      "id": "sw-artifacts",
+      "title": "Artifacts build reproducibly for every published platform",
+      "phase": "assure",
+      "track": "software",
+      "blocking": true,
+      "owner": "lea",
+      "status": "open",
+      "note": "release-v3.yml added 2026-06-29 (#5318) has never run; alphas ship via nightly-release-v3.yml. Needs a workflow_dispatch dry run on a throwaway tag.",
+      "updated": "2026-07-26T16:17:23+10:00"
+    },
+    {
+      "id": "sw-signing",
+      "title": "Artifacts signed; checksums and provenance published",
+      "phase": "assure",
+      "track": "software",
+      "blocking": true,
+      "status": "open"
+    },
+    {
+      "id": "sw-install",
+      "title": "Install verified from the published channel, not the build dir",
+      "phase": "assure",
+      "track": "software",
+      "blocking": true,
+      "status": "open"
+    },
+    {
+      "id": "sw-perf",
+      "title": "Performance and binary size compared against the previous release",
+      "phase": "assure",
+      "track": "software",
+      "blocking": false,
+      "status": "open"
+    },
+    {
+      "id": "sw-telemetry",
+      "title": "Error reporting/telemetry can distinguish the new version",
+      "phase": "assure",
+      "track": "software",
+      "blocking": false,
+      "status": "open"
+    },
+    {
+      "id": "sw-a11y-i18n",
+      "title": "Accessibility and localisation checks on new UI surfaces",
+      "phase": "assure",
+      "track": "software",
+      "blocking": false,
+      "status": "open"
+    },
+    {
+      "id": "doc-notes",
+      "title": "Release notes written for users, not for git",
+      "phase": "docs",
+      "track": "docs",
+      "blocking": true,
+      "status": "open"
+    },
+    {
+      "id": "doc-changelog",
+      "title": "Changelog entry landed in the standard format",
+      "phase": "docs",
+      "track": "docs",
+      "blocking": true,
+      "status": "open"
+    },
+    {
+      "id": "doc-migration",
+      "title": "Migration guide covers every breaking change with before/after code",
+      "phase": "docs",
+      "track": "docs",
+      "blocking": true,
+      "status": "open"
+    },
+    {
+      "id": "doc-getting-started",
+      "title": "Getting started path works end to end on a clean machine",
+      "phase": "docs",
+      "track": "docs",
+      "blocking": true,
+      "status": "open"
+    },
+    {
+      "id": "doc-reference",
+      "title": "API reference regenerated and deployed",
+      "phase": "docs",
+      "track": "docs",
+      "blocking": true,
+      "status": "open",
+      "note": "v3 go test ./... passes locally; bundled runtime matches source",
+      "updated": "2026-07-26T16:17:23+10:00"
+    },
+    {
+      "id": "doc-site",
+      "title": "Docs site builds and deploys, including translated locales",
+      "phase": "docs",
+      "track": "docs",
+      "blocking": true,
+      "status": "open",
+      "note": "v3 docs (docs/, Astro+LLM pipeline) build clean: 1711 pages, 9 locales, Node 22. The failing 'Sync Translations' job is v2-only (website/, crowdin) and is excluded from ci-green.",
+      "updated": "2026-07-26T18:26:04+10:00"
+    },
+    {
+      "id": "doc-versioned",
+      "title": "Old version docs still reachable and labelled",
+      "phase": "docs",
+      "track": "docs",
+      "blocking": false,
+      "status": "open"
+    },
+    {
+      "id": "doc-examples",
+      "title": "Examples, templates and starter projects updated to the new version",
+      "phase": "docs",
+      "track": "docs",
+      "blocking": false,
+      "status": "open"
+    },
+    {
+      "id": "legal-licence",
+      "title": "Licence unchanged or change announced; LICENSE and headers correct",
+      "phase": "assure",
+      "track": "legal",
+      "blocking": true,
+      "status": "open"
+    },
+    {
+      "id": "legal-deps",
+      "title": "Dependency licences reviewed; third-party notices file current",
+      "phase": "assure",
+      "track": "legal",
+      "blocking": true,
+      "status": "open"
+    },
+    {
+      "id": "legal-provenance",
+      "title": "Contributions covered by CLA/DCO; no unattributed third-party code",
+      "phase": "assure",
+      "track": "legal",
+      "blocking": true,
+      "status": "open",
+      "note": "CONTRIBUTING.md does not state licence/DCO/CLA terms",
+      "updated": "2026-07-26T16:17:23+10:00"
+    },
+    {
+      "id": "legal-export",
+      "title": "Trademark and export-control use in name, binaries and site checked",
+      "phase": "assure",
+      "track": "legal",
+      "blocking": false,
+      "status": "open"
+    },
+    {
+      "id": "sec-review",
+      "title": "Security review of new attack surface complete",
+      "phase": "assure",
+      "track": "legal",
+      "blocking": true,
+      "status": "open"
+    },
+    {
+      "id": "sec-advisories",
+      "title": "Embargoed advisories drafted; CVE/GHSA IDs reserved; disclosure timed to release",
+      "phase": "assure",
+      "track": "legal",
+      "blocking": true,
+      "status": "open"
+    },
+    {
+      "id": "com-positioning",
+      "title": "One-liner, problem, proof and CTA agreed",
+      "phase": "plan",
+      "track": "comms",
+      "blocking": true,
+      "status": "open"
+    },
+    {
+      "id": "com-announcement",
+      "title": "Announcement post written and reviewed",
+      "phase": "comms",
+      "track": "comms",
+      "blocking": true,
+      "status": "open"
+    },
+    {
+      "id": "com-channels",
+      "title": "Channel plan: who posts what, where, when",
+      "phase": "comms",
+      "track": "comms",
+      "blocking": true,
+      "status": "open"
+    },
+    {
+      "id": "com-assets",
+      "title": "Screenshots, demo video or GIF produced",
+      "phase": "comms",
+      "track": "comms",
+      "blocking": false,
+      "status": "open"
+    },
+    {
+      "id": "com-site",
+      "title": "Website updated: version, download links, comparison and pricing pages",
+      "phase": "comms",
+      "track": "comms",
+      "blocking": true,
+      "status": "open"
+    },
+    {
+      "id": "com-community",
+      "title": "Community briefed: maintainers, sponsors, plugin authors, downstream packagers",
+      "phase": "comms",
+      "track": "comms",
+      "blocking": false,
+      "status": "open"
+    },
+    {
+      "id": "com-faq",
+      "title": "FAQ and objection responses prepared for the launch thread",
+      "phase": "comms",
+      "track": "comms",
+      "blocking": false,
+      "status": "open"
+    },
+    {
+      "id": "ops-runbook",
+      "title": "Launch-day runbook written: sequence, owners, abort criteria",
+      "phase": "assure",
+      "track": "ops",
+      "blocking": true,
+      "status": "open"
+    },
+    {
+      "id": "ops-support",
+      "title": "Support rota staffed for the first 72 hours",
+      "phase": "assure",
+      "track": "ops",
+      "blocking": true,
+      "status": "open"
+    },
+    {
+      "id": "ops-hotfix",
+      "title": "Hotfix path rehearsed: branch, build, publish within one working day",
+      "phase": "assure",
+      "track": "ops",
+      "blocking": true,
+      "status": "open"
+    },
+    {
+      "id": "ops-monitoring",
+      "title": "Dashboards and alerts cover the new release's failure modes",
+      "phase": "assure",
+      "track": "ops",
+      "blocking": false,
+      "status": "open"
+    },
+    {
+      "id": "ops-metrics",
+      "title": "Success metrics agreed before launch, with a review date",
+      "phase": "plan",
+      "track": "ops",
+      "blocking": false,
+      "status": "open"
+    }
+  ],
+  "audit": {
+    "versionFiles": [
+      "v3/internal/version/version.txt"
+    ],
+    "changelogPath": "CHANGELOG.md",
+    "migrationGuide": "docs/src/content/docs/migration",
+    "generated": [
+      {
+        "name": "bundled runtime",
+        "dir": "v3",
+        "command": "(cd internal/runtime/desktop/@wailsio/runtime && npm ci --silent) && task runtime:build:assets",
+        "paths": [
+          "v3/internal/assetserver/bundledassets"
+        ]
+      }
+    ],
+    "docsBuild": {
+      "dir": "docs",
+      "command": "PATH=/opt/homebrew/opt/node@22/bin:$PATH npm ci --silent && PATH=/opt/homebrew/opt/node@22/bin:$PATH npm run build"
+    },
+    "testCommand": {
+      "dir": "v3",
+      "command": "go test ./..."
+    },
+    "workflows": [
+      "release-v3.yml",
+      "nightly-release-v3.yml",
+      "publish-npm.yml",
+      "verify-runtime-assets.yml"
+    ],
+    "ignoreWorkflows": [
+      "Sync Translations",
+      "Upload Source Documents"
+    ],
+    "baseBranch": "master"
+  },
+  "headlines": [],
+  "breaking": []
+}


### PR DESCRIPTION
**Draft, on `releases/v3-beta`. Nothing here is published and nothing goes near master.**

Puts the release plan, the gate configuration and the per-channel comms drafts in the repository beside the code, so the beta is resumable by someone who is not the person who prepared it. `.release/v3.0.0-beta.0/`.

## What is filled in

- **`comms/launch-sequence.md`** — the ordered runbook, made specific to this project rather than generic: `release.go` tags and bumps `version.txt`, the tag push triggers `release-v3.yml`, `version.txt` moving triggers the npm publish, docs deploy to Cloudflare Pages. Plus the abort criteria, and an honest rollback section noting that npm cannot be unpublished after 72 hours and the Go module proxy caches permanently, so the real recovery is a fast patch.
- **`comms/packagers.md`** — the facts downstream needs: the version-series move, the runtime now matching the CLI version, checksums and provenance now shipping, artifact names unchanged, `go.work` gone, and macOS signing conditional on credentials.
- **`plan.json`** — schedule, gates and the audit configuration for this repo, so `relman audit` keeps working for whoever runs the release.
- **`README.md`** — what each file is, and the preconditions that still block tagging.

## What is deliberately empty

`positioning` and `headlines` in `plan.json`, and therefore the TODOs in the announcement and social drafts.

I had filled these with placeholder copy while dry-running the tooling, and stripped it before committing. Inventing a release's one-liner, problem statement and proof point produces text that reads plausibly and says something nobody decided to say, which is worse than a blank field. Fill those five fields and re-run `relman kit -plan .release/v3.0.0-beta.0/plan.json` and every channel draft regenerates with real copy.

## Audit state on this branch

17 passing, 0 warnings, 2 blockers. `changelog-entry` clears at release time when `release.go` folds the unreleased changelog in; `ci-green` just needs the plan's branch name to match what CI runs against.