### PR TITLE
fix(v3/windows): pass HWND to AllowDarkModeForWindow

### DIFF
--- a/v3/pkg/w32/theme.go
+++ b/v3/pkg/w32/theme.go
@@ -114,7 +114,7 @@ func init() {
 					if allow {
 						allowInt = 1
 					}
-					ret, _, _ := syscall.SyscallN(procAllowDarkModeForWindow, uintptr(allowInt))
+					ret, _, _ := syscall.SyscallN(procAllowDarkModeForWindow, uintptr(hwnd), uintptr(allowInt))
 					return ret
 				}
 			}

--- a/v3/pkg/w32/theme_test.go
+++ b/v3/pkg/w32/theme_test.go
@@ -1,0 +1,66 @@
+//go:build windows
+
+package w32
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"testing"
+)
+
+func TestAllowDarkModeForWindowPassesHWNDAndAllowFlag(t *testing.T) {
+	file, err := parser.ParseFile(token.NewFileSet(), "theme.go", nil, 0)
+	if err != nil {
+		t.Fatalf("parse theme.go: %v", err)
+	}
+
+	var syscallCall *ast.CallExpr
+	ast.Inspect(file, func(node ast.Node) bool {
+		call, ok := node.(*ast.CallExpr)
+		if !ok || len(call.Args) == 0 {
+			return true
+		}
+
+		selector, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok || selector.Sel.Name != "SyscallN" {
+			return true
+		}
+
+		proc, ok := call.Args[0].(*ast.Ident)
+		if ok && proc.Name == "procAllowDarkModeForWindow" {
+			syscallCall = call
+			return false
+		}
+		return true
+	})
+
+	if syscallCall == nil {
+		t.Fatal("AllowDarkModeForWindow syscall not found")
+	}
+	if len(syscallCall.Args) != 3 {
+		t.Fatalf("SyscallN argument count = %d; want 3 (procedure, HWND, allow flag)", len(syscallCall.Args))
+	}
+
+	assertUintptrIdent(t, syscallCall.Args[1], "hwnd")
+	assertUintptrIdent(t, syscallCall.Args[2], "allowInt")
+}
+
+func assertUintptrIdent(t *testing.T, expression ast.Expr, name string) {
+	t.Helper()
+
+	conversion, ok := expression.(*ast.CallExpr)
+	if !ok || len(conversion.Args) != 1 {
+		t.Fatalf("argument is not a single-value uintptr conversion: %#v", expression)
+	}
+
+	typeName, ok := conversion.Fun.(*ast.Ident)
+	if !ok || typeName.Name != "uintptr" {
+		t.Fatalf("argument conversion = %#v; want uintptr", conversion.Fun)
+	}
+
+	identifier, ok := conversion.Args[0].(*ast.Ident)
+	if !ok || identifier.Name != name {
+		t.Fatalf("converted argument = %#v; want %s", conversion.Args[0], name)
+	}
+}

--- a/v3/pkg/w32/theme_test.go
+++ b/v3/pkg/w32/theme_test.go
@@ -6,11 +6,19 @@ import (
 	"go/ast"
 	"go/parser"
 	"go/token"
+	"path/filepath"
+	"runtime"
 	"testing"
 )
 
 func TestAllowDarkModeForWindowPassesHWNDAndAllowFlag(t *testing.T) {
-	file, err := parser.ParseFile(token.NewFileSet(), "theme.go", nil, 0)
+	_, testFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("locate theme_test.go")
+	}
+
+	themeFile := filepath.Join(filepath.Dir(testFile), "theme.go")
+	file, err := parser.ParseFile(token.NewFileSet(), themeFile, nil, 0)
 	if err != nil {
 		t.Fatalf("parse theme.go: %v", err)
 	}

--- a/v3/pkg/w32/theme_test.go
+++ b/v3/pkg/w32/theme_test.go
@@ -5,7 +5,7 @@ package w32
 import (
 	"go/ast"
 	"go/parser"
-	"go/token"
+	gotoken "go/token"
 	"path/filepath"
 	"runtime"
 	"testing"
@@ -18,7 +18,7 @@ func TestAllowDarkModeForWindowPassesHWNDAndAllowFlag(t *testing.T) {
 	}
 
 	themeFile := filepath.Join(filepath.Dir(testFile), "theme.go")
-	file, err := parser.ParseFile(token.NewFileSet(), themeFile, nil, 0)
+	file, err := parser.ParseFile(gotoken.NewFileSet(), themeFile, nil, 0)
 	if err != nil {
 		t.Fatalf("parse theme.go: %v", err)
 	}


### PR DESCRIPTION
## Summary

Follow-up to #5873.

- passes both native arguments required by ordinal 133: `HWND` and the allow flag
- adds a Windows-only AST regression test that verifies the `SyscallN` call preserves the native ABI argument order

## Why

The wrapper was declared as `AllowDarkModeForWindow(HWND, bool)` but invoked `SyscallN` with only the Boolean value. Lowering the uxtheme gate in #5873 expanded that broken call path to Windows build 17763, so this corrects the ABI immediately while keeping the original fix independently merged.

## Testing

CI should exercise the Windows package and the new regression test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dark mode handling on Windows by correctly applying the setting to the selected window.

* **Tests**
  * Added Windows-specific validation to ensure dark mode requests use the correct parameters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->