### PR TITLE
fix(v3): preserve macOS zoom restore state after dragging

### DIFF
--- a/v3/pkg/application/webview_window_darwin.m
+++ b/v3/pkg/application/webview_window_darwin.m
@@ -239,11 +239,14 @@ static const NSTimeInterval MacZoomAnimationFrameInterval = 1.0 / 60.0;
     if (self.zoomAnimationTimer && !self.applyingZoomAnimationFrame) {
         [self cancelZoomAnimation];
     }
+    NSSize oldSize = self.frame.size;
     if (self.hasZoomRestoreFrame &&
         !self.applyingZoomAnimationFrame &&
         ![super isZoomed] &&
-        !NSEqualSizes(self.frame.size, frameRect.size)) {
-        self.zoomRestoreFrame = frameRect;
+        !NSEqualSizes(oldSize, frameRect.size)) {
+        [super setFrame:frameRect display:displayFlag];
+        self.zoomRestoreFrame = self.frame;
+        return;
     }
     [super setFrame:frameRect display:displayFlag];
 }
@@ -251,11 +254,14 @@ static const NSTimeInterval MacZoomAnimationFrameInterval = 1.0 / 60.0;
     if (self.zoomAnimationTimer && !self.applyingZoomAnimationFrame) {
         [self cancelZoomAnimation];
     }
+    NSSize oldSize = self.frame.size;
     if (self.hasZoomRestoreFrame &&
         !self.applyingZoomAnimationFrame &&
         ![super isZoomed] &&
-        !NSEqualSizes(self.frame.size, frameRect.size)) {
-        self.zoomRestoreFrame = frameRect;
+        !NSEqualSizes(oldSize, frameRect.size)) {
+        [super setFrame:frameRect display:displayFlag animate:animateFlag];
+        self.zoomRestoreFrame = self.frame;
+        return;
     }
     [super setFrame:frameRect display:displayFlag animate:animateFlag];
 }

--- a/v3/pkg/application/webview_window_darwin.m
+++ b/v3/pkg/application/webview_window_darwin.m
@@ -31,6 +31,8 @@ static const NSTimeInterval MacZoomAnimationFrameInterval = 1.0 / 60.0;
 @property BOOL zoomAnimationTargetIsZoomed;
 @property BOOL preparingZoomAnimationTarget;
 @property BOOL applyingZoomAnimationFrame;
+@property NSRect zoomRestoreFrame;
+@property BOOL hasZoomRestoreFrame;
 
 @end
 
@@ -237,11 +239,23 @@ static const NSTimeInterval MacZoomAnimationFrameInterval = 1.0 / 60.0;
     if (self.zoomAnimationTimer && !self.applyingZoomAnimationFrame) {
         [self cancelZoomAnimation];
     }
+    if (self.hasZoomRestoreFrame &&
+        !self.applyingZoomAnimationFrame &&
+        ![super isZoomed] &&
+        !NSEqualSizes(self.frame.size, frameRect.size)) {
+        self.zoomRestoreFrame = frameRect;
+    }
     [super setFrame:frameRect display:displayFlag];
 }
 - (void)setFrame:(NSRect)frameRect display:(BOOL)displayFlag animate:(BOOL)animateFlag {
     if (self.zoomAnimationTimer && !self.applyingZoomAnimationFrame) {
         [self cancelZoomAnimation];
+    }
+    if (self.hasZoomRestoreFrame &&
+        !self.applyingZoomAnimationFrame &&
+        ![super isZoomed] &&
+        !NSEqualSizes(self.frame.size, frameRect.size)) {
+        self.zoomRestoreFrame = frameRect;
     }
     [super setFrame:frameRect display:displayFlag animate:animateFlag];
 }
@@ -255,6 +269,9 @@ static const NSTimeInterval MacZoomAnimationFrameInterval = 1.0 / 60.0;
         self.applyingZoomAnimationFrame = YES;
         [super setFrame:self.zoomAnimationTargetFrame display:YES animate:NO];
         self.applyingZoomAnimationFrame = NO;
+        if (!self.zoomAnimationTargetIsZoomed) {
+            self.hasZoomRestoreFrame = NO;
+        }
         [self cancelZoomAnimation];
         return;
     }
@@ -277,11 +294,15 @@ static const NSTimeInterval MacZoomAnimationFrameInterval = 1.0 / 60.0;
     self.applyingZoomAnimationFrame = NO;
 
     if (progress >= 1.0) {
+        if (!self.zoomAnimationTargetIsZoomed) {
+            self.hasZoomRestoreFrame = NO;
+        }
         [self cancelZoomAnimation];
     }
 }
 - (void)zoom:(id)sender {
     NSRect startFrame = self.frame;
+    BOOL startIsZoomed = [super isZoomed];
     BOOL interruptedAnimation = self.zoomAnimationTimer != nil;
     NSRect previousTargetFrame = self.zoomAnimationTargetFrame;
     [self cancelZoomAnimation];
@@ -305,12 +326,32 @@ static const NSTimeInterval MacZoomAnimationFrameInterval = 1.0 / 60.0;
     NSRect targetFrame = self.frame;
     BOOL targetIsZoomed = [super isZoomed];
     if (NSEqualRects(startFrame, targetFrame)) {
-        return;
+        if (startIsZoomed && self.hasZoomRestoreFrame) {
+            targetFrame = self.zoomRestoreFrame;
+            targetIsZoomed = NO;
+        } else {
+            return;
+        }
+    }
+
+    if (targetIsZoomed) {
+        if (!self.hasZoomRestoreFrame) {
+            self.zoomRestoreFrame = startFrame;
+            self.hasZoomRestoreFrame = YES;
+        }
+    } else if (self.hasZoomRestoreFrame) {
+        targetFrame = self.zoomRestoreFrame;
     }
 
     // Reduced-motion users should not receive a replacement animation. AppKit
     // has already applied the correct target and updated its zoom state.
     if ([self shouldReduceZoomMotion]) {
+        if (!targetIsZoomed) {
+            self.applyingZoomAnimationFrame = YES;
+            [super setFrame:targetFrame display:YES animate:NO];
+            self.applyingZoomAnimationFrame = NO;
+            self.hasZoomRestoreFrame = NO;
+        }
         return;
     }
 
@@ -326,6 +367,9 @@ static const NSTimeInterval MacZoomAnimationFrameInterval = 1.0 / 60.0;
         self.applyingZoomAnimationFrame = YES;
         [super setFrame:targetFrame display:YES animate:NO];
         self.applyingZoomAnimationFrame = NO;
+        if (!targetIsZoomed) {
+            self.hasZoomRestoreFrame = NO;
+        }
         return;
     }
 
@@ -497,11 +541,16 @@ static const NSTimeInterval MacZoomAnimationFrameInterval = 1.0 / 60.0;
 - (void)handleLeftMouseDown:(NSEvent *)event {
     self.leftMouseEvent = event;
     NSWindow *window = [event window];
-    WebviewWindowDelegate* delegate = (WebviewWindowDelegate*)[window delegate];
     if( self.invisibleTitleBarHeight > 0 ) {
         NSPoint location = [event locationInWindow];
         NSRect frame = [window frame];
         if( location.y > frame.size.height - self.invisibleTitleBarHeight ) {
+            // Only the first click can begin a drag. Starting another native
+            // drag for the second click races the JavaScript double-click
+            // handler and can make AppKit discard the zoom restore frame.
+            if (event.clickCount != 1) {
+                return;
+            }
             // Skip drag if the click is near a window edge (resize zone).
             // This prevents conflict between dragging and native top-corner resizing,
             // which causes window content to shake/jitter (#4960).


### PR DESCRIPTION
# Description

Preserve the macOS user restore frame across the native titlebar maximize/drag sequence introduced by #5853 and animated by #5856.

After a maximized window is moved, AppKit can replace its user restore frame with the moved full-size frame. A later `zoom:` call can therefore leave both the frame and `isZoomed` unchanged, preventing the window from returning to its original bounds. This change keeps Wails' own restore frame, uses it when AppKit's zoom toggle becomes a no-op, and updates it after genuine manual resizing.

The invisible-titlebar mouse handler now also starts a native drag only for the first click, so the second click of a double-click cannot race the JavaScript titlebar handler.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] WEP (proposal only; no implementation)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [ ] Windows
- [x] macOS
- [ ] Linux

Automated checks:

- `go test ./pkg/application -count=1`
- `git diff --check`

Native macOS UI automation reproduced the failing sequence:

1. Start at `{206, 148}`, `1099 x 719`.
2. Double-click the titlebar to maximize.
3. Move the maximized window.
4. Double-click to maximize again.
5. Double-click to restore.

Before this change, the fifth step left the window maximized. With this change, it returns to `{206, 148}`, `1099 x 719`.

## Test Configuration

- macOS 26.5.2 (25F84), Apple Silicon arm64
- Apple M5 Pro, 48 GB RAM
- Go 1.26.5
- Wails CLI v3.0.0-dev
- Xcode command-line tools 2416

# Checklist:

- [ ] (v2 only) I have updated `website/src/pages/changelog.mdx` with details of this PR (v3 changelog entries are added automatically)
- [x] My code follows the general coding style of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes do not require documentation updates
- [x] My changes generate no new warnings
- [x] I have tested the regression through native macOS UI automation
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved macOS window zoom behavior by reliably preserving and restoring the previous size and position.
  * Fixed zoom transitions when animations are reduced or interrupted.
  * Prevented title-bar dragging from conflicting with multi-click zoom actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->