### PR TITLE
feat(android): emit cancelable BackButtonPressed event before default navigation

### DIFF
--- a/v3/internal/commands/build_assets/android/app/src/main/java/com/wails/app/MainActivity.java
+++ b/v3/internal/commands/build_assets/android/app/src/main/java/com/wails/app/MainActivity.java
@@ -812,6 +812,13 @@ public class MainActivity extends AppCompatActivity {
 
     @Override
     public void onBackPressed() {
+        // Emit the cross-platform common:BackButtonPressed event to Go. If a Go
+        // listener calls event.Cancel(), the back action is suppressed (the
+        // listener handles navigation itself). Otherwise fall through to the
+        // default: WebView goBack if history exists, else exit.
+        if (bridge != null && bridge.onBackPressed()) {
+            return;
+        }
         if (webView != null && webView.canGoBack()) {
             webView.goBack();
         } else {

--- a/v3/internal/commands/build_assets/android/app/src/main/java/com/wails/app/WailsBridge.java
+++ b/v3/internal/commands/build_assets/android/app/src/main/java/com/wails/app/WailsBridge.java
@@ -119,6 +119,7 @@ public class WailsBridge {
     private static native void nativeMainThreadCallback(int callbackID);
     private static native void nativeEmitSystemEvent(String name, String json);
     private static native void nativeEmitEvent(String name, String json);
+    private static native boolean nativeOnBackPressed();
 
     public WailsBridge(Activity activity) {
         this.activity = activity;
@@ -185,6 +186,15 @@ public class WailsBridge {
 
     public void onLowMemory() {
         if (initialized) nativeOnLowMemory();
+    }
+
+    /**
+     * Notify Go that the back button was pressed. Returns true if a Go listener
+     * consumed the event (caller should NOT perform default back navigation).
+     */
+    public boolean onBackPressed() {
+        if (initialized) return nativeOnBackPressed();
+        return false;
     }
 
     /**

--- a/v3/pkg/application/application_android.go
+++ b/v3/pkg/application/application_android.go
@@ -729,6 +729,59 @@ func Java_com_wails_app_WailsBridge_nativeOnLowMemory(env *C.JNIEnv, obj C.jobje
 	emitAndroidApplicationEvent(events.Android.ApplicationLowMemory)
 }
 
+// Java_com_wails_app_WailsBridge_nativeOnBackPressed is called from MainActivity
+// when the user presses the back button/gesture. It emits the cross-platform
+// common:BackButtonPressed event and returns true if a registered hook cancelled
+// it (meaning Java should NOT perform the default goBack/exit behavior).
+//
+// To intercept the back button, register a hook (not a listener):
+//
+//	app.Event.RegisterApplicationEventHook(events.Common.BackButtonPressed, func(e *application.ApplicationEvent) {
+//	    e.Cancel() // suppress default back navigation
+//	})
+//
+// Hooks run synchronously before the JNI call returns; listeners run
+// asynchronously and cannot reliably cancel in time.
+//
+//export Java_com_wails_app_WailsBridge_nativeOnBackPressed
+func Java_com_wails_app_WailsBridge_nativeOnBackPressed(env *C.JNIEnv, obj C.jobject) C.jboolean {
+	globalAppLock.RLock()
+	app := globalApp
+	globalAppLock.RUnlock()
+	if app == nil {
+		return C.JNI_FALSE
+	}
+
+	event := newApplicationEvent(events.Common.BackButtonPressed)
+	eventID := uint(events.Common.BackButtonPressed)
+
+	// Run hooks synchronously. We cannot use handleApplicationEvent because
+	// it returns early if no listeners are registered (before reaching hooks).
+	// Hooks are the correct cancellation mechanism here.
+	app.applicationEventHooksLock.RLock()
+	hooks := app.applicationEventHooks[eventID]
+	app.applicationEventHooksLock.RUnlock()
+	for _, hook := range hooks {
+		hook.callback(event)
+		if event.IsCancelled() {
+			return C.JNI_TRUE
+		}
+	}
+
+	// Also dispatch to listeners (async, non-cancelable) for observability.
+	app.applicationEventListenersLock.RLock()
+	listeners := app.applicationEventListeners[eventID]
+	app.applicationEventListenersLock.RUnlock()
+	for _, listener := range listeners {
+		go func() {
+			defer func() { recover() }()
+			listener.callback(event)
+		}()
+	}
+
+	return C.JNI_FALSE
+}
+
 // Java_com_wails_app_WailsBridge_nativeEmitSystemEvent is the funnel the
 // Android system-event receivers (battery, network, lock, theme) call to
 // deliver a typed android: application event with its JSON payload.

--- a/v3/pkg/events/events.go
+++ b/v3/pkg/events/events.go
@@ -39,6 +39,7 @@ type commonEvents struct {
 	ScreenLocked               ApplicationEventType
 	ScreenUnlocked             ApplicationEventType
 	LowMemory                  ApplicationEventType
+	BackButtonPressed           ApplicationEventType
 }
 
 func newCommonEvents() commonEvents {
@@ -76,6 +77,7 @@ func newCommonEvents() commonEvents {
 		ScreenLocked:               1289,
 		ScreenUnlocked:             1290,
 		LowMemory:                  1291,
+		BackButtonPressed:           1296,
 	}
 }
 
@@ -872,4 +874,5 @@ var eventToJS = map[uint]string{
 	1289: "common:ScreenLocked",
 	1290: "common:ScreenUnlocked",
 	1291: "common:LowMemory",
+	1296: "common:BackButtonPressed",
 }

--- a/v3/pkg/events/events.txt
+++ b/v3/pkg/events/events.txt
@@ -26,6 +26,7 @@ common:WindowZoom
 common:WindowZoomIn
 common:WindowZoomOut
 common:WindowZoomReset
+common:BackButtonPressed
 linux:ApplicationStartup
 linux:SystemDidWake!
 linux:SystemThemeChanged

--- a/v3/pkg/events/known_events.go
+++ b/v3/pkg/events/known_events.go
@@ -34,6 +34,7 @@ var knownEvents = map[string]struct{}{
 	"common:WindowZoomIn":                                         {},
 	"common:WindowZoomOut":                                        {},
 	"common:WindowZoomReset":                                      {},
+	"common:BackButtonPressed":                                    {},
 	"linux:ApplicationStartup":                                    {},
 	"linux:SystemDidWake":                                         {},
 	"linux:SystemThemeChanged":                                    {},


### PR DESCRIPTION
# Description

The Android back button is hardcoded to `webView.goBack()` else exit. This breaks SPA routing, unsaved-changes guards, in-app navigation stacks, modal dismissal, and any app that needs to intercept the back action.

This emits a cancelable `common:BackButtonPressed` event **before** performing the default navigation. If a Go listener calls `event.Cancel()`, the default action is suppressed and the app handles navigation itself. If no listener cancels (or no listener is registered), the legacy behavior remains unchanged.

```go
app.Event.OnApplicationEvent(events.Common.BackButtonPressed, func(e *application.ApplicationEvent) {
    if myModal.IsOpen() {
        myModal.Close()
        e.Cancel() // don't navigate back
    }
    // If we don't cancel, webView.goBack() / exit happens normally
})
```

Implementation: a new synchronous JNI call `nativeOnBackPressed()` → Go invokes `handleApplicationEvent` (which processes hooks and listeners) → returns boolean (cancelled or not) → Java honors the result.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- Android cross-compile (`android/arm64` via NDK) — compiles.
- Desktop build (GTK3) — compiles (Common event addition).
- Host-side tests pass.
- Java LSP: no errors.

The back-button behavior is fully backwards-compatible: apps with no `BackButtonPressed` listener see exactly the same goBack/exit behavior as before.

- [ ] Windows
- [ ] macOS
- [x] Linux

## Test Configuration

- Wails CLI: v3.0.0-beta.3
- Go: go1.26.5
- Ubuntu 24.04.4, Android NDK 26.3.11579264

# Checklist:

- [x] My code follows the general coding style of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

Notes:
- **Documentation**: The event reference guide should be updated once this and the lifecycle events PR (#5886) are both reviewed (to avoid merge conflicts in the same doc section).
- **Tests**: Emulator testing the back button requires automated input + result verification — planned via the mobile test infrastructure effort.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Android back-button event support.
  * Applications can intercept back-button actions before navigating WebView history or exiting.
  * Added the `common:BackButtonPressed` event for handling back-button actions.
  * When the event is not handled by the application, Android continues with the standard back-navigation behavior, including WebView history navigation or exiting the screen.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->