### PR TITLE
fix(docs): repair docs site build after Starlight 0.41 / starlight-blog 0.28 bump

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -168,7 +168,7 @@ export default defineConfig({
         {
           label: "Tutorials",
           collapsed: true,
-          autogenerate: { directory: "tutorials" },
+          items: [{ autogenerate: { directory: "tutorials" } }],
         },
 
         // Core Concepts
@@ -244,47 +244,47 @@ export default defineConfig({
             {
               label: "Autostart",
               collapsed: true,
-              autogenerate: { directory: "features/autostart" },
+              items: [{ autogenerate: { directory: "features/autostart" } }],
             },
             {
               label: "Clipboard",
               collapsed: true,
-              autogenerate: { directory: "features/clipboard" },
+              items: [{ autogenerate: { directory: "features/clipboard" } }],
             },
             {
               label: "Browser",
               collapsed: true,
-              autogenerate: { directory: "features/browser" },
+              items: [{ autogenerate: { directory: "features/browser" } }],
             },
             {
               label: "Drag & Drop",
               collapsed: true,
-              autogenerate: { directory: "features/drag-and-drop" },
+              items: [{ autogenerate: { directory: "features/drag-and-drop" } }],
             },
             {
               label: "Keyboard",
               collapsed: true,
-              autogenerate: { directory: "features/keyboard" },
+              items: [{ autogenerate: { directory: "features/keyboard" } }],
             },
             {
               label: "Notifications",
               collapsed: true,
-              autogenerate: { directory: "features/notifications" },
+              items: [{ autogenerate: { directory: "features/notifications" } }],
             },
             {
               label: "Screens",
               collapsed: true,
-              autogenerate: { directory: "features/screens" },
+              items: [{ autogenerate: { directory: "features/screens" } }],
             },
             {
               label: "Environment",
               collapsed: true,
-              autogenerate: { directory: "features/environment" },
+              items: [{ autogenerate: { directory: "features/environment" } }],
             },
             {
               label: "Platform-Specific",
               collapsed: true,
-              autogenerate: { directory: "features/platform" },
+              items: [{ autogenerate: { directory: "features/platform" } }],
             },
           ],
         },
@@ -446,10 +446,10 @@ export default defineConfig({
                 { label: "Overview", link: "/community/showcase" },
                 {
                   label: "Applications",
-                  autogenerate: {
+                  items: [{ autogenerate: {
                     directory: "community/showcase",
                     collapsed: true,
-                  },
+                  } }],
                 },
               ],
             },

--- a/docs/src/content/authors.ts
+++ b/docs/src/content/authors.ts
@@ -1,6 +1,9 @@
 import type { StarlightBlogUserConfig } from "starlight-blog";
 
-type Authors = NonNullable<StarlightBlogUserConfig>["authors"];
+// starlight-blog v0.28 accepts either one blog config or an array of them.
+// Authors live on a single config, so narrow the union before indexing it.
+type BlogConfig = Exclude<NonNullable<StarlightBlogUserConfig>, readonly unknown[]>;
+type Authors = BlogConfig["authors"];
 export const authors: Authors = {
   leaanthony: {
     name: "Lea Anthony",


### PR DESCRIPTION
The docs site does not build on `master`. Two independent breakages, both introduced by the same dependency bump.

## Root cause

`e4d9b5416` (#5871, Dependabot) bumped Astro 6→7, Starlight 0.38.4→0.41.6 and starlight-blog 0.26.1→0.28.0. These are exact pins in `docs/package.json`, so this is not version drift — the config was never migrated alongside the bump.

**1. Starlight 0.39.0 removed `label` on `autogenerate` sidebar groups.**

```
[AstroUserError] Invalid config passed to starlight integration
  sidebar.3: Did not match union.
  Found an `autogenerate` object with a `label`. Support for autogenerated
  sidebar groups was removed in Starlight v0.39.0.
```

All 11 groups in `docs/astro.config.mjs` use the old form; the error only names the first two. Migrated mechanically to the documented replacement — the group keeps its `label` and `collapsed`, and the `autogenerate` config moves into an `items` array:

```js
- autogenerate: { directory: "tutorials" },
+ items: [{ autogenerate: { directory: "tutorials" } }],
```

**2. starlight-blog 0.28.0 added multi-blog support.** Its user config became `BlogConfig | BlogConfig[]`:

```ts
const configSchema = z.union([blogConfigSchema, z.array(blogConfigSchema).min(1)])
```

`docs/src/content/authors.ts` indexes `["authors"]` on that union, which no longer type-checks (`astro check` fails with `ts(2339)`). Narrowed to the object member before indexing.

## Verification

Cold build (`rm -rf dist .astro node_modules/.astro`) on Node 22.22.3:

```
Result (7 files):
- 0 errors
· All internal links are valid. ·
180 page(s) built in 6.53s
Complete!
```

Sidebar autogeneration still populates rather than silently emptying — Tutorials 5 links, Autostart 1, Showcase 37.

## Note: no CI covers this

None of the 19 workflows in `.github/workflows` run `astro build` or work in `docs/`, which is why #5871 could merge with the site build broken. Worth adding a docs build check so the next dependency bump can't do the same — not included here to keep this PR to the fix.

## Note for contributors

Astro 7 requires Node ≥22.12.0. `docs/.nvmrc` and `docs/.node-version` already pin `22.12.0`, but nothing enforces it, so an older Node fails earlier with `Node.js v20.x.x is not supported by Astro!` and hides the errors above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved documentation navigation by organizing tutorials, feature sections, and community showcases into nested sidebar sections.
  * Updated author configuration handling to maintain compatibility with the latest blog documentation setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->