### PR TITLE
fix(v3): reflow macOS webviews during window transitions

### DIFF
--- a/v3/pkg/application/webview_window_darwin.h
+++ b/v3/pkg/application/webview_window_darwin.h
@@ -13,6 +13,8 @@
 - (BOOL) becomeFirstResponder;
 - (BOOL) resignFirstResponder;
 - (WebviewWindow*) initWithContentRect:(NSRect)contentRect styleMask:(NSUInteger)windowStyle backing:(NSBackingStoreType)bufferingType defer:(BOOL)deferCreation;
+- (void)syncWebViewFrame;
+- (void)animateFullScreenTransitionFromFrame:(NSRect)startFrame toFrame:(NSRect)targetFrame duration:(NSTimeInterval)duration;
 
 @property (assign) WKWebView* webView; // We already retain WKWebView since it's part of the Window.
 @property BOOL disableEscapeExitsFullscreen;
@@ -26,6 +28,8 @@
 @property unsigned int invisibleTitleBarHeight;
 @property BOOL showToolbarWhenFullscreen;
 @property NSWindowStyleMask previousStyleMask; // Used to restore the window style mask when using frameless
+@property NSRect frameBeforeFullScreen;
+@property BOOL hasFrameBeforeFullScreen;
 
 - (void)handleLeftMouseUp:(NSWindow *)window;
 - (void)handleLeftMouseDown:(NSEvent*)event;

--- a/v3/pkg/application/webview_window_darwin.m
+++ b/v3/pkg/application/webview_window_darwin.m
@@ -33,6 +33,12 @@ static const NSTimeInterval MacZoomAnimationFrameInterval = 1.0 / 60.0;
 @property BOOL applyingZoomAnimationFrame;
 @property NSRect zoomRestoreFrame;
 @property BOOL hasZoomRestoreFrame;
+@property (retain) NSTimer* fullScreenAnimationTimer;
+@property NSRect fullScreenAnimationStartFrame;
+@property NSRect fullScreenAnimationTargetFrame;
+@property CFTimeInterval fullScreenAnimationStartTime;
+@property NSTimeInterval fullScreenAnimationDuration;
+@property BOOL applyingFullScreenAnimationFrame;
 
 @end
 
@@ -40,6 +46,8 @@ static const NSTimeInterval MacZoomAnimationFrameInterval = 1.0 / 60.0;
 - (WebviewWindow*) initWithContentRect:(NSRect)contentRect styleMask:(NSUInteger)windowStyle backing:(NSBackingStoreType)bufferingType defer:(BOOL)deferCreation;
 {
     self = [super initWithContentRect:contentRect styleMask:windowStyle backing:bufferingType defer:deferCreation];
+    // Render the webview throughout native resize animations instead of stretching a cached window snapshot.
+    [self setPreservesContentDuringLiveResize:NO];
     [self setAlphaValue:1.0];
     [self setBackgroundColor:[NSColor clearColor]];
     [self setOpaque:NO];
@@ -216,6 +224,77 @@ static const NSTimeInterval MacZoomAnimationFrameInterval = 1.0 / 60.0;
     }
     [super cancelOperation:sender];
 }
+- (void)syncWebViewFrame {
+    // AppKit may advance the window frame before WebKit's autoresizing pass during zoom and fullscreen transitions.
+    NSView *container = self.webView.superview;
+    if (!container) {
+        return;
+    }
+    [container layoutSubtreeIfNeeded];
+    [self.webView setFrame:container.bounds];
+}
+- (void)cancelFullScreenAnimation {
+    [self.fullScreenAnimationTimer invalidate];
+    self.fullScreenAnimationTimer = nil;
+}
+- (void)stepFullScreenAnimation:(NSTimer*)timer {
+    if (timer != self.fullScreenAnimationTimer) {
+        [timer invalidate];
+        return;
+    }
+
+    double progress = (CACurrentMediaTime() - self.fullScreenAnimationStartTime) / self.fullScreenAnimationDuration;
+    progress = MIN(1.0, MAX(0.0, progress));
+    double easedProgress = progress * progress * (3.0 - (2.0 * progress));
+
+    NSRect start = self.fullScreenAnimationStartFrame;
+    NSRect target = self.fullScreenAnimationTargetFrame;
+    NSRect frame = NSMakeRect(
+        start.origin.x + ((target.origin.x - start.origin.x) * easedProgress),
+        start.origin.y + ((target.origin.y - start.origin.y) * easedProgress),
+        start.size.width + ((target.size.width - start.size.width) * easedProgress),
+        start.size.height + ((target.size.height - start.size.height) * easedProgress)
+    );
+
+    self.applyingFullScreenAnimationFrame = YES;
+    [super setFrame:frame display:YES animate:NO];
+    self.applyingFullScreenAnimationFrame = NO;
+    [self syncWebViewFrame];
+
+    if (progress >= 1.0) {
+        [self cancelFullScreenAnimation];
+    }
+}
+- (void)animateFullScreenTransitionFromFrame:(NSRect)startFrame toFrame:(NSRect)targetFrame duration:(NSTimeInterval)duration {
+    [self cancelFullScreenAnimation];
+
+    if ([[NSWorkspace sharedWorkspace] accessibilityDisplayShouldReduceMotion] || duration <= 0) {
+        self.applyingFullScreenAnimationFrame = YES;
+        [super setFrame:targetFrame display:YES animate:NO];
+        self.applyingFullScreenAnimationFrame = NO;
+        [self syncWebViewFrame];
+        return;
+    }
+
+    // Establish the visible starting geometry before driving the custom transition.
+    self.applyingFullScreenAnimationFrame = YES;
+    [super setFrame:startFrame display:YES animate:NO];
+    self.applyingFullScreenAnimationFrame = NO;
+    [self syncWebViewFrame];
+
+    self.fullScreenAnimationStartFrame = startFrame;
+    self.fullScreenAnimationTargetFrame = targetFrame;
+    self.fullScreenAnimationStartTime = CACurrentMediaTime();
+    self.fullScreenAnimationDuration = duration;
+
+    NSTimer *timer = [NSTimer timerWithTimeInterval:MacZoomAnimationFrameInterval
+        target:self
+        selector:@selector(stepFullScreenAnimation:)
+        userInfo:nil
+        repeats:YES];
+    self.fullScreenAnimationTimer = timer;
+    [[NSRunLoop mainRunLoop] addTimer:timer forMode:NSRunLoopCommonModes];
+}
 - (void)cancelZoomAnimation {
     [self.zoomAnimationTimer invalidate];
     self.zoomAnimationTimer = nil;
@@ -236,34 +315,46 @@ static const NSTimeInterval MacZoomAnimationFrameInterval = 1.0 / 60.0;
     return [super animationResizeTime:newFrame];
 }
 - (void)setFrame:(NSRect)frameRect display:(BOOL)displayFlag {
+    if (self.fullScreenAnimationTimer && !self.applyingFullScreenAnimationFrame) {
+        [self cancelFullScreenAnimation];
+    }
     if (self.zoomAnimationTimer && !self.applyingZoomAnimationFrame) {
         [self cancelZoomAnimation];
     }
     NSSize oldSize = self.frame.size;
     if (self.hasZoomRestoreFrame &&
         !self.applyingZoomAnimationFrame &&
+        !self.applyingFullScreenAnimationFrame &&
         ![super isZoomed] &&
         !NSEqualSizes(oldSize, frameRect.size)) {
         [super setFrame:frameRect display:displayFlag];
         self.zoomRestoreFrame = self.frame;
+        [self syncWebViewFrame];
         return;
     }
     [super setFrame:frameRect display:displayFlag];
+    [self syncWebViewFrame];
 }
 - (void)setFrame:(NSRect)frameRect display:(BOOL)displayFlag animate:(BOOL)animateFlag {
+    if (self.fullScreenAnimationTimer && !self.applyingFullScreenAnimationFrame) {
+        [self cancelFullScreenAnimation];
+    }
     if (self.zoomAnimationTimer && !self.applyingZoomAnimationFrame) {
         [self cancelZoomAnimation];
     }
     NSSize oldSize = self.frame.size;
     if (self.hasZoomRestoreFrame &&
         !self.applyingZoomAnimationFrame &&
+        !self.applyingFullScreenAnimationFrame &&
         ![super isZoomed] &&
         !NSEqualSizes(oldSize, frameRect.size)) {
         [super setFrame:frameRect display:displayFlag animate:animateFlag];
         self.zoomRestoreFrame = self.frame;
+        [self syncWebViewFrame];
         return;
     }
     [super setFrame:frameRect display:displayFlag animate:animateFlag];
+    [self syncWebViewFrame];
 }
 - (void)stepZoomAnimation:(NSTimer*)timer {
     if (timer != self.zoomAnimationTimer) {
@@ -403,10 +494,12 @@ static const NSTimeInterval MacZoomAnimationFrameInterval = 1.0 / 60.0;
 }
 - (void)close {
     [self cancelZoomAnimation];
+    [self cancelFullScreenAnimation];
     [super close];
 }
 - (void) dealloc {
     [self cancelZoomAnimation];
+    [self cancelFullScreenAnimation];
     // Remove the script handler, otherwise WebviewWindowDelegate won't get deallocated
     // See: https://stackoverflow.com/questions/26383031/wkwebview-causes-my-view-controller-to-leak
     [self.webView.configuration.userContentController removeScriptMessageHandlerForName:@"external"];
@@ -598,6 +691,22 @@ static const NSTimeInterval MacZoomAnimationFrameInterval = 1.0 / 60.0;
         return proposedOptions | NSApplicationPresentationAutoHideToolbar;
     }
 }
+- (NSArray<NSWindow *> *)customWindowsToEnterFullScreenForWindow:(NSWindow *)window {
+    return @[window];
+}
+- (void)window:(NSWindow *)window startCustomAnimationToEnterFullScreenWithDuration:(NSTimeInterval)duration {
+    WebviewWindow *webviewWindow = (WebviewWindow *)window;
+    NSScreen *screen = window.screen ?: NSScreen.mainScreen;
+    [webviewWindow animateFullScreenTransitionFromFrame:self.frameBeforeFullScreen toFrame:screen.frame duration:duration];
+}
+- (NSArray<NSWindow *> *)customWindowsToExitFullScreenForWindow:(NSWindow *)window {
+    return @[window];
+}
+- (void)window:(NSWindow *)window startCustomAnimationToExitFullScreenWithDuration:(NSTimeInterval)duration {
+    WebviewWindow *webviewWindow = (WebviewWindow *)window;
+    NSRect fullScreenFrame = window.frame;
+    [webviewWindow animateFullScreenTransitionFromFrame:fullScreenFrame toFrame:self.frameBeforeFullScreen duration:duration];
+}
 - (void)windowDidChangeOcclusionState:(NSNotification *)notification {
     NSWindow *window = notification.object;
     BOOL isVisible = ([window occlusionState] & NSWindowOcclusionStateVisible) != 0;
@@ -731,6 +840,7 @@ static const NSTimeInterval MacZoomAnimationFrameInterval = 1.0 / 60.0;
     }
 }
 - (void)windowDidExitFullScreen:(NSNotification *)notification {
+    self.hasFrameBeforeFullScreen = NO;
     if( hasListeners(EventWindowDidExitFullScreen) ) {
         processWindowEvent(self.windowId, EventWindowDidExitFullScreen);
     }
@@ -781,6 +891,8 @@ static const NSTimeInterval MacZoomAnimationFrameInterval = 1.0 / 60.0;
     }
 }
 - (void)windowDidResize:(NSNotification *)notification {
+    WebviewWindow *window = notification.object;
+    [window syncWebViewFrame];
     if( hasListeners(EventWindowDidResize) ) {
         processWindowEvent(self.windowId, EventWindowDidResize);
     }
@@ -851,6 +963,10 @@ static const NSTimeInterval MacZoomAnimationFrameInterval = 1.0 / 60.0;
     }
 }
 - (void)windowWillEnterFullScreen:(NSNotification *)notification {
+    if (!self.hasFrameBeforeFullScreen) {
+        self.frameBeforeFullScreen = [notification.object frame];
+        self.hasFrameBeforeFullScreen = YES;
+    }
     if( hasListeners(EventWindowWillEnterFullScreen) ) {
         processWindowEvent(self.windowId, EventWindowWillEnterFullScreen);
     }


### PR DESCRIPTION
# Description

Keep the macOS WKWebView sized to its container throughout animated titlebar zoom and native fullscreen transitions.

## Root cause

Two AppKit behaviours were involved:

- During ordinary live resize and programmatic frame changes, AppKit can advance the window frame before WebKit's autoresizing/layout pass.
- Native fullscreen is a separate path. AppKit's default transition crossfades or scales preserved window contents and does not provide the intermediate model-frame changes needed for responsive web content to reflow.

The latter means a `windowDidResize:`-only fix still leaves the UI frozen at its original size until the fullscreen animation completes.

## What changed

- Disable preserved-content live resizing for the macOS window.
- Add a frame synchronisation helper that lays out the webview container and applies its current bounds to the `WKWebView`.
- Synchronise after programmatic frame changes and from `windowDidResize:`.
- Opt the Wails window into AppKit's documented custom fullscreen animation hooks.
- Drive the fullscreen window frame at 60 Hz for the duration supplied by AppKit, synchronising the WKWebView on each frame so responsive content receives intermediate viewport sizes.
- Preserve the pre-fullscreen frame for the exit animation and honour the system Reduce Motion preference.
- Cancel active transition timers safely when a window closes or another frame change supersedes the animation.

The window still participates in macOS fullscreen Spaces and uses AppKit's transition lifecycle; Wails only supplies the frame animation so the live web content can reflow.

## User impact

Wails applications with responsive layouts, especially transparent or translucent windows, no longer show stale-sized web content and exposed background until a native fullscreen transition finishes. Entering and leaving fullscreen now updates the WKWebView throughout the transition.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] WEP (proposal only; no implementation)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [ ] Windows
- [x] macOS
- [ ] Linux

Automated checks:

- `go test ./pkg/application -count=1`
- `git diff --check`

Manual validation was performed with a packaged Wails desktop application using a translucent macOS window. A screen recording sampled throughout the transition confirmed that both the window and its responsive web content pass through multiple intermediate layouts instead of snapping to the final viewport after the animation.

# Checklist

- [ ] (v2 only) I have updated `website/src/pages/changelog.mdx` with details of this PR (v3 changelog entries are added automatically)
- [x] My code follows the general coding style of this project
- [x] I have performed a self-review of my own code
- [x] I have commented the code where the native fullscreen behavior is non-obvious
- [x] My changes do not require documentation updates
- [x] New and existing application package tests pass locally
