### PR TITLE
feat(v3): support native titlebar double-click on macOS

### DIFF
--- a/v3/internal/runtime/desktop/@wailsio/runtime/src/drag.ts
+++ b/v3/internal/runtime/desktop/@wailsio/runtime/src/drag.ts
@@ -8,7 +8,7 @@ The electron alternative for Go
 (c) Lea Anthony 2019-present
 */
 
-import { invoke, IsWindows, IsLinux } from "./system.js";
+import { invoke, IsWindows, IsLinux, IsMac } from "./system.js";
 import { GetFlag } from "./flags.js";
 import { canTrackButtons, eventTarget } from "./utils.js";
 
@@ -75,12 +75,35 @@ if (hasDOM) {
 }
 
 function suppressEvent(event: Event) {
+    if (
+        event.type === "dblclick"
+        && IsMac()
+        && window === window.top
+        && isDraggableEvent(event as MouseEvent)
+    ) {
+        event.stopImmediatePropagation();
+        event.stopPropagation();
+        event.preventDefault();
+        invoke("wails:drag:doubleclick");
+        return;
+    }
+
     // Suppress click events while resizing or dragging.
     if (dragging || resizing) {
         event.stopImmediatePropagation();
         event.stopPropagation();
         event.preventDefault();
     }
+}
+
+function isDraggableEvent(event: MouseEvent): boolean {
+    const target = eventTarget(event);
+    const style = window.getComputedStyle(target);
+    return (
+        style.getPropertyValue("--wails-draggable").trim() === "drag"
+        && event.offsetX - parseFloat(style.paddingLeft) < target.clientWidth
+        && event.offsetY - parseFloat(style.paddingTop) < target.clientHeight
+    );
 }
 
 // Use constants to avoid comparing strings multiple times.
@@ -173,18 +196,9 @@ function primaryDown(event: MouseEvent): void {
     }
 
     // Retrieve target element
-    const target = eventTarget(event);
-
     // Ready to drag if the primary button was pressed for the first time on a draggable element.
     // Ignore clicks on the scrollbar.
-    const style = window.getComputedStyle(target);
-    canDrag = (
-        style.getPropertyValue("--wails-draggable").trim() === "drag"
-        && (
-            event.offsetX - parseFloat(style.paddingLeft) < target.clientWidth
-            && event.offsetY - parseFloat(style.paddingTop) < target.clientHeight
-        )
-    );
+    canDrag = isDraggableEvent(event);
 }
 
 function primaryUp(event: MouseEvent) {

--- a/v3/pkg/application/titlebar_doubleclick_action.go
+++ b/v3/pkg/application/titlebar_doubleclick_action.go
@@ -1,0 +1,20 @@
+package application
+
+type titlebarDoubleClickAction uint8
+
+const (
+	titlebarDoubleClickNone titlebarDoubleClickAction = iota
+	titlebarDoubleClickToggleMaximise
+	titlebarDoubleClickMinimise
+)
+
+func parseMacTitlebarDoubleClickAction(preference string) titlebarDoubleClickAction {
+	switch preference {
+	case "", "Maximize":
+		return titlebarDoubleClickToggleMaximise
+	case "Minimize":
+		return titlebarDoubleClickMinimise
+	default:
+		return titlebarDoubleClickNone
+	}
+}

--- a/v3/pkg/application/webview_window.go
+++ b/v3/pkg/application/webview_window.go
@@ -785,6 +785,8 @@ func (w *WebviewWindow) HandleMessage(message string) {
 				}
 			})
 		}
+	case message == "wails:drag:doubleclick":
+		w.handleTitlebarDoubleClick()
 	case strings.HasPrefix(message, "wails:resize:"):
 		if !w.IsFullscreen() {
 			sl := strings.Split(message, ":")

--- a/v3/pkg/application/webview_window_darwin.go
+++ b/v3/pkg/application/webview_window_darwin.go
@@ -28,6 +28,12 @@ struct WebviewPreferences {
 
 extern void registerListener(unsigned int event);
 
+const char* windowTitlebarDoubleClickPreference(void) {
+	NSString *action = [[NSUserDefaults standardUserDefaults]
+		stringForKey:@"AppleActionOnDoubleClick"];
+	return action == nil ? "" : [action UTF8String];
+}
+
 // Create a new Window
 void* windowNew(unsigned int id, int width, int height, bool fraudulentWebsiteWarningEnabled, bool frameless, bool enableDragAndDrop, struct WebviewPreferences preferences, const char* applicationNameForUserAgent) {
 	NSWindowStyleMask styleMask = NSWindowStyleMaskTitled | NSWindowStyleMaskClosable | NSWindowStyleMaskMiniaturizable | NSWindowStyleMaskResizable;
@@ -1137,6 +1143,10 @@ func (w *macosWebviewWindow) maximise() {
 
 func (w *macosWebviewWindow) minimise() {
 	C.windowMinimise(w.nsWindow)
+}
+
+func platformTitlebarDoubleClickPreference() string {
+	return C.GoString(C.windowTitlebarDoubleClickPreference())
 }
 
 func (w *macosWebviewWindow) on(eventID uint) {

--- a/v3/pkg/application/webview_window_titlebar_doubleclick.go
+++ b/v3/pkg/application/webview_window_titlebar_doubleclick.go
@@ -1,0 +1,14 @@
+package application
+
+func (w *WebviewWindow) handleTitlebarDoubleClick() {
+	if w.IsFullscreen() {
+		return
+	}
+
+	switch parseMacTitlebarDoubleClickAction(platformTitlebarDoubleClickPreference()) {
+	case titlebarDoubleClickToggleMaximise:
+		w.ToggleMaximise()
+	case titlebarDoubleClickMinimise:
+		w.Minimise()
+	}
+}

--- a/v3/pkg/application/webview_window_titlebar_doubleclick_other.go
+++ b/v3/pkg/application/webview_window_titlebar_doubleclick_other.go
@@ -1,0 +1,7 @@
+//go:build !darwin || ios || server
+
+package application
+
+func platformTitlebarDoubleClickPreference() string {
+	return "None"
+}

--- a/v3/pkg/application/webview_window_titlebar_doubleclick_test.go
+++ b/v3/pkg/application/webview_window_titlebar_doubleclick_test.go
@@ -1,0 +1,25 @@
+package application
+
+import "testing"
+
+func TestParseMacTitlebarDoubleClickAction(t *testing.T) {
+	tests := []struct {
+		name       string
+		preference string
+		want       titlebarDoubleClickAction
+	}{
+		{name: "missing preference uses native default", want: titlebarDoubleClickToggleMaximise},
+		{name: "maximize", preference: "Maximize", want: titlebarDoubleClickToggleMaximise},
+		{name: "minimize", preference: "Minimize", want: titlebarDoubleClickMinimise},
+		{name: "none", preference: "None", want: titlebarDoubleClickNone},
+		{name: "unknown preference is ignored", preference: "FutureValue", want: titlebarDoubleClickNone},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := parseMacTitlebarDoubleClickAction(test.preference); got != test.want {
+				t.Fatalf("parseMacTitlebarDoubleClickAction(%q) = %d, want %d", test.preference, got, test.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Ports and improves the macOS custom-titlebar behaviour proposed for v2 in #4996.

Double-clicking a v3 draggable region now follows the native macOS title-bar preference:

- **Maximize** toggles maximised/restored state
- **Minimize** minimises the window
- **None** leaves the window unchanged
- fullscreen windows ignore the gesture

## Design

The v2 PR injects an additional `WKUserScript` and sends a magic message directly through the WebKit bridge. The v3 port instead:

- reuses the existing `--wails-draggable` hit-testing in the bundled runtime;
- emits a dedicated drag double-click message only on macOS;
- accepts the gesture only in the top-level document, preventing iframe-triggered window actions;
- routes it through `WebviewWindow.HandleMessage`;
- reads `AppleActionOnDoubleClick` natively;
- defaults a missing preference to macOS zoom behaviour and safely ignores unknown future values;
- keeps non-macOS platforms as explicit no-ops.

Related: #4996
Addresses the v3 side of #3578.

## Validation

- TypeScript: `tsc --noEmit`
- Runtime tests: **1,169 passed**
- Go 1.25 focused preference-mapping test: passed
- `git diff --check`: passed
- CodeRabbit local review: no findings

A full Linux `pkg/application` build was attempted in the Go 1.25 container, but the container does not include GTK4/WebKitGTK 6 development packages. The failure was dependency discovery through `pkg-config`, before compiling these changes. macOS runtime verification remains required because the native implementation is Darwin-only.