### PR TITLE
Fix/linux dark mode flash

### DIFF
--- a/v3/pkg/application/webview_window_linux.go
+++ b/v3/pkg/application/webview_window_linux.go
@@ -390,6 +390,18 @@ func (w *linuxWebviewWindow) run() {
 	if w.parent.options.BackgroundType != BackgroundTypeSolid {
 		w.setTransparent()
 		w.setBackgroundColour(w.parent.options.BackgroundColour)
+	} else if w.parent.options.BackgroundColour.Alpha == 255 {
+		// Pin the webview's base colour for a solid window with an explicit opaque
+		// background, here — before setURL() below starts the first paint. WebKitGTK
+		// latches the base as the accelerated-compositing clear colour at first
+		// composite and does NOT refresh it from a later set_background_color call,
+		// so a base left at the WebKitGTK default (opaque white) is briefly exposed
+		// whenever the compositor re-tiles during animation: a periodic light flash
+		// on a dark page. (The page's own runtime theme repaint arrives after that
+		// first composite, so it can't fix the already-latched clear colour — the
+		// colour must be set now.) A zero/non-opaque colour is left to the WebKitGTK
+		// default so a solid window is never made accidentally see-through.
+		w.setBackgroundColour(w.parent.options.BackgroundColour)
 	}
 
 	w.setFrameless(w.parent.options.Frameless)


### PR DESCRIPTION
# Description

WebKitGTK latches its base colour as the accelerated-compositing clear colour at the first composite and doesn't refresh it from a later `set_background_color` call. When a solid window has an explicit opaque background, the base is left at WebKitGTK's default (opaque white), which is briefly exposed whenever the compositor re-tiles during animation — a periodic light flash on a dark page.

This sets the background colour before the first paint (before `setURL()`) for solid windows whose background is fully opaque (alpha 255). A zero or non-opaque colour is left to the WebKitGTK default so a solid window is never made
accidentally see-through.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Ran a solid opaque-background window with a dark page and confirmed the periodic
light flash during animation is gone; confirmed transparent/non-opaque windows
are unaffected.
- [ ] Windows
- [ ] macOS
- [x] Linux


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Opaque solid windows now display the configured background color before loading web content.
  * Transparent and non-solid windows continue to behave as before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->