### PR TITLE
Fix/linux isvisible before widget

### DIFF
--- a/v3/pkg/application/linux_cgo.go
+++ b/v3/pkg/application/linux_cgo.go
@@ -1166,6 +1166,17 @@ func (w *linuxWebviewWindow) isMinimised() bool {
 }
 
 func (w *linuxWebviewWindow) isVisible() bool {
+	// The GTK widget is created lazily in run() (windowNew). On GTK4 that only
+	// happens after the application's "activate" signal fires: WebviewWindow.Run
+	// sets w.impl and then blocks in waitForActivation *before* creating the
+	// widget, so there is a startup window in which w.impl != nil but w.window is
+	// still NULL. A window whose widget does not exist yet is, by definition, not
+	// visible; without this guard a visibility poll during that gap calls
+	// gtk_widget_is_visible(NULL), which trips a GTK-CRITICAL assertion and
+	// returns false anyway.
+	if w.window == nil {
+		return false
+	}
 	return C.gtk_widget_is_visible(w.gtkWidget()) != 0
 }
 

--- a/v3/pkg/application/linux_cgo_gtk3.go
+++ b/v3/pkg/application/linux_cgo_gtk3.go
@@ -1428,6 +1428,14 @@ func (w *linuxWebviewWindow) isMinimised() bool {
 }
 
 func (w *linuxWebviewWindow) isVisible() bool {
+	// The GTK widget is created lazily in run() (windowNew), so there is a
+	// startup window in which w.impl != nil (set at the top of WebviewWindow.Run)
+	// but w.window is still NULL. A window whose widget does not exist yet is, by
+	// definition, not visible; without this guard a visibility poll during that
+	// gap calls gtk_widget_is_visible(NULL), which trips a GTK-CRITICAL assertion.
+	if w.window == nil {
+		return false
+	}
 	if C.gtk_widget_is_visible(w.gtkWidget()) == 1 {
 		return true
 	}


### PR DESCRIPTION
# Description

`isVisible()` called `gtk_widget_is_visible(w.gtkWidget())` unconditionally, but the GTK widget is created lazily. On GTK4 that's deferred until after the app's `activate` signal: `Run` sets `w.impl` and then blocks in `waitForActivation` before the widget exists, leaving a startup window where `w.impl != nil` but `w.window` is NULL. An `IsVisible()` poll during that gap passed NULL to `gtk_widget_is_visible` and tripped a GTK-CRITICAL assertion. This guards the nil widget and reports not-visible, which is what such a window is.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Polled `IsVisible()` during startup (before the activate signal) and confirmed
it returns false with no GTK-CRITICAL output, on both GTK4 and GTK3 builds.
- [ ] Windows
- [ ] macOS
- [x] Linux 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved window visibility handling during startup.
  * Prevented visibility checks before the native window is fully initialized, reducing potential startup issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->