### PR TITLE
fix(v3): sync macOS frameless window controls

### DIFF
--- a/v3/pkg/application/webview_window_darwin.go
+++ b/v3/pkg/application/webview_window_darwin.go
@@ -1115,6 +1115,12 @@ func (w *macosWebviewWindow) setFrameless(frameless bool) {
 		C.windowSetTitleBarAppearsTransparent(w.nsWindow, C.bool(appearsTransparent))
 		C.windowSetHideTitle(w.nsWindow, C.bool(hideTitle))
 	}
+	// Native-default frameless windows retain the AppKit frame, so their title-bar
+	// buttons must be hidden explicitly and restored when the frame is shown again.
+	// True borderless square and custom-radius windows do not need this handling.
+	if usesNativeMacFramelessFrame(w.parent.options.Mac) {
+		w.applyWindowButtonStates()
+	}
 }
 
 func (w *macosWebviewWindow) setHasShadow(hasShadow bool) {
@@ -1537,21 +1543,9 @@ func (w *macosWebviewWindow) run() {
 		}
 		w.setTabbingMode(macOptions.TabbingMode)
 
-		// Initialise the window buttons
-		w.setMinimiseButtonState(options.MinimiseButtonState)
-		w.setCloseButtonState(options.CloseButtonState)
-		// On macOS, MaximiseButtonState and FullscreenButtonState both control NSWindowZoomButton.
-		// Apply the more restrictive state to prevent one from silently overriding the other.
-		zoomState := options.MaximiseButtonState
-		if options.FullscreenButtonState > zoomState {
-			zoomState = options.FullscreenButtonState
-		}
-		w.setMaximiseButtonState(zoomState)
-		if options.Frameless && macOptions.CornerType == MacWindowCornerTypeRounded && macOptions.CornerRadius == 0 {
-			w.setMinimiseButtonState(ButtonHidden)
-			w.setCloseButtonState(ButtonHidden)
-			w.setMaximiseButtonState(ButtonHidden)
-		}
+		// Initialise the window buttons, including the hidden state required when
+		// native AppKit corners are retained for a frameless window.
+		w.applyWindowButtonStates()
 
 		// Ignore mouse events if requested
 		w.setIgnoreMouseEvents(options.IgnoreMouseEvents)
@@ -1785,6 +1779,13 @@ func (w *macosWebviewWindow) setMaximiseButtonState(state ButtonState) {
 
 func (w *macosWebviewWindow) setCloseButtonState(state ButtonState) {
 	C.setCloseButtonState(w.nsWindow, C.int(state))
+}
+
+func (w *macosWebviewWindow) applyWindowButtonStates() {
+	states := effectiveMacWindowButtonStates(w.parent.options)
+	w.setMinimiseButtonState(states.minimise)
+	w.setCloseButtonState(states.close)
+	w.setMaximiseButtonState(states.zoom)
 }
 
 func (w *macosWebviewWindow) isIgnoreMouseEvents() bool {

--- a/v3/pkg/application/webview_window_options.go
+++ b/v3/pkg/application/webview_window_options.go
@@ -42,6 +42,34 @@ func useDarkNativeWindowsMenu(windowIsDark bool, systemAppsUseDarkMode func() bo
 	return windowIsDark && (systemAppsUseDarkMode == nil || systemAppsUseDarkMode())
 }
 
+type macWindowButtonStates struct {
+	minimise ButtonState
+	close    ButtonState
+	zoom     ButtonState
+}
+
+// usesNativeMacFramelessFrame reports whether frameless windows retain the
+// standard AppKit frame to preserve its native rounded corners.
+func usesNativeMacFramelessFrame(options MacWindow) bool {
+	return options.CornerType == MacWindowCornerTypeRounded && options.CornerRadius == 0
+}
+
+// effectiveMacWindowButtonStates returns the configured macOS title-bar button
+// states, hiding all controls while the native AppKit frame is used frameless.
+func effectiveMacWindowButtonStates(options WebviewWindowOptions) macWindowButtonStates {
+	result := macWindowButtonStates{
+		minimise: options.MinimiseButtonState,
+		close:    options.CloseButtonState,
+		zoom:     effectiveZoomButtonState(options.MaximiseButtonState, options.FullscreenButtonState),
+	}
+	if options.Frameless && usesNativeMacFramelessFrame(options.Mac) {
+		result.minimise = ButtonHidden
+		result.close = ButtonHidden
+		result.zoom = ButtonHidden
+	}
+	return result
+}
+
 type WindowStartPosition int
 
 const (

--- a/v3/pkg/application/webview_window_options_test.go
+++ b/v3/pkg/application/webview_window_options_test.go
@@ -479,3 +479,61 @@ func TestUseDarkNativeWindowsMenu(t *testing.T) {
 		})
 	}
 }
+
+func TestEffectiveMacWindowButtonStates(t *testing.T) {
+	configured := WebviewWindowOptions{
+		MinimiseButtonState:   ButtonDisabled,
+		CloseButtonState:      ButtonHidden,
+		MaximiseButtonState:   ButtonEnabled,
+		FullscreenButtonState: ButtonDisabled,
+	}
+	wantConfigured := macWindowButtonStates{
+		minimise: ButtonDisabled,
+		close:    ButtonHidden,
+		zoom:     ButtonDisabled,
+	}
+
+	tests := []struct {
+		name      string
+		frameless bool
+		mac       MacWindow
+		want      macWindowButtonStates
+	}{
+		{
+			name: "normal window restores configured states",
+			want: wantConfigured,
+		},
+		{
+			name:      "native-default frameless hides all controls",
+			frameless: true,
+			want: macWindowButtonStates{
+				minimise: ButtonHidden,
+				close:    ButtonHidden,
+				zoom:     ButtonHidden,
+			},
+		},
+		{
+			name:      "square frameless preserves configured states",
+			frameless: true,
+			mac:       MacWindow{CornerType: MacWindowCornerTypeSquare},
+			want:      wantConfigured,
+		},
+		{
+			name:      "custom-radius frameless preserves configured states",
+			frameless: true,
+			mac:       MacWindow{CornerRadius: 12},
+			want:      wantConfigured,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			options := configured
+			options.Frameless = tt.frameless
+			options.Mac = tt.mac
+			if got := effectiveMacWindowButtonStates(options); got != tt.want {
+				t.Fatalf("effectiveMacWindowButtonStates() = %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- hide minimise, close, and zoom controls when runtime transitions enter native-default rounded frameless mode
- restore configured minimise/close states and the effective maximise/fullscreen state when leaving that mode
- preserve square and custom-radius borderless behavior
- share creation-time and transition-time button-state calculation and cover it with focused tests

Fixes #5869

## Validation

- `go test webview_window_options.go webview_window_options_test.go options_test_stubs.go -run 'TestEffective(MacWindowButtonStates|ZoomButtonState)$' -count=1` (pass; temporary declarations supply unrelated package types only)
- `go test webview_window_options.go webview_window_options_test.go options_test_stubs.go -count=1` (pass; full options test file)
- `git diff --check` (pass)
- `coderabbit --plain` (installed CLI does not accept the legacy flag); equivalent plain `coderabbit review --uncommitted` completed with no findings

## Platform limits

Native AppKit behavior cannot be exercised on this Linux host. A Darwin cross-build is also unavailable: CGO-disabled compilation excludes the macOS package and CGO-enabled compilation lacks an Apple cross-compiler/frameworks (`cc: unrecognized command-line option -arch`). The state calculation is isolated in pure Go so both transition directions and square/custom-radius non-regression paths are covered here; native macOS CI/manual validation remains required.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved macOS window control behavior for minimize, close, and maximize/fullscreen buttons.
  * Frameless windows now consistently hide native title-bar controls when required.
  * Updated window state handling when switching between framed and frameless modes.

* **Tests**
  * Added coverage for macOS window button behavior across supported window styles and corner configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->