### PR TITLE
fix(mobile): return browser launch errors

### DIFF
--- a/v3/ANDROID.md
+++ b/v3/ANDROID.md
@@ -148,14 +148,14 @@ the `application.IOS*` surface, so one event-driven layer drives both platforms
 
 For the subset of capabilities whose signature is identical on both platforms,
 `application.Mobile` provides one build-guarded entry point: it dispatches to
-`Android` on Android, `IOS` on iOS, and a no-op stub on desktop — so
+`Android` on Android, `IOS` on iOS, and a desktop stub off-device — so
 cross-platform code can call e.g. `application.Mobile.StoragePath()` without its
 own `//go:build` split. Platform-specific calls stay on `Android` / `IOS`.
 
 | Capability | API | Notes |
 |---|---|---|
 | Share sheet | `Android.Share(json)` | `Intent.ACTION_SEND` |
-| Open URL externally | `Android.OpenURL(url)` | `Intent.ACTION_VIEW` |
+| Open URL externally | `Android.OpenURL(url) error` | Reports invalid URLs, unavailable handlers, and launch failures |
 | Keep screen awake | `Android.SetKeepAwake(bool)` | `FLAG_KEEP_SCREEN_ON` |
 | Torch / flashlight | `Android.SetTorch(bool)` | `CameraManager` → `common:torch` |
 | Safe-area insets | `Android.SafeAreaJSON()` | `{top,bottom,left,right}` |

--- a/v3/IOS.md
+++ b/v3/IOS.md
@@ -109,14 +109,14 @@ both platforms (see the `mobile` example's `registerNativeFeatures`).
 
 For the subset of capabilities whose signature is identical on both platforms,
 `application.Mobile` provides one build-guarded entry point: it dispatches to
-`IOS` on iOS, `Android` on Android, and a no-op stub on desktop — so
+`IOS` on iOS, `Android` on Android, and a desktop stub off-device — so
 cross-platform code can call e.g. `application.Mobile.StoragePath()` without its
 own `//go:build` split. Platform-specific calls stay on `IOS` / `Android`.
 
 | Capability | API | Notes |
 |---|---|---|
 | Share sheet | `IOS.Share(json)` | `UIActivityViewController` |
-| Open URL externally | `IOS.OpenURL(url)` | Opens in Safari |
+| Open URL externally | `IOS.OpenURL(url) error` | Reports invalid URLs and rejected launches |
 | Keep screen awake | `IOS.SetKeepAwake(bool)` | Idle-timer toggle |
 | Torch / flashlight | `IOS.SetTorch(bool)` | → `common:torch` event |
 | Safe-area insets | `IOS.SafeAreaJSON()` | `{top,bottom,left,right}` |

--- a/v3/examples/mobile/build/android/app/src/main/java/com/wails/app/WailsBridge.java
+++ b/v3/examples/mobile/build/android/app/src/main/java/com/wails/app/WailsBridge.java
@@ -59,8 +59,12 @@ import androidx.security.crypto.MasterKey;
 import org.json.JSONArray;
 import org.json.JSONObject;
 
+import java.net.URI;
 import java.util.Locale;
 import java.util.concurrent.Executor;
+import java.util.concurrent.FutureTask;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 /**
  * WailsBridge manages the connection between the Java/Android side and the Go
@@ -451,16 +455,50 @@ public class WailsBridge {
     /**
      * Open a URL in the system browser.
      */
-    public void openURL(final String url) {
-        mainHandler.post(() -> {
+    public String openURL(final String url) {
+        if (url == null || url.trim().isEmpty()) return "URL must not be empty";
+
+        Uri parsed;
+        try {
+            URI validated = new URI(url);
+            if (validated.getScheme() == null || validated.getScheme().isEmpty()) {
+                return "invalid URL: missing scheme";
+            }
+            parsed = Uri.parse(validated.toString());
+        } catch (Exception e) {
+            return "invalid URL: " + e.getMessage();
+        }
+
+        final Uri target = parsed;
+        FutureTask<String> launch = new FutureTask<>(() -> {
             try {
-                Intent view = new Intent(Intent.ACTION_VIEW, Uri.parse(url));
+                Intent view = new Intent(Intent.ACTION_VIEW, target);
                 view.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
                 activity.startActivity(view);
+                return "";
             } catch (Exception e) {
-                Log.e(TAG, "openURL failed", e);
+                return e.getClass().getSimpleName() + ": " + e.getMessage();
             }
         });
+
+        if (Looper.myLooper() == Looper.getMainLooper()) {
+            launch.run();
+        } else if (!mainHandler.post(launch)) {
+            return "failed to schedule browser launch on the main thread";
+        }
+
+        try {
+            return launch.get(30, TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+            launch.cancel(false);
+            Thread.currentThread().interrupt();
+            return "interrupted while launching URL";
+        } catch (TimeoutException e) {
+            launch.cancel(false);
+            return "timed out waiting for browser launch";
+        } catch (Exception e) {
+            return e.getClass().getSimpleName() + ": " + e.getMessage();
+        }
     }
 
     /**

--- a/v3/examples/mobile/native_features_android.go
+++ b/v3/examples/mobile/native_features_android.go
@@ -15,7 +15,9 @@ func registerNativeFeatures(app *application.App) {
 		application.Android.Share(payloadJSON(e.Data))
 	})
 	app.Event.On("common:openURL", func(e *application.CustomEvent) {
-		application.Android.OpenURL(eventString(e.Data, "url"))
+		if err := application.Android.OpenURL(eventString(e.Data, "url")); err != nil {
+			app.Logger.Error("open URL", "error", err)
+		}
 	})
 	app.Event.On("common:keepAwake", func(e *application.CustomEvent) {
 		application.Android.SetKeepAwake(eventBool(e.Data, "enabled", false))

--- a/v3/examples/mobile/native_features_ios.go
+++ b/v3/examples/mobile/native_features_ios.go
@@ -16,7 +16,9 @@ func registerNativeFeatures(app *application.App) {
 		application.IOS.Share(payloadJSON(e.Data))
 	})
 	app.Event.On("common:openURL", func(e *application.CustomEvent) {
-		application.IOS.OpenURL(eventString(e.Data, "url"))
+		if err := application.IOS.OpenURL(eventString(e.Data, "url")); err != nil {
+			app.Logger.Error("open URL", "error", err)
+		}
 	})
 	app.Event.On("common:keepAwake", func(e *application.CustomEvent) {
 		application.IOS.SetKeepAwake(eventBool(e.Data, "enabled", false))

--- a/v3/internal/commands/build_assets/android/app/src/main/java/com/wails/app/WailsBridge.java
+++ b/v3/internal/commands/build_assets/android/app/src/main/java/com/wails/app/WailsBridge.java
@@ -59,8 +59,12 @@ import androidx.security.crypto.MasterKey;
 import org.json.JSONArray;
 import org.json.JSONObject;
 
+import java.net.URI;
 import java.util.Locale;
 import java.util.concurrent.Executor;
+import java.util.concurrent.FutureTask;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 /**
  * WailsBridge manages the connection between the Java/Android side and the Go
@@ -451,16 +455,50 @@ public class WailsBridge {
     /**
      * Open a URL in the system browser.
      */
-    public void openURL(final String url) {
-        mainHandler.post(() -> {
+    public String openURL(final String url) {
+        if (url == null || url.trim().isEmpty()) return "URL must not be empty";
+
+        Uri parsed;
+        try {
+            URI validated = new URI(url);
+            if (validated.getScheme() == null || validated.getScheme().isEmpty()) {
+                return "invalid URL: missing scheme";
+            }
+            parsed = Uri.parse(validated.toString());
+        } catch (Exception e) {
+            return "invalid URL: " + e.getMessage();
+        }
+
+        final Uri target = parsed;
+        FutureTask<String> launch = new FutureTask<>(() -> {
             try {
-                Intent view = new Intent(Intent.ACTION_VIEW, Uri.parse(url));
+                Intent view = new Intent(Intent.ACTION_VIEW, target);
                 view.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
                 activity.startActivity(view);
+                return "";
             } catch (Exception e) {
-                Log.e(TAG, "openURL failed", e);
+                return e.getClass().getSimpleName() + ": " + e.getMessage();
             }
         });
+
+        if (Looper.myLooper() == Looper.getMainLooper()) {
+            launch.run();
+        } else if (!mainHandler.post(launch)) {
+            return "failed to schedule browser launch on the main thread";
+        }
+
+        try {
+            return launch.get(30, TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+            launch.cancel(false);
+            Thread.currentThread().interrupt();
+            return "interrupted while launching URL";
+        } catch (TimeoutException e) {
+            launch.cancel(false);
+            return "timed out waiting for browser launch";
+        } catch (Exception e) {
+            return e.getClass().getSimpleName() + ": " + e.getMessage();
+        }
     }
 
     /**

--- a/v3/internal/commands/mobile_openurl_test.go
+++ b/v3/internal/commands/mobile_openurl_test.go
@@ -1,0 +1,32 @@
+package commands
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAndroidOpenURLReturnsLaunchFailures(t *testing.T) {
+	generated, err := buildAssets.ReadFile("build_assets/android/app/src/main/java/com/wails/app/WailsBridge.java")
+	require.NoError(t, err)
+	example, err := os.ReadFile("../../examples/mobile/build/android/app/src/main/java/com/wails/app/WailsBridge.java")
+	require.NoError(t, err)
+
+	sources := map[string][]byte{
+		"generated host": generated,
+		"mobile example": example,
+	}
+	for name, source := range sources {
+		t.Run(name, func(t *testing.T) {
+			bridge := string(source)
+			assert.Contains(t, bridge, "public String openURL(final String url)")
+			assert.Contains(t, bridge, "new URI(url)")
+			assert.Contains(t, bridge, "FutureTask<String>")
+			assert.Contains(t, bridge, "launch.get(30, TimeUnit.SECONDS)")
+			assert.Contains(t, bridge, "launch.cancel(false)")
+			assert.NotContains(t, bridge, `Log.e(TAG, "openURL failed", e)`)
+		})
+	}
+}

--- a/v3/pkg/application/mobile.go
+++ b/v3/pkg/application/mobile.go
@@ -3,7 +3,7 @@ package application
 // MobileManager is the cross-platform surface common to the iOS and Android
 // native-feature managers. The package-level Mobile singleton implements it,
 // dispatching to the IOS or Android manager on the respective platform and to a
-// no-op stub on desktop builds. This lets cross-platform mobile code call
+// desktop stub on non-mobile builds. This lets cross-platform mobile code call
 // application.Mobile.* without splitting into //go:build ios / //go:build
 // android files of its own.
 //
@@ -18,9 +18,9 @@ package application
 // guarantees the two platform managers keep that method signature-identical: if
 // they ever drift, the platform build fails to compile.
 type MobileManager interface {
-	// One-way actions
+	// Actions
 	Share(jsonPayload string)
-	OpenURL(url string)
+	OpenURL(url string) error
 	SetKeepAwake(enabled bool)
 	SetTorch(enabled bool)
 

--- a/v3/pkg/application/mobile_features_android.go
+++ b/v3/pkg/application/mobile_features_android.go
@@ -2,6 +2,11 @@
 
 package application
 
+import (
+	"errors"
+	"fmt"
+)
+
 // Genuinely-mobile native capabilities for Android, mirroring the iOS surface
 // in mobile_features_ios.go. Each call is forwarded to a matching method on the
 // Java WailsBridge via the reflective bridge helpers. Asynchronous results
@@ -32,7 +37,16 @@ func boolToInt(b bool) int {
 func (androidManager) Share(jsonPayload string) { androidBridgeVoidString("share", jsonPayload) }
 
 // OpenURL opens the given URL in the system browser (Intent.ACTION_VIEW).
-func (androidManager) OpenURL(url string) { androidBridgeVoidString("openURL", url) }
+func (androidManager) OpenURL(url string) error {
+	result, ok := androidBridgeStringString("openURL", url)
+	if !ok {
+		return errors.New("android bridge is unavailable")
+	}
+	if result != "" {
+		return fmt.Errorf("open URL: %s", result)
+	}
+	return nil
+}
 
 // SetKeepAwake adds or clears FLAG_KEEP_SCREEN_ON on the activity window.
 func (androidManager) SetKeepAwake(enabled bool) {

--- a/v3/pkg/application/mobile_features_ios.go
+++ b/v3/pkg/application/mobile_features_ios.go
@@ -12,6 +12,7 @@ import "C"
 
 import (
 	"encoding/json"
+	"errors"
 	"unsafe"
 )
 
@@ -50,10 +51,13 @@ func (iosManager) Share(jsonPayload string) {
 }
 
 // OpenURL opens the given URL in the system browser (Safari).
-func (iosManager) OpenURL(url string) {
+func (iosManager) OpenURL(url string) error {
 	c, free := cString(url)
 	defer free()
-	C.ios_open_url(c)
+	if message := cStr(C.ios_open_url(c)); message != "" {
+		return errors.New(message)
+	}
+	return nil
 }
 
 // SetKeepAwake disables (true) or restores (false) the idle timer, keeping

--- a/v3/pkg/application/mobile_features_ios.h
+++ b/v3/pkg/application/mobile_features_ios.h
@@ -3,9 +3,9 @@
 
 #include <stdbool.h>
 
-// Phase A — one-way actions
+// Phase A — actions
 void ios_share(const char* json);
-void ios_open_url(const char* url);
+const char* ios_open_url(const char* url);
 void ios_set_keep_awake(bool enabled);
 void ios_set_torch(bool enabled);
 

--- a/v3/pkg/application/mobile_features_ios.m
+++ b/v3/pkg/application/mobile_features_ios.m
@@ -103,16 +103,20 @@ const char* ios_open_url(const char* curl) {
 
     __block NSString *errorMessage = nil;
     dispatch_semaphore_t completed = dispatch_semaphore_create(0);
-    dispatch_async(dispatch_get_main_queue(), ^{
+    dispatch_block_t launch = dispatch_block_create(0, ^{
         UIApplication *application = [UIApplication sharedApplication];
         [application openURL:url options:@{} completionHandler:^(BOOL success) {
             if (!success) errorMessage = @"application rejected URL";
             dispatch_semaphore_signal(completed);
         }];
     });
+    dispatch_async(dispatch_get_main_queue(), launch);
     long waitResult = dispatch_semaphore_wait(
         completed, dispatch_time(DISPATCH_TIME_NOW, 30 * NSEC_PER_SEC));
-    if (waitResult != 0) return mfDup(@"timed out waiting for application to open URL");
+    if (waitResult != 0) {
+        dispatch_block_cancel(launch);
+        return mfDup(@"timed out waiting for application to open URL");
+    }
     return mfDup(errorMessage);
 }
 

--- a/v3/pkg/application/mobile_features_ios.m
+++ b/v3/pkg/application/mobile_features_ios.m
@@ -21,6 +21,17 @@ static int g_mfOrientationMode = 0;   // 0=auto, 1=portrait, 2=landscape
 static int g_mfStatusBarStyle = 0;    // 0=default, 1=light content, 2=dark content
 static BOOL g_mfStatusBarHidden = NO;
 
+// dupCString clones an NSString into a malloc'd C string (caller frees).
+static const char* mfDup(NSString *str) {
+    if (str == nil) return NULL;
+    const char* utf8 = [str UTF8String];
+    if (utf8 == NULL) return NULL;
+    size_t len = strlen(utf8) + 1;
+    char* out = (char*)malloc(len);
+    if (out) memcpy(out, utf8, len);
+    return out;
+}
+
 // Run a block on the main thread without deadlocking when already on it.
 static void mfRunOnMain(void (^block)(void)) {
     if ([NSThread isMainThread]) {
@@ -80,14 +91,29 @@ void ios_share(const char* json) {
 
 // MARK: - Open URL externally
 
-void ios_open_url(const char* curl) {
-    if (curl == NULL) return;
+const char* ios_open_url(const char* curl) {
+    if (curl == NULL) return mfDup(@"URL must not be null");
     NSString *str = [NSString stringWithUTF8String:curl];
+    if (str == nil) return mfDup(@"invalid URL encoding");
     NSURL *url = [NSURL URLWithString:str];
-    if (url == nil) return;
-    mfRunOnMain(^{
-        [[UIApplication sharedApplication] openURL:url options:@{} completionHandler:nil];
+    if (url == nil || url.scheme.length == 0) return mfDup(@"invalid URL");
+    if ([NSThread isMainThread]) {
+        return mfDup(@"OpenURL cannot wait for completion on the iOS main thread");
+    }
+
+    __block NSString *errorMessage = nil;
+    dispatch_semaphore_t completed = dispatch_semaphore_create(0);
+    dispatch_async(dispatch_get_main_queue(), ^{
+        UIApplication *application = [UIApplication sharedApplication];
+        [application openURL:url options:@{} completionHandler:^(BOOL success) {
+            if (!success) errorMessage = @"application rejected URL";
+            dispatch_semaphore_signal(completed);
+        }];
     });
+    long waitResult = dispatch_semaphore_wait(
+        completed, dispatch_time(DISPATCH_TIME_NOW, 30 * NSEC_PER_SEC));
+    if (waitResult != 0) return mfDup(@"timed out waiting for application to open URL");
+    return mfDup(errorMessage);
 }
 
 // MARK: - Keep screen awake
@@ -137,17 +163,6 @@ void ios_set_torch(bool enabled) {
         iosEmitNativeEvent("common:torch", enabled ? "{\"on\":true,\"available\":true}"
                                                    : "{\"on\":false,\"available\":true}");
     });
-}
-
-// dupCString clones an NSString into a malloc'd C string (caller frees).
-static const char* mfDup(NSString *str) {
-    if (str == nil) return NULL;
-    const char* utf8 = [str UTF8String];
-    if (utf8 == NULL) return NULL;
-    size_t len = strlen(utf8) + 1;
-    char* out = (char*)malloc(len);
-    if (out) memcpy(out, utf8, len);
-    return out;
 }
 
 static void mfRunOnMainSync(void (^block)(void)) {

--- a/v3/pkg/application/mobile_features_source_test.go
+++ b/v3/pkg/application/mobile_features_source_test.go
@@ -1,0 +1,24 @@
+package application
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIOSOpenURLReturnsLaunchFailures(t *testing.T) {
+	header, err := os.ReadFile("mobile_features_ios.h")
+	require.NoError(t, err)
+	implementation, err := os.ReadFile("mobile_features_ios.m")
+	require.NoError(t, err)
+
+	assert.Contains(t, string(header), "const char* ios_open_url(const char* url)")
+	source := string(implementation)
+	assert.Contains(t, source, "if (str == nil) return mfDup(@\"invalid URL encoding\")")
+	assert.Contains(t, source, "completionHandler:^(BOOL success)")
+	assert.Contains(t, source, "if (!success) errorMessage")
+	assert.Contains(t, source, "timed out waiting for application to open URL")
+	assert.NotContains(t, source, "canOpenURL:url")
+}

--- a/v3/pkg/application/mobile_features_source_test.go
+++ b/v3/pkg/application/mobile_features_source_test.go
@@ -20,5 +20,7 @@ func TestIOSOpenURLReturnsLaunchFailures(t *testing.T) {
 	assert.Contains(t, source, "completionHandler:^(BOOL success)")
 	assert.Contains(t, source, "if (!success) errorMessage")
 	assert.Contains(t, source, "timed out waiting for application to open URL")
+	assert.Contains(t, source, "dispatch_block_create")
+	assert.Contains(t, source, "dispatch_block_cancel(launch)")
 	assert.NotContains(t, source, "canOpenURL:url")
 }

--- a/v3/pkg/application/mobile_stub.go
+++ b/v3/pkg/application/mobile_stub.go
@@ -2,16 +2,20 @@
 
 package application
 
-// mobileStub is the desktop implementation of MobileManager. Every action is a
-// no-op and every query returns its zero value, so cross-platform code that
-// calls application.Mobile.* compiles and runs off-device without effect.
+import "errors"
+
+// mobileStub is the desktop implementation of MobileManager. Unsupported
+// fallible operations return an error; other actions are no-ops and queries
+// return their zero value.
 type mobileStub struct{}
 
-// Mobile is the cross-platform mobile manager. Off-device it is a no-op stub.
+// Mobile is the cross-platform mobile manager. Off-device it is a desktop stub.
 var Mobile MobileManager = mobileStub{}
 
-func (mobileStub) Share(string)                 {}
-func (mobileStub) OpenURL(string)               {}
+func (mobileStub) Share(string) {}
+func (mobileStub) OpenURL(string) error {
+	return errors.New("mobile OpenURL is unavailable on this platform")
+}
 func (mobileStub) SetKeepAwake(bool)            {}
 func (mobileStub) SetTorch(bool)                {}
 func (mobileStub) SafeAreaJSON() string         { return "" }

--- a/v3/pkg/application/mobile_stub_test.go
+++ b/v3/pkg/application/mobile_stub_test.go
@@ -1,0 +1,13 @@
+//go:build !ios && !android
+
+package application
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMobileOpenURLReportsUnsupportedPlatform(t *testing.T) {
+	require.Error(t, Mobile.OpenURL("https://example.com"))
+}


### PR DESCRIPTION
# Description

Mobile `OpenURL` currently returns nothing on Android and iOS. Android posts `startActivity` and only logs exceptions, while iOS discards the `openURL` completion result. Callers therefore cannot distinguish a successful browser launch from an invalid URL, missing handler, or rejected launch.

This changes the shared contract to:

```go
OpenURL(url string) error
```

Android now validates URI syntax, performs the activity launch on the main thread, and returns launch exceptions through the existing JNI string bridge. iOS validates the URL and returns the asynchronous `UIApplication.openURL` completion result to Go. Both platforms use bounded waits so a stalled UI thread cannot block the caller indefinitely.

The desktop `Mobile` stub returns an unsupported-platform error. The generated Android host, checked-in mobile example, documentation, and example error handling are updated together. Focused source-contract tests protect the native bridge signatures and failure paths.

This was surfaced by PKCE browser flows: silently failing to launch a browser leaves authentication waiting for a callback that can never arrive. The behavior is general to all Wails mobile applications and does not depend on a particular authentication library.

## Compatibility note

Mobile support is experimental, but this changes the exported `MobileManager` method signature and therefore requires custom implementations to add the `error` result. Ordinary callers that invoke `OpenURL(...)` as a statement continue to compile.

Existing generated Android projects contain the old `void openURL(String)` host method. Because generated Java hosts are not updated automatically, those projects must regenerate the Android host or synchronize `WailsBridge.java` when upgrading.

_No matching open issue was found._

## Type of change

- [x] Bug fix (non-breaking for ordinary callers)
- [ ] New feature
- [x] Experimental API contract change
- [x] Documentation update

# How Has This Been Tested?

- `go test -count=1 ./internal/commands ./pkg/application`
- Verified the canonical and checked-in example Android bridge files are identical.
- Source-contract regression coverage for Android validation, UI-thread dispatch, timeout/cancellation, and returned failures.
- Source-contract regression coverage for iOS URL validation, completion rejection, timeout, and C/Go ownership signature.
- Council-style review covered native threading, JNI reflection, Objective-C ARC ownership, API compatibility, and test coverage; findings were applied and re-reviewed.

Honest caveats:

- Android and iOS launches were not exercised on a device from this Linux host.
- The standalone mobile example module currently requests an unrelated `go mod tidy`, so its module-wide test was not allowed to modify metadata.

- [ ] Windows
- [ ] macOS
- [x] Linux

## Test Configuration

- Go: go1.26.5
- OS: Ubuntu 24.04.4 LTS, amd64

# Checklist:

- [ ] (v2 only) changelog update — n/a; v3 entries are automated
- [x] My code follows the general coding style of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding documentation changes
- [x] My changes generate no new warnings in the tested packages
- [x] I have added tests that prove the fix is represented in generated/native sources
- [x] New and existing focused unit tests pass locally


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Mobile URL opening now validates URLs and reports launch failures, interruptions, timeouts, and unavailable handlers.
  - Android and iOS URL launches provide clear success or error results.
  - Desktop platforms now explicitly report that URL opening is unsupported.

- **Documentation**
  - Updated mobile API documentation with error behavior, URL validation, and platform capability details.

- **Tests**
  - Added coverage for unsupported desktop behavior and mobile URL launch failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->