### PR TITLE
fix(linux): support Blob fetch bodies on Node 22

### DIFF
--- a/v3/pkg/application/linux_blob_body_fetch_shim.js
+++ b/v3/pkg/application/linux_blob_body_fetch_shim.js
@@ -29,14 +29,14 @@
         var bytes;
 
         if (body instanceof Blob) {
-            headers = new Headers(hasInitHeaders ? init.headers : request && request.headers);
+            headers = new Headers(hasInitHeaders ? init.headers : request ? request.headers : undefined);
             if (body.type && !headers.has("Content-Type")) {
                 headers.set("Content-Type", body.type);
             }
             bytes = await body.arrayBuffer();
         } else if (body instanceof FormData) {
             var encoded = new Response(body);
-            headers = new Headers(hasInitHeaders ? init.headers : request && request.headers);
+            headers = new Headers(hasInitHeaders ? init.headers : request ? request.headers : undefined);
             var contentType = encoded.headers.get("Content-Type");
             if (contentType && !headers.has("Content-Type")) {
                 headers.set("Content-Type", contentType);


### PR DESCRIPTION
Fix the Linux Wails-scheme fetch shim when converting Blob or FormData bodies without supplied headers.

Node 22 rejects `new Headers(null)`; use `undefined` when neither explicit nor request headers exist. The existing executable shim test covers this path and was the failing CI test.

Verification:
- `PATH="/tmp/wails-node22-bin:$PATH" node --input-type=module --eval ...` (Blob conversion on Node 22)
- `go test ./pkg/application -run TestLinuxBlobBodyFetchShim -count=1` (not runnable locally on macOS because the tests are Linux-only)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved request handling for Blob and FormData bodies when no explicit headers are provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->