### PR TITLE
fix(darwin): link UniformTypeIdentifiers.framework for UTType

### DIFF
--- a/v2/internal/frontend/desktop/darwin/dialog.go
+++ b/v2/internal/frontend/desktop/darwin/dialog.go
@@ -5,7 +5,7 @@ package darwin
 
 /*
 #cgo CFLAGS: -x objective-c
-#cgo LDFLAGS: -framework Foundation -framework Cocoa -framework WebKit
+#cgo LDFLAGS: -framework Foundation -framework Cocoa -framework WebKit -framework UniformTypeIdentifiers
 #import <Foundation/Foundation.h>
 #import "Application.h"
 #import "WailsContext.h"


### PR DESCRIPTION
## Summary

`internal/frontend/desktop/darwin/dialog.go` references `UTType`, guarded by `#if __has_include(<UniformTypeIdentifiers/UTType.h>)` (true on every currently supported macOS SDK), but its `#cgo LDFLAGS` never links `UniformTypeIdentifiers.framework`. Any binary that imports this package fails at the final link step:

```
Undefined symbols for architecture arm64:
  "_OBJC_CLASS_$_UTType", referenced from:
       in dialog.o
ld: symbol(s) not found for architecture arm64
```

This fix adds `-framework UniformTypeIdentifiers` to `dialog.go`'s `#cgo LDFLAGS` line — a one-line change, same shape already used elsewhere in this package: `notifications.go` unconditionally links `UserNotifications.framework` for the same reason (a newer framework the older baseline `#cgo LDFLAGS` line didn't originally cover).

Since Go's cgo tool combines every `#cgo LDFLAGS` directive across all files in a package for the final link, this single addition also covers `WailsContext.m`'s own `UTType` usage in the same package.

## Reproduction

Hit on a downstream Wails v2 app's `go build -tags desktop,production ./...` on `macos-latest` (arm64) with Xcode's current SDK — a clean cgo build of any app importing this package.

## Test plan

- [x] `git diff` reviewed — single-line change, no other files touched
- [ ] Not verified against Wails' own CI (no access to trigger it from this fork) — a maintainer/CI run against a real macOS/arm64 toolchain would confirm the link succeeds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved macOS desktop compatibility by ensuring required system type-identification services are available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->