### PR TITLE
chore(beta): merge master into releases/v3-beta (third sync)

### DIFF
--- a/v3/UNRELEASED_CHANGELOG.md
+++ b/v3/UNRELEASED_CHANGELOG.md
@@ -24,6 +24,7 @@ After processing, the content will be moved to the main changelog and this file 
 
 ## Fixed
 <!-- Bug fixes -->
+- Handle cursor position failures gracefully on Windows for popup menus and screen enumeration in [PR](https://github.com/wailsapp/wails/pull/5789) by @wayneforrest
 - macOS open-file dialog filters extensions correctly and validates allowed files by suffix in [PR](https://github.com/wailsapp/wails/pull/5678) by @phergul
 - Guard Windows dark-mode initialization against nil API calls in [PR](https://github.com/wailsapp/wails/pull/5793) by @roachadam
 - Fix 32-bit build failure in the updater: the `maxArchiveTotalSize` constant (2 GiB) overflowed the platform `int` when passed to `fmt.Errorf` on `GOARCH=386`. It is now explicitly typed `int64`.

--- a/v3/UNRELEASED_CHANGELOG.md
+++ b/v3/UNRELEASED_CHANGELOG.md
@@ -24,6 +24,7 @@ After processing, the content will be moved to the main changelog and this file 
 
 ## Fixed
 <!-- Bug fixes -->
+- macOS open-file dialog filters extensions correctly and validates allowed files by suffix in [PR](https://github.com/wailsapp/wails/pull/5678) by @phergul
 - Guard Windows dark-mode initialization against nil API calls in [PR](https://github.com/wailsapp/wails/pull/5793) by @roachadam
 - Fix 32-bit build failure in the updater: the `maxArchiveTotalSize` constant (2 GiB) overflowed the platform `int` when passed to `fmt.Errorf` on `GOARCH=386`. It is now explicitly typed `int64`.
 - Fix a nil-pointer panic on startup when a window uses a Dark (or system-dark) title bar on Windows builds that do not load the dark-mode uxtheme APIs, such as Windows 10 1809 / Windows Server 2019 (build 17763). The `AllowDarkModeForWindow` calls in the window theme setup are now nil-guarded, matching the guard already used in `w32.SetMenuTheme`.

--- a/v3/old
+++ b/v3/old
@@ -1,1 +1,0 @@
-../../../GolandProjects/ios

--- a/v3/pkg/application/dialogs_darwin.go
+++ b/v3/pkg/application/dialogs_darwin.go
@@ -180,11 +180,23 @@ static void showOpenFileDialog(unsigned int dialogID,
 #if MAC_OS_X_VERSION_MAX_ALLOWED >= 110000
 		if (@available(macOS 11, *)) {
 			NSMutableArray *filterTypes = [NSMutableArray array];
-			// Iterate the filtertypes, create uti's that are limited to the file extensions then add
+			NSMutableArray *legacyTypes = [NSMutableArray array];
+
 			for (NSString *filterType in delegate.allowedExtensions) {
-				[filterTypes addObject:[UTType typeWithFilenameExtension:filterType]];
+				UTType *utType = [UTType typeWithFilenameExtension:filterType];
+				if (utType != nil) {
+					[filterTypes addObject:utType];
+				} else {
+					[legacyTypes addObject:filterType];
+				}
 			}
-			[panel setAllowedContentTypes:filterTypes];
+
+			if ([filterTypes count] > 0) {
+				[panel setAllowedContentTypes:filterTypes];
+			}
+			if ([legacyTypes count] > 0) {
+				[panel setAllowedFileTypes:legacyTypes];
+			}
 		}
 #else
 		[panel setAllowedFileTypes:delegate.allowedExtensions];

--- a/v3/pkg/application/dialogs_darwin_delegate.m
+++ b/v3/pkg/application/dialogs_darwin_delegate.m
@@ -20,14 +20,18 @@
         return YES;
     }
 
-    NSString *extension = [url.pathExtension lowercaseString];
-    if (extension == nil || [extension isEqualToString:@""]) {
+    NSString *filename = [[url lastPathComponent] lowercaseString];
+    if (filename == nil || [filename isEqualToString:@""]) {
         return NO;
     }
 
     // Check if the extension is in our allowed list (case insensitive)
     for (NSString *allowedExt in self.allowedExtensions) {
-        if ([[allowedExt lowercaseString] isEqualToString:extension]) {
+        NSString *allowed = [allowedExt lowercaseString];
+        if ([allowed length] == 0) {
+            continue;
+        }
+        if ([filename hasSuffix:[@"." stringByAppendingString:allowed]]) {
             return YES;
         }
     }

--- a/v3/pkg/application/popupmenu_windows.go
+++ b/v3/pkg/application/popupmenu_windows.go
@@ -339,8 +339,13 @@ func (p *Win32Menu) ShowAt(x int, y int) {
 
 func (p *Win32Menu) ShowAtCursor() {
 	x, y, ok := w32.GetCursorPos()
-	if ok == false {
-		globalApplication.fatal("GetCursorPos failed")
+	if !ok {
+		// GetCursorPos fails when the process is not on the interactive input
+		// desktop (locked / secure desktop). A context menu simply cannot be
+		// shown then - skip it, do NOT kill the app. Matches the graceful
+		// handling in windowsMenu.ShowAtCursor.
+		globalApplication.debug("GetCursorPos failed - cannot show context menu at cursor")
+		return
 	}
 
 	p.ShowAt(x, y)

--- a/v3/pkg/w32/screen.go
+++ b/v3/pkg/w32/screen.go
@@ -72,16 +72,28 @@ func GetRotationForMonitor(displayName [32]uint16) (float32, error) {
 	return -1, nil
 }
 
+// cursorPosForScreens reports the current cursor position and whether the
+// query succeeded. GetCursorPos returns FALSE (ERROR_ACCESS_DENIED) when the
+// calling process is not attached to the interactive input desktop - e.g. the
+// workstation is locked or on the secure/UAC desktop, or mid session switch
+// (logon, RDP, fast-user-switch). Exposed as a package variable so tests can
+// simulate that failure. Defaults to the real GetCursorPos syscall.
+var cursorPosForScreens = func() (cursor POINT, ok bool) {
+	ret, _, _ := procGetCursorPos.Call(uintptr(unsafe.Pointer(&cursor)))
+	return cursor, ret != 0
+}
+
 func GetAllScreens() ([]*Screen, error) {
 	var result []*Screen
 	var errMessage string
 
-	// Get cursor position to determine the current monitor
-	var cursor POINT
-	ret, _, _ := procGetCursorPos.Call(uintptr(unsafe.Pointer(&cursor)))
-	if ret == 0 {
-		return nil, fmt.Errorf("GetCursorPos failed")
-	}
+	// The cursor position is used only to set the cosmetic IsCurrent flag
+	// (which monitor the pointer is on). A failed query must NOT abort
+	// enumeration: processAndCacheScreens() treats any error here as fatal at
+	// startup (os.Exit), so a locked/secure desktop at launch would crash the
+	// app before it ever shows. Degrade gracefully - no screen is marked
+	// current, and the flag self-corrects on the next display-change re-cache.
+	cursor, cursorOK := cursorPosForScreens()
 
 	// Enumerate the monitors
 	enumFunc := func(hMonitor uintptr, hdc uintptr, lprcMonitor *RECT, lParam uintptr) uintptr {
@@ -101,7 +113,7 @@ func GetAllScreens() ([]*Screen, error) {
 			MONITORINFOEX: monitor,
 			HMonitor:      hMonitor,
 			IsPrimary:     monitor.DwFlags == MONITORINFOF_PRIMARY,
-			IsCurrent:     rectContainsPoint(monitor.RcMonitor, cursor),
+			IsCurrent:     cursorOK && rectContainsPoint(monitor.RcMonitor, cursor),
 		}
 
 		// Get monitor name
@@ -130,7 +142,7 @@ func GetAllScreens() ([]*Screen, error) {
 		return 1 // Continue enumeration
 	}
 
-	ret, _, _ = procEnumDisplayMonitors.Call(0, 0, syscall.NewCallback(enumFunc), 0)
+	ret, _, _ := procEnumDisplayMonitors.Call(0, 0, syscall.NewCallback(enumFunc), 0)
 	if ret == 0 {
 		return nil, fmt.Errorf("EnumDisplayMonitors failed: %s", errMessage)
 	}

--- a/v3/pkg/w32/screen_cursorfail_test.go
+++ b/v3/pkg/w32/screen_cursorfail_test.go
@@ -1,0 +1,48 @@
+//go:build windows
+
+package w32
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestGetAllScreensToleratesCursorFailure is the regression test for the
+// startup crash where a failed GetCursorPos (workstation locked / secure
+// desktop at launch) aborted screen enumeration. processAndCacheScreens()
+// treats that error as fatal (os.Exit) during app.Run, so the whole app died
+// before it ever showed. GetAllScreens must now degrade gracefully.
+//
+// The assertion is display-independent: on a headless runner EnumDisplayMonitors
+// may legitimately fail, but the returned error must NEVER be the cursor error,
+// and no screen may be marked current when the cursor position is unknown.
+func TestGetAllScreensToleratesCursorFailure(t *testing.T) {
+	orig := cursorPosForScreens
+	t.Cleanup(func() { cursorPosForScreens = orig })
+
+	// Simulate GetCursorPos returning FALSE (ERROR_ACCESS_DENIED).
+	cursorPosForScreens = func() (POINT, bool) { return POINT{}, false }
+
+	screens, err := GetAllScreens()
+
+	if err != nil && strings.Contains(err.Error(), "GetCursorPos") {
+		t.Fatalf("GetAllScreens must not fail on a cursor-position error; got: %v", err)
+	}
+	for i, s := range screens {
+		if s.IsCurrent {
+			t.Errorf("screen[%d] marked IsCurrent despite the cursor query failing", i)
+		}
+	}
+}
+
+// TestCursorPosForScreensDefaultCallable confirms the default seam is wired to
+// the real syscall and is safe to call (ok is true or false depending on the
+// session's desktop state; both are valid).
+func TestCursorPosForScreensDefaultCallable(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("default cursorPosForScreens panicked: %v", r)
+		}
+	}()
+	_, _ = cursorPosForScreens()
+}


### PR DESCRIPTION
Third sync. Picks up the four fixes merged since the last one:

- macOS OpenFile dialog crash when UTType cannot resolve filter extensions (#5678)
- the stray `v3/old` symlink pointing at a local `GolandProjects` path (#5785)
- Windows fatal on `GetCursorPos` failure on locked and secure desktops (#5789), which also fixed an app launching on a locked workstation exiting before it drew a window
- the accompanying changelog entries

Clean merge, no conflicts. Verified after merging: `version.txt` still `v3.0.0-beta.0`, and `v3/old` is correctly absent.

Batched deliberately rather than syncing after each merge: every sync is cheap on this branch, but a PR per fix is noise in the branch history.