### PR TITLE
feat: add native WebContentsView panels

### DIFF
--- a/IMPLEMENTATION.md
+++ b/IMPLEMENTATION.md
@@ -70,6 +70,71 @@ This document tracks the implementation of WebKitGTK 6.0 (GTK4) support for Wail
 
 **Decision**: No changes needed - system tray is already GTK-agnostic.
 
+### Decision 6: Native Child-Webview Composition (2026-08-09)
+
+**Context**: A secondary native browser cannot be represented by the host webview's DOM. GTK windows also accept one content child, so placing an independently-sized `WebKitWebView` beside the existing host layout would either replace the host or make its bounds participate in the host layout.
+
+**Decision**: The native window root is a `GtkOverlay`: the existing Wails `GtkBox` remains its main child, while each registered `ChildView` is a directly positioned `GtkOverlay` child. `WebviewWindow.AddChildView` and `RemoveChildView` own attach/detach timing; `WebContentsView` defers GTK/WebKit allocation until the application has activated.
+
+**Rationale**:
+- Preserves the host webview and menu layout unchanged.
+- Gives product code a Go-owned, window-managed lifecycle with deterministic teardown.
+- Avoids the GTK activation crash caused by constructing a `WebKitWebView` before the application is active.
+- Keeps the default GTK4 path and the supported `-tags gtk3` legacy path source-compatible.
+- Does not install a full-window `GtkFixed` input layer above the host webview; host controls in the uncovered area remain clickable while the child browser continues to receive its own input.
+
+**Current scope**: GTK4/WebKitGTK 6 provides embedding, bounds, navigation/back, snapshots, and JavaScript execution. GTK3 retains basic embedding/navigation/script execution for the final legacy cycle.
+
+### Decision 7: Deferred Native Browser Allocation (2026-08-09)
+
+**Context**: Constructing a GTK `WebKitWebView` before GTK activation segfaults, and the imported macOS tests documented the equivalent risk of constructing `WKWebView` before an `NSApplication`/window runloop exists. WebView2 also rejects controller operations before its asynchronous initialization completes.
+
+**Decision**: `NewWebContentsView` only records configuration on every desktop platform. Native allocation is deferred to the window-managed `Attach` lifecycle; queued navigation/script work is applied after a platform view becomes ready. Windows reads source/history through readiness-guarded native WebView2 calls.
+
+**Rationale**:
+- Makes pre-`App.Run` registration through `WebviewWindow.AddChildView` safe and deterministic.
+- Uses the existing Wails main-thread dispatch rather than asking product code to reproduce platform timing rules.
+- Removes a startup crash class while preserving the imported API surface.
+
+### Decision 8: Keep the Upstream Primitive Secure and Narrow (2026-08-09)
+
+**Context**: The draft's macOS backend used private KVC keys to relax file/CORS restrictions and change WebKit background behavior.
+
+**Decision**: The native panel primitive keeps standard platform web security enabled and does not use those private KVC switches.
+
+**Rationale**:
+- Avoids unstable private APIs and does not silently weaken browser isolation for normal Wails applications.
+
+### Decision 9: Native Child Visibility Is Explicit (2026-08-09)
+
+**Context**: A `WebContentsView` is an OS-native surface layered above the host Wails webview. DOM z-index and a zero-sized frontend placeholder do not provide dependable visual hiding, especially while a browser view has intrinsic native content.
+
+**Decision**: The cross-platform primitive provides explicit `Show` and `Hide` operations. They preserve the attached native browser and session; permanent removal is still owned by `WebviewWindow.RemoveChildView`.
+
+**Rationale**:
+- Keeps React/frontend layout state from being mistaken for native visibility state.
+- Makes browser panels reliable for tabs, modals, and workspace switching on GTK4, GTK3 legacy, WebView2, and WKWebView.
+- Avoids recreating a browser session merely to temporarily reveal frontend UI.
+
+`RemoveChildView` is reversible. `WebContentsView.Destroy` is the explicit
+permanent release operation and must follow removal from the owning window.
+
+### Decision 10: Serialize Native View Operations (2026-08-09)
+
+**Context**: Application bindings may issue navigation, resizing, screenshot,
+and lifecycle operations from separate Go goroutines. The platform-native
+browser objects and their pending-script state are not safe for overlapping
+access.
+
+**Decision**: `WebContentsView` protects configuration with a state mutex and
+serializes every native operation through a separate operation mutex. Platform
+backends read immutable option snapshots during attachment instead of reading
+mutable state directly.
+
+**Rationale**:
+- Prevents native WebKit/WebView2/GTK object access from racing destruction or another UI operation.
+- Keeps late URL/bounds/visibility changes deterministic while native allocation is deferred.
+
 ## Implementation Progress
 
 ### Phase 1: Build Infrastructure ✅ COMPLETE
@@ -455,6 +520,30 @@ v3/internal/assetserver/webview/
 ```
 
 ## Changelog
+
+### 2026-08-09
+- Added window-managed native child-view lifecycle (`ChildView`, `AddChildView`, `RemoveChildView`) for the imported `WebContentsView` API.
+- Made the GTK window root a `GtkOverlay`, with each embedded browser positioned as a direct overlay child so empty regions continue to route input to the host webview.
+- Ported the default Linux implementation to GTK4 + WebKitGTK 6.0 and deferred native view allocation until application activation.
+- Added WebKitGTK snapshots and focused regression coverage.
+- Restored equivalent basic embed support for the legacy `-tags gtk3` GTK3/WebKit2GTK 4.1 path.
+- Deferred macOS `WKWebView` construction until a native host window attaches; the headless macOS API test now verifies that `NewWebContentsView` does not allocate a WebKit view.
+- Replaced the Windows draft's cached URL and JavaScript history fallback with readiness-guarded native WebView2 source/history calls.
+- Made native attachment idempotent across the desktop backends; a hidden Windows child view is shown and re-bounded when it is re-added to its host window.
+- Implemented the draft API's previously inert inline-HTML source mode across GTK4, GTK3, Windows, and macOS; `SetURL` and `SetHTML` now replace one another deterministically.
+- Implemented native WebView2 PNG snapshots with callback-held COM stream ownership.
+- Added explicit Show/Hide control for native browser surfaces across GTK4, GTK3 legacy, WebView2, and WKWebView; documented that DOM overlays cannot render above an attached native child view.
+- Added `v3/test/manual/webcontentsview`, a native desktop smoke application covering lifecycle, movement, visibility, source switching, JavaScript, snapshots, and remove/re-add behavior for runtime verification on each platform.
+- Exposed `webcontentsview.Enabled` and `webcontentsview.Disabled` preference helpers and corrected the browser-view guide so documented `WebPreferences` literals compile.
+- Retained each GTK child widget independently of its temporary `GtkFixed` parent, making `RemoveChildView` followed by `AddChildView` safe rather than leaving a dangling native pointer.
+- Added permanent native disposal through `WebContentsView.Destroy`; after removal from its owner, GTK releases the retained widget, WebView2 closes/releases its controller, and WKWebView is removed and released.
+- Serialized mutable view state and native operations, with a race-regression test covering concurrent application-style calls.
+- Added an explicit no-op `-tags server` WebContentsView backend so server builds preserve the API without claiming a native browser surface.
+- Removed private macOS KVC switches that disabled file/CORS restrictions or changed WebKit drawing behavior.
+- Verified focused `pkg/application` and `pkg/webcontentsview` suites on both default GTK4 and legacy GTK3; a real GTK4 probe loaded a native child view and captured a snapshot.
+- Files: `v3/pkg/application/linux_cgo.go`, `v3/pkg/application/linux_cgo_gtk3.go`,
+  `v3/pkg/application/webview_window.go`, `v3/pkg/application/webview_window_linux.go`,
+  `v3/pkg/application/child_view.go`, and `v3/pkg/webcontentsview/` Linux backends.
 
 ### 2026-07-26
 - Fixed GTK4 `Size()` returning the requested default instead of the live configured window size.

--- a/v3/go.mod
+++ b/v3/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/konoui/lipo v0.10.0
 	github.com/leaanthony/clir v1.7.0
 	github.com/leaanthony/dmg v0.0.0-20260731074841-5c28840cf819
+	github.com/leaanthony/u v1.1.1
 	github.com/leaanthony/winicon v1.0.0
 	github.com/matryer/is v1.4.1
 	github.com/mattn/go-colorable v0.1.14

--- a/v3/go.sum
+++ b/v3/go.sum
@@ -252,6 +252,8 @@ github.com/leaanthony/clir v1.7.0 h1:xiAnhl7ryPwuH3ERwPWZp/pCHk8wTeiwuAOt6MiNyAw
 github.com/leaanthony/clir v1.7.0/go.mod h1:k/RBkdkFl18xkkACMCLt09bhiZnrGORoxmomeMvDpE0=
 github.com/leaanthony/dmg v0.0.0-20260731074841-5c28840cf819 h1:XuDsI+4yv48FxBG5TetpcqLkIsvJP4G94BNbfQB8G0s=
 github.com/leaanthony/dmg v0.0.0-20260731074841-5c28840cf819/go.mod h1:gL114o+2XWHHI50xydocqXc4sBntbpiyaLyarUH0VA4=
+github.com/leaanthony/u v1.1.1 h1:TUFjwDGlNX+WuwVEzDqQwC2lOv0P4uhTQw7CMFdiK7M=
+github.com/leaanthony/u v1.1.1/go.mod h1:9+o6hejoRljvZ3BzdYlVL0JYCwtnAsVuN9pVTQcaRfI=
 github.com/leaanthony/winicon v1.0.0 h1:ZNt5U5dY71oEoKZ97UVwJRT4e+5xo5o/ieKuHuk8NqQ=
 github.com/leaanthony/winicon v1.0.0/go.mod h1:en5xhijl92aphrJdmRPlh4NI1L6wq3gEm0LpXAPghjU=
 github.com/lithammer/fuzzysearch v1.1.8 h1:/HIuJnjHuXS8bKaiTMeeDlW2/AyIWk2brx1V8LFgLN4=

--- a/v3/internal/webview2/internal/w32/w32.go
+++ b/v3/internal/webview2/internal/w32/w32.go
@@ -152,8 +152,12 @@ func Utf16PtrToString(p *uint16) string {
 }
 
 func SHCreateMemStream(data []byte) (uintptr, error) {
+	var dataPointer uintptr
+	if len(data) > 0 {
+		dataPointer = uintptr(unsafe.Pointer(&data[0]))
+	}
 	ret, _, err := shlwapiSHCreateMemStream.Call(
-		uintptr(unsafe.Pointer(&data[0])),
+		dataPointer,
 		uintptr(len(data)),
 	)
 	if ret == 0 {

--- a/v3/internal/webview2/pkg/edge/ICoreWebView2CapturePreviewCompletedHandler.go
+++ b/v3/internal/webview2/pkg/edge/ICoreWebView2CapturePreviewCompletedHandler.go
@@ -1,0 +1,62 @@
+//go:build windows
+
+package edge
+
+import "unsafe"
+
+type _ICoreWebView2CapturePreviewCompletedHandlerVtbl struct {
+	_IUnknownVtbl
+	Invoke ComProc
+}
+
+type iCoreWebView2CapturePreviewCompletedHandler struct {
+	vtbl *_ICoreWebView2CapturePreviewCompletedHandlerVtbl
+	impl _ICoreWebView2CapturePreviewCompletedHandlerImpl
+}
+
+func (i *iCoreWebView2CapturePreviewCompletedHandler) AddRef() uint32 {
+	ret, _, _ := i.vtbl.AddRef.Call(uintptr(unsafe.Pointer(i)))
+	return uint32(ret)
+}
+
+func (i *iCoreWebView2CapturePreviewCompletedHandler) Release() uint32 {
+	ret, _, _ := i.vtbl.Release.Call(uintptr(unsafe.Pointer(i)))
+	return uint32(ret)
+}
+
+func iCoreWebView2CapturePreviewCompletedHandlerIUnknownQueryInterface(this *iCoreWebView2CapturePreviewCompletedHandler, refiid, object uintptr) uintptr {
+	return this.impl.QueryInterface(refiid, object)
+}
+
+func iCoreWebView2CapturePreviewCompletedHandlerIUnknownAddRef(this *iCoreWebView2CapturePreviewCompletedHandler) uintptr {
+	return this.impl.AddRef()
+}
+
+func iCoreWebView2CapturePreviewCompletedHandlerIUnknownRelease(this *iCoreWebView2CapturePreviewCompletedHandler) uintptr {
+	return this.impl.Release()
+}
+
+func iCoreWebView2CapturePreviewCompletedHandlerInvoke(this *iCoreWebView2CapturePreviewCompletedHandler, errorCode uintptr) uintptr {
+	return this.impl.CapturePreviewCompleted(errorCode)
+}
+
+type _ICoreWebView2CapturePreviewCompletedHandlerImpl interface {
+	_IUnknownImpl
+	CapturePreviewCompleted(errorCode uintptr) uintptr
+}
+
+var _ICoreWebView2CapturePreviewCompletedHandlerFn = _ICoreWebView2CapturePreviewCompletedHandlerVtbl{
+	_IUnknownVtbl{
+		NewComProc(iCoreWebView2CapturePreviewCompletedHandlerIUnknownQueryInterface),
+		NewComProc(iCoreWebView2CapturePreviewCompletedHandlerIUnknownAddRef),
+		NewComProc(iCoreWebView2CapturePreviewCompletedHandlerIUnknownRelease),
+	},
+	NewComProc(iCoreWebView2CapturePreviewCompletedHandlerInvoke),
+}
+
+func newICoreWebView2CapturePreviewCompletedHandler(impl _ICoreWebView2CapturePreviewCompletedHandlerImpl) *iCoreWebView2CapturePreviewCompletedHandler {
+	return &iCoreWebView2CapturePreviewCompletedHandler{
+		vtbl: &_ICoreWebView2CapturePreviewCompletedHandlerFn,
+		impl: impl,
+	}
+}

--- a/v3/internal/webview2/pkg/edge/IStream.go
+++ b/v3/internal/webview2/pkg/edge/IStream.go
@@ -15,6 +15,24 @@ type _IStreamVtbl struct {
 	_IUnknownVtbl
 	Read  ComProc
 	Write ComProc
+	Seek  ComProc
+}
+
+const streamSeekSet uint32 = 0
+
+// Seek repositions the read/write cursor in the COM stream.
+func (i *IStream) Seek(offset int64, origin uint32) (int64, error) {
+	var position int64
+	hr, _, _ := i.vtbl.Seek.Call(
+		uintptr(unsafe.Pointer(i)),
+		uintptr(offset),
+		uintptr(origin),
+		uintptr(unsafe.Pointer(&position)),
+	)
+	if windows.Handle(hr) != windows.S_OK {
+		return 0, syscall.Errno(hr)
+	}
+	return position, nil
 }
 
 type IStream struct {

--- a/v3/internal/webview2/pkg/edge/chromium.go
+++ b/v3/internal/webview2/pkg/edge/chromium.go
@@ -6,11 +6,13 @@ package edge
 import (
 	"errors"
 	"fmt"
+	"io"
 	"log"
 	"os"
 	"path/filepath"
 	"runtime"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"syscall"
 	"time"
@@ -108,6 +110,9 @@ type Chromium struct {
 	// Resize debouncing
 	lastBounds  *w32.Rect
 	resizeTimer *time.Timer
+
+	previewCallbacksMu sync.Mutex
+	previewCallbacks   map[*capturePreviewCallback]struct{}
 }
 
 func NewChromium() *Chromium {
@@ -158,6 +163,42 @@ func NewChromium() *Chromium {
 
 func (e *Chromium) ShuttingDown() {
 	e.shuttingDown = true
+}
+
+// Close permanently releases the native WebView2 controller. It must run on
+// the UI thread and is intentionally not reusable: create a new Chromium for
+// another browser surface.
+func (e *Chromium) Close() {
+	if e == nil {
+		return
+	}
+	e.shuttingDown = true
+	if e.resizeTimer != nil {
+		e.resizeTimer.Stop()
+		e.resizeTimer = nil
+	}
+	if e.webview != nil {
+		e.webview.Release()
+		e.webview = nil
+	}
+	if e.compositionController != nil {
+		e.releaseCompositionController()
+		if e.controller != nil {
+			e.controller.Release()
+			e.controller = nil
+		}
+	} else if e.controller != nil {
+		_ = e.controller.Close()
+		e.controller.Release()
+		e.controller = nil
+	}
+	e.releaseCompositionHost()
+	if e.environment != nil {
+		e.environment.Release()
+		e.environment = nil
+	}
+	e.hwnd = 0
+	atomic.StoreUintptr(&e.inited, 0)
 }
 
 func (e *Chromium) errorCallback(err error) {
@@ -291,6 +332,26 @@ func (e *Chromium) NavigateToString(content string) {
 	}
 }
 
+// Source returns the URL currently committed by WebView2.
+func (e *Chromium) Source() (string, error) {
+	if !e.IsReady() || e.webview == nil {
+		return "", errors.New("WebView2 is not ready")
+	}
+	return e.webview.GetSource()
+}
+
+// GoBack navigates through the native WebView2 history when possible.
+func (e *Chromium) GoBack() error {
+	if !e.IsReady() || e.webview == nil {
+		return errors.New("WebView2 is not ready")
+	}
+	canGoBack, err := e.webview.CanGoBack()
+	if err != nil || !canGoBack {
+		return err
+	}
+	return e.webview.GoBack()
+}
+
 func (e *Chromium) Init(script string) {
 	err := e.webview.AddScriptToExecuteOnDocumentCreated(script, nil)
 	if err != nil {
@@ -313,6 +374,75 @@ func (e *Chromium) Eval(script string) {
 		// process (errorCallback) is not.
 		log.Printf("[WebView2] Eval failed: %v", err)
 	}
+}
+
+// CapturePreview captures the current WebView2 viewport as PNG bytes. The
+// callback is invoked from WebView2's asynchronous completion handler.
+func (e *Chromium) CapturePreview(callback func([]byte, error)) error {
+	if !e.IsReady() || e.webview == nil {
+		return errors.New("WebView2 is not ready")
+	}
+	if callback == nil {
+		return errors.New("WebView2 preview callback is nil")
+	}
+
+	streamPointer, err := w32.SHCreateMemStream(nil)
+	if err != nil {
+		return fmt.Errorf("create WebView2 preview stream: %w", err)
+	}
+	stream := (*IStream)(unsafe.Pointer(streamPointer))
+	request := &capturePreviewCallback{owner: e, stream: stream, callback: callback}
+	request.handler = newICoreWebView2CapturePreviewCompletedHandler(request)
+
+	e.previewCallbacksMu.Lock()
+	if e.previewCallbacks == nil {
+		e.previewCallbacks = make(map[*capturePreviewCallback]struct{})
+	}
+	e.previewCallbacks[request] = struct{}{}
+	e.previewCallbacksMu.Unlock()
+
+	if err := e.webview.CapturePreview(CoreWebView2CapturePreviewImageFormatPNG, stream, request.handler); err != nil {
+		e.previewCallbacksMu.Lock()
+		delete(e.previewCallbacks, request)
+		e.previewCallbacksMu.Unlock()
+		_ = stream.Release()
+		return err
+	}
+	return nil
+}
+
+type capturePreviewCallback struct {
+	owner    *Chromium
+	stream   *IStream
+	handler  *iCoreWebView2CapturePreviewCompletedHandler
+	callback func([]byte, error)
+}
+
+func (c *capturePreviewCallback) QueryInterface(_, _ uintptr) uintptr { return 0 }
+func (c *capturePreviewCallback) AddRef() uintptr                     { return 1 }
+func (c *capturePreviewCallback) Release() uintptr                    { return 1 }
+
+func (c *capturePreviewCallback) CapturePreviewCompleted(errorCode uintptr) uintptr {
+	c.owner.previewCallbacksMu.Lock()
+	delete(c.owner.previewCallbacks, c)
+	c.owner.previewCallbacksMu.Unlock()
+	defer c.stream.Release()
+
+	if errorCode != 0 {
+		c.callback(nil, fmt.Errorf("WebView2 CapturePreview failed: HRESULT 0x%08x", uint32(errorCode)))
+		return 0
+	}
+	if _, err := c.stream.Seek(0, streamSeekSet); err != nil {
+		c.callback(nil, fmt.Errorf("rewind WebView2 preview stream: %w", err))
+		return 0
+	}
+	preview, err := io.ReadAll(c.stream)
+	if err != nil {
+		c.callback(nil, fmt.Errorf("read WebView2 preview stream: %w", err))
+		return 0
+	}
+	c.callback(preview, nil)
+	return 0
 }
 
 func (e *Chromium) Show() error {
@@ -360,7 +490,7 @@ func (e *Chromium) EnvironmentCompleted(res uintptr, env *ICoreWebView2Environme
 		}
 	}
 	if err != nil {
-		e.errorCallback(err)
+		e.errorCallback(fmt.Errorf("create WebView2 controller: %w", err))
 	}
 	return 0
 }
@@ -479,7 +609,7 @@ func (e *Chromium) initializeController(controller *ICoreWebView2Controller) uin
 		if !e.CompositionControllerEnabled {
 			// Use raw pixels mode for better performance during resize.
 			if err := controller3.PutBoundsMode(COREWEBVIEW2_BOUNDS_MODE_USE_RAW_PIXELS); err != nil {
-				e.errorCallback(err)
+				e.errorCallback(fmt.Errorf("initialise WebView2 controller: enable raw-pixel bounds: %w", err))
 			}
 
 			// ShouldDetectMonitorScaleChanges is deliberately left at its default
@@ -498,53 +628,53 @@ func (e *Chromium) initializeController(controller *ICoreWebView2Controller) uin
 	var token _EventRegistrationToken
 	e.webview, err = e.controller.GetCoreWebView2()
 	if err != nil {
-		e.errorCallback(err)
+		e.errorCallback(fmt.Errorf("initialise WebView2 controller: get CoreWebView2: %w", err))
 	}
 
 	e.webview.AddRef()
 	if e.NonClientRegionSupportEnabled {
 		if err := e.PutIsNonClientRegionSupportEnabled(true); err != nil {
 			if !errors.Is(err, UnsupportedCapabilityError) {
-				e.errorCallback(err)
+				e.errorCallback(fmt.Errorf("initialise WebView2 controller: enable non-client regions: %w", err))
 			}
 		}
 	}
 	err = e.webview.AddWebMessageReceived(e.webMessageReceived, &token)
 	if err != nil {
-		e.errorCallback(err)
+		e.errorCallback(fmt.Errorf("initialise WebView2 controller: register web-message handler: %w", err))
 	}
 	err = e.webview.AddPermissionRequested(e.permissionRequested, &token)
 	if err != nil {
-		e.errorCallback(err)
+		e.errorCallback(fmt.Errorf("initialise WebView2 controller: register permission handler: %w", err))
 	}
 	err = e.webview.AddWebResourceRequested(e.webResourceRequested, &token)
 	if err != nil {
-		e.errorCallback(err)
+		e.errorCallback(fmt.Errorf("initialise WebView2 controller: register resource handler: %w", err))
 	}
 	err = e.webview.AddNavigationStarting(e.navigationStarting, &token)
 	if err != nil {
-		e.errorCallback(err)
+		e.errorCallback(fmt.Errorf("initialise WebView2 controller: register navigation-starting handler: %w", err))
 	}
 	err = e.webview.AddNavigationCompleted(e.navigationCompleted, &token)
 	if err != nil {
-		e.errorCallback(err)
+		e.errorCallback(fmt.Errorf("initialise WebView2 controller: register navigation-completed handler: %w", err))
 	}
 	err = e.webview.AddProcessFailed(e.processFailed, &token)
 	if err != nil {
-		e.errorCallback(err)
+		e.errorCallback(fmt.Errorf("initialise WebView2 controller: register process-failed handler: %w", err))
 	}
 	err = e.webview.AddContainsFullScreenElementChanged(e.containsFullScreenElementChanged, &token)
 	if err != nil {
-		e.errorCallback(err)
+		e.errorCallback(fmt.Errorf("initialise WebView2 controller: register fullscreen handler: %w", err))
 	}
 	err = e.controller.AddAcceleratorKeyPressed(e.acceleratorKeyPressed, &token)
 	if err != nil {
-		e.errorCallback(err)
+		e.errorCallback(fmt.Errorf("initialise WebView2 controller: register accelerator-key handler: %w", err))
 	}
 	if e.compositionController != nil {
 		err = e.compositionController.AddCursorChanged(e.cursorChanged, &token)
 		if err != nil {
-			e.errorCallback(err)
+			e.errorCallback(fmt.Errorf("initialise WebView2 controller: register cursor handler: %w", err))
 		}
 	}
 

--- a/v3/internal/webview2/pkg/edge/corewebview2.go
+++ b/v3/internal/webview2/pkg/edge/corewebview2.go
@@ -4,6 +4,7 @@
 package edge
 
 import (
+	"errors"
 	"fmt"
 	"log"
 	"runtime"
@@ -46,6 +47,13 @@ const (
 	CoreWebView2PermissionStateDefault CoreWebView2PermissionState = iota
 	CoreWebView2PermissionStateAllow
 	CoreWebView2PermissionStateDeny
+)
+
+type CoreWebView2CapturePreviewImageFormat uint32
+
+const (
+	CoreWebView2CapturePreviewImageFormatPNG CoreWebView2CapturePreviewImageFormat = iota
+	CoreWebView2CapturePreviewImageFormatJPEG
 )
 
 // ComProc stores a COM procedure.
@@ -323,6 +331,22 @@ func (i *ICoreWebView2) ExecuteScript(javascript string, handler *iCoreWebView2E
 	return nil
 }
 
+func (i *ICoreWebView2) CapturePreview(format CoreWebView2CapturePreviewImageFormat, stream *IStream, handler *iCoreWebView2CapturePreviewCompletedHandler) error {
+	if stream == nil {
+		return errors.New("capture preview stream is nil")
+	}
+	hr, _, _ := i.vtbl.CapturePreview.Call(
+		uintptr(unsafe.Pointer(i)),
+		uintptr(format),
+		uintptr(unsafe.Pointer(stream)),
+		uintptr(unsafe.Pointer(handler)),
+	)
+	if windows.Handle(hr) != windows.S_OK {
+		return windows.Errno(hr)
+	}
+	return nil
+}
+
 func (i *ICoreWebView2) GetSettings() (*ICoreWebViewSettings, error) {
 
 	var settings *ICoreWebViewSettings
@@ -348,6 +372,29 @@ func (i *ICoreWebView2) GetSource() (string, error) {
 	source := windows.UTF16PtrToString(_source)
 	windows.CoTaskMemFree(unsafe.Pointer(_source))
 	return source, nil
+}
+
+// CanGoBack reports whether the WebView2 history has an entry before the
+// current document.
+func (i *ICoreWebView2) CanGoBack() (bool, error) {
+	var result int32
+	hr, _, _ := i.vtbl.GetCanGoBack.Call(
+		uintptr(unsafe.Pointer(i)),
+		uintptr(unsafe.Pointer(&result)),
+	)
+	if windows.Handle(hr) != windows.S_OK {
+		return false, windows.Errno(hr)
+	}
+	return result != 0, nil
+}
+
+// GoBack navigates to the previous history entry.
+func (i *ICoreWebView2) GoBack() error {
+	hr, _, _ := i.vtbl.GoBack.Call(uintptr(unsafe.Pointer(i)))
+	if windows.Handle(hr) != windows.S_OK {
+		return windows.Errno(hr)
+	}
+	return nil
 }
 
 func (i *ICoreWebView2) GetContainsFullScreenElement() (bool, error) {

--- a/v3/pkg/application/child_view.go
+++ b/v3/pkg/application/child_view.go
@@ -1,0 +1,9 @@
+package application
+
+// ChildView is a native view that can be owned by a Window. It is intended for
+// advanced integrations such as embedded browser surfaces. Implementations must
+// make Attach and Detach safe to call once during the parent window lifecycle.
+type ChildView interface {
+	Attach(Window)
+	Detach()
+}

--- a/v3/pkg/application/child_view_test.go
+++ b/v3/pkg/application/child_view_test.go
@@ -1,0 +1,42 @@
+package application
+
+import "testing"
+
+type testChildView struct {
+	attached int
+	detached int
+}
+
+func (v *testChildView) Attach(Window) { v.attached++ }
+func (v *testChildView) Detach()       { v.detached++ }
+
+func TestWebviewWindowChildViewsAreManagedOnce(t *testing.T) {
+	window := &WebviewWindow{}
+	view := &testChildView{}
+
+	window.AddChildView(view)
+	window.AddChildView(view)
+	if got := len(window.childViews); got != 1 {
+		t.Fatalf("registered views = %d, want 1", got)
+	}
+
+	window.RemoveChildView(view)
+	if view.detached != 1 {
+		t.Fatalf("detach calls = %d, want 1", view.detached)
+	}
+	if got := len(window.childViews); got != 0 {
+		t.Fatalf("registered views after removal = %d, want 0", got)
+	}
+}
+
+func TestWebviewWindowRemovingUnknownChildViewDoesNotDetach(t *testing.T) {
+	window := &WebviewWindow{}
+	registered := &testChildView{}
+	unknown := &testChildView{}
+	window.AddChildView(registered)
+
+	window.RemoveChildView(unknown)
+	if unknown.detached != 0 {
+		t.Fatalf("unknown view detached %d times", unknown.detached)
+	}
+}

--- a/v3/pkg/application/linux_cgo.go
+++ b/v3/pkg/application/linux_cgo.go
@@ -1188,7 +1188,7 @@ func (w *linuxWebviewWindow) minimise() {
 	C.gtk_window_minimize(w.gtkWindow())
 }
 
-func windowNew(application pointer, menu pointer, menuStyle LinuxMenuStyle, windowId uint, gpuPolicy WebviewGpuPolicy) (window, webview, vbox pointer) {
+func windowNew(application pointer, menu pointer, menuStyle LinuxMenuStyle, windowId uint, gpuPolicy WebviewGpuPolicy) (window, webview, vbox, overlay pointer) {
 	window = pointer(C.gtk_application_window_new((*C.GtkApplication)(application)))
 	C.g_object_ref_sink(C.gpointer(window))
 
@@ -1200,7 +1200,9 @@ func windowNew(application pointer, menu pointer, menuStyle LinuxMenuStyle, wind
 	defer C.free(unsafe.Pointer(name))
 	C.gtk_widget_set_name((*C.GtkWidget)(vbox), name)
 
-	C.gtk_window_set_child((*C.GtkWindow)(window), (*C.GtkWidget)(vbox))
+	overlay = pointer(C.gtk_overlay_new())
+	C.gtk_overlay_set_child((*C.GtkOverlay)(overlay), (*C.GtkWidget)(vbox))
+	C.gtk_window_set_child((*C.GtkWindow)(window), (*C.GtkWidget)(overlay))
 
 	if menu != nil {
 		switch menuStyle {

--- a/v3/pkg/application/linux_cgo_gtk3.go
+++ b/v3/pkg/application/linux_cgo_gtk3.go
@@ -1450,7 +1450,7 @@ func (w *linuxWebviewWindow) minimise() {
 	C.gtk_window_iconify(w.gtkWindow())
 }
 
-func windowNew(application pointer, menu pointer, _ LinuxMenuStyle, windowId uint, gpuPolicy WebviewGpuPolicy) (window, webview, vbox pointer) {
+func windowNew(application pointer, menu pointer, _ LinuxMenuStyle, windowId uint, gpuPolicy WebviewGpuPolicy) (window, webview, vbox, overlay pointer) {
 	window = pointer(C.gtk_application_window_new((*C.GtkApplication)(application)))
 	C.g_object_ref_sink(C.gpointer(window))
 	webview = windowNewWebview(windowId, gpuPolicy)
@@ -1459,7 +1459,9 @@ func windowNew(application pointer, menu pointer, _ LinuxMenuStyle, windowId uin
 	defer C.free(unsafe.Pointer(name))
 	C.gtk_widget_set_name((*C.GtkWidget)(vbox), name)
 
-	C.gtk_container_add((*C.GtkContainer)(window), (*C.GtkWidget)(vbox))
+	overlay = pointer(C.gtk_overlay_new())
+	C.gtk_container_add((*C.GtkContainer)(overlay), (*C.GtkWidget)(vbox))
+	C.gtk_container_add((*C.GtkContainer)(window), (*C.GtkWidget)(overlay))
 	if menu != nil {
 		C.gtk_box_pack_start((*C.GtkBox)(vbox), (*C.GtkWidget)(menu), 0, 0, 0)
 	}

--- a/v3/pkg/application/webview_window.go
+++ b/v3/pkg/application/webview_window.go
@@ -3,6 +3,7 @@ package application
 import (
 	"encoding/json"
 	"fmt"
+	"reflect"
 	"runtime"
 	"slices"
 	"strings"
@@ -205,6 +206,9 @@ type WebviewWindow struct {
 	savedMaxWidth    int
 	savedMaxHeight   int
 	constraintsSaved bool
+
+	childViews     []ChildView
+	childViewsLock sync.RWMutex
 }
 
 func (w *WebviewWindow) SetMenu(menu *Menu) {
@@ -335,6 +339,7 @@ func NewWindow(options WebviewWindowOptions) *WebviewWindow {
 	// Listen for window closing events and de
 	result.OnWindowEvent(events.Common.WindowClosing, func(event *WindowEvent) {
 		atomic.StoreUint32(&result.unconditionallyClose, 1)
+		result.detachChildViews()
 		InvokeSync(result.markAsDestroyed)
 		InvokeSync(result.impl.close)
 		globalApplication.Window.Remove(result.id)
@@ -467,6 +472,83 @@ func (w *WebviewWindow) Run() {
 	}
 
 	InvokeSync(w.impl.run)
+	w.attachChildViews()
+}
+
+// AddChildView registers a native child view with this window. If the window is
+// already running the view is attached immediately; otherwise it attaches when
+// Run creates the native window.
+func (w *WebviewWindow) AddChildView(view ChildView) {
+	if view == nil || w.isDestroyed() {
+		return
+	}
+	w.childViewsLock.Lock()
+	for _, existing := range w.childViews {
+		if sameChildView(existing, view) {
+			w.childViewsLock.Unlock()
+			return
+		}
+	}
+	w.childViews = append(w.childViews, view)
+	w.childViewsLock.Unlock()
+	if w.impl != nil && w.NativeWindow() != nil {
+		view.Attach(w)
+	}
+}
+
+// RemoveChildView detaches a registered native child view and stops the window
+// from attaching it again during future lifecycle transitions.
+func (w *WebviewWindow) RemoveChildView(view ChildView) {
+	if view == nil {
+		return
+	}
+	w.childViewsLock.Lock()
+	removed := false
+	for i, existing := range w.childViews {
+		if sameChildView(existing, view) {
+			w.childViews = append(w.childViews[:i], w.childViews[i+1:]...)
+			removed = true
+			break
+		}
+	}
+	w.childViewsLock.Unlock()
+	if removed {
+		view.Detach()
+	}
+}
+
+func sameChildView(left, right ChildView) bool {
+	if left == nil || right == nil || reflect.TypeOf(left) != reflect.TypeOf(right) {
+		return false
+	}
+	value := reflect.ValueOf(left)
+	switch value.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Map, reflect.Pointer, reflect.Slice, reflect.UnsafePointer:
+		return value.Pointer() == reflect.ValueOf(right).Pointer()
+	default:
+		// Child views are normally pointers. Treat non-pointer implementations as
+		// distinct rather than risking an interface equality panic for a
+		// non-comparable value type.
+		return false
+	}
+}
+
+func (w *WebviewWindow) attachChildViews() {
+	w.childViewsLock.RLock()
+	views := append([]ChildView(nil), w.childViews...)
+	w.childViewsLock.RUnlock()
+	for _, view := range views {
+		view.Attach(w)
+	}
+}
+
+func (w *WebviewWindow) detachChildViews() {
+	w.childViewsLock.RLock()
+	views := append([]ChildView(nil), w.childViews...)
+	w.childViewsLock.RUnlock()
+	for _, view := range views {
+		view.Detach()
+	}
 }
 
 // SetAlwaysOnTop sets the window to be always on top.

--- a/v3/pkg/application/webview_window_linux.go
+++ b/v3/pkg/application/webview_window_linux.go
@@ -34,6 +34,7 @@ type linuxWebviewWindow struct {
 	parent        *WebviewWindow
 	menubar       pointer
 	vbox          pointer
+	overlay       pointer
 	accels        pointer
 	lastWidth     int
 	lastHeight    int
@@ -353,7 +354,7 @@ func (w *linuxWebviewWindow) run() {
 		w.gtkmenu = (globalApplication.applicationMenu.impl).(*linuxMenu).native
 	}
 
-	w.window, w.webview, w.vbox = windowNew(app.application, w.gtkmenu, w.parent.options.Linux.MenuStyle, w.parent.id, w.parent.options.Linux.WebviewGpuPolicy)
+	w.window, w.webview, w.vbox, w.overlay = windowNew(app.application, w.gtkmenu, w.parent.options.Linux.MenuStyle, w.parent.id, w.parent.options.Linux.WebviewGpuPolicy)
 	app.registerWindow(w.window, w.parent.id) // record our mapping
 	w.connectSignals()
 	if w.parent.options.EnableFileDrop {

--- a/v3/pkg/webcontentsview/README.md
+++ b/v3/pkg/webcontentsview/README.md
@@ -1,0 +1,59 @@
+# WebContentsView for Wails v3
+
+`WebContentsView` embeds a second, native browser surface in a Wails window.
+It is useful when a product needs a browser panel that follows a desktop layout
+without turning that panel into an iframe inside the application's frontend.
+
+The implementation uses WKWebView on macOS, WebView2 on Windows, and
+WebKitGTK on Linux. The default Linux backend is GTK4 + WebKitGTK 6.0; the
+legacy GTK3 backend remains available with `-tags gtk3` for one v3 cycle.
+
+## Lifecycle
+
+Create the view in Go, add it to the owning `WebviewWindow`, and update its
+native rectangle as the frontend layout changes. A view can be registered
+before `App.Run`; native browser creation is deferred until the host window is
+ready.
+
+```go
+browser := webcontentsview.NewWebContentsView(webcontentsview.WebContentsViewOptions{
+	Name:   "documentation",
+	URL:    "https://wails.io",
+	Bounds: application.Rect{X: 24, Y: 96, Width: 900, Height: 600},
+	WebPreferences: webcontentsview.WebPreferences{
+		DevTools:   webcontentsview.Enabled,
+		Javascript: webcontentsview.Enabled,
+	},
+})
+
+window.AddChildView(browser)
+```
+
+`SetBounds` moves and resizes the native surface. Use `Show` and `Hide` to
+switch visibility while retaining its browser session. `RemoveChildView`
+detaches it and permits a later re-add; `Destroy` permanently releases its
+native resources and cannot be reversed.
+
+```go
+browser.SetBounds(application.Rect{X: 300, Y: 96, Width: 600, Height: 600})
+browser.Hide()
+browser.Show()
+window.RemoveChildView(browser)
+browser.Destroy()
+```
+
+The public API also supports `SetURL`, `SetHTML`, `ExecJS`, `GoBack`,
+`GetURL`, and `TakeSnapshot`. `SetURL` and `SetHTML` replace one another as
+the pending source. Native child surfaces always render above the host Wails
+webview, so frontend DOM stacking cannot overlay a visible `WebContentsView`.
+
+## Platform notes
+
+- **Windows:** each view has an app- and view-specific WebView2 user-data
+  directory, avoiding an incompatible environment with the host Wails webview.
+- **Linux:** native views are positioned as direct GTK overlay children, so
+  uncovered host UI remains interactive.
+- **macOS:** WKWebView creation is deferred until an NSWindow is attached.
+
+`WebContentsView` provides a native browser panel with a deliberately small,
+platform-neutral lifecycle API.

--- a/v3/pkg/webcontentsview/snapshot.go
+++ b/v3/pkg/webcontentsview/snapshot.go
@@ -1,0 +1,31 @@
+package webcontentsview
+
+import (
+	"sync"
+	"sync/atomic"
+)
+
+var snapshotCallbacks sync.Map
+var snapshotCallbackID uintptr
+
+func registerSnapshotCallback(ch chan string) uintptr {
+	id := atomic.AddUintptr(&snapshotCallbackID, 1)
+	snapshotCallbacks.Store(id, ch)
+	return id
+}
+
+func dispatchSnapshotResult(id uintptr, data string) {
+	if ch, ok := snapshotCallbacks.LoadAndDelete(id); ok {
+		// A native browser can terminate before completing a snapshot. Do not
+		// let a late completion block the platform callback after the caller has
+		// already given up waiting.
+		select {
+		case ch.(chan string) <- data:
+		default:
+		}
+	}
+}
+
+func unregisterSnapshotCallback(id uintptr) {
+	snapshotCallbacks.Delete(id)
+}

--- a/v3/pkg/webcontentsview/webcontentsview.go
+++ b/v3/pkg/webcontentsview/webcontentsview.go
@@ -1,0 +1,213 @@
+package webcontentsview
+
+import (
+	"sync"
+	"sync/atomic"
+	"unsafe"
+
+	"github.com/wailsapp/wails/v3/pkg/application"
+)
+
+// WebContentsViewOptions represents the options for creating a WebContentsView.
+type WebContentsViewOptions struct {
+	Name           string
+	URL            string
+	HTML           string
+	Bounds         application.Rect
+	WebPreferences WebPreferences
+}
+
+// WebContentsView represents a native webview that can be embedded into a window.
+type WebContentsView struct {
+	mu          sync.RWMutex
+	operationMu sync.Mutex
+	options     WebContentsViewOptions
+	id          uint
+	impl        webContentsViewImpl
+	visible     bool
+	destroyed   bool
+}
+
+var webContentsViewID uintptr
+
+func boolToInt(value bool) int {
+	if value {
+		return 1
+	}
+	return 0
+}
+
+// NewWebContentsView creates a new WebContentsView with the given options.
+func NewWebContentsView(options WebContentsViewOptions) *WebContentsView {
+	result := &WebContentsView{
+		id:      uint(atomic.AddUintptr(&webContentsViewID, 1)),
+		options: options,
+		visible: true,
+	}
+	result.impl = newWebContentsViewImpl(result)
+	return result
+}
+
+// SetBounds sets the position and size of the WebContentsView relative to its parent.
+func (v *WebContentsView) SetBounds(bounds application.Rect) {
+	v.mu.Lock()
+	if v.destroyed {
+		v.mu.Unlock()
+		return
+	}
+	v.options.Bounds = bounds
+	v.mu.Unlock()
+	v.withLiveImpl(func(impl webContentsViewImpl) { impl.setBounds(bounds) })
+}
+
+// SetURL loads the given URL into the WebContentsView.
+func (v *WebContentsView) SetURL(url string) {
+	v.mu.Lock()
+	if v.destroyed {
+		v.mu.Unlock()
+		return
+	}
+	v.options.URL = url
+	v.options.HTML = ""
+	v.mu.Unlock()
+	v.withLiveImpl(func(impl webContentsViewImpl) { impl.setURL(url) })
+}
+
+// SetHTML loads inline HTML into the WebContentsView. It replaces any pending
+// URL configured through WebContentsViewOptions or SetURL.
+func (v *WebContentsView) SetHTML(html string) {
+	v.mu.Lock()
+	if v.destroyed {
+		v.mu.Unlock()
+		return
+	}
+	v.options.HTML = html
+	v.options.URL = ""
+	v.mu.Unlock()
+	v.withLiveImpl(func(impl webContentsViewImpl) { impl.setHTML(html) })
+}
+
+// ExecJS executes the given javascript in the WebContentsView.
+func (v *WebContentsView) ExecJS(js string) {
+	v.withLiveImpl(func(impl webContentsViewImpl) { impl.execJS(js) })
+}
+
+// GoBack navigates to the previous page in history.
+func (v *WebContentsView) GoBack() {
+	v.withLiveImpl(func(impl webContentsViewImpl) { impl.goBack() })
+}
+
+// GetURL returns the current URL of the view.
+func (v *WebContentsView) GetURL() string {
+	var url string
+	v.withLiveImpl(func(impl webContentsViewImpl) { url = impl.getURL() })
+	return url
+}
+
+// TakeSnapshot returns a base64 encoded PNG of the current view.
+func (v *WebContentsView) TakeSnapshot() string {
+	var snapshot string
+	v.withLiveImpl(func(impl webContentsViewImpl) { snapshot = impl.takeSnapshot() })
+	return snapshot
+}
+
+// Show makes an attached WebContentsView visible. Native child views are
+// rendered above the host webview, so use this rather than relying on a
+// zero-sized frontend placeholder to hide one.
+func (v *WebContentsView) Show() {
+	v.mu.Lock()
+	if v.destroyed {
+		v.mu.Unlock()
+		return
+	}
+	v.visible = true
+	v.mu.Unlock()
+	v.withLiveImpl(func(impl webContentsViewImpl) { impl.setVisible(true) })
+}
+
+// Hide hides an attached WebContentsView without removing it from its host
+// window. A later Show restores the same native view and browser session.
+func (v *WebContentsView) Hide() {
+	v.mu.Lock()
+	if v.destroyed {
+		v.mu.Unlock()
+		return
+	}
+	v.visible = false
+	v.mu.Unlock()
+	v.withLiveImpl(func(impl webContentsViewImpl) { impl.setVisible(false) })
+}
+
+// Attach binds the WebContentsView to a Wails Window.
+func (v *WebContentsView) Attach(window application.Window) {
+	v.withLiveImpl(func(impl webContentsViewImpl) { impl.attach(window) })
+}
+
+// Detach removes the WebContentsView from the Wails Window.
+func (v *WebContentsView) Detach() {
+	v.withLiveImpl(func(impl webContentsViewImpl) { impl.detach() })
+}
+
+// Destroy permanently releases the native browser surface. Remove the view
+// from its owner first with WebviewWindow.RemoveChildView so the window no
+// longer retains this ChildView; a destroyed view cannot be attached again.
+func (v *WebContentsView) Destroy() {
+	v.operationMu.Lock()
+	defer v.operationMu.Unlock()
+	v.mu.Lock()
+	if v.destroyed {
+		v.mu.Unlock()
+		return
+	}
+	v.visible = false
+	v.destroyed = true
+	impl := v.impl
+	v.mu.Unlock()
+	impl.detach()
+	impl.destroy()
+}
+
+// withLiveImpl serializes access to the platform-native view. State is not
+// locked during the callback because platform attach paths obtain snapshots of
+// that state while running on the UI thread.
+func (v *WebContentsView) withLiveImpl(fn func(webContentsViewImpl)) bool {
+	v.operationMu.Lock()
+	defer v.operationMu.Unlock()
+	v.mu.RLock()
+	if v.destroyed {
+		v.mu.RUnlock()
+		return false
+	}
+	impl := v.impl
+	v.mu.RUnlock()
+	fn(impl)
+	return true
+}
+
+func (v *WebContentsView) optionsSnapshot() WebContentsViewOptions {
+	v.mu.RLock()
+	defer v.mu.RUnlock()
+	return v.options
+}
+
+func (v *WebContentsView) visibleSnapshot() bool {
+	v.mu.RLock()
+	defer v.mu.RUnlock()
+	return v.visible
+}
+
+// webContentsViewImpl is the interface that platform-specific implementations must satisfy.
+type webContentsViewImpl interface {
+	setBounds(bounds application.Rect)
+	setURL(url string)
+	setHTML(html string)
+	execJS(js string)
+	goBack()
+	getURL() string
+	takeSnapshot() string
+	setVisible(visible bool)
+	attach(window application.Window)
+	detach()
+	destroy()
+	nativeView() unsafe.Pointer
+}

--- a/v3/pkg/webcontentsview/webcontentsview_android.go
+++ b/v3/pkg/webcontentsview/webcontentsview_android.go
@@ -1,0 +1,30 @@
+//go:build android
+
+package webcontentsview
+
+import (
+	"github.com/wailsapp/wails/v3/pkg/application"
+	"unsafe"
+)
+
+type androidWebContentsView struct {
+	parent *WebContentsView
+}
+
+func newWebContentsViewImpl(parent *WebContentsView) webContentsViewImpl {
+	return &androidWebContentsView{parent: parent}
+}
+
+func (w *androidWebContentsView) setBounds(bounds application.Rect) {}
+func (w *androidWebContentsView) setURL(url string)                 {}
+func (w *androidWebContentsView) setHTML(html string)               {}
+func (w *androidWebContentsView) execJS(js string)                  {}
+func (w *androidWebContentsView) goBack()                           {}
+func (w *androidWebContentsView) getURL() string                    { return "" }
+func (w *androidWebContentsView) takeSnapshot() string              { return "" }
+func (w *androidWebContentsView) setVisible(bool)                   {}
+
+func (w *androidWebContentsView) attach(window application.Window) {}
+func (w *androidWebContentsView) detach()                          {}
+func (w *androidWebContentsView) destroy()                         {}
+func (w *androidWebContentsView) nativeView() unsafe.Pointer       { return nil }

--- a/v3/pkg/webcontentsview/webcontentsview_darwin.go
+++ b/v3/pkg/webcontentsview/webcontentsview_darwin.go
@@ -1,0 +1,188 @@
+//go:build darwin && !server
+
+package webcontentsview
+
+/*
+#cgo CFLAGS: -x objective-c
+#cgo LDFLAGS: -framework Foundation -framework Cocoa -framework WebKit
+#import "webcontentsview_darwin.h"
+#include <stdlib.h>
+*/
+import "C"
+
+import (
+	"time"
+	"unsafe"
+
+	"github.com/wailsapp/wails/v3/pkg/application"
+)
+
+type macosWebContentsView struct {
+	parent    *WebContentsView
+	nsView    unsafe.Pointer
+	nsWindow  unsafe.Pointer
+	pendingJS []string
+}
+
+const nativeSnapshotCallbackTimeout = 30 * time.Second
+
+func newWebContentsViewImpl(parent *WebContentsView) webContentsViewImpl {
+	return &macosWebContentsView{parent: parent}
+}
+
+func (w *macosWebContentsView) createView() {
+	if w.nsView != nil {
+		return
+	}
+	options := w.parent.optionsSnapshot()
+	var cUserAgent *C.char
+	if options.WebPreferences.UserAgent != "" {
+		cUserAgent = C.CString(options.WebPreferences.UserAgent)
+		defer C.free(unsafe.Pointer(cUserAgent))
+	}
+	prefs := C.WebContentsViewPreferences{
+		devTools:                 C.bool(!options.WebPreferences.DevTools.IsSet() || options.WebPreferences.DevTools.Get()),
+		javascript:               C.bool(!options.WebPreferences.Javascript.IsSet() || options.WebPreferences.Javascript.Get()),
+		webSecurity:              C.bool(!options.WebPreferences.WebSecurity.IsSet() || options.WebPreferences.WebSecurity.Get()),
+		images:                   C.bool(!options.WebPreferences.Images.IsSet() || options.WebPreferences.Images.Get()),
+		plugins:                  C.bool(options.WebPreferences.Plugins.IsSet() && options.WebPreferences.Plugins.Get()),
+		zoomFactor:               C.double(options.WebPreferences.ZoomFactor),
+		defaultFontSize:          C.int(options.WebPreferences.DefaultFontSize),
+		defaultMonospaceFontSize: C.int(options.WebPreferences.DefaultMonospaceFontSize),
+		minimumFontSize:          C.int(options.WebPreferences.MinimumFontSize),
+		userAgent:                cUserAgent,
+	}
+	if prefs.zoomFactor == 0 {
+		prefs.zoomFactor = 1.0
+	}
+	w.nsView = C.createWebContentsView(C.int(options.Bounds.X), C.int(options.Bounds.Y), C.int(options.Bounds.Width), C.int(options.Bounds.Height), prefs)
+}
+
+func (w *macosWebContentsView) setBounds(bounds application.Rect) {
+	if w.nsView != nil {
+		application.InvokeSync(func() {
+			C.webContentsViewSetBounds(w.nsView, C.int(bounds.X), C.int(bounds.Y), C.int(bounds.Width), C.int(bounds.Height))
+		})
+	}
+}
+
+func (w *macosWebContentsView) setURL(url string) {
+	if w.nsView == nil {
+		return
+	}
+	cURL := C.CString(url)
+	defer C.free(unsafe.Pointer(cURL))
+	application.InvokeSync(func() { C.webContentsViewSetURL(w.nsView, cURL) })
+}
+
+func (w *macosWebContentsView) setHTML(html string) {
+	if w.nsView == nil {
+		return
+	}
+	cHTML := C.CString(html)
+	defer C.free(unsafe.Pointer(cHTML))
+	application.InvokeSync(func() { C.webContentsViewSetHTML(w.nsView, cHTML) })
+}
+
+func (w *macosWebContentsView) execJS(js string) {
+	if w.nsView == nil {
+		w.pendingJS = append(w.pendingJS, js)
+		return
+	}
+	cJS := C.CString(js)
+	defer C.free(unsafe.Pointer(cJS))
+	application.InvokeSync(func() { C.webContentsViewExecJS(w.nsView, cJS) })
+}
+
+func (w *macosWebContentsView) goBack() {
+	if w.nsView != nil {
+		application.InvokeSync(func() { C.webContentsViewGoBack(w.nsView) })
+	}
+}
+
+func (w *macosWebContentsView) getURL() string {
+	if w.nsView == nil {
+		return ""
+	}
+	var cURL *C.char
+	application.InvokeSync(func() { cURL = C.webContentsViewGetURL(w.nsView) })
+	if cURL == nil {
+		return ""
+	}
+	defer C.free(unsafe.Pointer(cURL))
+	return C.GoString(cURL)
+}
+
+func (w *macosWebContentsView) takeSnapshot() string {
+	if w.nsView == nil {
+		return ""
+	}
+	result := make(chan string, 1)
+	id := registerSnapshotCallback(result)
+	application.InvokeSync(func() { C.webContentsViewTakeSnapshot(w.nsView, C.uintptr_t(id)) })
+	select {
+	case snapshot := <-result:
+		return snapshot
+	case <-time.After(nativeSnapshotCallbackTimeout):
+		unregisterSnapshotCallback(id)
+		return ""
+	}
+}
+
+func (w *macosWebContentsView) setVisible(visible bool) {
+	if w.nsView != nil {
+		application.InvokeSync(func() { C.webContentsViewSetVisible(w.nsView, C.bool(visible)) })
+	}
+}
+
+func (w *macosWebContentsView) attach(window application.Window) {
+	nativeWindow := window.NativeWindow()
+	if nativeWindow == nil || w.nsWindow == nativeWindow {
+		return
+	}
+	application.InvokeSync(func() {
+		if w.nsWindow != nil {
+			C.windowRemoveWebContentsView(w.nsWindow, w.nsView)
+		}
+		w.createView()
+		options := w.parent.optionsSnapshot()
+		w.nsWindow = nativeWindow
+		C.windowAddWebContentsView(w.nsWindow, w.nsView)
+		C.webContentsViewSetVisible(w.nsView, C.bool(w.parent.visibleSnapshot()))
+		if options.URL != "" {
+			w.setURL(options.URL)
+		} else if options.HTML != "" {
+			w.setHTML(options.HTML)
+		}
+		for _, js := range w.pendingJS {
+			w.execJS(js)
+		}
+		w.pendingJS = nil
+	})
+}
+
+func (w *macosWebContentsView) detach() {
+	if w.nsWindow != nil {
+		application.InvokeSync(func() { C.windowRemoveWebContentsView(w.nsWindow, w.nsView) })
+		w.nsWindow = nil
+	}
+}
+
+func (w *macosWebContentsView) destroy() {
+	if w.nsView != nil {
+		application.InvokeSync(func() { C.webContentsViewDestroy(w.nsView) })
+		w.nsView = nil
+		w.nsWindow = nil
+	}
+}
+
+func (w *macosWebContentsView) nativeView() unsafe.Pointer { return w.nsView }
+
+//export browserViewSnapshotCallback
+func browserViewSnapshotCallback(callbackID C.uintptr_t, base64 *C.char) {
+	snapshot := ""
+	if base64 != nil {
+		snapshot = C.GoString(base64)
+	}
+	dispatchSnapshotResult(uintptr(callbackID), snapshot)
+}

--- a/v3/pkg/webcontentsview/webcontentsview_darwin.h
+++ b/v3/pkg/webcontentsview/webcontentsview_darwin.h
@@ -1,0 +1,34 @@
+#ifndef webcontentsview_darwin_h
+#define webcontentsview_darwin_h
+
+#import <Foundation/Foundation.h>
+#import <Cocoa/Cocoa.h>
+#import <WebKit/WebKit.h>
+
+typedef struct {
+    bool devTools;
+    bool javascript;
+    bool webSecurity;
+    bool images;
+    bool plugins;
+    double zoomFactor;
+    int defaultFontSize;
+    int defaultMonospaceFontSize;
+    int minimumFontSize;
+    const char* userAgent;
+} WebContentsViewPreferences;
+
+extern void* createWebContentsView(int x, int y, int w, int h, WebContentsViewPreferences prefs);
+extern void webContentsViewSetBounds(void* view, int x, int y, int w, int h);
+extern void webContentsViewSetVisible(void* view, bool visible);
+extern void webContentsViewDestroy(void* view);
+extern void webContentsViewSetURL(void* view, const char* url);
+extern void webContentsViewSetHTML(void* view, const char* html);
+extern void webContentsViewExecJS(void* view, const char* js);
+extern void webContentsViewGoBack(void* view);
+extern const char* webContentsViewGetURL(void* view);
+extern void webContentsViewTakeSnapshot(void* view, uintptr_t callbackID);
+extern void windowAddWebContentsView(void* nsWindow, void* view);
+extern void windowRemoveWebContentsView(void* nsWindow, void* view);
+
+#endif

--- a/v3/pkg/webcontentsview/webcontentsview_darwin.m
+++ b/v3/pkg/webcontentsview/webcontentsview_darwin.m
@@ -1,0 +1,100 @@
+#import "webcontentsview_darwin.h"
+
+extern void browserViewSnapshotCallback(uintptr_t callbackID, const char* base64);
+
+void* createWebContentsView(int x, int y, int w, int h, WebContentsViewPreferences prefs) {
+    WKWebViewConfiguration* config = [[WKWebViewConfiguration alloc] init];
+    WKPreferences* preferences = [[WKPreferences alloc] init];
+    @try {
+        if (@available(macOS 10.11, *)) {
+            [preferences setValue:@(prefs.devTools) forKey:@"developerExtrasEnabled"];
+        }
+        if (@available(macOS 11.0, *)) {
+            WKWebpagePreferences* webpagePreferences = [[WKWebpagePreferences alloc] init];
+            webpagePreferences.allowsContentJavaScript = prefs.javascript;
+            config.defaultWebpagePreferences = webpagePreferences;
+        } else {
+            preferences.javaScriptEnabled = prefs.javascript;
+        }
+        config.preferences = preferences;
+    } @catch (NSException* ignored) {
+    }
+    WKWebView* webView = [[WKWebView alloc] initWithFrame:NSMakeRect(x, y, w, h) configuration:config];
+    if (prefs.userAgent != NULL) {
+        webView.customUserAgent = [NSString stringWithUTF8String:prefs.userAgent];
+    }
+    return webView;
+}
+
+void webContentsViewSetBounds(void* view, int x, int y, int w, int h) {
+    WKWebView* webView = (WKWebView*)view;
+    NSView* superview = webView.superview;
+    CGFloat cocoaY = superview == nil ? y : superview.bounds.size.height - y - h;
+    webView.frame = NSMakeRect(x, cocoaY, w, h);
+}
+
+void webContentsViewSetVisible(void* view, bool visible) { [(WKWebView*)view setHidden:!visible]; }
+
+void webContentsViewDestroy(void* view) {
+    WKWebView* webView = (WKWebView*)view;
+    if (webView == nil) return;
+    [webView stopLoading];
+    [webView removeFromSuperview];
+    [webView release];
+}
+
+void webContentsViewSetURL(void* view, const char* url) {
+    WKWebView* webView = (WKWebView*)view;
+    NSString* value = [NSString stringWithUTF8String:url];
+    dispatch_async(dispatch_get_main_queue(), ^{ [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:value]]]; });
+}
+
+void webContentsViewSetHTML(void* view, const char* html) {
+    WKWebView* webView = (WKWebView*)view;
+    NSString* value = html == NULL ? @"" : [NSString stringWithUTF8String:html];
+    dispatch_async(dispatch_get_main_queue(), ^{ [webView loadHTMLString:value baseURL:nil]; });
+}
+
+void webContentsViewExecJS(void* view, const char* js) {
+    WKWebView* webView = (WKWebView*)view;
+    NSString* value = [NSString stringWithUTF8String:js];
+    dispatch_async(dispatch_get_main_queue(), ^{ [webView evaluateJavaScript:value completionHandler:nil]; });
+}
+
+void windowAddWebContentsView(void* nsWindow, void* view) {
+    WKWebView* webView = (WKWebView*)view;
+    [((NSWindow*)nsWindow).contentView addSubview:webView];
+    webView.wantsLayer = YES;
+    webView.layer.zPosition = 9999.0;
+}
+
+void windowRemoveWebContentsView(void* nsWindow, void* view) { [(WKWebView*)view removeFromSuperview]; }
+
+void webContentsViewGoBack(void* view) {
+    WKWebView* webView = (WKWebView*)view;
+    dispatch_async(dispatch_get_main_queue(), ^{ if (webView.canGoBack) [webView goBack]; });
+}
+
+const char* webContentsViewGetURL(void* view) {
+    __block const char* result = NULL;
+    void (^readURL)(void) = ^{ WKWebView* webView = (WKWebView*)view; if (webView.URL != nil) result = strdup(webView.URL.absoluteString.UTF8String); };
+    if ([NSThread isMainThread]) readURL(); else dispatch_sync(dispatch_get_main_queue(), readURL);
+    return result;
+}
+
+void webContentsViewTakeSnapshot(void* view, uintptr_t callbackID) {
+    WKWebView* webView = (WKWebView*)view;
+    dispatch_async(dispatch_get_main_queue(), ^{
+        if (@available(macOS 10.13, *)) {
+            [webView takeSnapshotWithConfiguration:[[WKSnapshotConfiguration alloc] init] completionHandler:^(NSImage* image, NSError* error) {
+                if (error != nil || image == nil) { browserViewSnapshotCallback(callbackID, NULL); return; }
+                NSBitmapImageRep* bitmap = [[NSBitmapImageRep alloc] initWithCGImage:[image CGImageForProposedRect:NULL context:nil hints:nil]];
+                NSData* png = [bitmap representationUsingType:NSBitmapImageFileTypePNG properties:@{}];
+                NSString* dataURL = png == nil ? nil : [NSString stringWithFormat:@"data:image/png;base64,%@", [png base64EncodedStringWithOptions:0]];
+                browserViewSnapshotCallback(callbackID, dataURL == nil ? NULL : dataURL.UTF8String);
+            }];
+        } else {
+            browserViewSnapshotCallback(callbackID, NULL);
+        }
+    });
+}

--- a/v3/pkg/webcontentsview/webcontentsview_darwin_test.go
+++ b/v3/pkg/webcontentsview/webcontentsview_darwin_test.go
@@ -1,0 +1,71 @@
+//go:build darwin && !server
+
+package webcontentsview
+
+import (
+	"testing"
+	"unsafe"
+
+	"github.com/wailsapp/wails/v3/pkg/application"
+)
+
+// Dummy mock window that satisfies the interface
+// and returns a nil NativeWindow so we can test the Attach nil-handling safely
+// without spinning up the full NSApplication runloop in a headless test environment.
+type mockWindow struct {
+	application.Window
+}
+
+func (m *mockWindow) NativeWindow() unsafe.Pointer {
+	return nil
+}
+
+func TestWebContentsView_APISurface(t *testing.T) {
+	// We primarily want to ensure that the API surface compiles and functions
+	// correctly at a struct level. Note: Full WKWebView instantiation without an NSApplication
+	// runloop will crash on macOS, so we test the struct wiring here instead of the native allocations.
+
+	options := WebContentsViewOptions{
+		Name: "TestBrowser",
+		URL:  "https://example.com",
+		Bounds: application.Rect{
+			X:      0,
+			Y:      0,
+			Width:  800,
+			Height: 600,
+		},
+		WebPreferences: WebPreferences{
+			DevTools:    Enabled,
+			Javascript:  Enabled,
+			WebSecurity: Disabled, // Disable CORS
+			ZoomFactor:  1.2,
+		},
+	}
+
+	// Native allocation is deferred to Attach after the host window exists, so
+	// construction remains safe in a headless test without an NSApplication.
+	view := NewWebContentsView(options)
+	impl, ok := view.impl.(*macosWebContentsView)
+	if !ok {
+		t.Fatalf("implementation = %T, want *macosWebContentsView", view.impl)
+	}
+	if impl.nsView != nil {
+		t.Fatal("WKWebView was created before a native window attached")
+	}
+
+	// 2. Test SetBounds
+	view.SetBounds(application.Rect{X: 10, Y: 10, Width: 400, Height: 400})
+
+	// 3. Test SetURL
+	view.SetURL("https://google.com")
+
+	// 4. Test ExecJS
+	view.ExecJS("console.log('test');")
+
+	// 5. Test Attach and Detach using a mock window
+	win := &mockWindow{}
+	view.Attach(win)
+	view.Detach()
+
+	t.Log("macOS WebContentsView API surface tests passed successfully.")
+}

--- a/v3/pkg/webcontentsview/webcontentsview_ios.go
+++ b/v3/pkg/webcontentsview/webcontentsview_ios.go
@@ -1,0 +1,30 @@
+//go:build ios
+
+package webcontentsview
+
+import (
+	"github.com/wailsapp/wails/v3/pkg/application"
+	"unsafe"
+)
+
+type iosWebContentsView struct {
+	parent *WebContentsView
+}
+
+func newWebContentsViewImpl(parent *WebContentsView) webContentsViewImpl {
+	return &iosWebContentsView{parent: parent}
+}
+
+func (w *iosWebContentsView) setBounds(bounds application.Rect) {}
+func (w *iosWebContentsView) setURL(url string)                 {}
+func (w *iosWebContentsView) setHTML(html string)               {}
+func (w *iosWebContentsView) execJS(js string)                  {}
+func (w *iosWebContentsView) goBack()                           {}
+func (w *iosWebContentsView) getURL() string                    { return "" }
+func (w *iosWebContentsView) takeSnapshot() string              { return "" }
+func (w *iosWebContentsView) setVisible(bool)                   {}
+
+func (w *iosWebContentsView) attach(window application.Window) {}
+func (w *iosWebContentsView) detach()                          {}
+func (w *iosWebContentsView) destroy()                         {}
+func (w *iosWebContentsView) nativeView() unsafe.Pointer       { return nil }

--- a/v3/pkg/webcontentsview/webcontentsview_linux.go
+++ b/v3/pkg/webcontentsview/webcontentsview_linux.go
@@ -1,0 +1,316 @@
+//go:build linux && cgo && !gtk3 && !android && !server
+
+package webcontentsview
+
+/*
+#cgo linux pkg-config: gtk4 webkitgtk-6.0
+#include <gtk/gtk.h>
+#include <webkit/webkit.h>
+#include <stdint.h>
+
+static void* createWebContentsView_linux(int x, int y, int w, int h, int devTools, int js, int images) {
+    WebKitSettings *settings = webkit_settings_new();
+
+    webkit_settings_set_enable_developer_extras(settings, devTools ? TRUE : FALSE);
+    webkit_settings_set_enable_javascript(settings, js ? TRUE : FALSE);
+    webkit_settings_set_auto_load_images(settings, images ? TRUE : FALSE);
+
+    GtkWidget *webview = webkit_web_view_new();
+    webkit_web_view_set_settings(WEBKIT_WEB_VIEW(webview), settings);
+    g_object_unref(settings);
+    // Keep a reference independent of the GtkFixed parent. Detach removes the
+    // parent-owned reference, but WebContentsView supports later reattachment.
+    g_object_ref_sink(webview);
+    gtk_widget_set_size_request(webview, w, h);
+    return webview;
+}
+
+static void webContentsViewSetBounds_linux(void* view, void* parentOverlay, int x, int y, int w, int h) {
+    GtkWidget *webview = (GtkWidget*)view;
+    gtk_widget_set_size_request(webview, w, h);
+    if (parentOverlay != NULL) {
+        // This is an overlay child itself, rather than a child of a full-size
+        // GtkFixed overlay. The latter receives pointer hits across its empty
+        // area and prevents the host Wails webview from receiving controls.
+        gtk_widget_set_margin_start(webview, x);
+        gtk_widget_set_margin_top(webview, y);
+    }
+}
+
+static void webContentsViewSetVisible_linux(void* view, int visible) {
+    gtk_widget_set_visible(GTK_WIDGET(view), visible ? TRUE : FALSE);
+}
+
+static void webContentsViewSetURL_linux(void* view, const char* url) {
+    webkit_web_view_load_uri(WEBKIT_WEB_VIEW((GtkWidget*)view), url);
+}
+
+static void webContentsViewSetHTML_linux(void* view, const char* html) {
+    webkit_web_view_load_html(WEBKIT_WEB_VIEW((GtkWidget*)view), html, NULL);
+}
+
+static void webContentsViewExecJS_linux(void* view, const char* js) {
+    webkit_web_view_evaluate_javascript(WEBKIT_WEB_VIEW((GtkWidget*)view), js, -1, NULL, NULL, NULL, NULL, NULL);
+}
+
+static void webContentsViewGoBack_linux(void* view) {
+    WebKitWebView *webview = WEBKIT_WEB_VIEW((GtkWidget*)view);
+    if (webkit_web_view_can_go_back(webview)) webkit_web_view_go_back(webview);
+}
+
+static const char* webContentsViewGetURL_linux(void* view) {
+    return webkit_web_view_get_uri(WEBKIT_WEB_VIEW((GtkWidget*)view));
+}
+
+typedef struct { GMainLoop *loop; char *data; } SnapshotResult;
+static void webContentsViewSnapshotReady(GObject *source, GAsyncResult *result, gpointer user_data) {
+    SnapshotResult *snapshot = (SnapshotResult*)user_data;
+    GError *error = NULL;
+    GdkTexture *texture = webkit_web_view_get_snapshot_finish(WEBKIT_WEB_VIEW(source), result, &error);
+    if (texture != NULL) {
+        GBytes *png = gdk_texture_save_to_png_bytes(texture);
+        if (png != NULL) {
+            gsize size = 0;
+            const guchar *bytes = g_bytes_get_data(png, &size);
+            snapshot->data = g_base64_encode(bytes, size);
+            g_bytes_unref(png);
+        }
+        g_object_unref(texture);
+    }
+    if (error != NULL) g_error_free(error);
+    g_main_loop_quit(snapshot->loop);
+}
+static char* webContentsViewTakeSnapshot_linux(void* view) {
+    SnapshotResult snapshot = {0};
+    snapshot.loop = g_main_loop_new(NULL, FALSE);
+    webkit_web_view_get_snapshot(WEBKIT_WEB_VIEW(view), WEBKIT_SNAPSHOT_REGION_VISIBLE, WEBKIT_SNAPSHOT_OPTIONS_NONE, NULL, webContentsViewSnapshotReady, &snapshot);
+    g_main_loop_run(snapshot.loop);
+    g_main_loop_unref(snapshot.loop);
+    return snapshot.data;
+}
+
+static void* webContentsViewAttach_linux(void* window, void* view, int x, int y) {
+    GtkWindow *gtkWindow = GTK_WINDOW(window);
+    GtkWidget *child = gtk_window_get_child(gtkWindow);
+    if (child != NULL && GTK_IS_OVERLAY(child)) {
+        GtkWidget *webview = GTK_WIDGET(view);
+        gtk_widget_set_halign(webview, GTK_ALIGN_START);
+        gtk_widget_set_valign(webview, GTK_ALIGN_START);
+        gtk_widget_set_margin_start(webview, x);
+        gtk_widget_set_margin_top(webview, y);
+        gtk_overlay_add_overlay(GTK_OVERLAY(child), webview);
+        gtk_widget_set_visible(GTK_WIDGET(view), TRUE);
+        return child;
+    }
+    return NULL;
+}
+
+static void webContentsViewDetach_linux(void* view, void* overlay) {
+    GtkWidget *webview = (GtkWidget*)view;
+    if (overlay != NULL && GTK_IS_OVERLAY(overlay)) {
+        gtk_overlay_remove_overlay(GTK_OVERLAY(overlay), webview);
+    }
+}
+
+static void webContentsViewDestroy_linux(void* view) {
+    if (view != NULL) g_object_unref(view);
+}
+*/
+import "C"
+import (
+	"unsafe"
+
+	"github.com/wailsapp/wails/v3/pkg/application"
+)
+
+type linuxWebContentsView struct {
+	parent               *WebContentsView
+	widget               unsafe.Pointer
+	fixed                unsafe.Pointer
+	pendingJS            []string
+	devTools, js, images int
+}
+
+func newWebContentsViewImpl(parent *WebContentsView) webContentsViewImpl {
+	options := parent.optionsSnapshot()
+	devTools := 1
+	if !options.WebPreferences.DevTools.Get() && options.WebPreferences.DevTools.IsSet() {
+		devTools = 0
+	}
+
+	js := 1
+	if !options.WebPreferences.Javascript.Get() && options.WebPreferences.Javascript.IsSet() {
+		js = 0
+	}
+
+	images := 1
+	if !options.WebPreferences.Images.Get() && options.WebPreferences.Images.IsSet() {
+		images = 0
+	}
+
+	return &linuxWebContentsView{
+		parent:   parent,
+		devTools: devTools,
+		js:       js,
+		images:   images,
+	}
+}
+
+func (w *linuxWebContentsView) createWidget() {
+	if w.widget != nil {
+		return
+	}
+
+	options := w.parent.optionsSnapshot()
+	w.widget = C.createWebContentsView_linux(
+		C.int(options.Bounds.X),
+		C.int(options.Bounds.Y),
+		C.int(options.Bounds.Width),
+		C.int(options.Bounds.Height),
+		C.int(w.devTools),
+		C.int(w.js),
+		C.int(w.images),
+	)
+}
+
+func (w *linuxWebContentsView) setBounds(bounds application.Rect) {
+	if w.widget == nil {
+		return
+	}
+	application.InvokeSync(func() {
+		C.webContentsViewSetBounds_linux(w.widget, w.fixed, C.int(bounds.X), C.int(bounds.Y), C.int(bounds.Width), C.int(bounds.Height))
+	})
+}
+
+func (w *linuxWebContentsView) setURL(url string) {
+	if w.widget == nil {
+		return
+	}
+	cUrl := C.CString(url)
+	defer C.free(unsafe.Pointer(cUrl))
+	application.InvokeSync(func() {
+		C.webContentsViewSetURL_linux(w.widget, cUrl)
+	})
+}
+
+func (w *linuxWebContentsView) setHTML(html string) {
+	if w.widget == nil {
+		return
+	}
+	cHTML := C.CString(html)
+	defer C.free(unsafe.Pointer(cHTML))
+	application.InvokeSync(func() {
+		C.webContentsViewSetHTML_linux(w.widget, cHTML)
+	})
+}
+
+func (w *linuxWebContentsView) goBack() {
+	if w.widget == nil {
+		return
+	}
+	application.InvokeSync(func() {
+		C.webContentsViewGoBack_linux(w.widget)
+	})
+}
+
+func (w *linuxWebContentsView) getURL() string {
+	if w.widget == nil {
+		return ""
+	}
+	var url string
+	application.InvokeSync(func() {
+		if nativeURL := C.webContentsViewGetURL_linux(w.widget); nativeURL != nil {
+			// WebKit owns this pointer and may replace it on the next load event;
+			// copy it before returning from the GTK thread.
+			url = C.GoString(nativeURL)
+		}
+	})
+	return url
+}
+func (w *linuxWebContentsView) takeSnapshot() string {
+	if w.widget == nil {
+		return ""
+	}
+	var snapshot *C.char
+	application.InvokeSync(func() {
+		snapshot = C.webContentsViewTakeSnapshot_linux(w.widget)
+	})
+	if snapshot == nil {
+		return ""
+	}
+	defer C.free(unsafe.Pointer(snapshot))
+	return "data:image/png;base64," + C.GoString(snapshot)
+}
+
+func (w *linuxWebContentsView) setVisible(visible bool) {
+	if w.widget == nil {
+		return
+	}
+	application.InvokeSync(func() {
+		C.webContentsViewSetVisible_linux(w.widget, C.int(boolToInt(visible)))
+	})
+}
+
+func (w *linuxWebContentsView) execJS(js string) {
+	if w.widget == nil {
+		w.pendingJS = append(w.pendingJS, js)
+		return
+	}
+	cJs := C.CString(js)
+	defer C.free(unsafe.Pointer(cJs))
+	application.InvokeSync(func() {
+		C.webContentsViewExecJS_linux(w.widget, cJs)
+	})
+}
+
+func (w *linuxWebContentsView) attach(window application.Window) {
+	if window.NativeWindow() != nil && w.fixed == nil {
+		application.InvokeSync(func() {
+			w.createWidget()
+			options := w.parent.optionsSnapshot()
+			visible := w.parent.visibleSnapshot()
+			w.fixed = C.webContentsViewAttach_linux(window.NativeWindow(), w.widget, C.int(options.Bounds.X), C.int(options.Bounds.Y))
+			C.webContentsViewSetVisible_linux(w.widget, C.int(boolToInt(visible)))
+			if options.URL != "" {
+				cURL := C.CString(options.URL)
+				C.webContentsViewSetURL_linux(w.widget, cURL)
+				C.free(unsafe.Pointer(cURL))
+			} else if options.HTML != "" {
+				cHTML := C.CString(options.HTML)
+				C.webContentsViewSetHTML_linux(w.widget, cHTML)
+				C.free(unsafe.Pointer(cHTML))
+			}
+			for _, js := range w.pendingJS {
+				cJS := C.CString(js)
+				C.webContentsViewExecJS_linux(w.widget, cJS)
+				C.free(unsafe.Pointer(cJS))
+			}
+			w.pendingJS = nil
+		})
+	}
+}
+
+func (w *linuxWebContentsView) detach() {
+	if w.widget == nil {
+		return
+	}
+	application.InvokeSync(func() {
+		C.webContentsViewDetach_linux(w.widget, w.fixed)
+	})
+	w.fixed = nil
+}
+
+func (w *linuxWebContentsView) destroy() {
+	if w.widget == nil {
+		return
+	}
+	application.InvokeSync(func() {
+		C.webContentsViewDestroy_linux(w.widget)
+	})
+	w.widget = nil
+	w.fixed = nil
+}
+
+func (w *linuxWebContentsView) nativeView() unsafe.Pointer {
+	return w.widget
+}

--- a/v3/pkg/webcontentsview/webcontentsview_linux_gtk3.go
+++ b/v3/pkg/webcontentsview/webcontentsview_linux_gtk3.go
@@ -1,0 +1,230 @@
+//go:build linux && cgo && gtk3 && !android && !server
+
+package webcontentsview
+
+/*
+#cgo linux pkg-config: gtk+-3.0 webkit2gtk-4.1 gdk-3.0
+#include <gtk/gtk.h>
+#include <webkit2/webkit2.h>
+
+static void* createWebContentsView_gtk3(int w, int h, int devTools, int js, int images) {
+    WebKitSettings *settings = webkit_settings_new();
+    webkit_settings_set_enable_developer_extras(settings, devTools ? TRUE : FALSE);
+    webkit_settings_set_enable_javascript(settings, js ? TRUE : FALSE);
+    webkit_settings_set_auto_load_images(settings, images ? TRUE : FALSE);
+    GtkWidget *webview = webkit_web_view_new_with_settings(settings);
+    g_object_unref(settings);
+    // Keep a reference independent of the GtkFixed parent so RemoveChildView
+    // followed by AddChildView can safely reuse the same native browser.
+    g_object_ref_sink(webview);
+    gtk_widget_set_size_request(webview, w, h);
+    return webview;
+}
+
+static void webContentsViewSetBounds_gtk3(void* view, void* parentOverlay, int x, int y, int w, int h) {
+    GtkWidget *webview = (GtkWidget*)view;
+    gtk_widget_set_size_request(webview, w, h);
+    if (parentOverlay != NULL) {
+        gtk_widget_set_margin_left(webview, x);
+        gtk_widget_set_margin_top(webview, y);
+    }
+}
+
+static void webContentsViewSetVisible_gtk3(void* view, int visible) {
+    if (visible) gtk_widget_show(GTK_WIDGET(view));
+    else gtk_widget_hide(GTK_WIDGET(view));
+}
+
+static void webContentsViewSetURL_gtk3(void* view, const char* url) {
+    webkit_web_view_load_uri(WEBKIT_WEB_VIEW(view), url);
+}
+
+static void webContentsViewSetHTML_gtk3(void* view, const char* html) {
+    webkit_web_view_load_html(WEBKIT_WEB_VIEW(view), html, NULL);
+}
+
+static void webContentsViewExecJS_gtk3(void* view, const char* js) {
+    webkit_web_view_evaluate_javascript(WEBKIT_WEB_VIEW(view), js, -1, NULL, NULL, NULL, NULL, NULL);
+}
+
+static void webContentsViewGoBack_gtk3(void* view) {
+    WebKitWebView *webview = WEBKIT_WEB_VIEW(view);
+    if (webkit_web_view_can_go_back(webview)) webkit_web_view_go_back(webview);
+}
+
+static const char* webContentsViewGetURL_gtk3(void* view) {
+    return webkit_web_view_get_uri(WEBKIT_WEB_VIEW(view));
+}
+
+static void* webContentsViewAttach_gtk3(void* window, void* view, int x, int y) {
+    GtkWidget *child = gtk_bin_get_child(GTK_BIN(window));
+    if (child == NULL || !GTK_IS_OVERLAY(child)) return NULL;
+    GtkWidget *webview = GTK_WIDGET(view);
+    gtk_widget_set_halign(webview, GTK_ALIGN_START);
+    gtk_widget_set_valign(webview, GTK_ALIGN_START);
+    gtk_widget_set_margin_left(webview, x);
+    gtk_widget_set_margin_top(webview, y);
+    gtk_overlay_add_overlay(GTK_OVERLAY(child), webview);
+    gtk_widget_show(webview);
+    return child;
+}
+
+static void webContentsViewDetach_gtk3(void* view, void* overlay) {
+    GtkWidget *webview = GTK_WIDGET(view);
+    if (overlay != NULL && GTK_IS_OVERLAY(overlay)) gtk_container_remove(GTK_CONTAINER(overlay), webview);
+}
+
+static void webContentsViewDestroy_gtk3(void* view) {
+    if (view != NULL) g_object_unref(view);
+}
+*/
+import "C"
+
+import (
+	"unsafe"
+
+	"github.com/wailsapp/wails/v3/pkg/application"
+)
+
+type gtk3WebContentsView struct {
+	parent               *WebContentsView
+	widget               unsafe.Pointer
+	fixed                unsafe.Pointer
+	pendingJS            []string
+	devTools, js, images int
+}
+
+func newWebContentsViewImpl(parent *WebContentsView) webContentsViewImpl {
+	options := parent.optionsSnapshot()
+	devTools, js, images := 1, 1, 1
+	if options.WebPreferences.DevTools.IsSet() && !options.WebPreferences.DevTools.Get() {
+		devTools = 0
+	}
+	if options.WebPreferences.Javascript.IsSet() && !options.WebPreferences.Javascript.Get() {
+		js = 0
+	}
+	if options.WebPreferences.Images.IsSet() && !options.WebPreferences.Images.Get() {
+		images = 0
+	}
+	return &gtk3WebContentsView{parent: parent, devTools: devTools, js: js, images: images}
+}
+
+func (w *gtk3WebContentsView) createWidget() {
+	if w.widget == nil {
+		options := w.parent.optionsSnapshot()
+		w.widget = C.createWebContentsView_gtk3(C.int(options.Bounds.Width), C.int(options.Bounds.Height), C.int(w.devTools), C.int(w.js), C.int(w.images))
+	}
+}
+
+func (w *gtk3WebContentsView) setBounds(bounds application.Rect) {
+	if w.widget != nil {
+		application.InvokeSync(func() {
+			C.webContentsViewSetBounds_gtk3(w.widget, w.fixed, C.int(bounds.X), C.int(bounds.Y), C.int(bounds.Width), C.int(bounds.Height))
+		})
+	}
+}
+
+func (w *gtk3WebContentsView) setURL(url string) {
+	if w.widget == nil {
+		return
+	}
+	cURL := C.CString(url)
+	defer C.free(unsafe.Pointer(cURL))
+	application.InvokeSync(func() { C.webContentsViewSetURL_gtk3(w.widget, cURL) })
+}
+
+func (w *gtk3WebContentsView) setHTML(html string) {
+	if w.widget == nil {
+		return
+	}
+	cHTML := C.CString(html)
+	defer C.free(unsafe.Pointer(cHTML))
+	application.InvokeSync(func() { C.webContentsViewSetHTML_gtk3(w.widget, cHTML) })
+}
+
+func (w *gtk3WebContentsView) execJS(js string) {
+	if w.widget == nil {
+		w.pendingJS = append(w.pendingJS, js)
+		return
+	}
+	cJS := C.CString(js)
+	defer C.free(unsafe.Pointer(cJS))
+	application.InvokeSync(func() { C.webContentsViewExecJS_gtk3(w.widget, cJS) })
+}
+
+func (w *gtk3WebContentsView) goBack() {
+	if w.widget != nil {
+		application.InvokeSync(func() { C.webContentsViewGoBack_gtk3(w.widget) })
+	}
+}
+
+func (w *gtk3WebContentsView) getURL() string {
+	if w.widget == nil {
+		return ""
+	}
+	var url string
+	application.InvokeSync(func() {
+		if nativeURL := C.webContentsViewGetURL_gtk3(w.widget); nativeURL != nil {
+			// The WebKit-owned string is only stable for the current GTK call.
+			url = C.GoString(nativeURL)
+		}
+	})
+	return url
+}
+
+func (w *gtk3WebContentsView) takeSnapshot() string { return "" }
+
+func (w *gtk3WebContentsView) setVisible(visible bool) {
+	if w.widget == nil {
+		return
+	}
+	application.InvokeSync(func() {
+		C.webContentsViewSetVisible_gtk3(w.widget, C.int(boolToInt(visible)))
+	})
+}
+
+func (w *gtk3WebContentsView) attach(window application.Window) {
+	if window.NativeWindow() == nil || w.fixed != nil {
+		return
+	}
+	application.InvokeSync(func() {
+		w.createWidget()
+		options := w.parent.optionsSnapshot()
+		visible := w.parent.visibleSnapshot()
+		w.fixed = C.webContentsViewAttach_gtk3(window.NativeWindow(), w.widget, C.int(options.Bounds.X), C.int(options.Bounds.Y))
+		C.webContentsViewSetVisible_gtk3(w.widget, C.int(boolToInt(visible)))
+		if options.URL != "" {
+			cURL := C.CString(options.URL)
+			C.webContentsViewSetURL_gtk3(w.widget, cURL)
+			C.free(unsafe.Pointer(cURL))
+		} else if options.HTML != "" {
+			cHTML := C.CString(options.HTML)
+			C.webContentsViewSetHTML_gtk3(w.widget, cHTML)
+			C.free(unsafe.Pointer(cHTML))
+		}
+		for _, js := range w.pendingJS {
+			cJS := C.CString(js)
+			C.webContentsViewExecJS_gtk3(w.widget, cJS)
+			C.free(unsafe.Pointer(cJS))
+		}
+		w.pendingJS = nil
+	})
+}
+
+func (w *gtk3WebContentsView) detach() {
+	if w.widget != nil {
+		application.InvokeSync(func() { C.webContentsViewDetach_gtk3(w.widget, w.fixed) })
+		w.fixed = nil
+	}
+}
+
+func (w *gtk3WebContentsView) destroy() {
+	if w.widget == nil {
+		return
+	}
+	application.InvokeSync(func() { C.webContentsViewDestroy_gtk3(w.widget) })
+	w.widget = nil
+	w.fixed = nil
+}
+
+func (w *gtk3WebContentsView) nativeView() unsafe.Pointer { return w.widget }

--- a/v3/pkg/webcontentsview/webcontentsview_server.go
+++ b/v3/pkg/webcontentsview/webcontentsview_server.go
@@ -1,0 +1,33 @@
+//go:build server && !android && !ios
+
+package webcontentsview
+
+import (
+	"unsafe"
+
+	"github.com/wailsapp/wails/v3/pkg/application"
+)
+
+// serverWebContentsView preserves the public API for Wails server builds,
+// where no native window or browser engine exists. It intentionally exposes no
+// native view.
+type serverWebContentsView struct {
+	parent *WebContentsView
+}
+
+func newWebContentsViewImpl(parent *WebContentsView) webContentsViewImpl {
+	return &serverWebContentsView{parent: parent}
+}
+
+func (w *serverWebContentsView) setBounds(application.Rect) {}
+func (w *serverWebContentsView) setURL(string)              {}
+func (w *serverWebContentsView) setHTML(string)             {}
+func (w *serverWebContentsView) execJS(string)              {}
+func (w *serverWebContentsView) goBack()                    {}
+func (w *serverWebContentsView) getURL() string             { return w.parent.optionsSnapshot().URL }
+func (w *serverWebContentsView) takeSnapshot() string       { return "" }
+func (w *serverWebContentsView) setVisible(bool)            {}
+func (w *serverWebContentsView) attach(application.Window)  {}
+func (w *serverWebContentsView) detach()                    {}
+func (w *serverWebContentsView) destroy()                   {}
+func (w *serverWebContentsView) nativeView() unsafe.Pointer { return nil }

--- a/v3/pkg/webcontentsview/webcontentsview_server_test.go
+++ b/v3/pkg/webcontentsview/webcontentsview_server_test.go
@@ -1,0 +1,15 @@
+//go:build server && !android && !ios
+
+package webcontentsview
+
+import "testing"
+
+func TestServerWebContentsViewIsExplicitlyNonNative(t *testing.T) {
+	view := NewWebContentsView(WebContentsViewOptions{URL: "https://example.com"})
+	if _, ok := view.impl.(*serverWebContentsView); !ok {
+		t.Fatalf("implementation = %T, want *serverWebContentsView", view.impl)
+	}
+	if got := view.GetURL(); got != "https://example.com" {
+		t.Fatalf("GetURL() = %q, want requested URL", got)
+	}
+}

--- a/v3/pkg/webcontentsview/webcontentsview_test.go
+++ b/v3/pkg/webcontentsview/webcontentsview_test.go
@@ -1,0 +1,132 @@
+package webcontentsview
+
+import (
+	"sync"
+	"testing"
+	"unsafe"
+
+	"github.com/wailsapp/wails/v3/pkg/application"
+)
+
+// serializedTestImpl intentionally has no locks. The public WebContentsView
+// API must serialize access to it even when multiple callers
+// issue operations concurrently.
+type serializedTestImpl struct {
+	url       string
+	visible   bool
+	destroyed bool
+}
+
+func (i *serializedTestImpl) setBounds(application.Rect) {}
+func (i *serializedTestImpl) setURL(url string)          { i.url = url }
+func (i *serializedTestImpl) setHTML(string)             { i.url = "about:blank" }
+func (i *serializedTestImpl) execJS(string)              {}
+func (i *serializedTestImpl) goBack()                    {}
+func (i *serializedTestImpl) getURL() string             { return i.url }
+func (i *serializedTestImpl) takeSnapshot() string       { return "" }
+func (i *serializedTestImpl) setVisible(visible bool)    { i.visible = visible }
+func (i *serializedTestImpl) attach(application.Window)  {}
+func (i *serializedTestImpl) detach()                    {}
+func (i *serializedTestImpl) destroy()                   { i.destroyed = true }
+func (i *serializedTestImpl) nativeView() unsafe.Pointer { return nil }
+
+func TestWebContentsViewSwitchesBetweenURLAndInlineHTML(t *testing.T) {
+	view := NewWebContentsView(WebContentsViewOptions{URL: "https://example.com"})
+
+	view.SetHTML("<h1>inline</h1>")
+	if view.options.URL != "" {
+		t.Fatalf("URL after SetHTML = %q, want empty", view.options.URL)
+	}
+	if view.options.HTML != "<h1>inline</h1>" {
+		t.Fatalf("HTML after SetHTML = %q", view.options.HTML)
+	}
+
+	view.SetURL("https://wails.io")
+	if view.options.URL != "https://wails.io" {
+		t.Fatalf("URL after SetURL = %q", view.options.URL)
+	}
+	if view.options.HTML != "" {
+		t.Fatalf("HTML after SetURL = %q, want empty", view.options.HTML)
+	}
+}
+
+func TestWebContentsViewVisibilityDefaultsToShown(t *testing.T) {
+	view := NewWebContentsView(WebContentsViewOptions{})
+	if !view.visible {
+		t.Fatal("new WebContentsView is not visible by default")
+	}
+
+	view.Hide()
+	if view.visible {
+		t.Fatal("Hide did not record the hidden state")
+	}
+
+	view.Show()
+	if !view.visible {
+		t.Fatal("Show did not record the visible state")
+	}
+}
+
+func TestWebPreferencesOptionalBooleanHelpers(t *testing.T) {
+	if !Enabled.IsSet() || !Enabled.Get() {
+		t.Fatal("Enabled is not an explicit true preference")
+	}
+	if !Disabled.IsSet() || Disabled.Get() {
+		t.Fatal("Disabled is not an explicit false preference")
+	}
+}
+
+func TestWebContentsViewDestroyIsPermanent(t *testing.T) {
+	view := NewWebContentsView(WebContentsViewOptions{})
+	view.Destroy()
+	if !view.destroyed {
+		t.Fatal("Destroy did not record the destroyed state")
+	}
+
+	view.Show()
+	if view.visible {
+		t.Fatal("Show revived a destroyed WebContentsView")
+	}
+	if got := view.TakeSnapshot(); got != "" {
+		t.Fatalf("snapshot after Destroy = %q, want empty", got)
+	}
+	if got := view.GetURL(); got != "" {
+		t.Fatalf("URL after Destroy = %q, want empty", got)
+	}
+	view.Destroy()
+}
+
+func TestWebContentsViewSerializesConcurrentOperations(t *testing.T) {
+	view := NewWebContentsView(WebContentsViewOptions{})
+	impl := &serializedTestImpl{}
+	view.impl = impl
+
+	var group sync.WaitGroup
+	for worker := 0; worker < 16; worker++ {
+		group.Add(1)
+		go func(worker int) {
+			defer group.Done()
+			for iteration := 0; iteration < 64; iteration++ {
+				switch (worker + iteration) % 5 {
+				case 0:
+					view.SetURL("https://example.com")
+				case 1:
+					view.SetHTML("<p>test</p>")
+				case 2:
+					view.Show()
+				case 3:
+					view.Hide()
+				default:
+					view.ExecJS("void 0")
+				}
+				_ = view.GetURL()
+			}
+		}(worker)
+	}
+	group.Wait()
+
+	view.Destroy()
+	if !impl.destroyed {
+		t.Fatal("Destroy did not reach the serialized native implementation")
+	}
+}

--- a/v3/pkg/webcontentsview/webcontentsview_windows.go
+++ b/v3/pkg/webcontentsview/webcontentsview_windows.go
@@ -1,0 +1,323 @@
+//go:build windows && !server
+
+package webcontentsview
+
+import (
+	"crypto/sha256"
+	"encoding/base64"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+	"unsafe"
+
+	"github.com/wailsapp/wails/v3/internal/webview2/pkg/edge"
+	"github.com/wailsapp/wails/v3/pkg/application"
+	"github.com/wailsapp/wails/v3/pkg/w32"
+)
+
+type windowsWebContentsView struct {
+	parent     *WebContentsView
+	chromium   *edge.Chromium
+	hwnd       w32.HWND
+	nativeHWND w32.HWND
+	pendingJS  []string
+}
+
+func newWebContentsViewImpl(parent *WebContentsView) webContentsViewImpl {
+	chromium := edge.NewChromium()
+	// The host Wails window and this native panel construct independent
+	// WebView2 environments. WebView2 only permits environments sharing a
+	// user-data folder when every environment option is identical; the Wails
+	// host applies its application-level browser flags while this panel must not
+	// inherit private host configuration implicitly. Use a stable, app- and
+	// view-scoped folder to avoid an incompatible second environment and to keep
+	// panel sessions independent of the host frontend's browser session.
+	chromium.DataPath = windowsWebContentsUserDataPath(parent)
+
+	result := &windowsWebContentsView{
+		parent:   parent,
+		chromium: chromium,
+	}
+
+	return result
+}
+
+func windowsWebContentsUserDataPath(parent *WebContentsView) string {
+	configDirectory, err := os.UserConfigDir()
+	if err != nil {
+		return ""
+	}
+
+	appIdentity := "wails"
+	if executable, err := os.Executable(); err == nil {
+		appIdentity = executable
+	}
+	options := parent.optionsSnapshot()
+	viewIdentity := options.Name
+	if viewIdentity == "" {
+		viewIdentity = fmt.Sprintf("unnamed-%d", parent.id)
+	}
+	appHash := sha256.Sum256([]byte(appIdentity))
+	viewHash := sha256.Sum256([]byte(viewIdentity))
+	return filepath.Join(
+		configDirectory,
+		"Wails",
+		fmt.Sprintf("app-%x", appHash[:8]),
+		"WebContentsView",
+		fmt.Sprintf("view-%x", viewHash[:8]),
+	)
+}
+
+func (w *windowsWebContentsView) configure() {
+	options := w.parent.optionsSnapshot()
+	settings, err := w.chromium.GetSettings()
+	if err == nil {
+		if !options.WebPreferences.DevTools.IsSet() || options.WebPreferences.DevTools.Get() {
+			settings.PutAreDevToolsEnabled(true)
+			settings.PutAreDefaultContextMenusEnabled(true)
+		} else {
+			settings.PutAreDevToolsEnabled(false)
+			settings.PutAreDefaultContextMenusEnabled(false)
+		}
+
+		if !options.WebPreferences.Javascript.IsSet() || options.WebPreferences.Javascript.Get() {
+			settings.PutIsScriptEnabled(true)
+		} else {
+			settings.PutIsScriptEnabled(false)
+		}
+
+		if options.WebPreferences.ZoomFactor > 0 {
+			w.chromium.PutZoomFactor(options.WebPreferences.ZoomFactor)
+		}
+
+		if options.WebPreferences.UserAgent != "" {
+			settings.PutUserAgent(options.WebPreferences.UserAgent)
+		}
+	}
+
+}
+
+func (w *windowsWebContentsView) setBounds(bounds application.Rect) {
+	if w.chromium != nil && w.chromium.IsReady() {
+		edgeBounds := edge.Rect{
+			Left:   int32(bounds.X),
+			Top:    int32(bounds.Y),
+			Right:  int32(bounds.X + bounds.Width),
+			Bottom: int32(bounds.Y + bounds.Height),
+		}
+		application.InvokeSync(func() {
+			w.chromium.ResizeWithBounds(&edgeBounds)
+			w.bringNativeSurfaceToFront()
+		})
+	}
+}
+
+func (w *windowsWebContentsView) setURL(url string) {
+	if w.chromium != nil && w.chromium.IsReady() {
+		application.InvokeSync(func() {
+			log.Printf("[WebContentsView] navigating native browser to %s", url)
+			w.chromium.Navigate(url)
+		})
+	}
+}
+
+func (w *windowsWebContentsView) setHTML(html string) {
+	if w.chromium != nil && w.chromium.IsReady() {
+		application.InvokeSync(func() {
+			w.chromium.NavigateToString(html)
+		})
+	}
+}
+
+func (w *windowsWebContentsView) goBack() {
+	if w.chromium != nil && w.chromium.IsReady() {
+		application.InvokeSync(func() {
+			_ = w.chromium.GoBack()
+		})
+	}
+}
+
+func (w *windowsWebContentsView) getURL() string {
+	if w.chromium != nil && w.chromium.IsReady() {
+		var url string
+		application.InvokeSync(func() {
+			url, _ = w.chromium.Source()
+		})
+		if url != "" {
+			return url
+		}
+	}
+	return w.parent.optionsSnapshot().URL
+}
+
+func (w *windowsWebContentsView) execJS(js string) {
+	if w.chromium == nil || !w.chromium.IsReady() {
+		w.pendingJS = append(w.pendingJS, js)
+		return
+	}
+	application.InvokeSync(func() {
+		w.chromium.Eval(js)
+	})
+}
+
+func (w *windowsWebContentsView) takeSnapshot() string {
+	if w.chromium == nil || !w.chromium.IsReady() {
+		return ""
+	}
+	type screenshotResult struct {
+		data []byte
+		err  error
+	}
+	resultCh := make(chan screenshotResult, 1)
+	var requestErr error
+	application.InvokeSync(func() {
+		requestErr = w.chromium.CapturePreview(func(data []byte, err error) {
+			resultCh <- screenshotResult{data: data, err: err}
+		})
+	})
+	if requestErr != nil {
+		return ""
+	}
+	select {
+	case result := <-resultCh:
+		if result.err != nil || len(result.data) == 0 {
+			return ""
+		}
+		return "data:image/png;base64," + base64.StdEncoding.EncodeToString(result.data)
+	case <-time.After(30 * time.Second):
+		return ""
+	}
+}
+
+func (w *windowsWebContentsView) setVisible(visible bool) {
+	if w.chromium == nil || !w.chromium.IsReady() {
+		return
+	}
+	application.InvokeSync(func() {
+		if visible {
+			_ = w.chromium.Show()
+			w.bringNativeSurfaceToFront()
+		} else {
+			_ = w.chromium.Hide()
+		}
+	})
+}
+
+func (w *windowsWebContentsView) attach(window application.Window) {
+	if window.NativeWindow() == nil || w.chromium == nil {
+		return
+	}
+	if w.chromium.IsReady() {
+		options := w.parent.optionsSnapshot()
+		visible := w.parent.visibleSnapshot()
+		w.setBounds(options.Bounds)
+		application.InvokeSync(func() {
+			if visible {
+				_ = w.chromium.Show()
+			} else {
+				_ = w.chromium.Hide()
+			}
+		})
+		return
+	}
+	application.InvokeSync(func() {
+		w.hwnd = w32.HWND(uintptr(window.NativeWindow()))
+		knownChromeChildren := chromeWidgetChildren(w.hwnd)
+		if !w.chromium.Embed(uintptr(w.hwnd)) || !w.chromium.IsReady() {
+			log.Printf("[WebContentsView] native WebView2 did not become ready")
+			return
+		}
+		w.nativeHWND = newChromeWidgetChild(w.hwnd, knownChromeChildren)
+		if w.nativeHWND != 0 {
+			log.Printf("[WebContentsView] native browser surface ready: hwnd=0x%x", uintptr(w.nativeHWND))
+			w.bringNativeSurfaceToFront()
+		} else {
+			log.Printf("[WebContentsView] native browser surface ready; no Chrome child HWND was discovered")
+		}
+		w.configure()
+		options := w.parent.optionsSnapshot()
+		visible := w.parent.visibleSnapshot()
+		w.setBounds(options.Bounds)
+		if visible {
+			_ = w.chromium.Show()
+		} else {
+			_ = w.chromium.Hide()
+		}
+
+		if options.URL != "" {
+			log.Printf("[WebContentsView] navigating native browser to initial URL %s", options.URL)
+			w.chromium.Navigate(options.URL)
+		} else if options.HTML != "" {
+			w.chromium.NavigateToString(options.HTML)
+		}
+		for _, js := range w.pendingJS {
+			w.chromium.Eval(js)
+		}
+		w.pendingJS = nil
+	})
+}
+
+// chromeWidgetChildren returns WebView2's HWND-hosted renderer windows below
+// a Wails window. A normal Wails window owns one such child already; a native
+// WebContentsView creates another. The latter must be promoted after creation
+// or the host webview can cover it completely despite correct controller bounds.
+func chromeWidgetChildren(parent w32.HWND) map[w32.HWND]struct{} {
+	children := make(map[w32.HWND]struct{})
+	w32.EnumChildWindows(parent, func(hwnd w32.HWND, _ w32.LPARAM) w32.LRESULT {
+		if strings.HasPrefix(w32.GetClassName(hwnd), "Chrome_WidgetWin_") {
+			children[hwnd] = struct{}{}
+		}
+		return 1
+	})
+	return children
+}
+
+func newChromeWidgetChild(parent w32.HWND, existing map[w32.HWND]struct{}) w32.HWND {
+	for hwnd := range chromeWidgetChildren(parent) {
+		if _, found := existing[hwnd]; !found {
+			return hwnd
+		}
+	}
+	return 0
+}
+
+func (w *windowsWebContentsView) bringNativeSurfaceToFront() {
+	if w.nativeHWND == 0 {
+		return
+	}
+	if !w32.SetWindowPos(
+		w.nativeHWND,
+		w32.HWND_TOP,
+		0,
+		0,
+		0,
+		0,
+		w32.SWP_NOMOVE|w32.SWP_NOSIZE|w32.SWP_NOACTIVATE,
+	) {
+		log.Printf("[WebContentsView] could not promote native browser surface: hwnd=0x%x", uintptr(w.nativeHWND))
+	}
+}
+
+func (w *windowsWebContentsView) detach() {
+	if w.chromium != nil && w.chromium.IsReady() {
+		application.InvokeSync(func() {
+			_ = w.chromium.Hide()
+		})
+	}
+}
+
+func (w *windowsWebContentsView) destroy() {
+	if w.chromium == nil {
+		return
+	}
+	application.InvokeSync(w.chromium.Close)
+	w.hwnd = 0
+	w.nativeHWND = 0
+}
+
+func (w *windowsWebContentsView) nativeView() unsafe.Pointer {
+	return unsafe.Pointer(w.chromium)
+}

--- a/v3/pkg/webcontentsview/webcontentsview_windows_test.go
+++ b/v3/pkg/webcontentsview/webcontentsview_windows_test.go
@@ -1,0 +1,66 @@
+//go:build windows && !server
+
+package webcontentsview
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/wailsapp/wails/v3/pkg/application"
+)
+
+func TestWindowsWebContentsViewDefersControllerOperations(t *testing.T) {
+	view := NewWebContentsView(WebContentsViewOptions{
+		URL:    "https://example.com",
+		Bounds: application.Rect{X: 10, Y: 20, Width: 640, Height: 480},
+	})
+	impl, ok := view.impl.(*windowsWebContentsView)
+	if !ok {
+		t.Fatalf("implementation = %T, want *windowsWebContentsView", view.impl)
+	}
+	if impl.chromium == nil {
+		t.Fatal("WebView2 wrapper was not initialized")
+	}
+	if impl.chromium.IsReady() {
+		t.Fatal("WebView2 controller unexpectedly initialized without a host window")
+	}
+
+	// These calls are valid before Attach: requested URL/bounds stay on the
+	// parent view, and scripts wait until the native controller is ready.
+	view.SetBounds(application.Rect{X: 30, Y: 40, Width: 800, Height: 600})
+	view.SetURL("https://wails.io")
+	view.ExecJS("window.__wailsProbe = true")
+	view.GoBack()
+
+	if got := view.GetURL(); got != "https://wails.io" {
+		t.Fatalf("GetURL() = %q, want requested URL", got)
+	}
+	if got := len(impl.pendingJS); got != 1 {
+		t.Fatalf("queued scripts = %d, want 1", got)
+	}
+}
+
+func TestWindowsWebContentsViewUsesStableIsolatedUserDataPath(t *testing.T) {
+	newPath := func(name string) string {
+		view := NewWebContentsView(WebContentsViewOptions{Name: name})
+		impl, ok := view.impl.(*windowsWebContentsView)
+		if !ok {
+			t.Fatalf("implementation = %T, want *windowsWebContentsView", view.impl)
+		}
+		return impl.chromium.DataPath
+	}
+
+	first := newPath("agent-browser")
+	if first == "" {
+		t.Fatal("child WebView2 user-data path must not fall back to the host default")
+	}
+	if filepath.Clean(first) != first {
+		t.Fatalf("user-data path is not clean: %q", first)
+	}
+	if again := newPath("agent-browser"); again != first {
+		t.Fatalf("same view name has unstable user-data paths: first=%q second=%q", first, again)
+	}
+	if other := newPath("agent-browser-2"); other == first {
+		t.Fatalf("different views share user-data path %q", first)
+	}
+}

--- a/v3/pkg/webcontentsview/webpreferences.go
+++ b/v3/pkg/webcontentsview/webpreferences.go
@@ -1,0 +1,57 @@
+package webcontentsview
+
+import "github.com/leaanthony/u"
+
+// Enabled and Disabled configure an optional WebPreferences boolean. Leaving a
+// preference unset selects the platform default.
+var (
+	Enabled  = u.True
+	Disabled = u.False
+)
+
+// WebPreferences closely mirrors Electron's webPreferences for WebContentsView.
+type WebPreferences struct {
+	// DevTools enables or disables the developer tools. Default is true.
+	DevTools u.Bool
+
+	// Javascript enables or disables javascript execution. Default is true.
+	Javascript u.Bool
+
+	// WebSecurity enables or disables web security (CORS, etc.). Default is true.
+	WebSecurity u.Bool
+
+	// AllowRunningInsecureContent allows an https page to run http code. Default is false.
+	AllowRunningInsecureContent u.Bool
+
+	// Images enables or disables image loading. Default is true.
+	Images u.Bool
+
+	// TextAreasAreResizable controls whether text areas can be resized. Default is true.
+	TextAreasAreResizable u.Bool
+
+	// WebGL enables or disables WebGL. Default is true.
+	WebGL u.Bool
+
+	// Plugins enables or disables plugins. Default is false.
+	Plugins u.Bool
+
+	// ZoomFactor sets the default zoom factor of the page. Default is 1.0.
+	ZoomFactor float64
+
+	// NavigateOnDragDrop controls whether dropping files triggers navigation. Default is false.
+	NavigateOnDragDrop u.Bool
+
+	// DefaultFontSize sets the default font size. Default is 16.
+	DefaultFontSize int
+
+	// DefaultMonospaceFontSize sets the default monospace font size. Default is 13.
+	DefaultMonospaceFontSize int
+
+	// MinimumFontSize sets the minimum font size. Default is 0.
+	MinimumFontSize int
+
+	// DefaultEncoding sets the default character encoding. Default is "UTF-8".
+	DefaultEncoding string
+	// UserAgent sets a custom user agent for the webview.
+	UserAgent string
+}


### PR DESCRIPTION
## Summary

Adds a cross-platform `WebContentsView` and a window-managed `ChildView` lifecycle for native embedded browser panels.

- Provides native attach/detach, bounds, navigation, inline HTML, JavaScript execution, visibility, history back, and snapshots.
- Uses WKWebView on macOS, WebView2 on Windows, and WebKitGTK on Linux.
- Makes the Linux host root a GTK overlay so native child panels can follow a layout without blocking uncovered host UI.
- Adds an app- and view-scoped WebView2 user-data directory, plus native z-order handling so the panel is visible above the Wails host webview.
- Keeps GTK3/WebKit2GTK 4.1 as the existing temporary `-tags gtk3` compatibility path.

`WebContentsView` is deliberately scoped as a native panel primitive with a small lifecycle API.

## Validation

- `go test ./pkg/webcontentsview ./pkg/application`
- `go test -race ./pkg/webcontentsview ./pkg/application`
- `go test -tags gtk3 ./pkg/webcontentsview ./pkg/application`
- `go test -tags server ./pkg/webcontentsview`
- Windows amd64 cross-compilation for `pkg/webcontentsview`, `pkg/application`, and `internal/webview2/pkg/edge`
- Manual runtime verification: Linux GTK4 and Windows WebView2 (embedded YouTube panel, bounds updates, resizing, and host/browser interaction)

macOS compilation and runtime verification still require an Apple host.
