### PR TITLE
fix(v3/linux): emit launch URL and file-association events on GTK4

### DIFF
--- a/v3/UNRELEASED_CHANGELOG.md
+++ b/v3/UNRELEASED_CHANGELOG.md
@@ -23,6 +23,7 @@ After processing, the content will be moved to the main changelog and this file 
 
 ## Fixed
 <!-- Bug fixes -->
+- Fix GTK4 Linux host dropping custom-protocol and file-association launch arguments in [PR](https://github.com/wailsapp/wails/pull/6000) by @midagedev
 
 ## Deprecated
 <!-- Soon-to-be removed features -->

--- a/v3/pkg/application/application_linux.go
+++ b/v3/pkg/application/application_linux.go
@@ -18,6 +18,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"strings"
 	"sync"
 
@@ -87,6 +88,46 @@ func (a *linuxApp) name() string {
 }
 
 func (a *linuxApp) run() error {
+	// Inspect argv the same way the GTK3 host and the Windows host do.
+	// g_application_run is invoked with argc=0, so GApplication never sees
+	// the launch argument; custom-protocol URLs and file associations are
+	// delivered only through this check.
+	if len(os.Args) == 2 { // Case: program + 1 argument
+		arg1 := os.Args[1]
+		// Check if the argument is likely a URL from a custom protocol invocation
+		if strings.Contains(arg1, "://") {
+			a.parent.debug("Application launched with argument, potentially a URL from custom protocol", "url", arg1)
+			eventContext := newApplicationEventContext()
+			eventContext.setURL(arg1)
+			applicationEvents <- &ApplicationEvent{
+				Id:  uint(events.Common.ApplicationLaunchedWithUrl),
+				ctx: eventContext,
+			}
+		} else {
+			// Check if the argument matches any file associations
+			matched := false
+			if a.parent.options.FileAssociations != nil {
+				ext := filepath.Ext(arg1)
+				if slices.Contains(a.parent.options.FileAssociations, ext) {
+					a.parent.debug("File opened via file association", "file", arg1, "extension", ext)
+					eventContext := newApplicationEventContext()
+					eventContext.setOpenedWithFile(arg1)
+					applicationEvents <- &ApplicationEvent{
+						Id:  uint(events.Common.ApplicationOpenedWithFile),
+						ctx: eventContext,
+					}
+					matched = true
+				}
+			}
+			if !matched {
+				a.parent.debug("Application launched with single argument (not a URL), potential file open?", "arg", arg1)
+			}
+		}
+	} else if len(os.Args) > 2 {
+		// Log if multiple arguments are passed
+		a.parent.debug("Application launched with multiple arguments", "args", os.Args[1:])
+	}
+
 	a.parent.Event.OnApplicationEvent(events.Linux.ApplicationStartup, func(evt *ApplicationEvent) {
 		if err := a.processAndCacheScreens(); err != nil {
 			a.parent.handleError(err)

--- a/v3/pkg/application/application_linux.go
+++ b/v3/pkg/application/application_linux.go
@@ -88,44 +88,26 @@ func (a *linuxApp) name() string {
 }
 
 func (a *linuxApp) run() error {
-	// Inspect argv the same way the GTK3 host and the Windows host do.
-	// g_application_run is invoked with argc=0, so GApplication never sees
-	// the launch argument; custom-protocol URLs and file associations are
-	// delivered only through this check.
-	if len(os.Args) == 2 { // Case: program + 1 argument
+	if len(os.Args) == 2 {
 		arg1 := os.Args[1]
-		// Check if the argument is likely a URL from a custom protocol invocation
 		if strings.Contains(arg1, "://") {
-			a.parent.debug("Application launched with argument, potentially a URL from custom protocol", "url", arg1)
 			eventContext := newApplicationEventContext()
 			eventContext.setURL(arg1)
 			applicationEvents <- &ApplicationEvent{
 				Id:  uint(events.Common.ApplicationLaunchedWithUrl),
 				ctx: eventContext,
 			}
-		} else {
-			// Check if the argument matches any file associations
-			matched := false
-			if a.parent.options.FileAssociations != nil {
-				ext := filepath.Ext(arg1)
-				if slices.Contains(a.parent.options.FileAssociations, ext) {
-					a.parent.debug("File opened via file association", "file", arg1, "extension", ext)
-					eventContext := newApplicationEventContext()
-					eventContext.setOpenedWithFile(arg1)
-					applicationEvents <- &ApplicationEvent{
-						Id:  uint(events.Common.ApplicationOpenedWithFile),
-						ctx: eventContext,
-					}
-					matched = true
+		} else if a.parent.options.FileAssociations != nil {
+			ext := filepath.Ext(arg1)
+			if slices.Contains(a.parent.options.FileAssociations, ext) {
+				eventContext := newApplicationEventContext()
+				eventContext.setOpenedWithFile(arg1)
+				applicationEvents <- &ApplicationEvent{
+					Id:  uint(events.Common.ApplicationOpenedWithFile),
+					ctx: eventContext,
 				}
 			}
-			if !matched {
-				a.parent.debug("Application launched with single argument (not a URL), potential file open?", "arg", arg1)
-			}
 		}
-	} else if len(os.Args) > 2 {
-		// Log if multiple arguments are passed
-		a.parent.debug("Application launched with multiple arguments", "args", os.Args[1:])
 	}
 
 	a.parent.Event.OnApplicationEvent(events.Linux.ApplicationStartup, func(evt *ApplicationEvent) {


### PR DESCRIPTION
# Description

On the default Linux build (GTK4 + WebKitGTK 6.0), launching an app with a
custom-protocol URL or an associated file silently drops the argument:
`events.Common.ApplicationLaunchedWithUrl` and
`events.Common.ApplicationOpenedWithFile` never fire.

The GTK3 host (`-tags gtk3`, `application_linux_gtk3.go`) inspects `os.Args`
at the start of `run()` and emits those events — the block added in #4289.
Windows does the same (`application_windows.go`). macOS delivers the URL via
an Apple Event. When #5463 promoted the GTK4 host to the default Linux path,
its `run()` never received that argv block, so the documented behaviour
(the Linux tab of the custom-protocols guide, and the single-instance
example's "On Windows and Linux the URL is passed through argv") stopped
working on the default build. Same class of GTK4-default-path omission as
#5477 and #5971.

Both Linux hosts call `g_application_run(app, 0, nil)`, so GApplication never
sees the argument — the Go-side check is the only delivery path.

Fixes # (no pre-existing issue found — searched `ApplicationLaunchedWithUrl`,
`gtk4 protocol`, `custom protocol linux`, `FileAssociations`; closest are
#4567 (macOS config.yml) and #5089 (macOS single-instance relay), neither of
which is this.)

## Change

Port the GTK3 argv block into the GTK4 `run()`, in the same position (before
`appRun`). Classification is unchanged from GTK3/Windows:

- `len(os.Args) == 2` and the argument contains `://` → `ApplicationLaunchedWithUrl`
- otherwise, if `filepath.Ext(arg)` is in `options.FileAssociations` → `ApplicationOpenedWithFile`
- any other single argument, or more than one argument → debug log only

The GTK3 file is untouched. No new options, events, or public API — this
restores documented behaviour on the default path, so no WEP.

Related: #4289, #5463, #5477, #5971. Not related: #4567, #5808 (mobile
cold-start URLs — different files, different platforms).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [ ] Windows
- [ ] macOS
- [x] Linux

Distro: Ubuntu 24.04.4 (noble) containers, headless — details below.

**Compile + unit tests, both tags** (throwaway Ubuntu 24.04 container,
Go 1.25.0, libgtk-4-dev 4.14.5, libwebkitgtk-6.0-dev 2.52.3, libgtk-3-dev
3.24.41, libwebkit2gtk-4.1-dev 2.52.3):

- `go build ./pkg/application` — exit 0 on the GTK4 default and with `-tags gtk3`
- `go test ./pkg/application -count=1` — ok on both tags
- `gofmt -l pkg/application/application_linux.go` — empty

**Runtime A/B, headless.** `App.Run()` starts the application-event consumer
before calling the platform host's `run()`, and this patch's argv block runs
before `appRun` (the call that needs a display). So the event delivery is
observable in a container with no display: a minimal app (listeners for both
events, `FileAssociations: [".wails"]`, no window) prints what it receives,
then `appRun` fails on the missing display as expected.

With `DISPLAY` unset, GTK prints "Failed to open display" and terminates the
process (it does not return an error to Go) — the argv event is still
delivered first:

- patched + `myapp://test/action` → `EVENT-URL: myapp://test/action`
- patched + `demo.wails` → `EVENT-FILE: <that path>`
- patched + `demo.txt` (not in FileAssociations) → `NO-EVENT` (under Xvfb;
  headless the process dies before the 5s negative wait can print)
- patched + no args → `NO-EVENT` (same)
- the same four argv on the parent commit (`713dc89`) → `NO-EVENT`
- patched rebuilt with `-tags gtk3`, URL argv → `EVENT-URL` (non-regression)

This is not a desktop test: no `.desktop` registration, no `xdg-open`, no
file-manager double-click, no real Wayland/X11 session. It shows the GTK4
argv block emits the same events GTK3/Windows already emit, and that the
unpatched host does not.

To reproduce on a real GTK4 desktop: build
`v3/examples/custom-protocol-example` without `-tags gtk3` and run
`./custom-protocol-example 'wailsexample://test/action'` — the URL should
reach the `ApplicationLaunchedWithUrl` listener; for files, build
`v3/examples/file-association` and run `./fileassoc /tmp/demo.wails`.

## Test Configuration

No Linux desktop was available to run `wails3 doctor`; the build/test
environment was: Ubuntu 24.04.4 LTS (noble) container, Go 1.25.0
(GOTOOLCHAIN=local), gcc 13.2.0, pkg-config 1.8.1, gtk4 4.14.5
(libgtk-4-dev), webkitgtk-6.0 2.52.3 (libwebkitgtk-6.0-dev), and for the
GTK3 non-regression: gtk+-3.0 3.24.41, webkit2gtk-4.1 2.52.3.

# Checklist:

- [ ] (v2 only) I have updated `website/src/pages/changelog.mdx` with details of this PR (v3 changelog entries are added automatically)
- [x] My code follows the general coding style of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

(Documentation: the custom-protocols guide already documents this behaviour
for Linux — this PR makes the default build match the docs. One adjacent gap
noticed but left out of this PR to keep it single-purpose:
`guides/file-associations.mdx` still lists only Windows and macOS, while both
Linux hosts now emit `ApplicationOpenedWithFile` from argv.)

The argv classification is adapted from the existing GTK3 host in this
repository; no third-party code is included.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed GTK4 Linux startup handling for custom-protocol URLs and file associations.
  * Launching with a URL now opens the associated destination correctly.
  * Opening supported files now triggers the appropriate application action.
  * Unrecognized or multiple launch arguments are handled safely.

* **Documentation**
  * Added changelog entries covering Linux launch-argument handling and changelog validation fixes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->