### PR TITLE
docs: credit @DevLumuz on the event ordering changelog entry

### DIFF
--- a/docs/src/content/docs/changelog.mdx
+++ b/docs/src/content/docs/changelog.mdx
@@ -31,6 +31,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 */
 ## [Unreleased]
 
+
+### Added
+
+- Implement generic asynchronous FIFO mailbox for ordered event delivery in [PR](https://github.com/wailsapp/wails/pull/5851) by @savely-krasovsky and @DevLumuz
 ## v3.0.0-beta.6 - 2026-08-09
 
 ## Added
@@ -87,7 +91,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## v3.0.0-alpha2.122 - 2026-08-01
 
 ## Added
-- Implement generic asynchronous FIFO mailbox for ordered event delivery in [PR](https://github.com/wailsapp/wails/pull/5851) by @savely-krasovsky and @DevLumuz
 
 ## Changed
 - Add support for rounded, square, and custom radius corners on macOS frameless windows in [PR](https://github.com/wailsapp/wails/pull/5866) by @leaanthony

--- a/docs/src/content/docs/changelog.mdx
+++ b/docs/src/content/docs/changelog.mdx
@@ -87,7 +87,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## v3.0.0-alpha2.122 - 2026-08-01
 
 ## Added
-- Implement generic asynchronous FIFO mailbox for ordered event delivery in [PR](https://github.com/wailsapp/wails/pull/5851) by @savely-krasovsky
+- Implement generic asynchronous FIFO mailbox for ordered event delivery in [PR](https://github.com/wailsapp/wails/pull/5851) by @savely-krasovsky and @DevLumuz
 
 ## Changed
 - Add support for rounded, square, and custom radius corners on macOS frameless windows in [PR](https://github.com/wailsapp/wails/pull/5866) by @leaanthony


### PR DESCRIPTION
@savely-krasovsky intended to co-author @DevLumuz on #5851 and [said so on #5757](https://github.com/wailsapp/wails/pull/5757#issuecomment-5137745615), but the `Co-authored-by` trailer did not survive the squash merge, and the changelog generator only picks up the PR author. So the person who diagnosed the bug first is not credited anywhere on master.

@DevLumuz opened #5757 on 6 July, three weeks before #5850 was filed, and identified the cause: `Emit` handing each dispatch to its own goroutine. #5851 is that analysis implemented with a mailbox.

One-line docs change adding them to the existing entry.

Worth noting the general failure mode: an explicit `--body` on a squash merge replaces the auto-composed message, which silently drops any `Co-authored-by` trailers from the branch commits. Easy to miss.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] WEP (proposal only; no implementation)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

Documentation only; no code paths affected.

- [ ] Windows
- [x] macOS
- [ ] Linux

# Checklist:

- [ ] (v2 only) I have updated `website/src/pages/changelog.mdx` with details of this PR (v3 changelog entries are added automatically)
- [x] My code follows the general coding style of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added an unreleased changelog entry for the generic asynchronous FIFO mailbox.
  * Removed the entry from the previous alpha release section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->