### PR TITLE
fix(v2/templates): migrate svelte templates to the Svelte 5 mount API

### DIFF
--- a/v2/pkg/templates/templates/svelte-ts/frontend/src/main.ts
+++ b/v2/pkg/templates/templates/svelte-ts/frontend/src/main.ts
@@ -1,8 +1,9 @@
+import { mount } from 'svelte'
 import './style.css'
 import App from './App.svelte'
 
-const app = new App({
-  target: document.getElementById('app')
+const app = mount(App, {
+  target: document.getElementById('app') as HTMLElement
 })
 
 export default app

--- a/v2/pkg/templates/templates/svelte/frontend/src/main.js
+++ b/v2/pkg/templates/templates/svelte/frontend/src/main.js
@@ -1,7 +1,8 @@
+import { mount } from 'svelte'
 import './style.css'
 import App from './App.svelte'
 
-const app = new App({
+const app = mount(App, {
   target: document.getElementById('app')
 })
 

--- a/website/src/pages/changelog.mdx
+++ b/website/src/pages/changelog.mdx
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed v2 `svelte` and `svelte-ts` templates scaffolding a blank page by migrating from the removed Svelte 4 `new App()` API to Svelte 5 `mount()` [#6001](https://github.com/wailsapp/wails/issues/6001) by @haoku123
+
 ## v2.15.0 - 2026-08-17
 
 ### Added


### PR DESCRIPTION
## Problem

Fixes #6001

The v2 `svelte` and `svelte-ts` templates pin `svelte: ^5.55.7` (Svelte 5), but their generated `main.js`/`main.ts` still bootstrap the app with the Svelte 4 component instantiation API:

```js
const app = new App({ target: document.getElementById('app') })
```

This API was removed in Svelte 5 in favor of `mount()`. A freshly scaffolded project (`wails init -t svelte-ts`) builds and runs but renders a blank page, with a runtime error in the browser console.

## Solution

Migrate both templates to the Svelte 5 `mount()` API, matching what the v3 svelte template already does:

```js
import { mount } from 'svelte'
const app = mount(App, { target: document.getElementById('app') })
```

For the TS template, `target` is cast to `HTMLElement` since `getElementById` returns `HTMLElement | null`.

## Changes

- `v2/pkg/templates/templates/svelte/frontend/src/main.js`
- `v2/pkg/templates/templates/svelte-ts/frontend/src/main.ts`
- Added changelog entry under `[Unreleased]` in `website/src/pages/changelog.mdx`

## Verification

- Both templates previously used the identical `new App()` bootstrap; v3's svelte template already uses `mount()`, confirming the correct API.
- Svelte 5 removed `new Component({ target })` in favor of `mount()` (see [Svelte 5 migration guide](https://svelte.dev/docs/svelte/v5-migration-guide)).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed blank pages in newly generated Svelte and Svelte TypeScript applications.
  - Updated app startup to use Svelte 5’s supported mounting approach.

- **Documentation**
  - Added an unreleased changelog entry describing the template fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->