### PR TITLE
fix(linux): apply the window title to frameless windows

### DIFF
--- a/v3/UNRELEASED_CHANGELOG.md
+++ b/v3/UNRELEASED_CHANGELOG.md
@@ -23,6 +23,7 @@ After processing, the content will be moved to the main changelog and this file 
 
 ## Fixed
 <!-- Bug fixes -->
+- Apply the window title to frameless windows on Linux, so taskbars and window switchers can tell an application's windows apart in [PR](https://github.com/wailsapp/wails/pull/5960) by @julianstorer
 
 ## Deprecated
 <!-- Soon-to-be removed features -->

--- a/v3/pkg/application/linux_cgo.go
+++ b/v3/pkg/application/linux_cgo.go
@@ -1306,11 +1306,13 @@ func (w *linuxWebviewWindow) present() {
 }
 
 func (w *linuxWebviewWindow) setTitle(title string) {
-	if !w.parent.options.Frameless {
-		cTitle := C.CString(title)
-		C.gtk_window_set_title(w.gtkWindow(), cTitle)
-		C.free(unsafe.Pointer(cTitle))
-	}
+	// Set unconditionally, frameless included: gtk_window_set_title writes the
+	// WM_NAME/_NET_WM_NAME hints that taskbars and window switchers label the
+	// window with, it does not draw a titlebar. Decorations are governed
+	// separately, by gtk_window_set_decorated.
+	cTitle := C.CString(title)
+	C.gtk_window_set_title(w.gtkWindow(), cTitle)
+	C.free(unsafe.Pointer(cTitle))
 }
 
 func (w *linuxWebviewWindow) setSize(width, height int) {

--- a/v3/pkg/application/linux_cgo_gtk3.go
+++ b/v3/pkg/application/linux_cgo_gtk3.go
@@ -1728,11 +1728,13 @@ func (w *linuxWebviewWindow) setOpacity(opacity float64) {
 }
 
 func (w *linuxWebviewWindow) setTitle(title string) {
-	if !w.parent.options.Frameless {
-		cTitle := C.CString(title)
-		C.gtk_window_set_title(w.gtkWindow(), cTitle)
-		C.free(unsafe.Pointer(cTitle))
-	}
+	// Set unconditionally, frameless included: gtk_window_set_title writes the
+	// WM_NAME/_NET_WM_NAME hints that taskbars and window switchers label the
+	// window with, it does not draw a titlebar. Decorations are governed
+	// separately, by gtk_window_set_decorated.
+	cTitle := C.CString(title)
+	C.gtk_window_set_title(w.gtkWindow(), cTitle)
+	C.free(unsafe.Pointer(cTitle))
 }
 
 func (w *linuxWebviewWindow) setIcon(icon pointer) {


### PR DESCRIPTION
## Description

`linuxWebviewWindow.setTitle` skips `gtk_window_set_title` entirely when the window was created with `Frameless: true`:

```go
func (w *linuxWebviewWindow) setTitle(title string) {
	if !w.parent.options.Frameless {
		...
	}
}
```

`newWindowImpl` applies `options.Title` through that same method, so a frameless window never receives a title at all, and every later `SetTitle` call is dropped too. The window keeps whatever the WM falls back to — the `g_set_prgname` program name — for its entire lifetime.

The guard looks like it is protecting a titlebar, but on Linux the title is not a titlebar: `gtk_window_set_title` writes the `WM_NAME` / `_NET_WM_NAME` hints that taskbars, window switchers and pagers label the window with. It draws nothing on an undecorated window. Decorations are governed separately, by `gtk_window_set_decorated` in `setFrameless` / `setBorderless`, so removing this guard does not bring a titlebar back.

The user-visible effect is that a frameless app with multiple windows shows the *same* label for every one of them, so they cannot be told apart in the taskbar or in alt-tab. This was reported against a frameless Wails app by a user on Cinnamon/X11, but it applies to any frameless window on any Linux desktop.

Windows (`SetWindowText`) and macOS (`setTitle:`) have no equivalent guard, so this is Linux-only.

## Changes

- Remove the `Frameless` guard from `setTitle` in both the GTK4 (`linux_cgo.go`) and GTK3 (`linux_cgo_gtk3.go`) backends, and note why the call is unconditional.
- Add an entry to `v3/UNRELEASED_CHANGELOG.md`.

No API or behaviour change for decorated windows — for them this path was already running.

## Testing

Verified by inspection and by the reported symptom: the change unwraps three unchanged statements from an `if`, so decorated windows are unaffected, and frameless windows now get their `_NET_WM_NAME` set at creation and on each `SetTitle`.

Worth a second pair of eyes from someone running a frameless v3 app on GTK4 and GTK3 to confirm the taskbar label updates as expected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Frameless Linux windows now display their titles in taskbars and window switchers.
  * Window titles are applied consistently across supported GTK versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->