### PR TITLE
fix(v3/windows): load dark-mode uxtheme exports on 1809 so menus are …

### DIFF
--- a/v3/UNRELEASED_CHANGELOG.md
+++ b/v3/UNRELEASED_CHANGELOG.md
@@ -23,6 +23,7 @@ After processing, the content will be moved to the main changelog and this file 
 
 ## Fixed
 <!-- Bug fixes -->
+- Fix unreadable native menus on Windows 10 1809 / Windows Server 2019 (build 17763). The dark-mode uxtheme exports were gated on build 18334, so the app-level dark-mode opt-in never ran on those hosts: the menu background was painted dark but Windows kept drawing menu text in the light theme, leaving dark text on a dark background. The ordinals exist from 17763, so the gate now matches.
 
 ## Deprecated
 <!-- Soon-to-be removed features -->

--- a/v3/pkg/application/webview_window_windows.go
+++ b/v3/pkg/application/webview_window_windows.go
@@ -1449,9 +1449,8 @@ func (w *windowsWebviewWindow) disableIcon() {
 
 // applyDarkMode opts the window into dark mode via the uxtheme
 // AllowDarkModeForWindow export. That export is only loaded on Windows builds
-// that provide it (>= 18334); on older builds such as Windows 10 1809 / build
-// 17763 it is nil, so this guards the call to avoid a nil-pointer panic on
-// startup.
+// that provide it (>= 17763); on older builds it is nil, so this guards the
+// call to avoid a nil-pointer panic on startup.
 func (w *windowsWebviewWindow) applyDarkMode() {
 	if w32.AllowDarkModeForWindow != nil {
 		w32.AllowDarkModeForWindow(w.hwnd, true)

--- a/v3/pkg/w32/theme.go
+++ b/v3/pkg/w32/theme.go
@@ -96,8 +96,15 @@ var (
 )
 
 func init() {
-	if IsWindowsVersionAtLeast(10, 0, 18334) {
-		// AllowDarkModeForWindow is only available on Windows 10+
+	// The dark-mode uxtheme exports (ordinals 132/133/135/136/104) exist from
+	// Windows 10 1809 (build 17763), which includes Windows Server 2019. Gating
+	// them on a later build left those hosts with unreadable menus: the menu
+	// background is painted dark regardless (updateTheme applies a MENUINFO
+	// brush), but Windows draws menu text from the process's immersive colour
+	// policy, and the opt-in below never ran - so the text stayed light-theme
+	// dark on a dark background. On 1809, ordinal 135 is AllowDarkModeForApp and
+	// PreferredAppModeAllowDark is 1, so that call is the opt-in this host needs.
+	if IsWindowsVersionAtLeast(10, 0, 17763) {
 		localUXTheme, err := windows.LoadLibrary("uxtheme.dll")
 		if err == nil {
 			procAllowDarkModeForWindow, err := windows.GetProcAddressByOrdinal(localUXTheme, uintptr(133))


### PR DESCRIPTION
# Description

On Windows 10 1809 / Windows Server 2019 (build 17763), any user running Windows in dark mode gets dark menu text on a dark menu background in every Wails v3 app, making menus effectively unreadable.

`pkg/w32/theme.go`'s `init()` gated the undocumented dark-mode uxtheme exports on build `>= 18334`. Those ordinals (132 / 133 / 135 / 136 / 104) exist from Windows 10 1809 (build 17763), so on those hosts all five stayed `nil`.

That produced a half-themed menu:

- The menu **background** still went dark. `updateTheme` applies a `#212121` brush via `MENUINFO`/`HbrBack` independently of any uxtheme call, and `SetMenuTheme`'s `SetWindowTheme(hwnd, "DarkMode_Explorer")` is name-resolved so it runs there too.
- The menu **text** colour did not follow. Windows draws it from the process's immersive colour policy, and the call that opts the process in sits inside the gate: `init()` only reaches `SetPreferredAppMode(PreferredAppModeAllowDark)` when the build check passes. On 1809, ordinal 135 is `AllowDarkModeForApp` and `PreferredAppModeAllowDark` is `1`, so that call is precisely the opt-in this host needs — it simply never ran.

The process was therefore never registered as dark-aware, Windows kept drawing menu text in the light theme, and it landed on a dark background.

Lowering the gate to 17763 makes the opt-in run and Windows renders the menu text light. **This is an opt-in fix rather than a repaint** — the resulting menu is drawn natively by Windows, which is why it looks like a standard dark menu and not a custom-painted one.

**Why 17763, and what this can affect**

17763 is where these ordinals first exist. Going lower would be unsafe, not merely untested: ordinals are not stable across Windows versions, and `GetProcAddressByOrdinal` returns whatever export occupies that slot without erroring, so a lower gate risks calling an unrelated function as `AllowDarkModeForWindow`. The version check is the only guard.

The blast radius is correspondingly narrow. The condition only newly admits builds in `[17763, 18334)`; anything at or above 18334 already satisfied the old gate and is unaffected, and anything below 17763 stays excluded. In retail terms that window contains exactly one release — Windows 10 1809 / Server 2019 / LTSC 2019. 18334 was a 19H1 Insider build; 19H1 shipped as 18362.

`SupportsThemes()` and `SupportsCustomThemes()` in the same file already use 17763 as their floor, so this also makes the gate consistent with the rest of the package. Wails' own v2 ordinal table (`v2/internal/platform/win32/consts.go`) documents this same set as the 1809 block, with later additions annotated separately as `Insider 18290` and `Insider 18334`.

This does **not** affect the title bar. DWM already handles that on 17763 via the `DwmwaUseImmersiveDarkModeBefore20h1` attribute that `SetTheme` sets.

Fixes #5872

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] WEP (proposal only; no implementation)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Tested on a real Windows Server 2019 host, build 17763, with two binaries built from the same source tree: one at the `v3.0.0-beta.2` tag unmodified, one with only this change applied. Each opened a window with a native menu, and each was run with the OS in both dark and light mode.

Confirmed before testing that neither masking condition was active — either would have invalidated the comparison:

- **High Contrast off.** `updateTheme` returns early when it is on, so no theming code runs at all.
- **DWM `ColorPrevalence` off.** It paints captions from the accent colour for every app regardless of theme.

| OS mode | window theme | before | after |
|---|---|---|---|
| dark | `Dark` | unreadable | readable |
| dark | `SystemDefault` | unreadable | readable |
| light | `Dark` | unreadable | unreadable (unchanged) |
| light | `SystemDefault` | readable | readable |

A strict improvement: both broken dark-mode cases fixed, no regression in the others.

The remaining `light OS + explicit Theme: Dark` case is a separate, pre-existing bug that is **not** specific to 1809 — `updateTheme` paints a dark menu background whenever the window resolves to dark, while `SetMenuTheme` downgrades to the light theme when `ShouldAppsUseDarkMode()` returns false. I confirmed it reproduces on unmodified `v3.0.0-beta.2` and will file it separately rather than widen this PR.

- [x] Windows
- [ ] macOS
- [ ] Linux

Not applicable to macOS or Linux.

## Test Configuration

```
Wails:   v3.0.0-beta.2 (built from the release tag)
OS:      Windows Server 2019 Standard Evaluation, Version 1809 (Build 17763)
Arch:    amd64
WebView2 runtime: 150.0.4078.65

High Contrast:        off
DWM ColorPrevalence:  0
AppsUseLightTheme:    0 (apps dark) for the failing cases
```

My development machine is macOS and the Windows host has no Wails toolchain installed, so I cannot provide `wails3 doctor` output from it. Binaries were cross-compiled with `GOOS=windows GOARCH=amd64` and copied across.

# Checklist:
- [x] My code follows the general coding style of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation — none needed; no public API or documented behaviour changes
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works — see note below
- [x] New and existing unit tests pass locally with my changes

**On tests:** the behavior under test is the color of native menu text on a specific Windows build, which I could not find a way to assert in a unit test — the existing `pkg/w32` Windows tests cover handle lifecycles rather than rendering. I have included a measured before/after matrix from real hardware instead, and am happy to add a test if a maintainer can suggest a workable approach.

I have also added an entry to `v3/UNRELEASED_CHANGELOG.md` to control the wording, as described in CONTRIBUTING.md.

**AI Usage Disclosure**: I used AI in investigating and preparing this change to confirm my own initial findings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed unreadable native menus when dark mode is enabled on Windows 10 version 1809 and Windows Server 2019.
  * Improved dark-mode compatibility on supported Windows versions while preserving fallback behavior.

* **Documentation**
  * Added a changelog entry documenting the Windows menu rendering fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->