### PR TITLE
fix(security): update website nanoid lockfiles

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -13425,9 +13425,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",

--- a/website/pnpm-lock.yaml
+++ b/website/pnpm-lock.yaml
@@ -3776,8 +3776,8 @@ packages:
     resolution: {integrity: sha512-2eznPJP8z2BFLX50tf0LuODrpINqP1RVIm/CObbTcBRITQgmC/TjcREF1NeTBzIcR5XO/ukWo+YHOjBbFwIupg==}
     hasBin: true
 
-  nanoid@3.3.15:
-    resolution: {integrity: sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -10528,7 +10528,7 @@ snapshots:
       dns-packet: 5.6.1
       thunky: 1.1.0
 
-  nanoid@3.3.15: {}
+  nanoid@3.3.18: {}
 
   negotiator@0.6.3: {}
 
@@ -11172,7 +11172,7 @@ snapshots:
 
   postcss@8.5.16:
     dependencies:
-      nanoid: 3.3.15
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 


### PR DESCRIPTION
## Summary

- update the npm website lockfile from nanoid 3.3.16 to patched 3.3.18
- update the pnpm website lockfile from nanoid 3.3.15 to patched 3.3.18
- keep the lockfile diff limited to nanoid version, tarball, and integrity entries

Fixes #5983.

## Verification

- `pnpm install --frozen-lockfile --lockfile-only`
- clean `npm ci`
- `npm ls nanoid --all --json` resolves only nanoid 3.3.18
- production `npm run build` completes all seven locales
- `npm audit --omit=dev --json` contains no nanoid advisory
- vulnerable-version scan across both lockfiles
- `git diff --check`
- required `coderabbit --plain` invocation (CLI reports the flag is unsupported); supported review attempted but lockfiles were excluded as “No files to review”