### PR TITLE
fix: split vue template script import and closing tag

### DIFF
--- a/v2/pkg/templates/generate/assets/vue-ts/frontend/src/App.vue
+++ b/v2/pkg/templates/generate/assets/vue-ts/frontend/src/App.vue
@@ -1,5 +1,6 @@
 <script lang="ts" setup>
-import HelloWorld from './components/HelloWorld.vue'</script>
+import HelloWorld from './components/HelloWorld.vue'
+</script>
 
 <template>
   <img id="logo" alt="Wails logo" src="./assets/images/logo-universal.png"/>

--- a/v2/pkg/templates/generate/assets/vue/frontend/src/App.vue
+++ b/v2/pkg/templates/generate/assets/vue/frontend/src/App.vue
@@ -1,5 +1,6 @@
 <script setup>
-import HelloWorld from './components/HelloWorld.vue'</script>
+import HelloWorld from './components/HelloWorld.vue'
+</script>
 
 <template>
   <img id="logo" alt="Wails logo" src="./assets/images/logo-universal.png"/>

--- a/v2/pkg/templates/templates/vue-ts/frontend/src/App.vue
+++ b/v2/pkg/templates/templates/vue-ts/frontend/src/App.vue
@@ -1,5 +1,6 @@
 <script lang="ts" setup>
-import HelloWorld from './components/HelloWorld.vue'</script>
+import HelloWorld from './components/HelloWorld.vue'
+</script>
 
 <template>
   <img id="logo" alt="Wails logo" src="./assets/images/logo-universal.png"/>

--- a/v2/pkg/templates/templates/vue/frontend/src/App.vue
+++ b/v2/pkg/templates/templates/vue/frontend/src/App.vue
@@ -1,5 +1,6 @@
 <script setup>
-import HelloWorld from './components/HelloWorld.vue'</script>
+import HelloWorld from './components/HelloWorld.vue'
+</script>
 
 <template>
   <img id="logo" alt="Wails logo" src="./assets/images/logo-universal.png"/>

--- a/website/src/pages/changelog.mdx
+++ b/website/src/pages/changelog.mdx
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added `EnableAutoplayWithoutUserAction` macOS webview preference to allow HTML5 media to autoplay without a user gesture [#5512](https://github.com/wailsapp/wails/pull/5512) by @Eyalm321
 
+### Fixed
+
+- Fixed `vue-tsc` build failure (`TS1005: ';' expected`) caused by the Vue `App.vue` templates having the import statement and closing `</script>` tag on the same line
+
 ## v2.14.0 - 2026-08-10
 
 ### Fixed


### PR DESCRIPTION
The Vue `App.vue` templates shipped in the generated templates (and their `generate/assets` sources) had the import statement and the closing `</script>` tag on the same line. `vue-tsc` (run as part of `wails build`) fails to parse this and aborts with `error TS1005: ';' expected`. Split them onto separate lines.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] WEP (proposal only; no implementation)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Created a fresh project with `wails init -t vue-ts` and `-t vue` using the fixed templates, then ran `wails build`. The frontend compilation (including `vue-tsc --noEmit`) and the full build succeed.

- [ ] Windows
- [ ] macOS
- [x] Linux

Linux: Fedora 44

## Test Configuration

- Wails: v2.14.0
- Go: go1.26.5
- OS: Fedora Linux 44 (amd64)

# Checklist:

- [x] (v2 only) I have updated `website/src/pages/changelog.mdx` with details of this PR
- [x] My code follows the general coding style of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Vue template formatting that could cause `vue-tsc` build failures.
  * Updated Vue and Vue TypeScript templates for improved build compatibility.

* **Documentation**
  * Added an unreleased changelog entry describing the Vue template build fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->