### PR TITLE
Fix/mac background app focus steal

### DIFF
--- a/v3/pkg/application/application_darwin.go
+++ b/v3/pkg/application/application_darwin.go
@@ -314,7 +314,14 @@ func (m *macosApp) run() error {
 				C.bool(m.parent.options.Mac.ApplicationShouldTerminateAfterLastWindowClosed),
 			)
 			C.setActivationPolicy(C.int(m.parent.options.Mac.ActivationPolicy))
-			C.activateIgnoringOtherApps()
+			// Only bring the app to the foreground for a regular (UI) app.
+			// Accessory and Prohibited apps are background/agent processes;
+			// force-activating them steals focus from whatever the user was
+			// using (e.g. the terminal that launched a headless server), which a
+			// background app should never do.
+			if m.parent.options.Mac.ActivationPolicy == ActivationPolicyRegular {
+				C.activateIgnoringOtherApps()
+			}
 			if err := m.processAndCacheScreens(); err != nil {
 				m.parent.handleError(err)
 			}


### PR DESCRIPTION
# Description

`activateIgnoringOtherApps` was called unconditionally in `applicationDidFinishLaunching`, dragging even `Accessory`/`Prohibited` (background/agent) apps to the foreground and taking focus from whatever the user was doing — for instance the terminal that launched a headless process.

This force-activates only when the activation policy is `Regular`, so background/agent apps launch without grabbing focus.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Launched an app with an `Accessory` activation policy from a terminal and
confirmed focus stayed with the terminal; confirmed a normal `Regular` app still
activates on launch as before.
- [ ] Windows
- [x] macOS   <!-- edit to match -->
- [ ] Linux


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved macOS application activation behavior.
  * Accessory and background applications no longer appear unexpectedly when launched.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->