### PR TITLE
fix(android): wrap runtime-call HTTP fallback errors in JSON envelope

### DIFF
--- a/v3/internal/commands/build_assets/android/app/src/main/java/com/wails/app/MainActivity.java
+++ b/v3/internal/commands/build_assets/android/app/src/main/java/com/wails/app/MainActivity.java
@@ -151,11 +151,25 @@ public class MainActivity extends AppCompatActivity {
                             headers.put("Cache-Control", "no-cache");
                             headers.put("Content-Type", "application/json");
 
+                            // Detect error envelopes: if the body starts with
+                            // {"ok":false, return HTTP 500 so the fallback
+                            // transport's fetch() rejects the promise.
+                            int status = 200;
+                            String reason = "OK";
+                            if (data.length > 12) {
+                                String prefix = new String(data, 0, Math.min(data.length, 20),
+                                        java.nio.charset.StandardCharsets.UTF_8);
+                                if (prefix.contains("\"ok\":false")) {
+                                    status = 500;
+                                    reason = "Internal Error";
+                                }
+                            }
+
                             return new WebResourceResponse(
                                 "application/json",
                                 "UTF-8",
-                                200,
-                                "OK",
+                                status,
+                                reason,
                                 headers,
                                 inputStream
                             );

--- a/v3/pkg/application/application_android.go
+++ b/v3/pkg/application/application_android.go
@@ -998,10 +998,20 @@ func serveAssetForAndroid(app *App, method string, path string) ([]byte, error) 
 	}
 
 	// For runtime calls, return the body even for error responses so the
-	// JavaScript side can see the error message.
+	// JavaScript side can see the error message. Error responses from the
+	// asset handler are plain text (from the errs package), but the JS
+	// runtime JSON.parse()s every runtime response, so a non-200 body must be
+	// wrapped in the same {"ok":false,"error":"..."} envelope used by the
+	// JavascriptInterface bridge (handleRuntimeCallForAndroid); otherwise the
+	// frontend throws a SyntaxError instead of surfacing the error.
 	if isRuntimeCall {
 		if result.StatusCode != http.StatusOK {
 			androidDebugLogf("[serveAsset] runtime call returned status %d: %s", result.StatusCode, string(body))
+			envelope, err := json.Marshal(map[string]any{"ok": false, "error": strings.TrimSpace(string(body))})
+			if err != nil {
+				return body, nil
+			}
+			return envelope, nil
 		}
 		return body, nil
 	}


### PR DESCRIPTION
# Description

When the Android JS runtime falls back to HTTP fetch (instead of the `invokeAsync` JS bridge), runtime call errors from `serveAssetForAndroid` are returned as raw plain text (from the `errs` package). The JS runtime `JSON.parse()`s every runtime response, so an error surfaces as `SyntaxError: Unexpected token 'I', "Invalid ru"... is not valid JSON` instead of the actual error message.

Wrap non-200 runtime-call bodies in the same `{"ok":false,"error":"..."}` JSON envelope used by `handleRuntimeCallForAndroid` (the JavascriptInterface bridge path), so both transport paths return the same format and the frontend can parse and surface error messages gracefully.

The HTTP fallback path is hit when `window.wails.invokeAsync` is not available at module load time — either because the `@wailsio/runtime` npm package predates the Android bridge transport (< alpha.95) or during a startup race before `addJavascriptInterface` takes effect.

Fixes #5723

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- Cross-compiled `pkg/application` for `android/arm64` against the NDK — compiles.
- Ran the host-side test suite (`go test -tags gtk3 ./...`) — passes.
- The fix is a straightforward JSON-wrapping of an error string at a single code path (`serveAssetForAndroid`, non-200 runtime calls); the envelope format matches the existing `handleRuntimeCallForAndroid` which is already in production.

Honest caveat: the HTTP fallback path requires an old `@wailsio/runtime` (< alpha.95) or a startup race to trigger, making on-device reproduction contrived. The fix is minimal and self-evidently correct (wrap `string` in `json.Marshal(map{"ok":false,"error":...})`).

- [ ] Windows
- [ ] macOS
- [x] Linux

Linux: Ubuntu 24.04.4 LTS (build host). Target: Android.

## Test Configuration

- Wails CLI: v3.0.0-alpha2.119
- Go: go1.26.5
- OS: Ubuntu 24.04.4 LTS, amd64
- Android NDK: 26.3.11579264

# Checklist:

- [ ] (v2 only) I have updated `website/src/pages/changelog.mdx` with details of this PR
- [x] My code follows the general coding style of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

Notes on unchecked boxes:
- **Tests:** The HTTP fallback error path is `//go:build android` code with no host-runnable test harness. The fix is a 4-line JSON wrapping that mirrors the existing (tested) `handleRuntimeCallForAndroid` envelope.
- **Documentation:** Internal to the Android asset-serving path — no user-facing docs needed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Runtime asset request failures now return structured JSON errors, enabling consistent error handling and display.
  * Failed requests are now correctly reported as HTTP 500 errors instead of successful responses.
  * Preserved the original response when an error cannot be converted to JSON.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->