### PR TITLE
feat(v3): add startup lifecycle events and harden release automation

### DIFF
--- a/.github/workflows/nightly-release-v3.yml
+++ b/.github/workflows/nightly-release-v3.yml
@@ -15,6 +15,11 @@ on:
         required: false
         default: true
         type: boolean
+      release_version:
+        description: 'Optional explicit version for an ad-hoc release (e.g. v3.0.0-beta.8)'
+        required: false
+        default: ''
+        type: string
 
 jobs:
   nightly-release:
@@ -89,50 +94,20 @@ jobs:
       id: quick_check
       run: |
         echo "🔍 Quick check for changes to determine if we should continue..."
-        
-        # Release bookkeeping can be committed after a tag is created. In
-        # particular, the auto-changelog workflow may add an entry to
-        # UNRELEASED_CHANGELOG.md after the release has already completed.
-        # That is not a new release input and must not create another nightly
-        # release on its own.
-        if CURRENT_TAG=$(git describe --tags --exact-match HEAD 2>/dev/null); then
-          LATEST_TAG="$CURRENT_TAG"
-          echo "Current commit has release tag: $LATEST_TAG"
-        else
-          # Only consider the active release series (alpha2/beta/rc): they
-          # outrank legacy alpha tags, and explicit patterns avoid stray tags
-          # such as v3.0.0-alpha.98-tui being selected as the baseline.
-          LATEST_TAG=$(git tag --list "v3.0.0-alpha2.*" "v3.0.0-beta.*" "v3.0.0-rc.*" | sort -V | tail -1)
-        fi
-
-        if [ -z "$LATEST_TAG" ]; then
-          echo "No previous release found; a release is eligible if changelog content exists."
-          if [ "${{ steps.changelog_check.outputs.has_unreleased_content }}" == "true" ]; then
-            echo "has_changes=true" >> $GITHUB_OUTPUT
-            echo "should_continue=true" >> $GITHUB_OUTPUT
-            echo "reason=Unreleased changelog content with no previous release" >> $GITHUB_OUTPUT
-          else
-            echo "has_changes=false" >> $GITHUB_OUTPUT
-            echo "should_continue=false" >> $GITHUB_OUTPUT
-            echo "reason=No previous release and no unreleased changelog content" >> $GITHUB_OUTPUT
-          fi
-        elif git diff --quiet "${LATEST_TAG}..HEAD" -- \
-          . \
-          ':(exclude)v3/internal/version/version.txt' \
-          ':(exclude)v3/UNRELEASED_CHANGELOG.md' \
-          ':(exclude)docs/src/content/docs/changelog.mdx' \
-          ':(exclude)v3/internal/runtime/desktop/@wailsio/runtime/package.json' \
-          ':(exclude)v3/internal/runtime/desktop/@wailsio/runtime/package-lock.json'; then
-          echo "No release inputs changed since $LATEST_TAG; skipping release."
-          echo "has_changes=false" >> $GITHUB_OUTPUT
-          echo "should_continue=false" >> $GITHUB_OUTPUT
-          echo "reason=Only release bookkeeping changed since $LATEST_TAG" >> $GITHUB_OUTPUT
-        else
-          CHANGE_COUNT=$(git rev-list "${LATEST_TAG}..HEAD" --count)
-          echo "Found release inputs in $CHANGE_COUNT commits since $LATEST_TAG"
+        # The unreleased changelog is the release input. Do not infer that a
+        # release is needed from arbitrary commits after the previous tag:
+        # release bookkeeping, documentation automation, and other unrelated
+        # commits must not create a release by themselves.
+        if [ "${{ steps.changelog_check.outputs.has_unreleased_content }}" == "true" ]; then
+          echo "✅ Found unreleased changelog content, proceeding with release"
           echo "has_changes=true" >> $GITHUB_OUTPUT
           echo "should_continue=true" >> $GITHUB_OUTPUT
-          echo "reason=Release inputs changed since $LATEST_TAG" >> $GITHUB_OUTPUT
+          echo "reason=Found unreleased changelog content" >> $GITHUB_OUTPUT
+        else
+          echo "ℹ️  No unreleased changelog content found; skipping release."
+          echo "has_changes=false" >> $GITHUB_OUTPUT
+          echo "should_continue=false" >> $GITHUB_OUTPUT
+          echo "reason=No unreleased changelog content" >> $GITHUB_OUTPUT
         fi
     
     - name: Early exit - No changes detected
@@ -176,11 +151,16 @@ jobs:
         # PAT produced a half-release: tag pushed, no GitHub release.
         WAILS_REPO_TOKEN: ${{ secrets.WAILS_REPO_TOKEN }}
         GITHUB_TOKEN: ${{ github.token }}
+        DRY_RUN: ${{ inputs.dry_run }}
+        RELEASE_VERSION: ${{ inputs.release_version }}
       run: |
         cd v3/tasks/release
         ARGS=()
-        if [ "${{ github.event.inputs.dry_run }}" == "true" ]; then
+        if [ "$DRY_RUN" == "true" ]; then
           ARGS+=(--dry-run)
+        fi
+        if [ -n "$RELEASE_VERSION" ]; then
+          ARGS+=(--version "$RELEASE_VERSION")
         fi
         go run release.go "${ARGS[@]}"
 

--- a/docs/src/content/docs/concepts/lifecycle.mdx
+++ b/docs/src/content/docs/concepts/lifecycle.mdx
@@ -43,6 +43,16 @@ ServiceStartup: "Service Startup" {
   style.fill: "#8B5CF6"
 }
 
+ApplicationStarting: "ApplicationStarting" {
+  shape: rectangle
+  style.fill: "#10B981"
+}
+
+ApplicationInitialized: "ApplicationInitialized" {
+  shape: rectangle
+  style.fill: "#10B981"
+}
+
 EventLoop: "Event Loop" {
   Process: "Process Events" {
     shape: rectangle
@@ -93,9 +103,11 @@ Start -> Init.Parse
 Init.Parse -> Init.Register
 Init.Register -> Init.Setup
 Init.Setup -> AppRun
-AppRun -> ServiceStartup
-ServiceStartup -> EventLoop.Process
-EventLoop.Process -> EventLoop.Handle
+AppRun -> EventLoop.Process
+EventLoop.Process -> ApplicationStarting
+ApplicationStarting -> ServiceStartup
+ServiceStartup -> ApplicationInitialized
+ApplicationInitialized -> EventLoop.Handle
 EventLoop.Handle -> EventLoop.Update
 EventLoop.Update -> EventLoop.Process: "Loop"
 EventLoop.Process -> QuitSignal: "User quits"
@@ -143,10 +155,28 @@ if err != nil {
 ```
 
 **What happens:**
-1. Services are started in registration order
-2. Event listeners are activated
-3. Windows can be created
-4. Event loop begins
+1. Event listeners and the native UI event loop are activated
+2. `ApplicationStarting` is emitted when window operations become available
+3. Services are started in registration order on a background goroutine
+4. `ApplicationInitialized` is emitted after all services start successfully
+5. Pending application windows are started
+
+The UI event loop remains responsive while services initialise. This allows an
+application to show and update a splash window during a long-running startup:
+
+```go
+app.Event.OnApplicationEvent(events.Common.ApplicationStarting, func(*application.ApplicationEvent) {
+    splash.Show()
+})
+
+app.Event.OnApplicationEvent(events.Common.ApplicationInitialized, func(*application.ApplicationEvent) {
+    splash.Close()
+    mainWindow.Show()
+})
+```
+
+Create windows that should not appear during initialisation with `Hidden: true`.
+If a service fails to start, `ApplicationInitialized` is not emitted.
 
 ### 3. Event Loop
 
@@ -704,7 +734,9 @@ func (s *WorkerService) runWorker(ctx context.Context) {
 
 | Hook/Interface | When Called | Can Cancel? | Use For |
 |----------------|-------------|-------------|---------|
-| `ServiceStartup` | During `app.Run()`, before event loop | No (return error to abort) | Initialisation |
+| `ApplicationStarting` | After the native event loop starts, before services initialise | No | Show startup UI |
+| `ServiceStartup` | During `app.Run()`, on the background startup goroutine | No (return error to abort) | Initialisation |
+| `ApplicationInitialized` | After every service starts successfully | No | Dismiss startup UI and show the application |
 | `ServiceShutdown` | During shutdown, after `OnShutdown` | No | Cleanup |
 | `OnShutdown` | When quit confirmed | No | Application cleanup |
 | `ShouldQuit` | When quit requested | Yes (return false) | Confirm quit |

--- a/docs/src/content/docs/reference/events.mdx
+++ b/docs/src/content/docs/reference/events.mdx
@@ -219,7 +219,9 @@ func (em *EventManager) OnApplicationEvent(
 Event constants live in the `events` package — `events.Common.*` for cross-platform events, `events.Mac.*` / `events.Windows.*` / `events.Linux.*` for platform-specific ones.
 
 **Common application events:**
-- `events.Common.ApplicationStarted` - Application has finished launching.
+- `events.Common.ApplicationStarted` - The platform has reached its ready boundary.
+- `events.Common.ApplicationStarting` - Background service initialisation is about to begin.
+- `events.Common.ApplicationInitialized` - All services have initialised successfully.
 - `events.Common.ThemeChanged` - System theme switched between light and dark.
 - `events.Common.ApplicationOpenedWithFile` - Launched via a file association.
 - `events.Common.ApplicationLaunchedWithUrl` - Launched via a URL scheme.
@@ -711,7 +713,9 @@ This mapping happens automatically in the background, so when you listen for `ev
 | Event | Description | When Emitted | Cancellable |
 |-------|-------------|--------------|-------------|
 | `ApplicationOpenedWithFile` | Application opened with a file | When app is launched with a file (e.g., from file association) | No |
-| `ApplicationStarted` | Application has finished launching | After app initialization is complete and app is ready | No |
+| `ApplicationStarted` | Native platform application launched | When the platform reports its ready boundary | No |
+| `ApplicationStarting` | Background initialisation is beginning | Before service startup | No |
+| `ApplicationInitialized` | Application services are ready | After all services start successfully | No |
 | `ApplicationLaunchedWithUrl` | Application launched with a URL | When app is launched via URL scheme | No |
 | `ThemeChanged` | System theme changed | When OS theme switches between light/dark mode | No |
 | `SystemWillSleep` | System is about to suspend | Just before the OS suspends (macOS / Windows / Linux-with-logind) | No |

--- a/v3/examples/splashscreen/README.md
+++ b/v3/examples/splashscreen/README.md
@@ -1,0 +1,12 @@
+# Splash screen lifecycle example
+
+This example demonstrates the `ApplicationStarting` and
+`ApplicationInitialized` lifecycle events. It shows a responsive splash window
+while an unchanged `ServiceStartup` implementation deliberately waits for five
+seconds, then closes the splash and reveals the main window.
+
+Run it from the `v3` directory:
+
+```sh
+go run ./examples/splashscreen
+```

--- a/v3/examples/splashscreen/main.go
+++ b/v3/examples/splashscreen/main.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"context"
+	"log"
+	"time"
+
+	"github.com/wailsapp/wails/v3/pkg/application"
+	"github.com/wailsapp/wails/v3/pkg/events"
+)
+
+const splashHTML = `<!doctype html>
+<html><head><meta charset="utf-8"><style>
+* { box-sizing: border-box; }
+html, body { width: 100%; height: 100%; margin: 0; }
+body { display: grid; place-items: center; color: #f7fafc; background: radial-gradient(circle at top, #384766, #111827 72%); font-family: system-ui, sans-serif; user-select: none; }
+main { text-align: center; }
+.mark { width: 74px; height: 74px; margin: 0 auto 22px; border: 5px solid rgba(255,255,255,.2); border-top-color: #70d6ff; border-radius: 50%; animation: spin .9s linear infinite; }
+h1 { margin: 0 0 8px; font-size: 27px; letter-spacing: .02em; }
+p { margin: 0; color: #b8c4da; font-size: 14px; }
+@keyframes spin { to { transform: rotate(360deg); } }
+</style></head><body><main><div class="mark"></div><h1>Starting Wails</h1><p>Initialising application services…</p></main></body></html>`
+
+const mainHTML = `<!doctype html>
+<html><head><meta charset="utf-8"><style>
+html, body { height: 100%; margin: 0; }
+body { display: grid; place-items: center; background: #f7fafc; color: #172033; font-family: system-ui, sans-serif; }
+main { max-width: 540px; padding: 48px; text-align: center; }
+h1 { font-size: 34px; margin-bottom: 12px; }
+p { color: #526079; line-height: 1.6; }
+</style></head><body><main><h1>Application initialised</h1><p>The native event loop remained responsive while the example service spent five seconds starting.</p></main></body></html>`
+
+type slowService struct{}
+
+func (*slowService) ServiceStartup(ctx context.Context, _ application.ServiceOptions) error {
+	log.Println("slow service: starting five-second initialisation")
+	timer := time.NewTimer(5 * time.Second)
+	defer timer.Stop()
+
+	select {
+	case <-timer.C:
+		log.Println("slow service: initialisation complete")
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func main() {
+	app := application.New(application.Options{
+		Name:        "Splash Screen Lifecycle Demo",
+		Description: "Shows a responsive splash screen while services initialise",
+		Services: []application.Service{
+			application.NewService(&slowService{}),
+		},
+		Mac: application.MacOptions{
+			ApplicationShouldTerminateAfterLastWindowClosed: true,
+		},
+	})
+
+	splash := app.Window.NewWithOptions(application.WebviewWindowOptions{
+		Name:            "splash",
+		Width:           460,
+		Height:          300,
+		Hidden:          true,
+		Frameless:       true,
+		DisableResize:   true,
+		AlwaysOnTop:     true,
+		InitialPosition: application.WindowCentered,
+		HTML:            splashHTML,
+	})
+
+	mainWindow := app.Window.NewWithOptions(application.WebviewWindowOptions{
+		Name:            "main",
+		Title:           "Wails Lifecycle Demo",
+		Width:           800,
+		Height:          520,
+		Hidden:          true,
+		InitialPosition: application.WindowCentered,
+		HTML:            mainHTML,
+	})
+
+	app.Event.OnApplicationEvent(events.Common.ApplicationStarting, func(*application.ApplicationEvent) {
+		log.Println("ApplicationStarting: showing splash")
+		splash.Show()
+	})
+
+	app.Event.OnApplicationEvent(events.Common.ApplicationInitialized, func(*application.ApplicationEvent) {
+		log.Println("ApplicationInitialized: replacing splash with main window")
+		splash.Close()
+		mainWindow.Show()
+	})
+
+	if err := app.Run(); err != nil {
+		log.Fatal(err)
+	}
+}

--- a/v3/pkg/application/application.go
+++ b/v3/pkg/application/application.go
@@ -14,10 +14,12 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 
 	"github.com/wailsapp/wails/v3/internal/assetserver"
 	"github.com/wailsapp/wails/v3/internal/assetserver/webview"
 	"github.com/wailsapp/wails/v3/internal/capabilities"
+	"github.com/wailsapp/wails/v3/pkg/events"
 	"github.com/wailsapp/wails/v3/pkg/updater"
 )
 
@@ -25,6 +27,8 @@ import (
 var alphaAssets embed.FS
 
 var globalApplication *App
+var startEventLoopsOnce sync.Once
+var activeEventLoopApp atomic.Pointer[App]
 
 // AlphaAssets is the default assets for the alpha application
 var AlphaAssets = AssetOptions{
@@ -664,106 +668,170 @@ func (a *App) Run() error {
 	// Ensure application context is canceled before service shutdown (duplicate calls don't hurt).
 	defer a.cancel()
 
-	// startup performs the remaining startup sequence: start services, spawn the
-	// event-handling reader goroutines, run any pending windows, and apply the
-	// menu/icon. On desktop this runs inline on the main goroutine. On iOS it is
-	// deferred to a background goroutine (see below).
-	startup := func() error {
-		// Startup services before dispatching any events.
-		// No need to hold the lock here because a.options.Services may only change when a.running is false.
-		services := a.options.Services
-		a.options.Services = nil
-		for i, service := range services {
-			if err := a.startupService(service); err != nil {
-				return fmt.Errorf("error starting service '%s': %w", getServiceName(service), err)
-			}
-			// Schedule started services for shutdown.
-			a.options.Services = services[:i+1]
-		}
+	// Start event handling before entering the native event loop. The remaining
+	// initialisation is triggered by the platform's ApplicationStarted event, so
+	// native window operations are available while services start in the
+	// background.
+	a.startEventLoops()
+	activeEventLoopApp.Store(a)
+	defer activeEventLoopApp.CompareAndSwap(a, nil)
 
-		// Start the MCP server when the application is built with -tags mcp.
-		// All configuration is read from environment variables (WAILS_MCP_HOST,
-		// WAILS_MCP_PORT, WAILS_MCP_TIMEOUT, WAILS_MCP_HIDE_CURSOR).
-		if err := startMCPServer(a); err != nil {
-			return fmt.Errorf("mcp: %w", err)
-		}
-
-		go func() {
-			for {
-				event := <-applicationEvents
-				go a.Event.handleApplicationEvent(event)
-			}
-		}()
-		go func() {
-			for {
-				event := <-windowEvents
-				go a.handleWindowEvent(event)
-			}
-		}()
-		go func() {
-			for {
-				request := <-webviewRequests
-				go a.handleWebViewRequest(request)
-			}
-		}()
-		go func() {
-			for {
-				event := <-windowMessageBuffer
-				go a.handleWindowMessage(event)
-			}
-		}()
-		go func() {
-			for {
-				event := <-windowKeyEvents
-				go a.handleWindowKeyEvent(event)
-			}
-		}()
-		go func() {
-			for {
-				dragAndDropMessage := <-windowDragAndDropBuffer
-				go a.handleDragAndDropMessage(dragAndDropMessage)
-			}
-		}()
-
-		go func() {
-			for {
-				menuItemID := <-menuItemClicked
-				go a.Menu.handleMenuItemClicked(menuItemID)
-			}
-		}()
-
-		a.runLock.Lock()
-		a.running = true
-		a.runLock.Unlock()
-
-		// Bind any global shortcuts that were registered before the app started.
-		a.GlobalShortcut.flushPending()
-
-		// No need to hold the lock here because
-		//   - a.pendingRun may only change while a.running is false.
-		//   - runnables are scheduled asynchronously anyway.
-		for _, pending := range a.pendingRun {
+	var startupOnce sync.Once
+	var startupErr error
+	var startupErrLock sync.Mutex
+	startupStarted := make(chan struct{})
+	startupDone := make(chan struct{})
+	a.Event.RegisterApplicationEventHook(events.Common.ApplicationStarted, func(*ApplicationEvent) {
+		startupOnce.Do(func() {
+			close(startupStarted)
 			go func() {
-				defer handlePanic()
-				pending.Run()
+				defer close(startupDone)
+				if err := a.finishStartup(); err != nil {
+					startupErrLock.Lock()
+					startupErr = err
+					startupErrLock.Unlock()
+					// Startup now happens asynchronously after the platform loop
+					// begins, so report the fatal failure immediately as well as
+					// returning it once the platform loop exits.
+					a.handleError(&FatalError{err: err})
+					a.Quit()
+				}
 			}()
-		}
-		a.pendingRun = nil
+		})
+	})
 
-		// set the application menu
-		if runtime.GOOS == "darwin" {
-			a.impl.setApplicationMenu(a.applicationMenu)
-		}
-		if a.options.Icon != nil {
-			a.impl.setIcon(a.options.Icon)
-		}
-		return nil
+	a.runLock.Lock()
+	a.running = true
+	a.runLock.Unlock()
+
+	// Bind any global shortcuts that were registered before the app started.
+	a.GlobalShortcut.flushPending()
+
+	// The menu and icon must be configured before the platform loop starts on
+	// platforms that consume them during native activation.
+	if runtime.GOOS == "darwin" {
+		a.impl.setApplicationMenu(a.applicationMenu)
+	}
+	if a.options.Icon != nil {
+		a.impl.setIcon(a.options.Icon)
 	}
 
-	if err := startup(); err != nil {
-		return err
+	runErr := a.impl.run()
+	// Prevent a late native ready event from starting services after the
+	// platform loop has already begun shutting down.
+	startupOnce.Do(func() {})
+	select {
+	case <-startupStarted:
+		<-startupDone
+	default:
 	}
-	return a.impl.run()
+	startupErrLock.Lock()
+	defer startupErrLock.Unlock()
+	if startupErr != nil {
+		return startupErr
+	}
+	return runErr
+}
+
+func (a *App) finishStartup() error {
+	// Dispatch framework lifecycle events directly so their listeners are
+	// scheduled before the next startup phase begins. Native application events
+	// continue to arrive through applicationEvents.
+	a.Event.handleApplicationEventSync(newApplicationEvent(events.Common.ApplicationStarting))
+
+	// No need to hold the lock here because a.options.Services may only change
+	// before Run is called. Services remain sequential even though the startup
+	// sequence itself runs away from the native UI thread.
+	a.serviceShutdownLock.Lock()
+	services := a.options.Services
+	a.options.Services = nil
+	for i, service := range services {
+		if err := a.startupService(service); err != nil {
+			a.serviceShutdownLock.Unlock()
+			return fmt.Errorf("error starting service '%s': %w", getServiceName(service), err)
+		}
+		// Schedule started services for shutdown.
+		a.options.Services = services[:i+1]
+	}
+	a.serviceShutdownLock.Unlock()
+
+	// Start the MCP server when the application is built with -tags mcp.
+	// All configuration is read from environment variables (WAILS_MCP_HOST,
+	// WAILS_MCP_PORT, WAILS_MCP_TIMEOUT, WAILS_MCP_HIDE_CURSOR).
+	if err := startMCPServer(a); err != nil {
+		return fmt.Errorf("mcp: %w", err)
+	}
+
+	a.Event.handleApplicationEventSync(newApplicationEvent(events.Common.ApplicationInitialized))
+
+	// Normal windows remain pending until all subsystems and services have
+	// initialised. A listener for ApplicationStarting may explicitly Show a
+	// pending window (for example a splash screen) while this work is running.
+	a.runLock.Lock()
+	pendingRun := a.pendingRun
+	a.pendingRun = nil
+	a.runLock.Unlock()
+	for _, pending := range pendingRun {
+		go func() {
+			defer handlePanic()
+			pending.Run()
+		}()
+	}
+	return nil
+}
+
+func (a *App) startEventLoops() {
+	startEventLoopsOnce.Do(func() {
+		go func() {
+			for event := range applicationEvents {
+				if app := activeEventLoopApp.Load(); app != nil {
+					go app.Event.handleApplicationEvent(event)
+				}
+			}
+		}()
+		go func() {
+			for event := range windowEvents {
+				if app := activeEventLoopApp.Load(); app != nil {
+					go app.handleWindowEvent(event)
+				}
+			}
+		}()
+		go func() {
+			for request := range webviewRequests {
+				if app := activeEventLoopApp.Load(); app != nil {
+					go app.handleWebViewRequest(request)
+				}
+			}
+		}()
+		go func() {
+			for event := range windowMessageBuffer {
+				if app := activeEventLoopApp.Load(); app != nil {
+					go app.handleWindowMessage(event)
+				}
+			}
+		}()
+		go func() {
+			for event := range windowKeyEvents {
+				if app := activeEventLoopApp.Load(); app != nil {
+					go app.handleWindowKeyEvent(event)
+				}
+			}
+		}()
+		go func() {
+			for message := range windowDragAndDropBuffer {
+				if app := activeEventLoopApp.Load(); app != nil {
+					go app.handleDragAndDropMessage(message)
+				}
+			}
+		}()
+		go func() {
+			for menuItemID := range menuItemClicked {
+				if app := activeEventLoopApp.Load(); app != nil {
+					go app.Menu.handleMenuItemClicked(menuItemID)
+				}
+			}
+		}()
+	})
 }
 
 func (a *App) startupService(service Service) error {
@@ -798,12 +866,13 @@ func (a *App) startupService(service Service) error {
 }
 
 func (a *App) shutdownServices() {
+	// Cancel first so an in-progress ServiceStartup can stop before shutdown
+	// waits for the startup goroutine to release serviceShutdownLock.
+	a.cancel()
+
 	// Acquire lock to prevent double calls (defer in Run() + OnShutdown)
 	a.serviceShutdownLock.Lock()
 	defer a.serviceShutdownLock.Unlock()
-
-	// Ensure app context is cancelled first (duplicate calls don't hurt).
-	a.cancel()
 
 	for len(a.options.Services) > 0 {
 		last := len(a.options.Services) - 1

--- a/v3/pkg/application/application_server.go
+++ b/v3/pkg/application/application_server.go
@@ -14,6 +14,8 @@ import (
 	"syscall"
 	"time"
 	"unsafe"
+
+	"github.com/wailsapp/wails/v3/pkg/events"
 )
 
 // serverApp implements platformApp for server mode.
@@ -135,6 +137,11 @@ func (h *serverApp) run() error {
 			errCh <- h.server.Serve(h.listener)
 		}
 	}()
+
+	// Server mode has no native application event to map to
+	// Common.ApplicationStarted. Treat a listening HTTP server as its ready
+	// boundary so the shared startup coordinator can initialise services.
+	applicationEvents <- newApplicationEvent(events.Common.ApplicationStarted)
 
 	// Wait for shutdown signal or error
 	quit := make(chan os.Signal, 1)

--- a/v3/pkg/application/application_startup_server_test.go
+++ b/v3/pkg/application/application_startup_server_test.go
@@ -1,0 +1,153 @@
+//go:build server
+
+package application
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/wailsapp/wails/v3/pkg/events"
+)
+
+type blockingStartupService struct {
+	started chan struct{}
+	release chan struct{}
+}
+
+func (s *blockingStartupService) ServiceStartup(ctx context.Context, _ ServiceOptions) error {
+	close(s.started)
+	select {
+	case <-s.release:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func TestApplicationLifecycleEventsSurroundServiceStartup(t *testing.T) {
+	resetGlobalApp()
+	t.Cleanup(resetGlobalApp)
+
+	service := &blockingStartupService{
+		started: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+	app := New(Options{
+		Name:     "Lifecycle startup test",
+		Services: []Service{NewService(service)},
+		Server: ServerOptions{
+			Host: "127.0.0.1",
+			Port: 18084,
+		},
+		Assets: AssetOptions{
+			Handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusOK)
+			}),
+		},
+	})
+
+	starting := make(chan struct{})
+	initialized := make(chan struct{})
+	app.Event.OnApplicationEvent(events.Common.ApplicationStarting, func(*ApplicationEvent) {
+		close(starting)
+	})
+	app.Event.OnApplicationEvent(events.Common.ApplicationInitialized, func(*ApplicationEvent) {
+		close(initialized)
+	})
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- app.Run()
+	}()
+
+	waitForSignal(t, starting, "ApplicationStarting")
+	waitForSignal(t, service.started, "service startup")
+
+	select {
+	case <-initialized:
+		t.Fatal("ApplicationInitialized was emitted before service startup completed")
+	default:
+	}
+
+	resp, err := http.Get("http://127.0.0.1:18084/health")
+	if err != nil {
+		t.Fatalf("application was unresponsive during service startup: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("health status during service startup = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+
+	close(service.release)
+	waitForSignal(t, initialized, "ApplicationInitialized")
+	app.Quit()
+
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Fatalf("app.Run() returned error: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for app shutdown")
+	}
+}
+
+func TestQuitCancelsServiceStartupBeforeWaitingForShutdown(t *testing.T) {
+	resetGlobalApp()
+	t.Cleanup(resetGlobalApp)
+
+	service := &blockingStartupService{
+		started: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+	app := New(Options{
+		Name:     "Lifecycle cancellation test",
+		Services: []Service{NewService(service)},
+		Server: ServerOptions{
+			Host: "127.0.0.1",
+			Port: 18085,
+		},
+		Assets: AssetOptions{
+			Handler: http.NotFoundHandler(),
+		},
+	})
+
+	initialized := make(chan struct{})
+	app.Event.OnApplicationEvent(events.Common.ApplicationInitialized, func(*ApplicationEvent) {
+		close(initialized)
+	})
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- app.Run()
+	}()
+
+	waitForSignal(t, service.started, "service startup")
+	app.Quit()
+
+	select {
+	case err := <-errCh:
+		if err == nil {
+			t.Fatal("app.Run() returned nil after service startup was cancelled")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("shutdown deadlocked waiting for service startup")
+	}
+
+	select {
+	case <-initialized:
+		t.Fatal("ApplicationInitialized was emitted after service startup was cancelled")
+	default:
+	}
+}
+
+func waitForSignal(t *testing.T, signal <-chan struct{}, name string) {
+	t.Helper()
+	select {
+	case <-signal:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("timed out waiting for %s", name)
+	}
+}

--- a/v3/pkg/application/event_manager.go
+++ b/v3/pkg/application/event_manager.go
@@ -141,19 +141,27 @@ func (em *EventManager) dispatch(event *CustomEvent) {
 
 // HandleApplicationEvent handles application events (internal use)
 func (em *EventManager) handleApplicationEvent(event *ApplicationEvent) {
+	em.handleApplicationEventWithMode(event, true)
+}
+
+// handleApplicationEventSync dispatches hooks and listeners synchronously. It
+// is reserved for framework lifecycle boundaries whose ordering is part of the
+// startup contract.
+func (em *EventManager) handleApplicationEventSync(event *ApplicationEvent) {
+	em.handleApplicationEventWithMode(event, false)
+}
+
+func (em *EventManager) handleApplicationEventWithMode(event *ApplicationEvent, async bool) {
 	defer handlePanic()
 	em.app.applicationEventListenersLock.RLock()
-	listeners, ok := em.app.applicationEventListeners[event.Id]
+	listeners := slices.Clone(em.app.applicationEventListeners[event.Id])
 	em.app.applicationEventListenersLock.RUnlock()
-	if !ok {
-		return
-	}
 
 	// Process Hooks
 	em.app.applicationEventHooksLock.RLock()
-	hooks, ok := em.app.applicationEventHooks[event.Id]
+	hooks := slices.Clone(em.app.applicationEventHooks[event.Id])
 	em.app.applicationEventHooksLock.RUnlock()
-	if ok {
+	if len(hooks) > 0 {
 		for _, thisHook := range hooks {
 			thisHook.callback(event)
 			if event.IsCancelled() {
@@ -161,14 +169,22 @@ func (em *EventManager) handleApplicationEvent(event *ApplicationEvent) {
 			}
 		}
 	}
+	if len(listeners) == 0 {
+		return
+	}
 
 	for _, listener := range listeners {
-		go func() {
+		invoke := func() {
 			if event.IsCancelled() {
 				return
 			}
 			defer handlePanic()
 			listener.callback(event)
-		}()
+		}
+		if async {
+			go invoke()
+		} else {
+			invoke()
+		}
 	}
 }

--- a/v3/pkg/application/internal/tests/services/shutdown/shutdown_test.go
+++ b/v3/pkg/application/internal/tests/services/shutdown/shutdown_test.go
@@ -54,7 +54,7 @@ func TestServiceShutdown(t *testing.T) {
 
 	app.RegisterService(services[5])
 
-	app.Event.OnApplicationEvent(events.Common.ApplicationStarted, func(*application.ApplicationEvent) {
+	app.Event.OnApplicationEvent(events.Common.ApplicationInitialized, func(*application.ApplicationEvent) {
 		app.Quit()
 	})
 

--- a/v3/pkg/application/internal/tests/services/shutdownerror/shutdownerror_test.go
+++ b/v3/pkg/application/internal/tests/services/shutdownerror/shutdownerror_test.go
@@ -81,7 +81,7 @@ func TestServiceShutdownError(t *testing.T) {
 
 	app.RegisterService(services[5])
 
-	app.Event.OnApplicationEvent(events.Common.ApplicationStarted, func(*application.ApplicationEvent) {
+	app.Event.OnApplicationEvent(events.Common.ApplicationInitialized, func(*application.ApplicationEvent) {
 		app.Quit()
 	})
 

--- a/v3/pkg/application/internal/tests/services/startup/startup_test.go
+++ b/v3/pkg/application/internal/tests/services/startup/startup_test.go
@@ -64,7 +64,7 @@ func TestServiceStartup(t *testing.T) {
 
 	app.RegisterService(services[5])
 
-	app.Event.OnApplicationEvent(events.Common.ApplicationStarted, func(*application.ApplicationEvent) {
+	app.Event.OnApplicationEvent(events.Common.ApplicationInitialized, func(*application.ApplicationEvent) {
 		app.Quit()
 	})
 

--- a/v3/pkg/application/internal/tests/services/startuperror/startuperror_test.go
+++ b/v3/pkg/application/internal/tests/services/startuperror/startuperror_test.go
@@ -55,7 +55,7 @@ func TestServiceStartupError(t *testing.T) {
 
 	app.RegisterService(services[5])
 
-	app.Event.OnApplicationEvent(events.Common.ApplicationStarted, func(*application.ApplicationEvent) {
+	app.Event.OnApplicationEvent(events.Common.ApplicationInitialized, func(*application.ApplicationEvent) {
 		t.Errorf("Application started")
 		app.Quit()
 	})

--- a/v3/pkg/application/internal/tests/services/startupshutdown/startupshutdown_test.go
+++ b/v3/pkg/application/internal/tests/services/startupshutdown/startupshutdown_test.go
@@ -54,7 +54,7 @@ func TestServiceStartupShutdown(t *testing.T) {
 
 	app.RegisterService(services[5])
 
-	app.Event.OnApplicationEvent(events.Common.ApplicationStarted, func(*application.ApplicationEvent) {
+	app.Event.OnApplicationEvent(events.Common.ApplicationInitialized, func(*application.ApplicationEvent) {
 		if count := seq.Load(); count != int64(len(services)) {
 			t.Errorf("Wrong startup call count: wanted %d, got %d", len(services), count)
 		}

--- a/v3/pkg/application/internal/tests/services/startupshutdownerror/startupshutdownerror_test.go
+++ b/v3/pkg/application/internal/tests/services/startupshutdownerror/startupshutdownerror_test.go
@@ -81,7 +81,7 @@ func TestServiceStartupShutdownError(t *testing.T) {
 
 	app.RegisterService(services[5])
 
-	app.Event.OnApplicationEvent(events.Common.ApplicationStarted, func(*application.ApplicationEvent) {
+	app.Event.OnApplicationEvent(events.Common.ApplicationInitialized, func(*application.ApplicationEvent) {
 		t.Errorf("Application started")
 		app.Quit()
 	})

--- a/v3/pkg/application/internal/tests/utils.go
+++ b/v3/pkg/application/internal/tests/utils.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"os"
 	"runtime"
+	"sync"
 	"testing"
 
 	"github.com/wailsapp/wails/v3/pkg/application"
@@ -28,10 +29,13 @@ func New(t *testing.T, options application.Options) *application.App {
 	}
 
 	errorHandler := options.ErrorHandler
+	var fatalErr error
+	var fatalErrLock sync.Mutex
 	options.ErrorHandler = func(err error) {
 		if fatal := (*application.FatalError)(nil); errors.As(err, &fatal) {
-			endChan <- err
-			select {} // Block forever
+			fatalErrLock.Lock()
+			fatalErr = err
+			fatalErrLock.Unlock()
 		} else if errorHandler != nil {
 			errorHandler(err)
 		} else {
@@ -44,7 +48,10 @@ func New(t *testing.T, options application.Options) *application.App {
 		if postShutdown != nil {
 			postShutdown()
 		}
-		endChan <- nil
+		fatalErrLock.Lock()
+		shutdownErr := fatalErr
+		fatalErrLock.Unlock()
+		endChan <- shutdownErr
 		select {} // Block forever
 	}
 
@@ -57,9 +64,6 @@ func Run(t *testing.T, app *application.App) error {
 	case err := <-errChan:
 		return err
 	case fatal := <-endChan:
-		if fatal != nil {
-			t.Fatal(fatal)
-		}
 		return fatal
 	}
 }

--- a/v3/pkg/application/webview_window.go
+++ b/v3/pkg/application/webview_window.go
@@ -171,6 +171,7 @@ type WebviewWindow struct {
 	options WebviewWindowOptions
 	impl    webviewWindowImpl
 	id      uint
+	runLock sync.Mutex
 
 	eventListeners     map[uint][]*WindowEventListener
 	eventListenersLock sync.RWMutex
@@ -478,6 +479,8 @@ func (w *WebviewWindow) SetSize(width, height int) Window {
 }
 
 func (w *WebviewWindow) Run() {
+	w.runLock.Lock()
+	defer w.runLock.Unlock()
 	if w.impl != nil {
 		return
 	}
@@ -507,6 +510,9 @@ func (w *WebviewWindow) SetAlwaysOnTop(b bool) Window {
 
 // Show shows the window.
 func (w *WebviewWindow) Show() Window {
+	w.runLock.Lock()
+	w.options.Hidden = false
+	w.runLock.Unlock()
 	if globalApplication.impl == nil {
 		return w
 	}
@@ -514,7 +520,6 @@ func (w *WebviewWindow) Show() Window {
 		InvokeSync(w.Run)
 		return w
 	}
-	w.options.Hidden = false
 	InvokeSync(w.impl.show)
 	return w
 }

--- a/v3/pkg/application/webview_window_options_test.go
+++ b/v3/pkg/application/webview_window_options_test.go
@@ -4,6 +4,19 @@ import (
 	"testing"
 )
 
+func TestShowClearsHiddenBeforeWindowRuns(t *testing.T) {
+	previousApp := globalApplication
+	globalApplication = &App{}
+	defer func() { globalApplication = previousApp }()
+
+	window := &WebviewWindow{options: WebviewWindowOptions{Hidden: true}}
+	window.Show()
+
+	if window.options.Hidden {
+		t.Fatal("Show left a not-yet-created window hidden")
+	}
+}
+
 func TestNewRGBA(t *testing.T) {
 	rgba := NewRGBA(100, 150, 200, 255)
 

--- a/v3/pkg/events/events.go
+++ b/v3/pkg/events/events.go
@@ -8,6 +8,8 @@ var Common = newCommonEvents()
 type commonEvents struct {
 	ApplicationOpenedWithFile  ApplicationEventType
 	ApplicationStarted         ApplicationEventType
+	ApplicationStarting        ApplicationEventType
+	ApplicationInitialized     ApplicationEventType
 	ApplicationLaunchedWithUrl ApplicationEventType
 	ThemeChanged               ApplicationEventType
 	SystemDidWake              ApplicationEventType
@@ -45,6 +47,8 @@ func newCommonEvents() commonEvents {
 	return commonEvents{
 		ApplicationOpenedWithFile:  1024,
 		ApplicationStarted:         1025,
+		ApplicationStarting:        1292,
+		ApplicationInitialized:     1293,
 		ApplicationLaunchedWithUrl: 1026,
 		ThemeChanged:               1027,
 		SystemDidWake:              1028,
@@ -872,4 +876,6 @@ var eventToJS = map[uint]string{
 	1289: "common:ScreenLocked",
 	1290: "common:ScreenUnlocked",
 	1291: "common:LowMemory",
+	1292: "common:ApplicationStarting",
+	1293: "common:ApplicationInitialized",
 }

--- a/v3/pkg/events/known_events.go
+++ b/v3/pkg/events/known_events.go
@@ -8,6 +8,8 @@ func IsKnownEvent(name string) bool {
 var knownEvents = map[string]struct{}{
 	"common:ApplicationOpenedWithFile":                            {},
 	"common:ApplicationStarted":                                   {},
+	"common:ApplicationStarting":                                  {},
+	"common:ApplicationInitialized":                               {},
 	"common:ApplicationLaunchedWithUrl":                           {},
 	"common:ThemeChanged":                                         {},
 	"common:SystemDidWake":                                        {},

--- a/v3/scripts/auto-changelog.go
+++ b/v3/scripts/auto-changelog.go
@@ -8,13 +8,21 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"os"
+	"path"
+	"path/filepath"
 	"regexp"
 	"strings"
 	"time"
 )
 
 const changelogPath = "v3/UNRELEASED_CHANGELOG.md"
+
+const (
+	docsContentPrefix = "docs/src/content/docs/"
+	docsSiteURL       = "https://v3.wails.io"
+)
 
 // httpClient bounds every outbound request so a stalled GitHub API or model
 // response can't hang the changelog job until the runner timeout.
@@ -71,6 +79,17 @@ func main() {
 	fmt.Printf("✅ Section: %s\n", section)
 	fmt.Printf("✅ Entry:   %s\n", entry)
 
+	// Documentation is still being built when this job runs, so the public URL
+	// must be derived from the source path rather than checked against the live
+	// site. Only Added entries get the link; the generated prose remains model
+	// controlled, while the URL is deterministic and cannot be hallucinated.
+	docURLs, err := documentationURLs(pr.Files)
+	if err != nil {
+		fmt.Printf("⚠️  Could not calculate documentation URL: %v — continuing without a documentation link\n", err)
+	} else if section == "Added" || isFeatureChange(pr.Title) {
+		entry = appendDocumentationLinks(entry, docURLs)
+	}
+
 	prURL := fmt.Sprintf("https://github.com/%s/pull/%s", repo, prNumber)
 	bullet := fmt.Sprintf("- %s in [PR](%s) by @%s", entry, prURL, pr.Author)
 
@@ -111,6 +130,7 @@ func fetchCodeRabbitSummary(repo, prNumber, token string) (string, error) {
 type prInfo struct {
 	Title  string
 	Author string
+	Files  []string
 }
 
 func fetchPR(repo, prNumber, token string) (prInfo, error) {
@@ -128,7 +148,144 @@ func fetchPR(repo, prNumber, token string) (prInfo, error) {
 	if err := json.Unmarshal(body, &raw); err != nil {
 		return prInfo{}, fmt.Errorf("parse PR: %w", err)
 	}
-	return prInfo{Title: raw.Title, Author: raw.User.Login}, nil
+
+	files, err := fetchPRFiles(repo, prNumber, token)
+	if err != nil {
+		// The changelog entry is still useful if the files endpoint is
+		// temporarily unavailable. Documentation links are an enhancement, not
+		// a reason to fail the whole merge automation.
+		fmt.Printf("⚠️  Could not fetch changed files: %v — continuing without documentation link\n", err)
+	}
+	return prInfo{Title: raw.Title, Author: raw.User.Login, Files: files}, nil
+}
+
+func fetchPRFiles(repo, prNumber, token string) ([]string, error) {
+	var files []string
+	for page := 1; page <= 10; page++ {
+		apiURL := fmt.Sprintf("https://api.github.com/repos/%s/pulls/%s/files?per_page=100&page=%d", repo, prNumber, page)
+		body, err := githubGet(apiURL, token)
+		if err != nil {
+			return nil, err
+		}
+
+		var raw []struct {
+			Filename string `json:"filename"`
+		}
+		if err := json.Unmarshal(body, &raw); err != nil {
+			return nil, fmt.Errorf("parse changed files: %w", err)
+		}
+		for _, file := range raw {
+			files = append(files, file.Filename)
+		}
+		if len(raw) < 100 {
+			break
+		}
+	}
+	return files, nil
+}
+
+func documentationURLs(files []string) ([]string, error) {
+	var urls []string
+	seen := make(map[string]bool)
+	for _, file := range files {
+		if !isDocumentationPage(file) {
+			continue
+		}
+		docURL, err := documentationURLForFile(file)
+		if err != nil {
+			return nil, err
+		}
+		if docURL == "" || seen[docURL] {
+			continue
+		}
+		seen[docURL] = true
+		urls = append(urls, docURL)
+	}
+	return urls, nil
+}
+
+func isDocumentationPage(file string) bool {
+	file = filepath.ToSlash(file)
+	if !strings.HasPrefix(file, docsContentPrefix) {
+		return false
+	}
+	base := path.Base(file)
+	return base != "changelog.md" && base != "changelog.mdx"
+}
+
+func documentationURLForFile(file string) (string, error) {
+	file = filepath.ToSlash(file)
+	if !isDocumentationPage(file) {
+		return "", nil
+	}
+
+	slug, err := readFrontmatterSlug(file)
+	if err != nil {
+		return "", err
+	}
+	return documentationURLFromPath(file, slug)
+}
+
+func documentationURLFromPath(file, slug string) (string, error) {
+	file = filepath.ToSlash(file)
+	if !isDocumentationPage(file) {
+		return "", nil
+	}
+
+	relative := strings.TrimPrefix(file, docsContentPrefix)
+	if slug != "" {
+		relative = strings.TrimPrefix(slug, "/")
+	} else {
+		ext := path.Ext(relative)
+		relative = strings.TrimSuffix(relative, ext)
+		if path.Base(relative) == "index" {
+			relative = path.Dir(relative)
+		}
+	}
+
+	if relative == "." || relative == "" {
+		relative = "/"
+	} else {
+		relative = "/" + strings.Trim(relative, "/")
+	}
+	return (&url.URL{Scheme: "https", Host: strings.TrimPrefix(docsSiteURL, "https://"), Path: relative}).String(), nil
+}
+
+func readFrontmatterSlug(file string) (string, error) {
+	data, err := os.ReadFile(file)
+	if err != nil {
+		return "", err
+	}
+	content := string(data)
+	if !strings.HasPrefix(content, "---") {
+		return "", nil
+	}
+	end := strings.Index(content[3:], "\n---")
+	if end == -1 {
+		return "", nil
+	}
+	frontmatter := content[3 : end+3]
+	match := regexp.MustCompile(`(?m)^slug:\s*["']?([^"'\n]+?)["']?\s*$`).FindStringSubmatch(frontmatter)
+	if len(match) == 2 {
+		return strings.TrimSpace(match[1]), nil
+	}
+	return "", nil
+}
+
+func appendDocumentationLinks(entry string, docURLs []string) string {
+	if len(docURLs) == 0 {
+		return entry
+	}
+	links := make([]string, 0, len(docURLs))
+	for _, docURL := range docURLs {
+		links = append(links, fmt.Sprintf("[documentation](%s)", docURL))
+	}
+	return entry + " — see " + strings.Join(links, " and ")
+}
+
+func isFeatureChange(title string) bool {
+	m := internalTitleRe.FindStringSubmatch(strings.TrimSpace(title))
+	return m != nil && strings.EqualFold(m[1], "feat")
 }
 
 func githubGet(url, token string) ([]byte, error) {

--- a/v3/scripts/auto-changelog_test.go
+++ b/v3/scripts/auto-changelog_test.go
@@ -1,0 +1,51 @@
+//go:build ignore
+
+package main
+
+import "testing"
+
+func TestDocumentationURLForFile(t *testing.T) {
+	tests := []struct {
+		name string
+		file string
+		want string
+	}{
+		{
+			name: "regular page",
+			file: "docs/src/content/docs/features/windows/options.mdx",
+			want: "https://v3.wails.io/features/windows/options",
+		},
+		{
+			name: "index page",
+			file: "docs/src/content/docs/guides/mobile/index.mdx",
+			want: "https://v3.wails.io/guides/mobile",
+		},
+		{
+			name: "localized page",
+			file: "docs/src/content/docs/de/quick-start/installation.mdx",
+			want: "https://v3.wails.io/de/quick-start/installation",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := documentationURLFromPath(test.file, "")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got != test.want {
+				t.Fatalf("documentationURLFromPath(%q) = %q, want %q", test.file, got, test.want)
+			}
+		})
+	}
+}
+
+func TestDocumentationURLForSlug(t *testing.T) {
+	got, err := documentationURLFromPath("docs/src/content/docs/blog/legacy-name.md", "blog/the-road-to-wails-v3")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "https://v3.wails.io/blog/the-road-to-wails-v3" {
+		t.Fatalf("got %q", got)
+	}
+}


### PR DESCRIPTION
## Summary

- Add asynchronous application startup lifecycle events and a splash-screen example for v3.
- Make scheduled nightly releases changelog-driven so unrelated commits cannot trigger a release.
- Add an explicit release-version input for ad-hoc beta releases.
- Add deterministic documentation links to AI-generated feature changelog entries based on changed docs paths.

## Why

The nightly workflow previously used commits after the latest release tag as a fallback signal, which could cause an unnecessary release after release bookkeeping or automation commits. Documentation pages also need links before the site is deployed, so URLs are now calculated from the checked-out docs source, including index routes, locale prefixes, and frontmatter slugs.

## Validation

- `go test v3/scripts/auto-changelog.go v3/scripts/auto-changelog_test.go`
- `go test ./internal/changelog ./tasks/release`
- Application startup lifecycle subpackage tests pass.
- The broader application package suite has one environment-sensitive X11 failure: `TestX11GlobalShortcutEndToEnd` did not receive its synthesized keypress in the headless test environment.
