### PR TITLE
fix(v2/linux): handle native file drops without WebKit navigation

### DIFF
--- a/v2/internal/frontend/desktop/linux/window.c
+++ b/v2/internal/frontend/desktop/linux/window.c
@@ -551,7 +551,7 @@ static gboolean onDragDrop(GtkWidget* self, GdkDragContext* context, gint x, gin
     }
 
     processMessage(res);
-    return FALSE;
+    return TRUE;
 }
 
 // WebView
@@ -566,7 +566,7 @@ GtkWidget *SetupWebview(void *contentManager, GtkWindow *window, int hideWindowO
     webkit_web_context_register_uri_scheme(context, "wails", (WebKitURISchemeRequestCallback)processURLRequest, NULL, NULL);
     g_signal_connect(G_OBJECT(webview), "load-changed", G_CALLBACK(webviewLoadChanged), NULL);
 
-    if(disableWebViewDragAndDrop)
+    if(disableWebViewDragAndDrop && !enableDragAndDrop)
     {
         gtk_drag_dest_unset(webview);
     }

--- a/website/src/pages/changelog.mdx
+++ b/website/src/pages/changelog.mdx
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added `EnableAutoplayWithoutUserAction` macOS webview preference to allow HTML5 media to autoplay without a user gesture [#5512](https://github.com/wailsapp/wails/pull/5512) by @Eyalm321
 
+### Fixed
+
+- Fixed drag-and-drop on Linux, allowing both native file drops and HTML5 drag-and-drop to work without WebKit navigating to externally dropped files.
+
 ## v2.14.0 - 2026-08-10
 
 ### Fixed


### PR DESCRIPTION
# Description

Fix Linux drag-and-drop when Wails native file handling is enabled.

## Details

Two related problems seems to currently occur:

1. After Wails delivers native file paths, `onDragDrop()` returns `FALSE` and GTK therefore considers the drop not handled and allows WebKit to process it again. WebKit then navigates to the dropped image or other supported file, replacing the application UI.

2. When `EnableFileDrop` and `DisableWebViewDrop` are both true, `gtk_drag_dest_unset()` removes the destination required by Wails native file-drop handlers.

This change marks the native file drop as handled and prevents WebKit from navigating to the dropped file:

```
processMessage(res);
-return FALSE;
+return TRUE;
```

And this one preserves the existing GTK drag destination when native file handling is enabled:
```
-if(disableWebViewDragAndDrop)
+if(disableWebViewDragAndDrop && !enableDragAndDrop)
{
    gtk_drag_dest_unset(webview);
}
```

Not completely sure what should be the expected behavior, but with these changes both HTML5 drags and external file drops become usable.

- Fixes or relates to #3563 and #3686

## Type of change
  
Please select the option that is relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] WEP (proposal only; no implementation)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
  
- [ ] Windows
- [ ] macOS
- [x] Linux

Tested manually with and without the PR commit using all four option combinations.

Before:

| `EnableFileDrop` | `DisableWebViewDrop` | Internal HTML DnD | External file DnD |
| --- | --- | --- | --- |
| `false` | `false` | Works | WebKit navigates to the file |
| `true` | `false` | Works | Paths are handled, then WebKit navigates to the file replacing the UI |
| `false` | `true` | Disabled | Disabled |
| `true` | `true` | Disabled | Disabled |

After:

| `EnableFileDrop` | `DisableWebViewDrop` | Internal HTML DnD | External file DnD |
| --- | --- | --- | --- |
| `false` | `false` | Works | WebKit navigates to the file replacing the UI |
| `true` | `false` | Works | Paths delivered; no WebKit navigation |
| `false` | `true` | Disabled | Disabled |
| `true` | `true` | Works | Paths delivered; no WebKit navigation |

When both options are enabled, internal HTML drag-and-drop remains available because Wails relies on the same webview drop destination to receive external files. Fully disabling it would also prevent native file delivery.

## Test Configuration

Please paste the output of `wails doctor`. If you are unable to run this command, please describe your environment in as much detail as possible.
```
# System
┌───────────────────────────────────────────────────────────────────────────────────────┐
| OS           | Arch Linux                                                             |
| Version      | Unknown                                                                |
| ID           | arch                                                                   |
| Branding     |                                                                        |
| Go Version   | go1.26.5-X:nodwarf5                                                    |
| Platform     | linux                                                                  |
| Architecture | amd64                                                                  |
| CPU          | 11th Gen Intel(R) Core(TM) i5-1135G7 @ 2.40GHz                         |
| GPU          | TigerLake-LP GT2 [Iris Xe Graphics] (Intel Corporation) - Driver: i915 |
| Memory       | 15GB                                                                   |
└───────────────────────────────────────────────────────────────────────────────────────┘

# Dependencies
┌─────────────────────────────────────────────────────────────────────┐
| Dependency | Package Name | Status    | Version                     |
| *docker    | docker       | Installed | 1:29.6.2-1                  |
| gcc        | gcc          | Installed | 16.1.1+r595+g171d15ac6959-1 |
| libgtk-3   | gtk3         | Installed | 1:3.24.52-1                 |
| libwebkit  | Unknown      | Not Found |                             |
| npm        | npm          | Installed | 12.0.1-1                    |
| pkg-config | pkgconf      | Installed | 3.0.4-1                     |
|                                                                     |
└────────────────────── * - Optional Dependency ──────────────────────┘
```

Compiled with build tag `webkit2_41` and package `webkit2gtk-4.1 2.52.5-2` installed.

# Checklist:

- [x] (v2 only) I have updated `website/src/pages/changelog.mdx` with details of this PR (v3 changelog entries are added automatically)
- [x] My code follows the general coding style of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Linux drag-and-drop handling for native file drops and HTML5 drag-and-drop.
  * Prevented WebKit from navigating to externally dropped files.
* **Documentation**
  * Added an unreleased changelog entry describing the Linux drag-and-drop improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->