### PR TITLE
ci(v3): publish artifacts before immutable releases

### DIFF
--- a/.github/workflows/nightly-release-v3.yml
+++ b/.github/workflows/nightly-release-v3.yml
@@ -67,6 +67,20 @@ jobs:
           echo "has_tag=false" >> $GITHUB_OUTPUT
           echo "tag=" >> $GITHUB_OUTPUT
         fi
+
+    - name: Check whether a tagged commit still needs publication
+      id: publication_check
+      if: steps.check_tag.outputs.has_tag == 'true'
+      env:
+        GH_TOKEN: ${{ secrets.WAILS_REPO_TOKEN || github.token }}
+      run: |
+        tag="${{ steps.check_tag.outputs.tag }}"
+        if [[ "$tag" == v3.* ]] && ! gh release view "$tag" --repo "${{ github.repository }}" >/dev/null 2>&1; then
+          echo "needs_recovery=true" >> "$GITHUB_OUTPUT"
+          echo "Release $tag is missing; the desktop artifact workflow will be re-dispatched."
+        else
+          echo "needs_recovery=false" >> "$GITHUB_OUTPUT"
+        fi
     
     - name: Check for unreleased changelog content
       id: changelog_check
@@ -138,6 +152,7 @@ jobs:
     - name: Early exit - No changes detected
       if: |
         steps.quick_check.outputs.should_continue == 'false' && 
+        steps.publication_check.outputs.needs_recovery != 'true' &&
         github.event.inputs.force_release != 'true'
       run: |
         echo "🛑 EARLY EXIT: ${{ steps.quick_check.outputs.reason }}"
@@ -182,31 +197,74 @@ jobs:
         if [ "${{ github.event.inputs.dry_run }}" == "true" ]; then
           ARGS+=(--dry-run)
         fi
+        # Release v3 must create the GitHub release with its artifacts in the
+        # same operation. Publishing here first makes the release immutable and
+        # prevents the artifact workflow from uploading its outputs.
+        ARGS+=(--defer-github-release)
         go run release.go "${ARGS[@]}"
 
     # Tags created with GITHUB_TOKEN do not emit a push event that can trigger
-    # Release v3. Dispatch it explicitly so each published nightly also gets
-    # the platform binaries, checksums, and provenance attached to its release.
-    - name: Build and attach desktop artifacts
+    # Release v3. Dispatch it explicitly; this workflow is the sole publisher
+    # so the immutable release is created with its platform binaries,
+    # checksums, and provenance already attached.
+    - name: Build and publish release with desktop artifacts
       id: desktop_artifacts
-      if: steps.release.outcome == 'success' && steps.release.outputs.release_dry_run != 'true'
+      if: |
+        (steps.release.outcome == 'success' && steps.release.outputs.release_dry_run != 'true') ||
+        steps.publication_check.outputs.needs_recovery == 'true'
       env:
         GH_TOKEN: ${{ secrets.WAILS_REPO_TOKEN || github.token }}
+        RELEASE_NOTES: ${{ steps.release.outputs.release_notes }}
       run: |
-        tag="${{ steps.release.outputs.release_tag }}"
+        tag="${{ steps.release.outputs.release_tag || steps.check_tag.outputs.tag }}"
+        caller="$GITHUB_RUN_ID-$GITHUB_RUN_ATTEMPT"
+        run_title="Release v3 $tag ($caller)"
         pre_release=false
         if [[ "$tag" == *-* ]]; then
           pre_release=true
         fi
 
+        INPUTS=(
+          -f tag="$tag"
+          -f pre_release="$pre_release"
+          -f draft=false
+          -f orchestrator_run="$caller"
+        )
+        if [ -n "$RELEASE_NOTES" ]; then
+          INPUTS+=(-f release_notes="$RELEASE_NOTES")
+        fi
+
         gh workflow run release-v3.yml \
           --repo "${{ github.repository }}" \
           --ref master \
-          -f tag="$tag" \
-          -f pre_release="$pre_release" \
-          -f draft=false
+          "${INPUTS[@]}"
         echo "dispatched=true" >> "$GITHUB_OUTPUT"
-        echo "Dispatched Release v3 for $tag"
+        echo "Dispatched Release v3 to publish $tag with desktop artifacts"
+
+        run_id=""
+        for _ in $(seq 1 30); do
+          run_id=$(gh run list \
+            --repo "${{ github.repository }}" \
+            --workflow release-v3.yml \
+            --event workflow_dispatch \
+            --limit 20 \
+            --json databaseId,displayTitle \
+            --jq ".[] | select(.displayTitle == \"$run_title\") | .databaseId" \
+            | head -n 1)
+          if [ -n "$run_id" ]; then
+            break
+          fi
+          sleep 2
+        done
+        if [ -z "$run_id" ]; then
+          echo "::error::Unable to identify the dispatched Release v3 run for $tag."
+          exit 1
+        fi
+
+        echo "run_id=$run_id" >> "$GITHUB_OUTPUT"
+        echo "Waiting for Release v3 run $run_id"
+        gh run watch "$run_id" --repo "${{ github.repository }}" --exit-status
+        echo "published=true" >> "$GITHUB_OUTPUT"
 
     - name: Summary
       if: always()
@@ -226,9 +284,6 @@ jobs:
           if [ -n "${{ steps.release.outputs.release_url }}" ]; then
             echo "- **Release URL:** ${{ steps.release.outputs.release_url }}" >> $GITHUB_STEP_SUMMARY
           fi
-          if [ "${{ steps.desktop_artifacts.outputs.dispatched }}" == "true" ]; then
-            echo "- **Desktop artifacts:** Release v3 dispatched" >> $GITHUB_STEP_SUMMARY
-          fi
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### Changelog" >> $GITHUB_STEP_SUMMARY
           if [ "${{ steps.changelog_check.outputs.has_unreleased_content }}" == "true" ]; then
@@ -238,5 +293,10 @@ jobs:
           fi
         else
           echo "- Release script did not run (skipped or failed before execution)." >> $GITHUB_STEP_SUMMARY
+        fi
+        if [ "${{ steps.desktop_artifacts.outputs.published }}" == "true" ]; then
+          echo "- **Publication:** Release v3 completed with desktop artifacts" >> $GITHUB_STEP_SUMMARY
+        elif [ "${{ steps.desktop_artifacts.outputs.dispatched }}" == "true" ]; then
+          echo "- **Publication:** Release v3 run ${{ steps.desktop_artifacts.outputs.run_id }} failed or could not be tracked" >> $GITHUB_STEP_SUMMARY
         fi
     

--- a/.github/workflows/nightly-release-v3.yml
+++ b/.github/workflows/nightly-release-v3.yml
@@ -210,8 +210,9 @@ jobs:
     - name: Build and publish release with desktop artifacts
       id: desktop_artifacts
       if: |
-        (steps.release.outcome == 'success' && steps.release.outputs.release_dry_run != 'true') ||
-        steps.publication_check.outputs.needs_recovery == 'true'
+        github.event.inputs.dry_run != 'true' &&
+        ((steps.release.outcome == 'success' && steps.release.outputs.release_dry_run != 'true') ||
+        steps.publication_check.outputs.needs_recovery == 'true')
       env:
         GH_TOKEN: ${{ secrets.WAILS_REPO_TOKEN || github.token }}
         RELEASE_NOTES: ${{ steps.release.outputs.release_notes }}

--- a/.github/workflows/release-v3.yml
+++ b/.github/workflows/release-v3.yml
@@ -1,4 +1,5 @@
 name: Release v3
+run-name: Release v3 ${{ inputs.tag || github.ref_name }} (${{ inputs.orchestrator_run || 'direct' }})
 
 on:
   push:
@@ -20,6 +21,14 @@ on:
         required: false
         default: false
         type: boolean
+      release_notes:
+        description: 'Optional curated release notes supplied by the release orchestrator'
+        required: false
+        type: string
+      orchestrator_run:
+        description: 'Optional caller run identifier used to track this workflow'
+        required: false
+        type: string
 
 env:
   GO_VERSION: '1.25'
@@ -241,12 +250,17 @@ jobs:
           TAG: ${{ needs.preflight.outputs.tag }}
           PRE: ${{ needs.preflight.outputs.pre_release }}
           DRAFT: ${{ inputs.draft }}
+          RELEASE_NOTES: ${{ inputs.release_notes }}
         run: |
           FLAGS=(
             --repo "${{ github.repository }}"
             --title "Wails $TAG"
-            --generate-notes
           )
+          if [ -n "$RELEASE_NOTES" ]; then
+            FLAGS+=(--notes "$RELEASE_NOTES")
+          else
+            FLAGS+=(--generate-notes)
+          fi
           [[ "$PRE" == "true" ]] && FLAGS+=(--prerelease)
           # A draft release is visible only to maintainers and can be deleted,
           # which is what makes rehearsing the whole path possible without

--- a/v3/UNRELEASED_CHANGELOG.md
+++ b/v3/UNRELEASED_CHANGELOG.md
@@ -23,6 +23,7 @@ After processing, the content will be moved to the main changelog and this file 
 
 ## Fixed
 <!-- Bug fixes -->
+- Prevent nightly releases from becoming immutable before desktop binaries, checksums, and provenance are attached (#5876)
 
 ## Deprecated
 <!-- Soon-to-be removed features -->

--- a/v3/tasks/release/release.go
+++ b/v3/tasks/release/release.go
@@ -32,10 +32,11 @@ var (
 )
 
 type releaseOptions struct {
-	version string
-	dryRun  bool
-	branch  string
-	target  string
+	version            string
+	dryRun             bool
+	deferGitHubRelease bool
+	branch             string
+	target             string
 }
 
 var errNoUnreleasedContent = errors.New("No unreleased changelog content found.")
@@ -453,6 +454,7 @@ func parseReleaseArgs(args []string) (releaseOptions, error) {
 	fs.SetOutput(io.Discard)
 
 	dryRun := fs.Bool("dry-run", false, "simulate the release without pushing changes or creating a GitHub release")
+	deferGitHubRelease := fs.Bool("defer-github-release", false, "push the release commit and tag, but let the artifact workflow create the GitHub release")
 	branch := fs.String("branch", defaultReleaseBranch, "git branch to push release changes to")
 	target := fs.String("target", defaultReleaseTarget, "target reference for the GitHub release (usually the same as branch)")
 	versionFlag := fs.String("version", "", "explicit release version (overrides automatic increment)")
@@ -473,10 +475,11 @@ func parseReleaseArgs(args []string) (releaseOptions, error) {
 	}
 
 	return releaseOptions{
-		version: version,
-		dryRun:  *dryRun,
-		branch:  *branch,
-		target:  *target,
+		version:            version,
+		dryRun:             *dryRun,
+		deferGitHubRelease: *deferGitHubRelease,
+		branch:             *branch,
+		target:             *target,
 	}, nil
 }
 
@@ -562,6 +565,7 @@ func runRelease(opts releaseOptions) error {
 	writeGitHubOutput("release_version", newVersion)
 	writeGitHubOutput("release_tag", newVersion)
 	writeGitHubOutput("release_target", opts.target)
+	writeGitHubMultilineOutput("release_notes", releaseBody)
 
 	if opts.dryRun {
 		writeGitHubOutput("release_dry_run", "true")
@@ -610,6 +614,17 @@ func runRelease(opts releaseOptions) error {
 
 	if err := git.pushTag(newVersion, repoSlug, token); err != nil {
 		return err
+	}
+
+	// The nightly workflow delegates publication to release-v3.yml so that
+	// GitHub receives the binaries, checksums, and provenance before the
+	// release becomes immutable. Publishing here first would leave the
+	// artifact workflow unable to attach anything to the release.
+	if opts.deferGitHubRelease {
+		writeGitHubOutput("release_deferred", "true")
+		writeGitHubOutput("release_outcome", "success")
+		fmt.Println("📦 GitHub release creation deferred to the desktop artifact workflow.")
+		return nil
 	}
 
 	releaseTitle := fmt.Sprintf(defaultReleaseTitle, newVersion)
@@ -1091,6 +1106,28 @@ func writeGitHubOutput(key, value string) {
 	}
 	defer f.Close()
 	if _, err := fmt.Fprintf(f, "%s=%s\n", key, value); err != nil {
+		fmt.Printf("Warning: unable to persist %s to GITHUB_OUTPUT: %v\n", key, err)
+	}
+}
+
+func writeGitHubMultilineOutput(key, value string) {
+	outputPath := strings.TrimSpace(os.Getenv("GITHUB_OUTPUT"))
+	if outputPath == "" || key == "" || value == "" {
+		return
+	}
+
+	delimiter := "WAILS_RELEASE_NOTES_EOF"
+	for strings.Contains(value, delimiter) {
+		delimiter += "_X"
+	}
+
+	f, err := os.OpenFile(outputPath, os.O_APPEND|os.O_WRONLY, 0o644)
+	if err != nil {
+		fmt.Printf("Warning: unable to write %s to GITHUB_OUTPUT: %v\n", key, err)
+		return
+	}
+	defer f.Close()
+	if _, err := fmt.Fprintf(f, "%s<<%s\n%s\n%s\n", key, delimiter, value, delimiter); err != nil {
 		fmt.Printf("Warning: unable to persist %s to GITHUB_OUTPUT: %v\n", key, err)
 	}
 }

--- a/v3/tasks/release/release_test.go
+++ b/v3/tasks/release/release_test.go
@@ -253,6 +253,77 @@ func TestGetUnreleasedChangelogTemplate(t *testing.T) {
 	}
 }
 
+func TestParseReleaseArgs_DeferGitHubRelease(t *testing.T) {
+	opts, err := parseReleaseArgs([]string{
+		"--defer-github-release",
+		"--branch", "master",
+		"--target", "master",
+		"--version", "v3.0.0-beta.4",
+	})
+	if err != nil {
+		t.Fatalf("parseReleaseArgs() failed: %v", err)
+	}
+
+	if !opts.deferGitHubRelease {
+		t.Fatal("expected GitHub release creation to be deferred")
+	}
+	if opts.dryRun {
+		t.Fatal("defer-github-release must not implicitly enable dry-run")
+	}
+	if opts.version != "v3.0.0-beta.4" {
+		t.Fatalf("version = %q, want v3.0.0-beta.4", opts.version)
+	}
+}
+
+func TestNightlyDefersPublicationToArtifactWorkflow(t *testing.T) {
+	workflow, err := os.ReadFile("../../../.github/workflows/nightly-release-v3.yml")
+	if err != nil {
+		t.Fatalf("read nightly release workflow: %v", err)
+	}
+	contents := string(workflow)
+
+	deferFlag := strings.Index(contents, "ARGS+=(--defer-github-release)")
+	dispatch := strings.Index(contents, "gh workflow run release-v3.yml")
+	if deferFlag == -1 {
+		t.Fatal("nightly release must defer GitHub release creation")
+	}
+	if dispatch == -1 {
+		t.Fatal("nightly release must dispatch the desktop artifact workflow")
+	}
+	if deferFlag > dispatch {
+		t.Fatal("nightly release must defer publication before dispatching the artifact workflow")
+	}
+	if !strings.Contains(contents, "release_notes=\"$RELEASE_NOTES\"") {
+		t.Fatal("nightly release must pass curated notes to the artifact workflow")
+	}
+	if !strings.Contains(contents, "gh run watch \"$run_id\"") {
+		t.Fatal("nightly release must wait for the dispatched publication workflow")
+	}
+	if !strings.Contains(contents, "steps.publication_check.outputs.needs_recovery == 'true'") {
+		t.Fatal("nightly release must recover a tagged commit whose publication failed")
+	}
+}
+
+func TestWriteGitHubMultilineOutput(t *testing.T) {
+	output := filepath.Join(t.TempDir(), "github-output")
+	if err := os.WriteFile(output, nil, 0o644); err != nil {
+		t.Fatalf("create output file: %v", err)
+	}
+	t.Setenv("GITHUB_OUTPUT", output)
+
+	value := "first line\nWAILS_RELEASE_NOTES_EOF\nlast line"
+	writeGitHubMultilineOutput("release_notes", value)
+
+	data, err := os.ReadFile(output)
+	if err != nil {
+		t.Fatalf("read output file: %v", err)
+	}
+	want := "release_notes<<WAILS_RELEASE_NOTES_EOF_X\n" + value + "\nWAILS_RELEASE_NOTES_EOF_X\n"
+	if string(data) != want {
+		t.Fatalf("multiline output = %q, want %q", string(data), want)
+	}
+}
+
 func TestHasUnreleasedContent_WithContent(t *testing.T) {
 	cleanup, _ := setupTestEnvironment(t)
 	defer cleanup()
@@ -512,9 +583,9 @@ func TestCopyFile_NonexistentSource(t *testing.T) {
 // out-ranking the stray tag.
 func TestAlpha2OutranksStrayTuiTag(t *testing.T) {
 	const (
-		strayTag    = "v3.0.0-alpha.98-tui" // the tag stuck as @latest
+		strayTag     = "v3.0.0-alpha.98-tui" // the tag stuck as @latest
 		legacyLatest = "v3.0.0-alpha.102"    // highest legacy numeric alpha
-		nextTag     = "v3.0.0-alpha2.103"   // first tag the new scheme publishes
+		nextTag      = "v3.0.0-alpha2.103"   // first tag the new scheme publishes
 	)
 
 	for _, v := range []string{strayTag, legacyLatest, nextTag} {

--- a/v3/tasks/release/release_test.go
+++ b/v3/tasks/release/release_test.go
@@ -302,6 +302,9 @@ func TestNightlyDefersPublicationToArtifactWorkflow(t *testing.T) {
 	if !strings.Contains(contents, "steps.publication_check.outputs.needs_recovery == 'true'") {
 		t.Fatal("nightly release must recover a tagged commit whose publication failed")
 	}
+	if !strings.Contains(contents, "github.event.inputs.dry_run != 'true' &&") {
+		t.Fatal("manual dry runs must gate all artifact publication, including recovery")
+	}
 }
 
 func TestWriteGitHubMultilineOutput(t *testing.T) {


### PR DESCRIPTION
## Summary

- defer GitHub release creation in the nightly release task until desktop artifacts are ready
- pass curated release notes into the artifact workflow
- identify and wait for the dispatched Release v3 run, and recover a tagged commit with no release on the next nightly run
- add regression coverage and an unreleased changelog entry

Fixes #5876

## Root cause

The nightly release task published the GitHub release before dispatching Release v3. Repository release immutability then rejected Release v3's artifact upload with HTTP 422, even though all six binaries, checksums, and provenance had built successfully.

## Impact

Future nightly releases are created atomically by Release v3 with their desktop binaries, SHA256SUMS, and provenance attached. A failed child publication now fails the orchestrator visibly and is retried when the tagged commit still has no release. Dry runs remain non-mutating, and direct/manual Release v3 dispatches retain their existing generated-notes fallback.

## Validation

- `go test ./tasks/release`
- release script dry run for v3.0.0-beta.4
- YAML parse for both release workflows
- `actionlint` on both workflows (only the pre-existing `actions/setup-go@v4` age diagnostic)
- `git diff --check`
- CodeRabbit plain review; its async-dispatch finding was addressed, then the follow-up review hit the free OSS quota
- broader `go test ./...` attempted; blocked by missing GTK4/WebKitGTK/glib/libsoup development packages and existing GUI/path-sensitive tests in this environment

No workflow, tag, or release was dispatched or published by this PR.