### PR TITLE
fix(v2): select Safari WebKit by macOS deployment target

### DIFF
--- a/v2/pkg/commands/build/base.go
+++ b/v2/pkg/commands/build/base.go
@@ -251,6 +251,20 @@ func (b *BaseBuilder) CompileProject(options *Options) error {
 		ldflags.Add(options.LDFlags)
 	}
 
+	macOSConfig := macOSBuildConfig{}
+	if options.Platform == "darwin" {
+		macOSConfig, err = newMacOSBuildConfig(
+			os.Getenv("MACOSX_DEPLOYMENT_TARGET"),
+			os.Getenv("WAILS_MACOS_STAGED_FRAMEWORKS"),
+		)
+		if err != nil {
+			return err
+		}
+		if macOSConfig.externalLinkerArg != "" {
+			ldflags.Add(macOSConfig.externalLinkerArg)
+		}
+	}
+
 	if options.Mode == Production {
 		ldflags.Add("-w", "-s")
 		if options.Platform == "windows" && !options.WindowsConsole {
@@ -310,7 +324,7 @@ func (b *BaseBuilder) CompileProject(options *Options) error {
 					v += " "
 				}
 				if !strings.Contains(v, "-mmacosx-version-min") {
-					v += "-mmacosx-version-min=10.13"
+					v += "-mmacosx-version-min=" + macOSConfig.deploymentTarget
 				}
 			}
 			return v
@@ -320,6 +334,9 @@ func (b *BaseBuilder) CompileProject(options *Options) error {
 			if v != "" {
 				v += " "
 			}
+			if options.Platform == "darwin" && !strings.Contains(v, "-mmacosx-version-min") {
+				v += "-mmacosx-version-min=" + macOSConfig.deploymentTarget + " "
+			}
 			v += "-I" + buildBaseDir
 			return v
 		})
@@ -328,6 +345,10 @@ func (b *BaseBuilder) CompileProject(options *Options) error {
 			return "1"
 		})
 		if options.Platform == "darwin" {
+			cmd.Env = shell.UpsertEnv(cmd.Env, "MACOSX_DEPLOYMENT_TARGET", func(string) string {
+				return macOSConfig.deploymentTarget
+			})
+
 			// Determine version so we can link to newer frameworks
 			// Why doesn't CGO have this option?!?!
 			info, err := system.GetInfo()
@@ -348,8 +369,11 @@ func (b *BaseBuilder) CompileProject(options *Options) error {
 				if addUTIFramework {
 					v += "-framework UniformTypeIdentifiers "
 				}
+				if macOSConfig.stagedFrameworks != "" {
+					v += "-F" + macOSConfig.stagedFrameworks + " "
+				}
 				if !strings.Contains(v, "-mmacosx-version-min") {
-					v += "-mmacosx-version-min=10.13"
+					v += "-mmacosx-version-min=" + macOSConfig.deploymentTarget
 				}
 
 				return v

--- a/v2/pkg/commands/build/macos.go
+++ b/v2/pkg/commands/build/macos.go
@@ -1,0 +1,106 @@
+package build
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+const (
+	defaultMacOSDeploymentTarget = "10.13"
+	defaultSafariStagedFramework = "/Library/Apple/System/Library/StagedFrameworks/Safari"
+)
+
+var safariStagedFrameworks = []string{
+	"WebKit",
+	"JavaScriptCore",
+	"WebCore",
+	"WebKitLegacy",
+}
+
+type macOSVersion struct {
+	major int
+	minor int
+}
+
+type macOSBuildConfig struct {
+	deploymentTarget  string
+	stagedFrameworks  string
+	externalLinkerArg string
+}
+
+// newMacOSBuildConfig turns the standard deployment-target environment variable
+// into the additional flags needed by Apple's Safari-updated WebKit on Monterey.
+// The staged WebKit shipped with Safari 17.6 declares macOS 12.3 as its own
+// minimum. Older targets therefore retain Wails' normal system-WebKit path;
+// macOS 13 and newer already expose their current WebKit publicly.
+func newMacOSBuildConfig(deploymentTarget, stagedFrameworks string) (macOSBuildConfig, error) {
+	if deploymentTarget == "" {
+		deploymentTarget = defaultMacOSDeploymentTarget
+	}
+
+	version, err := parseMacOSVersion(deploymentTarget)
+	if err != nil {
+		return macOSBuildConfig{}, err
+	}
+
+	config := macOSBuildConfig{deploymentTarget: deploymentTarget}
+	if version.major != 12 || version.minor < 3 {
+		return config, nil
+	}
+
+	if stagedFrameworks == "" {
+		stagedFrameworks = defaultSafariStagedFramework
+	}
+	if err := validateSafariStagedFrameworks(stagedFrameworks); err != nil {
+		return macOSBuildConfig{}, err
+	}
+
+	config.stagedFrameworks = stagedFrameworks
+	config.externalLinkerArg = safariExternalLinkerArg(stagedFrameworks)
+	return config, nil
+}
+
+func parseMacOSVersion(value string) (macOSVersion, error) {
+	parts := strings.Split(value, ".")
+	if len(parts) > 2 || value == "" {
+		return macOSVersion{}, fmt.Errorf("MACOSX_DEPLOYMENT_TARGET must be a numeric macOS version: %s", value)
+	}
+
+	major, err := strconv.Atoi(parts[0])
+	if err != nil || major < 0 {
+		return macOSVersion{}, fmt.Errorf("MACOSX_DEPLOYMENT_TARGET must be a numeric macOS version: %s", value)
+	}
+
+	minor := 0
+	if len(parts) == 2 {
+		minor, err = strconv.Atoi(parts[1])
+		if err != nil || minor < 0 {
+			return macOSVersion{}, fmt.Errorf("MACOSX_DEPLOYMENT_TARGET must be a numeric macOS version: %s", value)
+		}
+	}
+
+	return macOSVersion{major: major, minor: minor}, nil
+}
+
+func validateSafariStagedFrameworks(root string) error {
+	for _, framework := range safariStagedFrameworks {
+		binary := filepath.Join(root, framework+".framework", "Versions", "A", framework)
+		if _, err := os.Stat(binary); err != nil {
+			return fmt.Errorf("Safari staged WebKit is incomplete: missing %s", filepath.Join(root, framework+".framework"))
+		}
+	}
+	return nil
+}
+
+func safariExternalLinkerArg(stagedFrameworks string) string {
+	flags := []string{
+		"-F" + stagedFrameworks,
+		"-framework UniformTypeIdentifiers",
+		"-Wl,-dyld_env,DYLD_VERSIONED_FRAMEWORK_PATH=" + stagedFrameworks,
+		"-Wl,-dyld_env,DYLD_VERSIONED_LIBRARY_PATH=" + stagedFrameworks,
+	}
+	return "-extldflags " + strconv.Quote(strings.Join(flags, " "))
+}

--- a/v2/pkg/commands/build/macos_test.go
+++ b/v2/pkg/commands/build/macos_test.go
@@ -1,0 +1,76 @@
+package build
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestNewMacOSBuildConfig(t *testing.T) {
+	tests := []struct {
+		name          string
+		deployment    string
+		staged        string
+		wantStaged    bool
+		wantErrorText string
+	}{
+		{name: "default target uses public WebKit", deployment: "13.0"},
+		{name: "older targets use public WebKit", deployment: "12.2"},
+		{name: "invalid target", deployment: "12.x", wantErrorText: "numeric macOS version"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			config, err := newMacOSBuildConfig(test.deployment, test.staged)
+			if test.wantErrorText != "" {
+				if err == nil || !strings.Contains(err.Error(), test.wantErrorText) {
+					t.Fatalf("newMacOSBuildConfig() error = %v, want %q", err, test.wantErrorText)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got := config.stagedFrameworks != ""; got != test.wantStaged {
+				t.Fatalf("staged framework selection = %t, want %t", got, test.wantStaged)
+			}
+		})
+	}
+
+	staged := makeSafariStagedFrameworks(t)
+	config, err := newMacOSBuildConfig("12.3", staged)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if config.stagedFrameworks != staged {
+		t.Fatalf("stagedFrameworks = %q, want %q", config.stagedFrameworks, staged)
+	}
+	for _, want := range []string{
+		"-F" + staged,
+		"-framework UniformTypeIdentifiers",
+		"DYLD_VERSIONED_FRAMEWORK_PATH=" + staged,
+		"DYLD_VERSIONED_LIBRARY_PATH=" + staged,
+	} {
+		if !strings.Contains(config.externalLinkerArg, want) {
+			t.Errorf("externalLinkerArg missing %q: %s", want, config.externalLinkerArg)
+		}
+	}
+	if _, err := newMacOSBuildConfig("12.3", t.TempDir()); err == nil {
+		t.Fatal("Monterey target must fail when Safari staged frameworks are incomplete")
+	}
+}
+
+func makeSafariStagedFrameworks(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	for _, framework := range safariStagedFrameworks {
+		binary := filepath.Join(root, framework+".framework", "Versions", "A", framework)
+		if err := os.MkdirAll(filepath.Dir(binary), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(binary, nil, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return root
+}


### PR DESCRIPTION
## Context

On macOS Monterey 12.7.6, the system WKWebView/JavaScriptCore can be older than the WebKit that Safari has staged in:

    /Library/Apple/System/Library/StagedFrameworks/Safari

Reasonix currently reaches JavaScript and RegExp features in markdownRemarkPlugins that Monterey's system engine cannot parse. The observed failure is:

    Invalid regular expression: invalid group specifier name

It happens while the bundle is being parsed, before React mounts, so the user sees a black/error window. This is a native WebKit version skew, not a Reasonix application-logic bug. Adding more JavaScript shims or repeatedly rewriting individual expressions only moves the compatibility burden to every application.

## What this PR changes

Wails now owns this macOS framework selection policy during the normal build:

- Read the standard MACOSX_DEPLOYMENT_TARGET value.
- For 12.3 <= target < 13, validate Safari's staged WebKit frameworks and link with their framework search path.
- Add versioned DYLD framework/library paths so the staged WebKit is selected at runtime, not only at link time.
- Propagate the same deployment target through CGO and the external linker.
- Keep the existing system-WebKit path for targets below 12.3 and for macOS 13+.
- Reject malformed deployment-target values with a build error.

The 12.3 boundary is intentional: the Safari staged framework set validated on Monterey declares macOS 12.3 as its minimum. Selecting it for 12.0–12.2 would produce an invalid deployment target rather than a supported binary.

The optional WAILS_MACOS_STAGED_FRAMEWORKS environment variable is available for controlled build/test environments; the default is Apple's standard staged-framework location.

## Why this belongs in Wails

The policy is about how a Wails application is linked and launched, not about Reasonix's frontend. Keeping it here gives every Wails v2 application the same opt-in behavior through:

    MACOSX_DEPLOYMENT_TARGET=12.3 wails build -platform darwin/amd64

It also covers manual builds and CI builds without requiring each consumer to duplicate framework validation, -F flags, DYLD_VERSIONED_* flags, and CGO linker plumbing.

## Compatibility evidence

This problem has repeatedly been addressed at the application layer:

- Reasonix issue [#7624](https://github.com/esengine/DeepSeek-Reasonix/issues/7624): Monterey 12.7.6 fails in markdownRemarkPlugins with the invalid group-specifier error.
- Reasonix PR [#1215](https://github.com/esengine/DeepSeek-Reasonix/pull/1215): removes RegExp lookbehind from the bundle and adds a narrowly-scoped build transform.
- Reasonix PR [#2886](https://github.com/esengine/DeepSeek-Reasonix/pull/2886): pins mdast-util-gfm-autolink-literal to an older version for Safari.
- Reasonix PR [#2883](https://github.com/esengine/DeepSeek-Reasonix/pull/2883): strips crossorigin from Wails-served assets for macOS 12's custom-scheme loading behavior.
- Reasonix PR [#6678](https://github.com/esengine/DeepSeek-Reasonix/pull/6678): installs an Object.hasOwn polyfill for legacy WebKit.
- Reasonix PR [#7615](https://github.com/esengine/DeepSeek-Reasonix/pull/7615): includes another old-WebKit-compatible local-path matcher.
- Wails PR [#3333](https://github.com/wailsapp/wails/pull/3333): reverts JavaScript class fields from the v3 runtime for older Safari.
- Wails issue [#2396](https://github.com/wailsapp/wails/issues/2396): Catalina reports a JavaScript parse error in a built Wails application.
- Wails issues [#694](https://github.com/wailsapp/wails/issues/694) and [#613](https://github.com/wailsapp/wails/issues/613): built applications render blank or report opaque Script error failures even when development mode works.

Not every historical report has the same immediate trigger: for example, crossorigin failures are custom-scheme/CORS behavior, not JavaScript syntax. The common maintenance problem is that applications have to discover and encode WebKit-version quirks independently.

## Maintenance impact

The paired Reasonix change is only five lines: it sets a 12.3 deployment-target default in its existing desktop build script and leaves all WebKit/linker policy to Wails. No Safari path, native linker flags, or Wails-specific compatibility test is added to the application.

Once this behavior is available in a released Wails version, the following Reasonix cleanup becomes possible as a separate, verifiable follow-up:

- remove the Object.hasOwn startup shim and its contract test;
- remove the mdast-util-gfm-autolink-literal Safari pin;
- remove the lookbehind-avoidance transforms and matchers that only exist for the old system engine;
- retain the crossorigin workaround unless a separate Wails custom-scheme fix makes it redundant, because that issue is transport behavior rather than JavaScript engine age.

This separates permanent product behavior from compatibility debt and makes future WebKit policy fixes reusable across Wails applications.

## Validation

- go test ./pkg/commands/build passes.
- bash -n scripts/desktop-build.sh and git diff --check pass in the paired Reasonix checkout.
- On macOS 12.7.6 Intel, the paired Reasonix build was run through its standard desktop-build.sh path with the local Wails CLI.
- The resulting binary advertises a 12.3 minimum, contains DYLD_VERSIONED_FRAMEWORK_PATH and DYLD_VERSIONED_LIBRARY_PATH for Safari's staged directory, loads WebKit, WebKitLegacy, JavaScriptCore, and WebCore from that directory, and passes deep strict code-signature verification.
- Targets 13.0 and later continue through the normal system-WebKit path.

## Paired PR

Reasonix consumer PR: https://github.com/esengine/DeepSeek-Reasonix/pull/7628

These two PRs should be reviewed and merged as a pair. The Reasonix PR deliberately contains only the deployment-target handoff; this PR contains the native WebKit policy.
