### PR TITLE
fix(v3/cli): give `generate icons` its documented default paths

### DIFF
--- a/v3/internal/commands/icons.go
+++ b/v3/internal/commands/icons.go
@@ -32,10 +32,10 @@ func (e *macAssetNotSupportedError) Error() string {
 
 type IconsOptions struct {
 	Example           bool   `description:"Generate example icon file (appicon.png) in the current directory"`
-	Input             string `description:"The input image file"`
+	Input             string `description:"The input image file" default:"build/appicon.png"`
 	Sizes             string `description:"The sizes to generate in .ico file (comma separated)" default:"256,128,64,48,32,16"`
-	WindowsFilename   string `description:"The output filename for the Windows icon"`
-	MacFilename       string `description:"The output filename for the Mac icon bundle"`
+	WindowsFilename   string `description:"The output filename for the Windows icon" default:"build/windows/icon.ico"`
+	MacFilename       string `description:"The output filename for the Mac icon bundle" default:"build/darwin/icon.icns"`
 	IconComposerInput string `description:"The input Icon Composer file (.icon)"`
 	MacAssetDir       string `description:"The output directory for the Mac assets (Assets.car and icons.icns)"`
 }


### PR DESCRIPTION
Closes #5699. Supersedes #5753 — see below.

## The fix

`wails3 generate icons` advertised input and output paths in its help text but had no defaults, so running it bare did nothing useful.

Three struct tags. The clir `default:` tag already works on this command — `Sizes` has carried one all along — so the other three fields just needed the same treatment.

## Why not #5753

#5753 restructured the subcommand to set the defaults imperatively, and **its CI is red on all three platforms**. It references `flags.GenerateIconsOptions`, which does not exist anywhere in v3, while `commands.GenerateIcons` takes `*IconsOptions`. It also renamed a local `task` variable to `Task`, set each default in two places at once (struct tag *and* imperative assignment, so the two can silently diverge), and stripped the trailing newline from four Go files.

None of that is needed once you notice the tag mechanism already works. Worth closing #5753 in favour of this.

## Verification

- `gofmt` clean.
- Built the CLI and ran the command, rather than inferring from the code:

```
  -input string
        The input image file (default "build/appicon.png")
  -macfilename string
        The output filename for the Mac icon bundle (default "build/darwin/icon.icns")
  -windowsfilename string
        The output filename for the Windows icon (default "build/windows/icon.ico")
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added default file paths for icon generation inputs and Windows/macOS output files.
  * Icon generation now works with standard paths when these options are omitted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->