### PR TITLE
ci(v3): skip nightly releases for bookkeeping-only changes

### DIFF
--- a/.github/workflows/nightly-release-v3.yml
+++ b/.github/workflows/nightly-release-v3.yml
@@ -90,56 +90,49 @@ jobs:
       run: |
         echo "🔍 Quick check for changes to determine if we should continue..."
         
-        # First check if we have unreleased changelog content
-        if [ "${{ steps.changelog_check.outputs.has_unreleased_content }}" == "true" ]; then
-          echo "✅ Found unreleased changelog content, proceeding with release"
-          echo "has_changes=true" >> $GITHUB_OUTPUT
-          echo "should_continue=true" >> $GITHUB_OUTPUT
-          echo "reason=Found unreleased changelog content" >> $GITHUB_OUTPUT
-          exit 0
+        # Release bookkeeping can be committed after a tag is created. In
+        # particular, the auto-changelog workflow may add an entry to
+        # UNRELEASED_CHANGELOG.md after the release has already completed.
+        # That is not a new release input and must not create another nightly
+        # release on its own.
+        if CURRENT_TAG=$(git describe --tags --exact-match HEAD 2>/dev/null); then
+          LATEST_TAG="$CURRENT_TAG"
+          echo "Current commit has release tag: $LATEST_TAG"
+        else
+          # Only consider the active release series (alpha2/beta/rc): they
+          # outrank legacy alpha tags, and explicit patterns avoid stray tags
+          # such as v3.0.0-alpha.98-tui being selected as the baseline.
+          LATEST_TAG=$(git tag --list "v3.0.0-alpha2.*" "v3.0.0-beta.*" "v3.0.0-rc.*" | sort -V | tail -1)
         fi
-        
-        # If no unreleased changelog content, check for git changes as fallback
-        echo "No unreleased changelog content found, checking for git changes..."
-        
-        # Check if current commit has a release tag
-        if git describe --tags --exact-match HEAD 2>/dev/null; then
-          CURRENT_TAG=$(git describe --tags --exact-match HEAD)
-          echo "Current commit has release tag: $CURRENT_TAG"
-          
-          # For tagged commits, check if there are changes since the tag
-          COMMIT_COUNT=$(git rev-list ${CURRENT_TAG}..HEAD --count)
-          if [ "$COMMIT_COUNT" -eq 0 ]; then
+
+        if [ -z "$LATEST_TAG" ]; then
+          echo "No previous release found; a release is eligible if changelog content exists."
+          if [ "${{ steps.changelog_check.outputs.has_unreleased_content }}" == "true" ]; then
+            echo "has_changes=true" >> $GITHUB_OUTPUT
+            echo "should_continue=true" >> $GITHUB_OUTPUT
+            echo "reason=Unreleased changelog content with no previous release" >> $GITHUB_OUTPUT
+          else
             echo "has_changes=false" >> $GITHUB_OUTPUT
             echo "should_continue=false" >> $GITHUB_OUTPUT
-            echo "reason=No changes since existing tag $CURRENT_TAG and no unreleased changelog content" >> $GITHUB_OUTPUT
-          else
-            echo "has_changes=true" >> $GITHUB_OUTPUT
-            echo "should_continue=true" >> $GITHUB_OUTPUT
+            echo "reason=No previous release and no unreleased changelog content" >> $GITHUB_OUTPUT
           fi
+        elif git diff --quiet "${LATEST_TAG}..HEAD" -- \
+          . \
+          ':(exclude)v3/internal/version/version.txt' \
+          ':(exclude)v3/UNRELEASED_CHANGELOG.md' \
+          ':(exclude)docs/src/content/docs/changelog.mdx' \
+          ':(exclude)v3/internal/runtime/desktop/@wailsio/runtime/package.json' \
+          ':(exclude)v3/internal/runtime/desktop/@wailsio/runtime/package-lock.json'; then
+          echo "No release inputs changed since $LATEST_TAG; skipping release."
+          echo "has_changes=false" >> $GITHUB_OUTPUT
+          echo "should_continue=false" >> $GITHUB_OUTPUT
+          echo "reason=Only release bookkeeping changed since $LATEST_TAG" >> $GITHUB_OUTPUT
         else
-          # No current tag, check against latest release.
-          # Only consider the active release series (alpha2/beta/rc): they
-          # outrank the legacy "alpha.*" tags in semver, and matching them
-          # explicitly keeps stray legacy tags (e.g. v3.0.0-alpha.98-tui) from
-          # being picked up as the latest release by a blanket glob.
-          LATEST_TAG=$(git tag --list "v3.0.0-alpha2.*" "v3.0.0-beta.*" "v3.0.0-rc.*" | sort -V | tail -1)
-          if [ -z "$LATEST_TAG" ]; then
-            echo "No previous release found, proceeding with release"
-            echo "has_changes=true" >> $GITHUB_OUTPUT
-            echo "should_continue=true" >> $GITHUB_OUTPUT
-          else
-            COMMIT_COUNT=$(git rev-list ${LATEST_TAG}..HEAD --count)
-            if [ "$COMMIT_COUNT" -gt 0 ]; then
-              echo "Found $COMMIT_COUNT commits since $LATEST_TAG"
-              echo "has_changes=true" >> $GITHUB_OUTPUT
-              echo "should_continue=true" >> $GITHUB_OUTPUT
-            else
-              echo "has_changes=false" >> $GITHUB_OUTPUT
-              echo "should_continue=false" >> $GITHUB_OUTPUT
-              echo "reason=No changes since latest release $LATEST_TAG and no unreleased changelog content" >> $GITHUB_OUTPUT
-            fi
-          fi
+          CHANGE_COUNT=$(git rev-list "${LATEST_TAG}..HEAD" --count)
+          echo "Found release inputs in $CHANGE_COUNT commits since $LATEST_TAG"
+          echo "has_changes=true" >> $GITHUB_OUTPUT
+          echo "should_continue=true" >> $GITHUB_OUTPUT
+          echo "reason=Release inputs changed since $LATEST_TAG" >> $GITHUB_OUTPUT
         fi
     
     - name: Early exit - No changes detected


### PR DESCRIPTION
Fixes the nightly no-change gate.

The previous workflow treated any UNRELEASED_CHANGELOG.md content as sufficient to release, so auto-generated release bookkeeping could create an additional beta without new release inputs.

This change compares master with the latest active beta/RC tag and ignores only release bookkeeping files: the version file, unreleased changelog, published changelog, and runtime package version metadata. Real source, docs, workflow, and runtime changes still trigger a release.

Validated against the actual beta.2 release commit: bookkeeping-only changes are skipped, while the real beta.1-to-beta.2 change set still triggers release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved release change detection by excluding release-bookkeeping updates from eligible changes.
  - Added support for recognizing tagged commits and selecting the latest active pre-release tag as the baseline.
  - Release checks now distinguish eligible changes from bookkeeping-only updates.
  - Added clearer status and reason reporting, including no-baseline and no-change outcomes.
  - Unreleased changelog content can now qualify a release when no previous release exists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->