### PR TITLE
fix(v3/windows): bound the WebView2 embed wait and re-enable the cookie test

### DIFF
--- a/v3/internal/webview2/internal/w32/w32.go
+++ b/v3/internal/webview2/internal/w32/w32.go
@@ -41,6 +41,13 @@ var (
 	User32SetWindowLongPtrW  = user32.NewProc("SetWindowLongPtrW")
 	User32AdjustWindowRect   = user32.NewProc("AdjustWindowRect")
 	User32SetWindowPos       = user32.NewProc("SetWindowPos")
+
+	// GetMessageW blocks until a message arrives, which makes any loop built on
+	// it unbounded. These two allow a message loop to wait with a deadline
+	// instead: MsgWaitForMultipleObjects returns on either input or timeout,
+	// and PeekMessageW then drains whatever arrived.
+	User32MsgWaitForMultipleObjects = user32.NewProc("MsgWaitForMultipleObjects")
+	User32PeekMessageW              = user32.NewProc("PeekMessageW")
 )
 
 const (
@@ -57,6 +64,17 @@ const (
 
 const (
 	SWShow = 5
+)
+
+const (
+	WM_QUIT = 0x0012
+
+	PM_REMOVE = 0x0001
+
+	// QS_ALLINPUT wakes MsgWaitForMultipleObjects for any queued message.
+	QS_ALLINPUT = 0x04FF
+
+	WAIT_TIMEOUT = 0x00000102
 )
 
 const (

--- a/v3/internal/webview2/pkg/edge/chromium.go
+++ b/v3/internal/webview2/pkg/edge/chromium.go
@@ -210,25 +210,74 @@ func (e *Chromium) Embed(hwnd uintptr) bool {
 		e.errorCallback(fmt.Errorf("error getting Webview2 runtime version: %s", err.Error()))
 	}
 
-	var msg w32.Msg
-	for {
-		if atomic.LoadUintptr(&e.inited) != 0 {
-			break
-		}
-		r, _, _ := w32.User32GetMessageW.Call(
-			uintptr(unsafe.Pointer(&msg)),
-			0,
-			0,
-			0,
-		)
-		if r == 0 {
-			break
-		}
-		w32.User32TranslateMessage.Call(uintptr(unsafe.Pointer(&msg)))
-		w32.User32DispatchMessageW.Call(uintptr(unsafe.Pointer(&msg)))
+	// Pump until the controller reports ready, but never without a deadline.
+	//
+	// CreateCoreWebView2Controller is asynchronous and is not guaranteed to
+	// call back at all: in a session with no interactive window station it
+	// returns success, reports no error, and simply never completes. A
+	// GetMessageW loop keyed only on e.inited then blocks forever, so a
+	// recoverable environment failure presents as a hung window with nothing
+	// logged. Wait on the message queue with a timeout instead, and give up.
+	if !e.pumpUntilInited(embedTimeout) {
+		e.errorCallback(fmt.Errorf("timed out after %s waiting for the WebView2 controller; "+
+			"the WebView2 runtime did not complete initialisation", embedTimeout))
+		return false
 	}
+
 	e.Init("window.external={invoke:s=>window.chrome.webview.postMessage(s)}")
 	return true
+}
+
+// embedTimeout bounds how long Embed waits for CreateCoreWebView2Controller to
+// complete. Controller creation is normally well under a second; this is a
+// backstop for the case where the callback never arrives, not a budget.
+const embedTimeout = 30 * time.Second
+
+// pumpUntilInited runs a message loop until the controller is ready, the queue
+// receives WM_QUIT, or timeout elapses. It reports whether the controller
+// became ready.
+func (e *Chromium) pumpUntilInited(timeout time.Duration) bool {
+	var msg w32.Msg
+	deadline := time.Now().Add(timeout)
+
+	for {
+		if atomic.LoadUintptr(&e.inited) != 0 {
+			return true
+		}
+
+		remaining := time.Until(deadline)
+		if remaining <= 0 {
+			return false
+		}
+
+		// Wake on any queued message or when the deadline expires, whichever
+		// comes first. Unlike GetMessageW this cannot park indefinitely.
+		r, _, _ := w32.User32MsgWaitForMultipleObjects.Call(
+			0, 0, 0,
+			uintptr(uint32(remaining.Milliseconds())),
+			w32.QS_ALLINPUT,
+		)
+		if r == w32.WAIT_TIMEOUT {
+			continue // re-check inited once more, then fail on the deadline
+		}
+
+		// MsgWaitForMultipleObjects only signals that the queue is non-empty;
+		// it does not remove anything. Drain what is there before waiting again,
+		// or the next wait returns immediately on the same message.
+		for {
+			got, _, _ := w32.User32PeekMessageW.Call(
+				uintptr(unsafe.Pointer(&msg)), 0, 0, 0, w32.PM_REMOVE,
+			)
+			if got == 0 {
+				break
+			}
+			if msg.Message == w32.WM_QUIT {
+				return atomic.LoadUintptr(&e.inited) != 0
+			}
+			w32.User32TranslateMessage.Call(uintptr(unsafe.Pointer(&msg)))
+			w32.User32DispatchMessageW.Call(uintptr(unsafe.Pointer(&msg)))
+		}
+	}
 }
 
 func (e *Chromium) SetPadding(padding Rect) {

--- a/v3/internal/webview2/pkg/edge/chromium.go
+++ b/v3/internal/webview2/pkg/edge/chromium.go
@@ -215,13 +215,16 @@ func (e *Chromium) Embed(hwnd uintptr) bool {
 	// CreateCoreWebView2Controller is asynchronous and is not guaranteed to
 	// call back at all: in a session with no interactive window station it
 	// returns success, reports no error, and simply never completes. A
-	// GetMessageW loop keyed only on e.inited then blocks forever, so a
-	// recoverable environment failure presents as a hung window with nothing
-	// logged. Wait on the message queue with a timeout instead, and give up.
+	// GetMessageW loop keyed only on e.inited then blocks forever, so the
+	// failure presents as a hung window with nothing logged. Wait on the
+	// message queue with a timeout instead, so it fails loudly and promptly.
+	//
+	// A webview that never initialises leaves nothing to host the application,
+	// so this is fatal by design: errorCallback reports and exits, and nothing
+	// below runs.
 	if !e.pumpUntilInited(embedTimeout) {
 		e.errorCallback(fmt.Errorf("timed out after %s waiting for the WebView2 controller; "+
 			"the WebView2 runtime did not complete initialisation", embedTimeout))
-		return false
 	}
 
 	e.Init("window.external={invoke:s=>window.chrome.webview.postMessage(s)}")

--- a/v3/internal/webview2/pkg/edge/cookies_test.go
+++ b/v3/internal/webview2/pkg/edge/cookies_test.go
@@ -3,7 +3,6 @@
 package edge
 
 import (
-	"os"
 	"runtime"
 	"testing"
 	"time"
@@ -16,22 +15,20 @@ import (
 )
 
 func TestCookieManager(t *testing.T) {
-	// This is the only test here that embeds a real WebView2. It needs an
-	// interactive window station and a runtime that delivers the
-	// environment-created callback, neither of which CI reliably provides.
+	// WebView2 has thread affinity: the control must be created on a thread
+	// with a message pump, and every later call on it — including the cookie
+	// manager and Release — has to happen on that same thread. A Go test
+	// goroutine is free to migrate between OS threads, so pin it for the whole
+	// test before initialising the apartment.
 	//
-	// When that callback does not arrive, Chromium.Embed's message pump has no
-	// deadline — GetMessageW returns 0 only on WM_QUIT — so it spins until the
-	// 10 minute package timeout and takes the whole Windows job down with it,
-	// blocking unrelated pull requests. Skipping keeps that failure mode out of
-	// CI; the pump itself still needs a deadline, which is tracked separately.
-	if os.Getenv("WAILS_TEST_WEBVIEW2") == "" && os.Getenv("CI") != "" {
-		t.Skip("skipping WebView2 embed test in CI; set WAILS_TEST_WEBVIEW2=1 to run it")
-	}
-
-	// Initialize COM
+	// This is also why the cookie assertions below are plain blocks rather than
+	// t.Run subtests: t.Run invokes each subtest on a new goroutine, and
+	// LockOSThread does not extend to it, so the subtests were calling into the
+	// control from outside the apartment that created it.
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()
+
+	// Initialize COM
 	err := windows.CoInitializeEx(0, windows.COINIT_APARTMENTTHREADED)
 	if err != nil {
 		t.Fatalf("Failed to initialize COM: %v", err)
@@ -100,7 +97,8 @@ func TestCookieManager(t *testing.T) {
 	err = cookieManager.DeleteAllCookies()
 	require.NoError(t, err, "Should delete all cookies without error")
 
-	t.Run("Test Cookie Creation and Properties", func(t *testing.T) {
+	// Cookie creation and properties.
+	{
 		// Create a new cookie
 		cookie, err := cookieManager.CreateCookie("testCookie", "testValue", "example.com", "/test")
 		require.NoError(t, err, "Should create cookie without error")
@@ -162,9 +160,10 @@ func TestCookieManager(t *testing.T) {
 		sameSite, err := cookie.GetSameSite()
 		assert.NoError(t, err, "Should get SameSite without error")
 		assert.Equal(t, int32(2), sameSite, "Cookie SameSite should be Lax")
-	})
+	}
 
-	t.Run("Test Cookie Management", func(t *testing.T) {
+	// Cookie management.
+	{
 		// Create and add a cookie
 		cookie, err := cookieManager.CreateCookie("managedCookie", "testValue", "example.com", "/test")
 		require.NoError(t, err, "Should create cookie without error")
@@ -180,5 +179,5 @@ func TestCookieManager(t *testing.T) {
 		// Delete all cookies
 		err = cookieManager.DeleteAllCookies()
 		assert.NoError(t, err, "Should delete all cookies without error")
-	})
+	}
 }


### PR DESCRIPTION
Follow-up to #5951, which skipped `TestCookieManager` in CI as a stopgap. This fixes the underlying cause and re-enables the test.

Reproduced and verified on a real Windows host, not inferred.

## The hang is a production bug, not a test bug

`Chromium.Embed` pumped messages with `GetMessageW` keyed only on `e.inited`. `CreateCoreWebView2Controller` is asynchronous and is **not guaranteed to call back at all** — in a session with no interactive window station it returns success, logs no error, and simply never completes. `GetMessageW` returns 0 only on `WM_QUIT`, so the loop had no way out.

The consequence outside CI: a user whose WebView2 runtime fails to bring up a controller gets a permanently hung window with nothing logged. In CI, Go's 10 minute test timeout was the only thing that ever broke the loop, which is why one flaky test killed the whole Windows job.

Verified on `win-node1` over SSH (session 0, no interactive window station) — this reproduces **deterministically**, unlike the 1-in-3 flake on GitHub runners:

```
=== RUN   TestCookieManager
[WebView2] Environment created successfully
panic: test timed out after 1m30s
	running tests:
		TestCookieManager (1m30s)
...
edge.(*Chromium).Embed(...) chromium.go:218
```

Note `Environment created successfully` — the environment succeeds and the *controller* never completes, with no error on any path.

## Changes

**Bound the wait.** `Embed` now waits with a deadline via `MsgWaitForMultipleObjects` + `PeekMessageW` instead of parking in `GetMessageW`. On timeout it reports through `errorCallback`, which is fatal by design — a webview that never initialises leaves nothing to host the application, so there is no recovery to return to. Adds those two procs and the four constants they need to `internal/w32`. The 30s constant is a backstop, not a budget — controller creation is normally well under a second.

**Pin the test to its apartment.** WebView2 has thread affinity: every call on the control must happen on the thread that created it. The test goroutine could migrate between OS threads, so it is now pinned before `CoInitializeEx` (kept from #5951, thanks @copilot).

**Flatten the subtests.** `t.Run` invokes each subtest on a *new* goroutine, and `runtime.LockOSThread` does not extend to it — so the cookie-manager calls and `Release` inside the two subtests were running outside the apartment that created the control. They are now plain blocks in the parent test. Thanks @coderabbitai, this was the substantive catch.

**Re-enable the test**, dropping the `WAILS_TEST_WEBVIEW2` / `CI` skip from #5951. This also moots CodeRabbit's note that the guard accepted any non-empty value rather than exactly `1`.

## Verification

**1. The timeout path, against a real WebView2** — same host and session that used to hang for 10 minutes:

```
=== RUN   TestCookieManager
[WebView2] Environment created successfully
[WebView2 Error] timed out after 30s waiting for the WebView2 controller; the WebView2 runtime did not complete initialisation
FAIL	github.com/wailsapp/wails/v3/internal/webview2/pkg/edge	30.047s
ELAPSED: 31s
```

10 minute hang that killed the job → 30 second stop naming the cause.

**2. The success path.** Replacing `GetMessageW` changes the path every Windows app takes, so it needed proving rather than assuming. A standalone harness on the same host, using the identical loop, posts a message and confirms it is dispatched to the `WndProc`, then confirms the deadline fires when nothing is posted:

```
dispatched=true elapsed=0s
timeout_path_returned=false elapsed=2.008s
RESULT: PASS
```

**3. Build.** `GOOS=windows go build ./...`, `go vet ./internal/webview2/...` and `go test -c` all clean. (`internal/commands/build_assets/ios` fails to build identically on clean master — pre-existing and unrelated.)

## What is not verified here

I could not run the full green path of `TestCookieManager` end to end: it needs an interactive window station, and the only interactive session on that host belongs to another user. CI is the check for that — the test passed there in ~14s before, and this change does not alter what happens once the controller completes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * WebView2 initialization now has a 30-second timeout instead of waiting indefinitely.
  * Initialization failures are reported clearly, improving application responsiveness.
  * WebView2 cookie operations now reliably run on the required Windows thread.
  * Message processing during startup is more responsive and stops cleanly when the application exits.

* **Tests**
  * Improved WebView2 embedding and cookie tests to better reflect Windows thread-affinity requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->