### PR TITLE
fix(v3/windows): recover from WebView2 process failures instead of leaving a blank window

### DIFF
--- a/v3/internal/webview2/internal/w32/w32.go
+++ b/v3/internal/webview2/internal/w32/w32.go
@@ -44,10 +44,13 @@ var (
 
 	// GetMessageW blocks until a message arrives, which makes any loop built on
 	// it unbounded. These two allow a message loop to wait with a deadline
-	// instead: MsgWaitForMultipleObjects returns on either input or timeout,
-	// and PeekMessageW then drains whatever arrived.
-	User32MsgWaitForMultipleObjects = user32.NewProc("MsgWaitForMultipleObjects")
-	User32PeekMessageW              = user32.NewProc("PeekMessageW")
+	// instead: MsgWaitForMultipleObjectsEx returns on input or timeout, and
+	// PeekMessageW then drains whatever arrived. The Ex variant is required
+	// for MWMO_INPUTAVAILABLE; without that flag the wait ignores messages
+	// that were already queued when it was entered, so a message landing
+	// between the drain and the next wait sleeps the full timeout.
+	User32MsgWaitForMultipleObjectsEx = user32.NewProc("MsgWaitForMultipleObjectsEx")
+	User32PeekMessageW                = user32.NewProc("PeekMessageW")
 )
 
 const (
@@ -71,8 +74,12 @@ const (
 
 	PM_REMOVE = 0x0001
 
-	// QS_ALLINPUT wakes MsgWaitForMultipleObjects for any queued message.
+	// QS_ALLINPUT wakes MsgWaitForMultipleObjectsEx for any queued message.
 	QS_ALLINPUT = 0x04FF
+
+	// MWMO_INPUTAVAILABLE makes MsgWaitForMultipleObjectsEx return when
+	// matching input is already available, not only when new input arrives.
+	MWMO_INPUTAVAILABLE = 0x0004
 
 	WAIT_TIMEOUT = 0x00000102
 )

--- a/v3/internal/webview2/pkg/edge/ICoreWebView2NavigationCompletedEventArgs.go
+++ b/v3/internal/webview2/pkg/edge/ICoreWebView2NavigationCompletedEventArgs.go
@@ -4,6 +4,8 @@ package edge
 
 import (
 	"unsafe"
+
+	"golang.org/x/sys/windows"
 )
 
 type _ICoreWebView2NavigationCompletedEventArgsVtbl struct {
@@ -27,4 +29,18 @@ func (i *ICoreWebView2NavigationCompletedEventArgs) Release() uint32 {
 	ret, _, _ := i.vtbl.Release.Call(uintptr(unsafe.Pointer(i)))
 
 	return uint32(ret)
+}
+
+func (i *ICoreWebView2NavigationCompletedEventArgs) GetIsSuccess() (bool, error) {
+	// BOOL out-params are 4 bytes; receiving into a 1-byte Go bool lets the
+	// callee write 3 bytes out of bounds on the stack.
+	var _resultInt int32
+	hr, _, _ := i.vtbl.GetIsSuccess.Call(
+		uintptr(unsafe.Pointer(i)),
+		uintptr(unsafe.Pointer(&_resultInt)),
+	)
+	if windows.Handle(hr) != windows.S_OK {
+		return false, windows.Errno(hr)
+	}
+	return _resultInt != 0, nil
 }

--- a/v3/internal/webview2/pkg/edge/chromium.go
+++ b/v3/internal/webview2/pkg/edge/chromium.go
@@ -499,6 +499,17 @@ func (e *Chromium) fallbackToCoreWebView2Controller(reason error) error {
 	return nil
 }
 
+// ReleaseCompositionResources drops the composition controller and the DComp
+// host targeting this Chromium's HWND. An HWND can carry only one DComp
+// target: while the old one exists, a replacement Chromium's composition
+// setup fails with DCOMPOSITION_ERROR_WINDOW_ALREADY_COMPOSED and silently
+// falls back to windowed hosting. A controller rebuild must call this on the
+// abandoned instance before creating its replacement.
+func (e *Chromium) ReleaseCompositionResources() {
+	e.releaseCompositionController()
+	e.releaseCompositionHost()
+}
+
 func (e *Chromium) releaseCompositionController() {
 	if e.compositionController4 != nil {
 		e.compositionController4.Release()

--- a/v3/internal/webview2/pkg/edge/chromium.go
+++ b/v3/internal/webview2/pkg/edge/chromium.go
@@ -255,16 +255,21 @@ func (e *Chromium) pumpUntilInited(timeout time.Duration) bool {
 
 		// Wake on any queued message or when the deadline expires, whichever
 		// comes first. Unlike GetMessageW this cannot park indefinitely.
-		r, _, _ := w32.User32MsgWaitForMultipleObjects.Call(
-			0, 0, 0,
+		// MWMO_INPUTAVAILABLE is load-bearing: without it the wait ignores
+		// messages already in the queue at entry, so a completion posted
+		// between the drain below and this wait sleeps the full deadline.
+		// (Note the Ex signature has no fWaitAll parameter.)
+		r, _, _ := w32.User32MsgWaitForMultipleObjectsEx.Call(
+			0, 0,
 			uintptr(uint32(remaining.Milliseconds())),
 			w32.QS_ALLINPUT,
+			w32.MWMO_INPUTAVAILABLE,
 		)
 		if r == w32.WAIT_TIMEOUT {
 			continue // re-check inited once more, then fail on the deadline
 		}
 
-		// MsgWaitForMultipleObjects only signals that the queue is non-empty;
+		// MsgWaitForMultipleObjectsEx only signals that the queue is non-empty;
 		// it does not remove anything. Drain what is there before waiting again,
 		// or the next wait returns immediately on the same message.
 		for {

--- a/v3/pkg/application/webview_window_windows.go
+++ b/v3/pkg/application/webview_window_windows.go
@@ -2696,9 +2696,17 @@ func (w *windowsWebviewWindow) navigationCompleted(
 	sender *edge.ICoreWebView2,
 	args *edge.ICoreWebView2NavigationCompletedEventArgs,
 ) {
-	// The webview loaded something, so any process-failure recovery that led
-	// here worked.
-	w.resetWebviewRecoveryBudget()
+	// Only a *successful* load means recovery worked. A dead render process
+	// leaves WebView2 on an error page, and that error page fires this callback
+	// too — resetting on it would hand a crash-looping renderer a fresh budget
+	// on every cycle and the attempt bound would never trip, which is the
+	// runaway it exists to stop. Treat an unreadable IsSuccess as unsuccessful
+	// for the same reason.
+	if ok, err := args.GetIsSuccess(); err != nil {
+		globalApplication.error("webview2: reading navigation success: %v", err)
+	} else if ok {
+		w.resetWebviewRecoveryBudget()
+	}
 
 	// Inject runtime core and window-specific flags together so side-effect
 	// runtime modules see a consistent _wails configuration at startup.
@@ -3181,6 +3189,12 @@ func (w *windowsWebviewWindow) processFailed(_ *edge.ICoreWebView2, args *edge.I
 			return
 		}
 		restore = func() {
+			// Same teardown race as rebuildWebView: shutting the app down kills
+			// the WebView2 processes, so this can land on a window that is
+			// already going away.
+			if w.parent.isDestroyed() || w.hwnd == 0 {
+				return
+			}
 			w.chromium.Navigate(url)
 		}
 	}

--- a/v3/pkg/application/webview_window_windows.go
+++ b/v3/pkg/application/webview_window_windows.go
@@ -63,11 +63,18 @@ type windowsWebviewWindow struct {
 	// the re-enable exists to avoid. Main-thread only.
 	monitorScaleDetectionOn bool
 	// lastNavigatedURL is the most recent URL passed to setURL. It is what
-	// processFailed restores after a WebView2 process failure: the live
+	// setupChromium restores after a WebView2 process failure: the live
 	// webview cannot be queried at that point (its COM objects are dead),
 	// so the last host-requested navigation is the only reliable record.
 	// Main-thread only, like the rest of the webview state.
 	lastNavigatedURL string
+	// webviewRecoveryAttempts counts consecutive process-failure recoveries
+	// that have not yet produced a completed navigation. navigationCompleted
+	// resets it, so a recovery that works costs nothing; a controller that
+	// dies again on every rebuild gives up after maxWebviewRecoveryAttempts
+	// rather than respawning WebView2 processes forever.
+	// Main-thread only, like the rest of the webview state.
+	webviewRecoveryAttempts int
 
 	// Window visibility management - robust fallback for issue #2861
 	showRequested     bool        // Track if show() was called before navigation completed
@@ -389,6 +396,25 @@ func (w *windowsWebviewWindow) extendFrameIntoClientArea(extend bool) error {
 	})
 }
 
+// newChromium creates a Chromium instance configured from this window's
+// options. Everything set here has to be set *before* Embed, so it cannot live
+// in setupChromium. Both start-up and the post-process-failure rebuild go
+// through this one function: when the rebuild carried its own copy of this
+// construction the two drifted, and a rebuilt window silently lost non-client
+// region support, composition hosting and cursor handling.
+func (w *windowsWebviewWindow) newChromium() *edge.Chromium {
+	options := w.parent.options
+
+	chromium := edge.NewChromium()
+	chromium.NonClientRegionSupportEnabled = options.Windows.NonClientRegionSupport
+	chromium.CompositionControllerEnabled = options.Windows.WebView2CompositionHosting
+	chromium.SetCursorChangedCallback(w.applyCompositionCursor)
+	if globalApplication.options.ErrorHandler != nil {
+		chromium.SetErrorCallback(globalApplication.options.ErrorHandler)
+	}
+	return chromium
+}
+
 func (w *windowsWebviewWindow) run() {
 
 	options := w.parent.options
@@ -397,13 +423,7 @@ func (w *windowsWebviewWindow) run() {
 	// Non-hidden windows should be shown by default
 	w.showRequested = !options.Hidden
 
-	w.chromium = edge.NewChromium()
-	w.chromium.NonClientRegionSupportEnabled = options.Windows.NonClientRegionSupport
-	w.chromium.CompositionControllerEnabled = options.Windows.WebView2CompositionHosting
-	w.chromium.SetCursorChangedCallback(w.applyCompositionCursor)
-	if globalApplication.options.ErrorHandler != nil {
-		w.chromium.SetErrorCallback(globalApplication.options.ErrorHandler)
-	}
+	w.chromium = w.newChromium()
 
 	exStyle := w32.WS_EX_CONTROLPARENT
 	if options.BackgroundType != BackgroundTypeSolid {
@@ -2609,7 +2629,21 @@ func (w *windowsWebviewWindow) setupChromium() {
 	}
 	chromium.AddWebResourceRequestedFilter("*", edge.COREWEBVIEW2_WEB_RESOURCE_CONTEXT_ALL)
 
-	if w.parent.options.HTML != "" {
+	// Land the fresh controller on the right page. lastNavigatedURL is empty on
+	// first start-up and set once the host has navigated anywhere, so on a
+	// rebuild after a process failure this restores where the window actually
+	// was — and it restores it directly, instead of loading the start URL and
+	// immediately throwing it away for the real one.
+	//
+	// Every branch must leave webviewNavigationCompleted false. That flag gates
+	// the Hide/Show visibility hack in navigationCompleted, and on a rebuild it
+	// is still true from the dead controller's last navigation; leaving it set
+	// would recover the webview into a window that is never made visible, which
+	// is the blank window this whole path exists to fix.
+	switch {
+	case w.lastNavigatedURL != "":
+		w.setURL(w.lastNavigatedURL)
+	case w.parent.options.HTML != "":
 		var script string
 		if w.parent.options.JS != "" {
 			script = w.parent.options.JS
@@ -2623,14 +2657,14 @@ func (w *windowsWebviewWindow) setupChromium() {
 		if script != "" {
 			chromium.Init(script)
 		}
+		w.webviewNavigationCompleted = false
 		chromium.NavigateToString(w.parent.options.HTML)
-	} else {
+	default:
 		startURL, err := assetserver.GetStartURL(w.parent.options.URL)
 		if err != nil {
 			globalApplication.handleFatalError(err)
 		}
-		w.webviewNavigationCompleted = false
-		chromium.Navigate(startURL)
+		w.setURL(startURL)
 	}
 
 }
@@ -2662,6 +2696,9 @@ func (w *windowsWebviewWindow) navigationCompleted(
 	sender *edge.ICoreWebView2,
 	args *edge.ICoreWebView2NavigationCompletedEventArgs,
 ) {
+	// The webview loaded something, so any process-failure recovery that led
+	// here worked.
+	w.resetWebviewRecoveryBudget()
 
 	// Inject runtime core and window-specific flags together so side-effect
 	// runtime modules see a consistent _wails configuration at startup.
@@ -3039,50 +3076,145 @@ func (w *windowsWebviewWindow) applyDisplayAffinity(affinity uint32) bool {
 	return true
 }
 
+// webviewRecoveryAction is what a WebView2 process failure calls for.
+type webviewRecoveryAction int
+
+const (
+	// webviewRecoveryNone leaves the failure to the browser process.
+	webviewRecoveryNone webviewRecoveryAction = iota
+	// webviewRecoveryRenavigate re-navigates the existing controller.
+	webviewRecoveryRenavigate
+	// webviewRecoveryRebuild replaces the controller entirely.
+	webviewRecoveryRebuild
+)
+
+// maxWebviewRecoveryAttempts bounds consecutive recovery attempts that never
+// reach a completed navigation. Without a bound, a controller that dies again
+// as soon as it is rebuilt turns recovery into a hot loop spawning WebView2
+// processes; with one, a permanently broken runtime costs a few attempts and
+// then leaves the window as it would have been without any recovery at all.
+const maxWebviewRecoveryAttempts = 3
+
+// webviewRecoveryActionFor maps a WebView2 process-failure kind to the recovery
+// it needs.
+//
+// A browser-process exit invalidates the whole controller — every subsequent
+// COM call returns ERROR_INVALID_STATE (0x8007139F) — so nothing short of a new
+// controller recovers it. Renderer failures leave the controller usable and a
+// re-navigation is enough.
+//
+// Everything else is deliberately left alone. GPU, utility and sandbox-helper
+// processes are restarted by Chromium itself, and if it gives up on them it
+// exits the browser process, which arrives back here as
+// BROWSER_PROCESS_EXITED. An out-of-process iframe (FRAME_RENDER_PROCESS_EXITED)
+// is likewise the browser's to re-create, and reloading the whole window over
+// one dead subframe would be far more destructive than the failure.
+func webviewRecoveryActionFor(kind edge.COREWEBVIEW2_PROCESS_FAILED_KIND) webviewRecoveryAction {
+	switch kind {
+	case edge.COREWEBVIEW2_PROCESS_FAILED_KIND_BROWSER_PROCESS_EXITED:
+		return webviewRecoveryRebuild
+	case edge.COREWEBVIEW2_PROCESS_FAILED_KIND_RENDER_PROCESS_EXITED,
+		edge.COREWEBVIEW2_PROCESS_FAILED_KIND_RENDER_PROCESS_UNRESPONSIVE:
+		return webviewRecoveryRenavigate
+	default:
+		return webviewRecoveryNone
+	}
+}
+
+// beginWebviewRecovery reports whether another recovery attempt is allowed,
+// counting it when it is. The counter is cleared by navigationCompleted, so it
+// only ever accumulates across failures that never managed to load anything —
+// which is exactly the runaway case maxWebviewRecoveryAttempts exists to stop.
+// RENDER_PROCESS_UNRESPONSIVE in particular re-fires for as long as the
+// renderer stays hung, so the bound applies to re-navigation as well as to
+// rebuilds.
+func (w *windowsWebviewWindow) beginWebviewRecovery() bool {
+	if w.webviewRecoveryAttempts >= maxWebviewRecoveryAttempts {
+		return false
+	}
+	w.webviewRecoveryAttempts++
+	return true
+}
+
+// resetWebviewRecoveryBudget restores the full attempt budget. Called from
+// navigationCompleted: the webview loaded something, so whatever recovery led
+// there worked, and a later unrelated failure should get a full set of attempts
+// of its own rather than inheriting a spent counter.
+func (w *windowsWebviewWindow) resetWebviewRecoveryBudget() {
+	w.webviewRecoveryAttempts = 0
+}
+
 // processFailed handles WebView2 process-failure notifications. Without a
 // handler, a dead browser process leaves the controller in a permanent
 // invalid state: every subsequent COM call fails with ERROR_INVALID_STATE
 // (0x8007139F), the window renders blank, and only an app restart recovers.
-// Renderer-level failures recover with a re-navigation; a browser-process
-// exit requires a full controller rebuild, deferred out of the callback per
-// WebView2 guidance. GPU and utility process failures are deliberately left
-// alone: Chromium restarts those processes itself, and if it gives up it
-// exits the browser process, which arrives here as BROWSER_PROCESS_EXITED.
+// Work is deferred out of the callback via InvokeAsync, per WebView2 guidance
+// about not calling controller methods reentrantly from an event handler.
 func (w *windowsWebviewWindow) processFailed(_ *edge.ICoreWebView2, args *edge.ICoreWebView2ProcessFailedEventArgs) {
 	kind, err := args.GetProcessFailedKind()
 	if err != nil {
 		globalApplication.error("webview2: process failed and failure kind unavailable: %v", err)
 		return
 	}
-	globalApplication.error("webview2: process failed: kind=%d", kind)
-	switch kind {
-	case edge.COREWEBVIEW2_PROCESS_FAILED_KIND_BROWSER_PROCESS_EXITED:
-		InvokeAsync(w.rebuildWebView)
-	case edge.COREWEBVIEW2_PROCESS_FAILED_KIND_RENDER_PROCESS_EXITED,
-		edge.COREWEBVIEW2_PROCESS_FAILED_KIND_RENDER_PROCESS_UNRESPONSIVE:
-		if url := w.lastNavigatedURL; url != "" {
-			InvokeAsync(func() {
-				w.chromium.Navigate(url)
-			})
+
+	action := webviewRecoveryActionFor(kind)
+	if action == webviewRecoveryNone {
+		globalApplication.info("webview2: process failed (kind=%d); leaving recovery to the browser process", kind)
+		return
+	}
+
+	// Work out what recovery would actually do before spending an attempt from
+	// the budget, so a no-op does not eat into it.
+	var restore func()
+	switch action {
+	case webviewRecoveryRebuild:
+		restore = w.rebuildWebView
+	case webviewRecoveryRenavigate:
+		url := w.lastNavigatedURL
+		if url == "" {
+			// A window still showing its options.HTML content has no URL to go
+			// back to — that content came from NavigateToString, and re-rendering
+			// it means the full rebuild path, which a renderer failure does not
+			// warrant on its own.
+			globalApplication.error(
+				"webview2: process failed (kind=%d) but there is no host navigation to restore; leaving the page as-is", kind)
+			return
+		}
+		restore = func() {
+			w.chromium.Navigate(url)
 		}
 	}
+
+	if !w.beginWebviewRecovery() {
+		globalApplication.error(
+			"webview2: process failed (kind=%d) and %d consecutive recovery attempts have not restored the webview; giving up, the window will stay blank until the application restarts",
+			kind, maxWebviewRecoveryAttempts,
+		)
+		return
+	}
+	globalApplication.error("webview2: process failed (kind=%d); recovery attempt %d of %d",
+		kind, w.webviewRecoveryAttempts, maxWebviewRecoveryAttempts)
+
+	InvokeAsync(restore)
 }
 
-// rebuildWebView replaces a dead WebView2 controller with a fresh one and
-// restores the last navigated URL. The old Chromium instance is abandoned
-// rather than re-embedded: after a browser-process exit every COM reference
-// it holds is dangling, and edge.Chromium.Embed's init-wait loop keys on a
-// per-instance flag that a used instance has already set, so re-embedding
-// the same instance would return before the new controller exists. The
-// construction mirrors run().
+// rebuildWebView replaces a dead WebView2 controller with a fresh one.
+// setupChromium re-applies every setting and restores lastNavigatedURL, so
+// this only has to supply the controller.
+//
+// The old Chromium instance is abandoned rather than re-embedded: after a
+// browser-process exit every COM reference it holds is dangling, and
+// edge.Chromium.Embed's init-wait loop keys on a per-instance flag that a used
+// instance has already set, so re-embedding the same instance would return
+// before the new controller exists.
 func (w *windowsWebviewWindow) rebuildWebView() {
+	// A window destroyed between the failure and this callback has no HWND to
+	// embed into — shutting the app down kills the WebView2 processes, so a
+	// process failure racing teardown is expected rather than exceptional.
+	if w.parent.isDestroyed() || w.hwnd == 0 {
+		return
+	}
 	globalApplication.info("webview2: rebuilding controller after browser process exit")
-	w.chromium = edge.NewChromium()
-	if globalApplication.options.ErrorHandler != nil {
-		w.chromium.SetErrorCallback(globalApplication.options.ErrorHandler)
-	}
+	w.chromium = w.newChromium()
 	w.setupChromium()
-	if url := w.lastNavigatedURL; url != "" {
-		w.setURL(url)
-	}
 }

--- a/v3/pkg/application/webview_window_windows.go
+++ b/v3/pkg/application/webview_window_windows.go
@@ -62,6 +62,12 @@ type windowsWebviewWindow struct {
 	// the scale during a mixed-DPI monitor cross is exactly the transient
 	// the re-enable exists to avoid. Main-thread only.
 	monitorScaleDetectionOn bool
+	// lastNavigatedURL is the most recent URL passed to setURL. It is what
+	// processFailed restores after a WebView2 process failure: the live
+	// webview cannot be queried at that point (its COM objects are dead),
+	// so the last host-requested navigation is the only reliable record.
+	// Main-thread only, like the rest of the webview state.
+	lastNavigatedURL string
 
 	// Window visibility management - robust fallback for issue #2861
 	showRequested     bool        // Track if show() was called before navigation completed
@@ -326,6 +332,7 @@ func (w *windowsWebviewWindow) setAlwaysOnTop(alwaysOnTop bool) {
 func (w *windowsWebviewWindow) setURL(url string) {
 	// Navigate to the given URL in the webview
 	w.webviewNavigationCompleted = false
+	w.lastNavigatedURL = url
 	w.chromium.Navigate(url)
 }
 
@@ -2429,6 +2436,7 @@ func (w *windowsWebviewWindow) setupChromium() {
 	chromium.NavigationStartingCallback = w.navigationStarting
 	chromium.NavigationCompletedCallback = w.navigationCompleted
 	chromium.AcceleratorKeyCallback = w.processKeyBinding
+	chromium.ProcessFailedCallback = w.processFailed
 
 	chromium.Embed(w.hwnd)
 
@@ -3029,4 +3037,52 @@ func (w *windowsWebviewWindow) applyDisplayAffinity(affinity uint32) bool {
 		return false
 	}
 	return true
+}
+
+// processFailed handles WebView2 process-failure notifications. Without a
+// handler, a dead browser process leaves the controller in a permanent
+// invalid state: every subsequent COM call fails with ERROR_INVALID_STATE
+// (0x8007139F), the window renders blank, and only an app restart recovers.
+// Renderer-level failures recover with a re-navigation; a browser-process
+// exit requires a full controller rebuild, deferred out of the callback per
+// WebView2 guidance. GPU and utility process failures are deliberately left
+// alone: Chromium restarts those processes itself, and if it gives up it
+// exits the browser process, which arrives here as BROWSER_PROCESS_EXITED.
+func (w *windowsWebviewWindow) processFailed(_ *edge.ICoreWebView2, args *edge.ICoreWebView2ProcessFailedEventArgs) {
+	kind, err := args.GetProcessFailedKind()
+	if err != nil {
+		globalApplication.error("webview2: process failed and failure kind unavailable: %v", err)
+		return
+	}
+	globalApplication.error("webview2: process failed: kind=%d", kind)
+	switch kind {
+	case edge.COREWEBVIEW2_PROCESS_FAILED_KIND_BROWSER_PROCESS_EXITED:
+		InvokeAsync(w.rebuildWebView)
+	case edge.COREWEBVIEW2_PROCESS_FAILED_KIND_RENDER_PROCESS_EXITED,
+		edge.COREWEBVIEW2_PROCESS_FAILED_KIND_RENDER_PROCESS_UNRESPONSIVE:
+		if url := w.lastNavigatedURL; url != "" {
+			InvokeAsync(func() {
+				w.chromium.Navigate(url)
+			})
+		}
+	}
+}
+
+// rebuildWebView replaces a dead WebView2 controller with a fresh one and
+// restores the last navigated URL. The old Chromium instance is abandoned
+// rather than re-embedded: after a browser-process exit every COM reference
+// it holds is dangling, and edge.Chromium.Embed's init-wait loop keys on a
+// per-instance flag that a used instance has already set, so re-embedding
+// the same instance would return before the new controller exists. The
+// construction mirrors run().
+func (w *windowsWebviewWindow) rebuildWebView() {
+	globalApplication.info("webview2: rebuilding controller after browser process exit")
+	w.chromium = edge.NewChromium()
+	if globalApplication.options.ErrorHandler != nil {
+		w.chromium.SetErrorCallback(globalApplication.options.ErrorHandler)
+	}
+	w.setupChromium()
+	if url := w.lastNavigatedURL; url != "" {
+		w.setURL(url)
+	}
 }

--- a/v3/pkg/application/webview_window_windows.go
+++ b/v3/pkg/application/webview_window_windows.go
@@ -3209,7 +3209,16 @@ func (w *windowsWebviewWindow) processFailed(_ *edge.ICoreWebView2, args *edge.I
 	globalApplication.error("webview2: process failed (kind=%d); recovery attempt %d of %d",
 		kind, w.webviewRecoveryAttempts, maxWebviewRecoveryAttempts)
 
-	InvokeAsync(restore)
+	// Not InvokeAsync directly: it runs its function inline when already on
+	// the main thread, and this callback IS the main thread — WebView2
+	// delivers ProcessFailed through the message loop. Inline, the restore
+	// runs inside the event handler, where a new controller's creation
+	// callback is never delivered (Embed then times out, 0/8 in repeated
+	// browser-kill trials). The WebView2 docs require scheduling the work
+	// "to take place after completion of the event handler"; the goroutine
+	// hop forces dispatchOnMainThread to actually post, so the handler
+	// returns before the restore runs.
+	go InvokeAsync(restore)
 }
 
 // rebuildWebView replaces a dead WebView2 controller with a fresh one.

--- a/v3/pkg/application/webview_window_windows.go
+++ b/v3/pkg/application/webview_window_windows.go
@@ -3238,6 +3238,12 @@ func (w *windowsWebviewWindow) rebuildWebView() {
 		return
 	}
 	globalApplication.info("webview2: rebuilding controller after browser process exit")
+	// The abandoned instance's DComp target stays bound to the HWND, and an
+	// HWND can only carry one: without this release the replacement fails
+	// composition setup with DCOMPOSITION_ERROR_WINDOW_ALREADY_COMPOSED and
+	// silently falls back to windowed hosting, so a WebView2CompositionHosting
+	// window would come back with the wrong hosting mode.
+	w.chromium.ReleaseCompositionResources()
 	w.chromium = w.newChromium()
 	w.setupChromium()
 }

--- a/v3/pkg/application/webview_window_windows_processfailed_test.go
+++ b/v3/pkg/application/webview_window_windows_processfailed_test.go
@@ -1,4 +1,4 @@
-//go:build windows
+//go:build windows && !server
 
 package application
 

--- a/v3/pkg/application/webview_window_windows_processfailed_test.go
+++ b/v3/pkg/application/webview_window_windows_processfailed_test.go
@@ -1,0 +1,137 @@
+//go:build windows
+
+package application
+
+import (
+	"testing"
+
+	"github.com/wailsapp/wails/v3/internal/webview2/pkg/edge"
+)
+
+// The recovery decision and the attempt budget are the two pieces of the
+// process-failure path that can be exercised without a live WebView2 runtime:
+// neither touches COM. The rest (rebuildWebView, the re-navigation itself) needs
+// a real controller and is covered by the manual matrix in issue #5733.
+
+func TestWebviewRecoveryActionFor(t *testing.T) {
+	tests := []struct {
+		name string
+		kind edge.COREWEBVIEW2_PROCESS_FAILED_KIND
+		want webviewRecoveryAction
+	}{
+		{
+			// A dead browser process invalidates the controller permanently,
+			// so only a new controller recovers it.
+			name: "browser process exit rebuilds",
+			kind: edge.COREWEBVIEW2_PROCESS_FAILED_KIND_BROWSER_PROCESS_EXITED,
+			want: webviewRecoveryRebuild,
+		},
+		{
+			name: "render process exit re-navigates",
+			kind: edge.COREWEBVIEW2_PROCESS_FAILED_KIND_RENDER_PROCESS_EXITED,
+			want: webviewRecoveryRenavigate,
+		},
+		{
+			name: "unresponsive render process re-navigates",
+			kind: edge.COREWEBVIEW2_PROCESS_FAILED_KIND_RENDER_PROCESS_UNRESPONSIVE,
+			want: webviewRecoveryRenavigate,
+		},
+		{
+			// Chromium re-creates a dead out-of-process iframe itself; reloading
+			// the whole window over one subframe would be worse than the failure.
+			name: "frame render process exit is left alone",
+			kind: edge.COREWEBVIEW2_PROCESS_FAILED_KIND_FRAME_RENDER_PROCESS_EXITED,
+			want: webviewRecoveryNone,
+		},
+		{
+			// Chromium restarts these itself, and when it gives up it exits the
+			// browser process, which comes back as BROWSER_PROCESS_EXITED.
+			name: "gpu process exit is left alone",
+			kind: edge.COREWEBVIEW2_PROCESS_FAILED_KIND_GPU_PROCESS_EXITED,
+			want: webviewRecoveryNone,
+		},
+		{
+			name: "utility process exit is left alone",
+			kind: edge.COREWEBVIEW2_PROCESS_FAILED_KIND_UTILITY_PROCESS_EXITED,
+			want: webviewRecoveryNone,
+		},
+		{
+			name: "sandbox helper process exit is left alone",
+			kind: edge.COREWEBVIEW2_PROCESS_FAILED_KIND_SANDBOX_HELPER_PROCESS_EXITED,
+			want: webviewRecoveryNone,
+		},
+		{
+			// GetProcessFailedKind seeds its out-param with 0xffffffff and a
+			// newer runtime may report a kind this build has no constant for.
+			// Anything unrecognised must fall through to "leave it alone"
+			// rather than trigger a rebuild.
+			name: "unknown kind is left alone",
+			kind: edge.COREWEBVIEW2_PROCESS_FAILED_KIND(0xffffffff),
+			want: webviewRecoveryNone,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := webviewRecoveryActionFor(tt.kind); got != tt.want {
+				t.Errorf("webviewRecoveryActionFor(%d) = %d, want %d", tt.kind, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBeginWebviewRecoveryStopsAtTheLimit(t *testing.T) {
+	w := &windowsWebviewWindow{}
+
+	for i := 1; i <= maxWebviewRecoveryAttempts; i++ {
+		if !w.beginWebviewRecovery() {
+			t.Fatalf("attempt %d refused, want allowed within the budget of %d",
+				i, maxWebviewRecoveryAttempts)
+		}
+		if w.webviewRecoveryAttempts != i {
+			t.Fatalf("after attempt %d: webviewRecoveryAttempts = %d, want %d",
+				i, w.webviewRecoveryAttempts, i)
+		}
+	}
+
+	// Past the budget it must keep refusing rather than letting the count (and
+	// the WebView2 process spawning behind it) run away.
+	for i := 0; i < 3; i++ {
+		if w.beginWebviewRecovery() {
+			t.Fatalf("attempt %d past the budget of %d was allowed",
+				maxWebviewRecoveryAttempts+i+1, maxWebviewRecoveryAttempts)
+		}
+	}
+	if w.webviewRecoveryAttempts != maxWebviewRecoveryAttempts {
+		t.Errorf("webviewRecoveryAttempts = %d after refused attempts, want %d",
+			w.webviewRecoveryAttempts, maxWebviewRecoveryAttempts)
+	}
+}
+
+// A completed navigation means recovery worked, so the budget must come back —
+// otherwise a long-running app that recovered once would have fewer attempts
+// available for an unrelated failure hours later, and eventually none.
+//
+// This covers resetWebviewRecoveryBudget, not its call site: navigationCompleted
+// needs a live controller to invoke.
+func TestResetWebviewRecoveryBudget(t *testing.T) {
+	w := &windowsWebviewWindow{}
+
+	for i := 0; i < maxWebviewRecoveryAttempts; i++ {
+		if !w.beginWebviewRecovery() {
+			t.Fatalf("attempt %d refused while filling the budget", i+1)
+		}
+	}
+	if w.beginWebviewRecovery() {
+		t.Fatal("budget not exhausted before the reset; test cannot prove the reset works")
+	}
+
+	w.resetWebviewRecoveryBudget()
+
+	if w.webviewRecoveryAttempts != 0 {
+		t.Errorf("webviewRecoveryAttempts = %d after reset, want 0", w.webviewRecoveryAttempts)
+	}
+	if !w.beginWebviewRecovery() {
+		t.Error("recovery still refused after the budget was reset")
+	}
+}


### PR DESCRIPTION
Windows WebView2 browser-process failures leave a permanently invalid controller and a blank application window. This PR recreates the controller after browser failure and restores URL or HTML content after renderer failure.

Closes #5733.

## Recovery behaviour

- Schedule recovery after the WebView2 event handler returns; `InvokeAsync` alone executes inline on the UI thread.
- Wake the controller initialization pump for previously seen queued input with `MsgWaitForMultipleObjectsEx` and `MWMO_INPUTAVAILABLE`. Preserve `WM_QUIT` for the outer application loop.
- Release the previous DirectComposition resources before embedding the replacement, preserving composition hosting.
- Reuse window configuration and restore the last host URL directly. HTML-backed windows also recover from renderer failure.
- Bound consecutive recovery attempts to three, reset only by successful navigation, and suppress overlapping attempts and callbacks from abandoned controllers.
- Return initialization errors during recovery instead of terminating the process. Release partial initialization resources and discard late creation callbacks. Failed initial startup remains fatal.
- Preserve master's Windows request-cancellation setup before navigation and close the previous request tracker during a rebuild.

## Contributor credit

The recovery approach and hardware validation are @randalmurphal's. His three hardware-fix commits are included unchanged, retaining their original author and commit identities:

- `fb6a1ed3cb0a02d918f815d3d8f8f6db7640c005`: post recovery out of the event handler.
- `a08b7c9f4dfbd404ccb8eca7b30c6937830ffed3`: wake for queued input.
- `001ae13278608ab0c79f6268dfc30d2a4f461455`: release the old DirectComposition target.

[Hardware validation report](https://github.com/wailsapp/wails/pull/6002#issuecomment-5349355667): Windows 11 26200 / WebView2 151.0.4129.93, including 8/8 browser-process recoveries with those fixes. That report predates the current integration and error-handling changes.

## Validation

- Windows amd64 and arm64 application and edge test binaries cross-compile.
- New Windows tests cover recoverable initialization errors, partial-controller cleanup, late callbacks, previously seen queued completion messages, quit-message preservation, and overlapping recovery suppression.
- Linux `go test -race ./internal/assetserver/... -count=1`: passes.
- Windows request-keepalive JavaScript tests: 6 pass.
- Windows vet: all 11 unsafe-pointer warnings reproduce on the merged master base; `go vet -unsafeptr=false ./internal/webview2/pkg/edge ./pkg/application` passes.
- `git diff --check`: passes.
- CodeRabbit follow-up review completed. Its initial-setup failure finding was fixed. An earlier HTML recovery finding was fixed; the suggestion to reset the attempt budget after failed navigation was rejected because it would renew the budget during a crash loop.
- Ripwire contract and quality checks reviewed. The additional error-handling branches and boilerplate similarity findings remain deliberate trade-offs; the structural gate is not claimed clean.

**Native execution of this updated head remains outstanding.** The local host is Linux and cannot currently access win-node1. Cross-compilation does not validate live WebView2 recovery.

Before merging, test browser and renderer kills with normal, frameless, composition-hosted and HTML windows; restoration after `SetURL`; repeated failures and successful-navigation budget reset; initialization failure with the app staying alive; and closing/quitting during recovery. The current master initialization timeout is 60 seconds.

Recovery recreates frontend state. Reloading an unresponsive renderer remains automatic, as in the original proposal; no new public Wails API is added.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Windows WebView2 recovery after browser or renderer failures.
  - Restores the last page, configured HTML, or default start page after recovery.
  - Prevents duplicate recovery attempts and handles shutdown scenarios more reliably.
  - Improved menu updates, including safe handling when no menu is configured.
  - Improved navigation failure handling and cleanup to prevent stalled or partially initialized windows.
  - Improved handling of WebView2 startup failures and partially initialized windows.

- **Tests**
  - Added coverage for startup failures, recovery limits, overlapping failures, and cleanup behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->