### PR TITLE
fix(v3/windows): preserve native menu readability

### DIFF
--- a/v3/UNRELEASED_CHANGELOG.md
+++ b/v3/UNRELEASED_CHANGELOG.md
@@ -23,6 +23,7 @@ After processing, the content will be moved to the main changelog and this file 
 
 ## Fixed
 <!-- Bug fixes -->
+- Prevent unreadable native menu text when a Windows application requests dark mode while the Windows app theme is light. The menu now uses the matching light native background until Windows can render dark menu text.
 - Fix unreadable native menus on Windows 10 1809 / Windows Server 2019 (build 17763). The dark-mode uxtheme exports were gated on build 18334, so the app-level dark-mode opt-in never ran on those hosts: the menu background was painted dark but Windows kept drawing menu text in the light theme, leaving dark text on a dark background. The ordinals exist from 17763, so the gate now matches.
 
 ## Deprecated

--- a/v3/pkg/application/webview_window_options.go
+++ b/v3/pkg/application/webview_window_options.go
@@ -33,6 +33,15 @@ func effectiveZoomButtonState(a, b ButtonState) ButtonState {
 	return a
 }
 
+// useDarkNativeWindowsMenu reports whether Windows can draw a dark native menu
+// for a dark application window. A menu background can be selected per window,
+// but Windows selects native menu text from its process-level colour policy. If
+// the system policy is light, retaining a dark background makes the text
+// unreadable, so callers must fall back to the matching light menu instead.
+func useDarkNativeWindowsMenu(windowIsDark bool, systemAppsUseDarkMode func() bool) bool {
+	return windowIsDark && (systemAppsUseDarkMode == nil || systemAppsUseDarkMode())
+}
+
 type WindowStartPosition int
 
 const (

--- a/v3/pkg/application/webview_window_options_test.go
+++ b/v3/pkg/application/webview_window_options_test.go
@@ -457,3 +457,25 @@ func TestEffectiveZoomButtonState(t *testing.T) {
 		})
 	}
 }
+
+func TestUseDarkNativeWindowsMenu(t *testing.T) {
+	tests := []struct {
+		name       string
+		windowDark bool
+		systemDark func() bool
+		want       bool
+	}{
+		{"light window", false, nil, false},
+		{"dark window with unavailable policy", true, nil, true},
+		{"dark window with dark system policy", true, func() bool { return true }, true},
+		{"dark window with light system policy", true, func() bool { return false }, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := useDarkNativeWindowsMenu(tt.windowDark, tt.systemDark); got != tt.want {
+				t.Fatalf("useDarkNativeWindowsMenu() = %t, want %t", got, tt.want)
+			}
+		})
+	}
+}

--- a/v3/pkg/application/webview_window_windows.go
+++ b/v3/pkg/application/webview_window_windows.go
@@ -1480,9 +1480,13 @@ func (w *windowsWebviewWindow) updateTheme(isDarkMode bool) {
 	}
 
 	w32.SetTheme(w.hwnd, isDarkMode)
+	// Native popup-menu text follows Windows' process-level colour policy, not
+	// the per-window DWM theme. Do not paint a dark menu background when that
+	// policy is light, otherwise Windows draws dark text on dark backgrounds.
+	menuIsDarkMode := useDarkNativeWindowsMenu(isDarkMode, w32.ShouldAppsUseDarkMode)
 
 	// Clear any existing theme first
-	if w.menubarTheme != nil && !isDarkMode {
+	if w.menubarTheme != nil && !menuIsDarkMode {
 		// Reset menu to default Windows theme when switching to light mode
 		w.menubarTheme = nil
 		if w.menu != nil {
@@ -1500,7 +1504,7 @@ func (w *windowsWebviewWindow) updateTheme(isDarkMode bool) {
 	// Custom theme
 	if w32.SupportsCustomThemes() {
 		var userTheme *MenuBarTheme
-		if isDarkMode {
+		if menuIsDarkMode {
 			userTheme = customTheme.DarkModeMenuBar
 		} else {
 			userTheme = customTheme.LightModeMenuBar
@@ -1508,7 +1512,7 @@ func (w *windowsWebviewWindow) updateTheme(isDarkMode bool) {
 
 		if userTheme != nil {
 			modeStr := "light"
-			if isDarkMode {
+			if menuIsDarkMode {
 				modeStr = "dark"
 			}
 			globalApplication.debug("Setting custom "+modeStr+" menubar theme", "window", w.parent.id)
@@ -1529,7 +1533,7 @@ func (w *windowsWebviewWindow) updateTheme(isDarkMode bool) {
 				w32.DrawMenuBar(w.hwnd)
 				w32.InvalidateRect(w.hwnd, nil, true)
 			}
-		} else if userTheme == nil && isDarkMode {
+		} else if userTheme == nil && menuIsDarkMode {
 			// Use default dark theme if no custom theme provided
 			globalApplication.debug("Setting default dark menubar theme", "window", w.parent.id)
 			w.menubarTheme = &w32.MenuBarTheme{
@@ -1549,7 +1553,7 @@ func (w *windowsWebviewWindow) updateTheme(isDarkMode bool) {
 				w32.DrawMenuBar(w.hwnd)
 				w32.InvalidateRect(w.hwnd, nil, true)
 			}
-		} else if userTheme == nil && !isDarkMode && w.menu != nil {
+		} else if userTheme == nil && !menuIsDarkMode && w.menu != nil {
 			// No custom theme for light mode - ensure menu is reset to default
 			globalApplication.debug("Resetting menu to default light theme", "window", w.parent.id)
 			var mi w32.MENUINFO


### PR DESCRIPTION
## Summary

- keep a requested dark application window dark
- use the matching light native menu palette when Windows is in light app mode and cannot render matching dark menu text
- add focused coverage for the native-menu policy decision

Fixes #5878

## Why

Native popup-menu text is selected from Windows process-level colour policy, while the menu background is selected per Wails window. A dark Wails window on a light Windows system therefore produced dark text on a dark background. This is the smallest safe Beta fix: it preserves legibility without introducing owner-drawn menus or a new public theming API.

## Validation

- `go test ./pkg/application -run 'Test(UseDarkNativeWindowsMenu|EffectiveZoomButtonState)$' -count=1`\n- `GOOS=windows GOARCH=amd64 go test -c ./pkg/application`\n- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows native menu readability when dark mode is requested while the app uses a light theme.
  * Native menu colors now correctly respect the system’s dark-mode preference.
* **Documentation**
  * Added a changelog entry describing the Windows menu appearance fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->