### PR TITLE
docs(release): reconcile tag-only beta evidence

### DIFF
--- a/.release/v3.0.0-beta.0/README.md
+++ b/.release/v3.0.0-beta.0/README.md
@@ -50,9 +50,10 @@ Against this branch: 17 checks passing, 0 warnings, 2 blockers.
    `go install github.com/wailsapp/wails/v3/cmd/wails3@latest`; desktop release
    binaries, checksums and platform signing are not part of this path. PR #5946
    removed the obsolete asset workflow and its nightly dispatch.
-2. Rehearse the tag-only path in dry-run mode and verify the candidate from the
-   Go module channel. A gate remains open until that evidence is recorded in
-   `plan.json`; the policy decision alone does not pass or waive it.
+2. Rehearse the tag-only path in dry-run mode and record the proposed version,
+   tag, changelog and release notes in `plan.json`. After publication, verify
+   the exact tag from the Go module channel on a clean machine and record that
+   result separately. The policy decision alone does not pass or waive a gate.
 3. This branch drifts behind master quickly. Re-sync and re-audit immediately
    before tagging; `relman audit` now blocks on it.
 

--- a/.release/v3.0.0-beta.0/README.md
+++ b/.release/v3.0.0-beta.0/README.md
@@ -51,8 +51,8 @@ Against this branch: 17 checks passing, 0 warnings, 2 blockers.
    binaries, checksums and platform signing are not part of this path. PR #5946
    removed the obsolete asset workflow and its nightly dispatch.
 2. Rehearse the tag-only path in dry-run mode and verify the candidate from the
-   Go module channel. A gate remains open until that evidence is recorded here;
-   the policy decision alone does not pass or waive it.
+   Go module channel. A gate remains open until that evidence is recorded in
+   `plan.json`; the policy decision alone does not pass or waive it.
 3. This branch drifts behind master quickly. Re-sync and re-audit immediately
    before tagging; `relman audit` now blocks on it.
 

--- a/.release/v3.0.0-beta.0/README.md
+++ b/.release/v3.0.0-beta.0/README.md
@@ -46,11 +46,13 @@ Against this branch: 17 checks passing, 0 warnings, 2 blockers.
 
 ## Known preconditions before tagging
 
-1. The six `APPLE_*` signing secrets do not exist on the repository. Without them
-   the macOS job stops in preflight with the names listed, or continues unsigned
-   if `allow_unsigned_macos` is set deliberately.
-2. `release-v3.yml` has never run. Rehearse it with `draft: true` on a throwaway
-   tag in the `alpha2.` series before using it for real.
+1. The current v3 publication policy is tag-only. The supported CLI channel is
+   `go install github.com/wailsapp/wails/v3/cmd/wails3@latest`; desktop release
+   binaries, checksums and platform signing are not part of this path. PR #5946
+   removed the obsolete asset workflow and its nightly dispatch.
+2. Rehearse the tag-only path in dry-run mode and verify the candidate from the
+   Go module channel. A gate remains open until that evidence is recorded here;
+   the policy decision alone does not pass or waive it.
 3. This branch drifts behind master quickly. Re-sync and re-audit immediately
    before tagging; `relman audit` now blocks on it.
 

--- a/.release/v3.0.0-beta.0/comms/launch-sequence.md
+++ b/.release/v3.0.0-beta.0/comms/launch-sequence.md
@@ -24,10 +24,10 @@ Owners are blank on purpose. Fill them in before the go/no-go, not on the day.
 | T-60m | Final `relman gono`; blockers green or waived in writing | |
 | T-45m | Run the approved tag-only release path. `release.go` bumps `version.txt`, folds `UNRELEASED_CHANGELOG.md` into the changelog, and publishes the tag/GitHub prerelease | |
 | T-40m | Verify the GitHub prerelease points at the intended commit and carries the approved notes. Zero attached desktop assets are expected under the current policy | |
+| T-30m | Docs deploy (Cloudflare Pages, "wails-v3-site"); confirm the version switcher and every locale | |
 | T-25m | `version.txt` moving triggers `publish-npm.yml`, which publishes `@wailsio/runtime` at the matching version | |
 | T-20m | Verify `go install github.com/wailsapp/wails/v3/cmd/wails3@<tag>` on a clean machine and confirm `wails3 version` reports the beta | |
 | T-15m | Repeat the published-channel install on each supported CLI platform; do not use a local build directory | |
-| T-10m | Docs deploy (Cloudflare Pages, "wails-v3-site"); confirm the version switcher and every locale | |
 | T-5m | Support rota on duty; hotfix path confirmed | |
 | T+0 | Announcement post live | |
 | T+5m | Community chat and forum: existing users hear it first | |
@@ -42,12 +42,17 @@ Owners are blank on purpose. Fill them in before the go/no-go, not on the day.
 
 Agreed in advance, while nobody is under pressure:
 
-- A pre-publication install fails on any supported platform: hold publication
-  and the announcement, then fix and reverify the candidate
-- A post-publication install failure, data-loss defect, or security regression:
-  hold the announcement, publish an advisory when appropriate, and recover with
-  a new semver patch tag rather than replacing the cached version
-- Docs site down or the upgrade guide missing: hold the announcement, ship the fix
+- A dry run or other candidate verification fails before publication: hold
+  publication and the announcement, then fix and reverify the candidate
+- A published-tag install failure, data-loss defect, or security regression
+  found before T+0: hold the announcement and publish an advisory when appropriate
+- The same problem found after T+0: correct the public communications immediately
+- For either published-version path, identify the affected Go tag and mitigation
+  in the advisory, deprecate the matching npm version when unpublishing is not
+  permitted, and recover with the next unused, monotonically higher prerelease
+  tag in the approved release line (for example, beta.10 after beta.9)
+- Docs site down or the upgrade guide missing: before T+0 hold the announcement;
+  after T+0 correct the public communications, then ship the fix
 - Anything else: continue, log it, decide at the T+3h sweep
 
 ## Rollback
@@ -56,8 +61,9 @@ Deleting the GitHub release or tag does not retract a version already cached by
 the Go module proxy. An npm version may be unpublished only when the current
 [registry criteria](https://docs.npmjs.com/policies/unpublish/) permit it;
 otherwise deprecate it, and an unpublished name/version still cannot be reused.
-In practice, the recovery for anything found after publishing is a fast patch
-release, which is why the hotfix path has to be rehearsed rather than assumed.
+In practice, recovery after publishing uses the next unused, monotonically
+higher tag in the approved release line, which is why the hotfix path has to be
+rehearsed rather than assumed.
 
-Write the exact commands here once step 2 has actually been executed, so this
+Write the exact commands here once step 3 has actually been executed, so this
 section describes something that has been done rather than something believed.

--- a/.release/v3.0.0-beta.0/comms/launch-sequence.md
+++ b/.release/v3.0.0-beta.0/comms/launch-sequence.md
@@ -11,10 +11,10 @@ Owners are blank on purpose. Fill them in before the go/no-go, not on the day.
 
 | # | Step | Owner |
 |---|---|---|
-| 1 | Configure the six Apple secrets (`APPLE_SIGNING_CERT`, `APPLE_CERT_PASSWORD`, `APPLE_SIGNING_IDENTITY`, `APPLE_NOTARIZE_USER`, `APPLE_NOTARIZE_PASSWORD`, `APPLE_TEAM_ID`), or decide to ship unsigned macOS binaries with `allow_unsigned_macos` | |
-| 2 | Rehearse the release: `release-v3.yml` via `workflow_dispatch` with `draft: true` on a throwaway tag. Use a tag in the `alpha2.` series (`v3.0.0-alpha2.999`); a tag like `v3.0.0-test.1` would outrank the real beta and hijack `@latest` | |
-| 3 | Delete the draft release and the throwaway tag once the rehearsal passes | |
-| 4 | Re-sync `releases/v3-beta` with master and re-run the audit. The branch drifted 31 commits, then 6 more within hours; `relman audit` blocks on it now | |
+| 1 | Confirm that the maintainer-approved policy is still tag-only and that no desktop binaries are expected. If policy changes, update this ledger before proceeding | |
+| 2 | Run the tag-only release task in dry-run mode against current `master`; verify the proposed version, tag, changelog and release notes without publishing | |
+| 3 | Verify the candidate commit through the Go module path on a clean machine, then record the commands and results in `plan.json` | |
+| 4 | Re-sync `releases/v3-beta` with master and re-run the audit. The branch drifts quickly; `relman audit` blocks on it | |
 | 5 | Warn downstream: packagers, template and plugin authors, translators (see `packagers.md`) | |
 
 ## Release day
@@ -22,18 +22,18 @@ Owners are blank on purpose. Fill them in before the go/no-go, not on the day.
 | When | Step | Owner |
 |---|---|---|
 | T-60m | Final `relman gono`; blockers green or waived in writing | |
-| T-45m | Tag from `releases/v3-beta`. `release.go` bumps `version.txt` and folds `UNRELEASED_CHANGELOG.md` into the changelog | |
-| T-40m | The tag push triggers `release-v3.yml`: preflight, three platform builds, sign and notarize, `SHA256SUMS`, provenance attestation | |
+| T-45m | Run the approved tag-only release path. `release.go` bumps `version.txt`, folds `UNRELEASED_CHANGELOG.md` into the changelog, and publishes the tag/GitHub prerelease | |
+| T-40m | Verify the GitHub prerelease points at the intended commit and carries the approved notes. Zero attached desktop assets are expected under the current policy | |
 | T-25m | `version.txt` moving triggers `publish-npm.yml`, which publishes `@wailsio/runtime` at the matching version | |
-| T-20m | Verify: download a binary, check it against `SHA256SUMS`, verify the attestation, run `wails3 version` and confirm it reports the beta | |
-| T-15m | Install on a clean machine per platform, from the published channel, not the build directory | |
+| T-20m | Verify `go install github.com/wailsapp/wails/v3/cmd/wails3@<tag>` on a clean machine and confirm `wails3 version` reports the beta | |
+| T-15m | Repeat the published-channel install on each supported CLI platform; do not use a local build directory | |
 | T-10m | Docs deploy (Cloudflare Pages, "wails-v3-site"); confirm the version switcher and every locale | |
 | T-5m | Support rota on duty; hotfix path confirmed | |
 | T+0 | Announcement post live | |
 | T+5m | Community chat and forum: existing users hear it first | |
 | T+10m | Show HN plus the first comment | |
 | T+15m | Social threads, newsletter | |
-| T+30m | Tell packagers the artifacts are live | |
+| T+30m | Tell packagers the source tag and Go module version are live; no prebuilt CLI assets are published under the current policy | |
 | T+1h | First sweep: install failures, docs 404s, thread questions | |
 | T+3h | Second sweep; decide on a same-day patch | |
 | T+24h | Summarise, file issues, hand over the rota | |

--- a/.release/v3.0.0-beta.0/comms/launch-sequence.md
+++ b/.release/v3.0.0-beta.0/comms/launch-sequence.md
@@ -1,9 +1,9 @@
 # Launch sequence: Wails v3 beta
 
 Publish in this order. The rule behind it: nothing is announced before it is
-installable, and nothing is installable before the docs describing it are live.
-Every step needs one named owner, because a step owned by everyone is owned by
-nobody at 3am.
+installable, and published-channel installation checks do not begin before the
+docs describing the release are live. Every step needs one named owner, because
+a step owned by everyone is owned by nobody at 3am.
 
 Owners are blank on purpose. Fill them in before the go/no-go, not on the day.
 
@@ -15,7 +15,8 @@ Owners are blank on purpose. Fill them in before the go/no-go, not on the day.
 | 2 | Re-sync `releases/v3-beta` with current `master` and re-run the audit. The ledger branch drifts quickly; `relman audit` blocks on it | |
 | 3 | Run the tag-only release task in dry-run mode against the audited `master` candidate; verify the proposed version, tag, changelog and release notes without publishing | |
 | 4 | Record the dry-run commands and results in `plan.json`, and prepare the post-publication clean-machine check for the exact tag. The install gate remains open until that check runs | |
-| 5 | Warn downstream: packagers, template and plugin authors, translators (see `packagers.md`) | |
+| 5 | Build the documentation from the audited candidate and verify a staged preview, including the version switcher, changelog, migration content and translated locales. Record the preview evidence; do not publish if it fails | |
+| 6 | Warn downstream: packagers, template and plugin authors, translators (see `packagers.md`) | |
 
 ## Release day
 

--- a/.release/v3.0.0-beta.0/comms/launch-sequence.md
+++ b/.release/v3.0.0-beta.0/comms/launch-sequence.md
@@ -42,18 +42,20 @@ Owners are blank on purpose. Fill them in before the go/no-go, not on the day.
 
 Agreed in advance, while nobody is under pressure:
 
-- Install fails on any supported platform: stop, unpublish, fix
-- Data loss or a security regression: stop, unpublish, advisory
+- A pre-publication install fails on any supported platform: hold publication
+  and the announcement, then fix and reverify the candidate
+- A post-publication install failure, data-loss defect, or security regression:
+  hold the announcement, publish an advisory when appropriate, and recover with
+  a new semver patch tag rather than replacing the cached version
 - Docs site down or the upgrade guide missing: hold the announcement, ship the fix
 - Anything else: continue, log it, decide at the T+3h sweep
 
 ## Rollback
 
-The GitHub release can be deleted and the tag removed, but **npm cannot be
-unpublished after 72 hours** and the Go module proxy caches versions
-permanently. In practice, the recovery for anything found after publishing is a
-fast patch release, which is why the hotfix path has to be rehearsed rather than
-assumed.
+Deleting the GitHub release or tag does not retract a version already cached by
+the Go module proxy, and **npm cannot be unpublished after 72 hours**. In
+practice, the recovery for anything found after publishing is a fast patch
+release, which is why the hotfix path has to be rehearsed rather than assumed.
 
 Write the exact commands here once step 2 has actually been executed, so this
 section describes something that has been done rather than something believed.

--- a/.release/v3.0.0-beta.0/comms/launch-sequence.md
+++ b/.release/v3.0.0-beta.0/comms/launch-sequence.md
@@ -12,9 +12,9 @@ Owners are blank on purpose. Fill them in before the go/no-go, not on the day.
 | # | Step | Owner |
 |---|---|---|
 | 1 | Confirm that the maintainer-approved policy is still tag-only and that no desktop binaries are expected. If policy changes, update this ledger before proceeding | |
-| 2 | Run the tag-only release task in dry-run mode against current `master`; verify the proposed version, tag, changelog and release notes without publishing | |
-| 3 | Verify the candidate commit through the Go module path on a clean machine, then record the commands and results in `plan.json` | |
-| 4 | Re-sync `releases/v3-beta` with master and re-run the audit. The branch drifts quickly; `relman audit` blocks on it | |
+| 2 | Re-sync `releases/v3-beta` with current `master` and re-run the audit. The ledger branch drifts quickly; `relman audit` blocks on it | |
+| 3 | Run the tag-only release task in dry-run mode against the audited `master` candidate; verify the proposed version, tag, changelog and release notes without publishing | |
+| 4 | Record the dry-run commands and results in `plan.json`, and prepare the post-publication clean-machine check for the exact tag. The install gate remains open until that check runs | |
 | 5 | Warn downstream: packagers, template and plugin authors, translators (see `packagers.md`) | |
 
 ## Release day
@@ -53,8 +53,10 @@ Agreed in advance, while nobody is under pressure:
 ## Rollback
 
 Deleting the GitHub release or tag does not retract a version already cached by
-the Go module proxy, and **npm cannot be unpublished after 72 hours**. In
-practice, the recovery for anything found after publishing is a fast patch
+the Go module proxy. An npm version may be unpublished only when the current
+[registry criteria](https://docs.npmjs.com/policies/unpublish/) permit it;
+otherwise deprecate it, and an unpublished name/version still cannot be reused.
+In practice, the recovery for anything found after publishing is a fast patch
 release, which is why the hotfix path has to be rehearsed rather than assumed.
 
 Write the exact commands here once step 2 has actually been executed, so this

--- a/.release/v3.0.0-beta.0/comms/packagers.md
+++ b/.release/v3.0.0-beta.0/comms/packagers.md
@@ -21,18 +21,17 @@ reported unrelated versions. From this release the package version is derived
 from the same file the CLI embeds. If you pin the runtime, expect the version
 string to jump series rather than increment.
 
-**Release artifacts now ship with checksums and provenance.** Each release
-carries a `SHA256SUMS` file generated in the same job that publishes the
-binaries, plus a signed build-provenance attestation. If you verify downloads,
-you can now do so properly.
+**The current beta is tag-only.** Wails does not publish prebuilt v3 CLI
+binaries, checksums or platform signatures under the current policy. Users
+install the CLI from the Go module channel:
 
-**Artifact names are unchanged:** `wails3-linux-amd64`, `wails3-linux-arm64`,
-`wails3-windows-amd64.exe`, `wails3-darwin-amd64`, `wails3-darwin-arm64`,
-`wails3-darwin-universal`.
+```sh
+go install github.com/wailsapp/wails/v3/cmd/wails3@latest
+```
 
-**macOS signing.** Whether the darwin binaries are signed and notarized in this
-release depends on the signing credentials being in place. If they are not, the
-release will say so explicitly rather than shipping silently unsigned binaries.
+Packagers should build from the published source tag and must not wait for
+GitHub release assets. If binary distribution returns later, this notice and
+the release ledger will be updated before that policy is used.
 
 **The repository no longer ships a `go.work`.** If your build tooling assumed a
 workspace at the repository root, it does not need one now.

--- a/.release/v3.0.0-beta.0/plan.json
+++ b/.release/v3.0.0-beta.0/plan.json
@@ -175,8 +175,8 @@
       "track": "software",
       "blocking": true,
       "status": "open",
-      "note": "v3.0.0-beta.0, beta.1, and beta.2 were published from master on 2026-08-02. Beta.3, beta.4, and beta.5 were subsequently published from master, but all three immutable releases have zero assets after their Release v3 upload jobs failed. This evidence ledger remains at its beta.0 path, and release-stage/version approval is not recorded, so this gate remains open.",
-      "updated": "2026-08-08T17:05:00+10:00"
+      "note": "v3.0.0-beta.0 through beta.8 were published from master; beta.8 was published at 2026-08-12T08:20:32Z by successful Nightly Release v3 run 31577849776. The beta.8 tag still contains runtime package metadata versioned 3.0.0-beta.7, while npm publication run 31583811321 later published @wailsio/runtime 3.0.0-beta.8 from post-tag master; PR #5959 proposes future lockstep but is not merged. Maintainer direction recorded in #5876 and implemented by merged PR #5946 defines the current v3 release as a source tag/GitHub prerelease with CLI installation through go install, without attached desktop binaries. This evidence ledger remains at its beta.0 path, and release-stage/version approval is not recorded, so this gate remains open.",
+      "updated": "2026-08-13T17:30:00+10:00"
     },
     {
     "id": "sw-compat",
@@ -220,8 +220,8 @@
       "blocking": true,
       "owner": "lea",
       "status": "open",
-      "note": "Release v3 workflow runs 30747695287 (beta.0) and 30748402783 (beta.1) published Linux amd64/arm64, Windows amd64, macOS amd64/arm64/universal, and SHA256SUMS. Published beta.2 has zero assets and no matching Release v3 run. Beta.3 Release v3 run 30829708574 built all six desktop binaries, generated SHA256SUMS, and created provenance attestation 38606755, but Publish Release failed with HTTP 422 because the nightly workflow had already published an immutable release. Scheduled Nightly Release v3 run 30926135808 then reached artifact dispatch with an empty tag after the release task skipped for an empty changelog; GitHub rejected the dispatch because required input `tag` was not provided. Published beta.4 and beta.5 are also immutable with zero assets: Release v3 runs 31022027159 and 31192135957 each built the same six binaries, generated SHA256SUMS, and created provenance attestations 39071317 and 39449314 respectively before their uploads failed with HTTP 422 `Cannot upload assets to an immutable release.` The workflow ordering and missing current assets are tracked in #5876; this gate remains open.",
-      "updated": "2026-08-08T17:05:00+10:00"
+      "note": "Historical Release v3 runs 30747695287 (beta.0) and 30748402783 (beta.1) published six desktop binaries plus SHA256SUMS. Beta.2 through beta.8 have zero attached assets. Before the tag-only decision was implemented, beta.3 through beta.7 Release v3 runs built the desktop set and failed to attach it to immutable releases; beta.6 run 31320435426 and beta.7 run 31506762359 are the latest examples, with beta.7 generating six binaries, SHA256SUMS, and provenance before HTTP 422. Maintainer direction in #5876 made zero-asset tag-only releases intentional, merged PR #5946 removed release-v3.yml plus its nightly dispatch, and successful run 31577849776 published beta.8 by the tag-only path. The artifact gate has not been explicitly redefined, passed, or waived for this policy, so it remains open.",
+      "updated": "2026-08-13T17:30:00+10:00"
     },
     {
       "id": "sw-signing",
@@ -230,8 +230,8 @@
       "track": "software",
       "blocking": true,
       "status": "open",
-      "note": "The beta.1 tag-triggered run 30748399250 failed because Apple signing credentials were absent. Commit 6603cde8e then removed signing/notarization steps and run 30748402783 published unsigned macOS binaries. Beta.3 run 30829708574, beta.4 run 31022027159, and beta.5 run 31192135957 created Sigstore build-provenance attestations 38606755, 39071317, and 39449314 respectively, for six binaries each; provenance is not platform code signing, and all three immutable releases rejected asset uploads. No explicit evidenced macOS signing/notarization waiver is recorded; tracked in #5876.",
-      "updated": "2026-08-08T17:05:00+10:00"
+      "note": "The beta.1 tag-triggered run 30748399250 failed because Apple signing credentials were absent; run 30748402783 then published unsigned macOS binaries after signing/notarization was removed. Maintainer direction in #5876 now makes v3 releases tag-only, and merged PR #5946 removed the desktop-binary workflow, so platform binary signing is not part of the current publication path. No explicit evidence redefines, passes, or waives this signing gate for source-tag distribution, so it remains open.",
+      "updated": "2026-08-13T17:30:00+10:00"
     },
     {
       "id": "sw-install",
@@ -240,8 +240,8 @@
       "track": "software",
       "blocking": true,
       "status": "open",
-      "note": "No published-channel installation evidence is recorded. Published beta.2, beta.3, beta.4, and beta.5 have zero downloadable assets. Beta.3 run 30829708574, beta.4 run 31022027159, and beta.5 run 31192135957 built the expected binaries but could not attach them to their immutable releases; the latest failed with HTTP 422 after generating SHA256SUMS and provenance attestation 39449314. Installation cannot be verified from the current Beta channel until #5876 is resolved.",
-      "updated": "2026-08-08T17:05:00+10:00"
+      "note": "Maintainer direction in #5876 identifies `go install github.com/wailsapp/wails/v3/cmd/wails3@latest` as the current published CLI channel, and merged PR #5946 removes the unused desktop-binary publication path. Beta.8 was published at 2026-08-12T08:20:32Z, but no clean-machine installation and version check from beta.8 or `@latest` is recorded in this ledger. The channel is now identified, but installation evidence is still absent, so this gate remains open.",
+      "updated": "2026-08-13T17:30:00+10:00"
     },
     {
       "id": "sw-perf",
@@ -454,8 +454,8 @@
       "track": "ops",
       "blocking": true,
       "status": "open",
-      "note": "Beta.0 and beta.1 were published with assets, while beta.2, beta.3, beta.4, and beta.5 have none. Beta.3 run 30829708574, beta.4 run 31022027159, and beta.5 run 31192135957 each built six binaries and provenance, then failed to attach the outputs because the release was already immutable. Scheduled runs 30926135808 and 31263736047 separately attempted Release v3 dispatches with no tag after release generation skipped for an empty changelog; GitHub rejected both with HTTP 422 because required input `tag` was absent. Scheduled run 31117548329 failed earlier during runner setup after GitHub returned Service Unavailable while resolving action downloads through two retries. No approved launch runbook or abort criteria are recorded, and the workflow did not stop before invalid artifact dispatch or immutable release publication. No signing waiver evidence is recorded. #5876 tracks the release-health blocker.",
-      "updated": "2026-08-09T17:10:31+10:00"
+      "note": "Beta.7 published as a zero-asset prerelease at 2026-08-11T15:23:34Z. The still-present desktop workflow then ran as 31506762359, built six binaries plus SHA256SUMS and provenance, and failed HTTP 422 against the immutable release. Maintainer direction in #5876 made that workflow obsolete, and merged PR #5946 removed release-v3.yml and its nightly dispatch. Successful Nightly Release v3 run 31577849776 then published beta.8 at 2026-08-12T08:20:32Z through the intended tag-only path. README.md and comms/launch-sequence.md now describe the tag-only/go-install path, but named owners, a completed rehearsal, and final approval are not recorded, so this gate remains open.",
+      "updated": "2026-08-13T17:30:00+10:00"
     },
     {
       "id": "ops-support",
@@ -472,8 +472,8 @@
       "track": "ops",
       "blocking": true,
       "status": "open",
-      "note": "The beta.3, beta.4, and beta.5 immutable releases cannot accept the artifacts produced by failed runs 30829708574, 31022027159, and 31192135957. Scheduled recovery runs 30926135808 and 31263736047 did not identify a releasable tag after the release task skipped for an empty changelog; both empty-tag Release v3 dispatches failed with HTTP 422. Scheduled run 31117548329 provided no recovery evidence because GitHub's action-download service stayed unavailable through runner retries and the job stopped during setup. No successful recovery or replacement path has been rehearsed, and remediation still requires a maintainer decision because automation is not authorised to replace tags or releases. #5876 remains open.",
-      "updated": "2026-08-09T17:10:31+10:00"
+      "note": "The current tag-only policy removes binary-asset recovery from the hotfix path. GitHub releases and Go module versions remain immutable once consumed, so recovery should use a new semver tag rather than replace a published version. Merged PR #5946 removed the obsolete asset workflow, but no end-to-end tag-only hotfix rehearsal or timed evidence is recorded. This gate remains open.",
+      "updated": "2026-08-13T17:30:00+10:00"
     },
     {
       "id": "ops-monitoring",
@@ -517,7 +517,6 @@
       "command": "go test ./..."
     },
     "workflows": [
-      "release-v3.yml",
       "nightly-release-v3.yml",
       "publish-npm.yml",
       "verify-runtime-assets.yml"

--- a/.release/v3.0.0-beta.0/plan.json
+++ b/.release/v3.0.0-beta.0/plan.json
@@ -102,7 +102,7 @@
     },
     {
       "id": "dry-run",
-      "title": "Full release dry run: build, sign, publish to a staging channel, install from it",
+      "title": "Tag-only release dry run: sync the ledger, preview the version, tag, changelog and release notes, then record the evidence",
       "phase": "assure",
       "offset": -3,
       "date": "2026-09-12"
@@ -175,8 +175,8 @@
       "track": "software",
       "blocking": true,
       "status": "open",
-      "note": "v3.0.0-beta.0 through beta.8 were published from master; beta.8 was published at 2026-08-12T08:20:32Z by successful Nightly Release v3 run 31577849776. The beta.8 tag still contains runtime package metadata versioned 3.0.0-beta.7, while npm publication run 31583811321 later published @wailsio/runtime 3.0.0-beta.8 from post-tag master; PR #5959 proposes future lockstep but is not merged. Maintainer direction recorded in #5876 and implemented by merged PR #5946 defines the current v3 release as a source tag/GitHub prerelease with CLI installation through go install, without attached desktop binaries. This evidence ledger remains at its beta.0 path, and release-stage/version approval is not recorded, so this gate remains open.",
-      "updated": "2026-08-13T17:30:00+10:00"
+      "note": "v3.0.0-beta.0 through beta.9 were published from master. Beta.8 exposed a tag/runtime metadata mismatch; merged PR #5959 added lockstep synchronization. Successful Nightly Release v3 run 31954639309 published beta.9 at 2026-08-16T15:06:42Z, and its tag records both the CLI version and runtime package/lockfile as 3.0.0-beta.9; publish-npm run 31954674432 then published the matching runtime package. Maintainer direction recorded in #5876 and implemented by merged PR #5946 defines the current v3 release as a source tag/GitHub prerelease with CLI installation through go install, without attached desktop binaries. This evidence ledger remains at its beta.0 path, and release-stage/version approval is not recorded, so this gate remains open.",
+      "updated": "2026-08-17T17:15:00+10:00"
     },
     {
     "id": "sw-compat",
@@ -220,8 +220,8 @@
       "blocking": true,
       "owner": "lea",
       "status": "open",
-      "note": "Historical Release v3 runs 30747695287 (beta.0) and 30748402783 (beta.1) published six desktop binaries plus SHA256SUMS. Beta.2 through beta.8 have zero attached assets. Before the tag-only decision was implemented, beta.3 through beta.7 Release v3 runs built the desktop set and failed to attach it to immutable releases; beta.6 run 31320435426 and beta.7 run 31506762359 are the latest examples, with beta.7 generating six binaries, SHA256SUMS, and provenance before HTTP 422. Maintainer direction in #5876 made zero-asset tag-only releases intentional, merged PR #5946 removed release-v3.yml plus its nightly dispatch, and successful run 31577849776 published beta.8 by the tag-only path. The artifact gate has not been explicitly redefined, passed, or waived for this policy, so it remains open.",
-      "updated": "2026-08-13T17:30:00+10:00"
+      "note": "Historical Release v3 runs 30747695287 (beta.0) and 30748402783 (beta.1) published six desktop binaries plus SHA256SUMS. Beta.2 through beta.9 have zero attached assets. Before the tag-only decision was implemented, beta.3 through beta.7 Release v3 runs built the desktop set and failed to attach it to immutable releases; beta.6 run 31320435426 and beta.7 run 31506762359 are the latest examples, with beta.7 generating six binaries, SHA256SUMS, and provenance before HTTP 422. Maintainer direction in #5876 made zero-asset tag-only releases intentional, merged PR #5946 removed release-v3.yml plus its nightly dispatch, and successful runs 31577849776 and 31954639309 published beta.8 and beta.9 by the tag-only path. The artifact gate has not been explicitly redefined, passed, or waived for this policy, so it remains open.",
+      "updated": "2026-08-17T17:15:00+10:00"
     },
     {
       "id": "sw-signing",
@@ -240,8 +240,8 @@
       "track": "software",
       "blocking": true,
       "status": "open",
-      "note": "Maintainer direction in #5876 identifies `go install github.com/wailsapp/wails/v3/cmd/wails3@latest` as the current published CLI channel, and merged PR #5946 removes the unused desktop-binary publication path. Beta.8 was published at 2026-08-12T08:20:32Z, but no clean-machine installation and version check from beta.8 or `@latest` is recorded in this ledger. The channel is now identified, but installation evidence is still absent, so this gate remains open.",
-      "updated": "2026-08-13T17:30:00+10:00"
+      "note": "Maintainer direction in #5876 identifies `go install github.com/wailsapp/wails/v3/cmd/wails3@latest` as the current published CLI channel, and merged PR #5946 removes the unused desktop-binary publication path. Beta.9 was published at 2026-08-16T15:06:42Z, and on 2026-08-17 the public Go proxy resolved `github.com/wailsapp/wails/v3@v3.0.0-beta.9` to tagged commit 9b3cd781fefc265813d3ca1cc12fa30010ef8ac6. No clean-machine installation and `wails3 version` check from beta.9 or `@latest` is recorded in this ledger, so this gate remains open.",
+      "updated": "2026-08-17T17:15:00+10:00"
     },
     {
       "id": "sw-perf",
@@ -454,8 +454,8 @@
       "track": "ops",
       "blocking": true,
       "status": "open",
-      "note": "Beta.7 published as a zero-asset prerelease at 2026-08-11T15:23:34Z. The still-present desktop workflow then ran as 31506762359, built six binaries plus SHA256SUMS and provenance, and failed HTTP 422 against the immutable release. Maintainer direction in #5876 made that workflow obsolete, and merged PR #5946 removed release-v3.yml and its nightly dispatch. Successful Nightly Release v3 run 31577849776 then published beta.8 at 2026-08-12T08:20:32Z through the intended tag-only path. README.md and comms/launch-sequence.md now describe the tag-only/go-install path, but named owners, a completed rehearsal, and final approval are not recorded, so this gate remains open.",
-      "updated": "2026-08-13T17:30:00+10:00"
+      "note": "Beta.7 published as a zero-asset prerelease at 2026-08-11T15:23:34Z. The still-present desktop workflow then ran as 31506762359, built six binaries plus SHA256SUMS and provenance, and failed HTTP 422 against the immutable release. Maintainer direction in #5876 made that workflow obsolete, and merged PR #5946 removed release-v3.yml and its nightly dispatch. Successful Nightly Release v3 runs 31577849776 and 31954639309 published beta.8 and beta.9 through the intended tag-only path; beta.9's matching runtime package was published by successful run 31954674432. README.md and comms/launch-sequence.md now describe the tag-only/go-install path, but named owners, a completed rehearsal, and final approval are not recorded, so this gate remains open.",
+      "updated": "2026-08-17T17:15:00+10:00"
     },
     {
       "id": "ops-support",


### PR DESCRIPTION
## Summary

- record beta.7 failure evidence and beta.8/beta.9 successful tag-only publication
- document the tag-only / `go install` policy across the release ledger and communication runbooks
- retain the historical beta.8 tag/runtime-version mismatch and record merged PR #5959 plus beta.9 lockstep evidence
- leave all 38 gate statuses unchanged, including all 27 blocking gates

Closes #5954.

## Validation

- `jq empty .release/v3.0.0-beta.0/plan.json`
- exact gate assertion: 38 total/open, 27 blocking/open, zero passed or waived
- baseline-vs-working comparison of every gate ID, status, and blocking flag
- stale asset-workflow/signing/binary instruction scan
- issue, PR, workflow-run, release, tag, runtime metadata, and Go proxy evidence verification
- `git diff --check`
- required `coderabbit --plain` invocation (installed CLI rejects the legacy flag and reports plain text is now the default); supported review against `origin/releases/v3-beta` found three runbook inconsistencies, all were reconciled, and the follow-up completed with no new findings
