### PR TITLE
fix(v2/templates): bump vite-plugin-svelte for Vite 8 peer range

### DIFF
--- a/v2/pkg/templates/templates/svelte-ts/frontend/package.json
+++ b/v2/pkg/templates/templates/svelte-ts/frontend/package.json
@@ -10,7 +10,7 @@
     "check": "svelte-check --tsconfig ./tsconfig.json"
   },
   "devDependencies": {
-    "@sveltejs/vite-plugin-svelte": "^6.0.0",
+    "@sveltejs/vite-plugin-svelte": "^7.3.0",
     "@tsconfig/svelte": "^5.0.0",
     "svelte": "^5.55.7",
     "svelte-check": "^4.0.0",

--- a/v2/pkg/templates/templates/svelte/frontend/package.json
+++ b/v2/pkg/templates/templates/svelte/frontend/package.json
@@ -9,7 +9,7 @@
     "preview": "vite preview"
   },
   "devDependencies": {
-    "@sveltejs/vite-plugin-svelte": "^6.0.0",
+    "@sveltejs/vite-plugin-svelte": "^7.3.0",
     "svelte": "^5.55.7",
     "vite": "^8.0.13"
   }


### PR DESCRIPTION
Closes #5989

## Problem

Fresh v2 `svelte` and `svelte-ts` projects fail `npm install` with `ERESOLVE`:

```
npm error peer vite@"^6.3.0 || ^7.0.0" from @sveltejs/vite-plugin-svelte@6.2.4
npm error   dev @sveltejs/vite-plugin-svelte@"^6.0.0" from the root project
```

The templates declare `vite: ^8.0.13`, which now resolves to `8.2.1`, while `@sveltejs/vite-plugin-svelte: ^6.0.0` resolves to `6.2.4`. That plugin's published peer range is `vite ^6.3.0 || ^7.0.0`, so npm rejects the tree.

## Fix

Bump the plugin to `^7.3.0` in both templates. Its peer range is `vite ^8.0.0-beta.7 || ^8.0.0`, and it requires `svelte ^5.46.4`, already satisfied by the templates' existing `svelte: ^5.55.7`. No other dependency needed changing.

## Verification

Against the acceptance criteria in #5989:

- [x] **Fresh projects install without `--force` / `--legacy-peer-deps`.** Both templates `npm install` cleanly (`found 0 vulnerabilities`).
- [x] **Supported peer combination.** `vite-plugin-svelte@7.3.0` + `vite@8.2.1` + `svelte@5.x` resolve with no peer warnings.
- [x] **Both generated projects build.** `npm run build` succeeds for both on a clean npm cache:

  ```
  dist/assets/index-BT2uU9Kw.js   24.59 kB │ gzip: 10.01 kB
  ✓ built in 1.18s
  ```

- [x] **Change limited to the required compatibility fix.** Two lines, one per template.

Testing note: I generated each template's `index.html` from `index.tmpl.html` to reproduce a post-generation project, since the raw template dir has no `index.html`.

## Pre-existing, not addressed here

`npm run check` in `svelte-ts` reports one `svelte-check` error:

```
Error: Type 'HTMLElement | null' is not assignable to type 'Document | Element | ShadowRoot'.
  const app = new App({ target: document.getElementById('app') })
```

This reproduces on `master` with the old `^6.0.0` plugin (installed via `--legacy-peer-deps`), so it predates this change and is out of scope per the last acceptance criterion. Happy to fix it in a separate PR if useful.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Svelte Vite plugin to a newer version in Svelte frontend templates.
  * Keeps generated Svelte projects aligned with the latest supported tooling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->