### PR TITLE
fix(linux): implement SetTooltip for the system tray

### DIFF
--- a/v3/UNRELEASED_CHANGELOG.md
+++ b/v3/UNRELEASED_CHANGELOG.md
@@ -23,6 +23,7 @@ After processing, the content will be moved to the main changelog and this file 
 
 ## Fixed
 <!-- Bug fixes -->
+- Fix `SystemTray.SetTooltip()` doing nothing on Linux: the StatusNotifierItem tooltip description is now set
 
 ## Deprecated
 <!-- Soon-to-be removed features -->

--- a/v3/UNRELEASED_CHANGELOG.md
+++ b/v3/UNRELEASED_CHANGELOG.md
@@ -23,7 +23,7 @@ After processing, the content will be moved to the main changelog and this file 
 
 ## Fixed
 <!-- Bug fixes -->
-- Fix `SystemTray.SetTooltip()` doing nothing on Linux: the StatusNotifierItem tooltip description is now set
+- Fix `SystemTray.SetTooltip()` doing nothing on Linux: the StatusNotifierItem tooltip description is now set (#6017)
 
 ## Deprecated
 <!-- Soon-to-be removed features -->

--- a/v3/pkg/application/systemtray_linux.go
+++ b/v3/pkg/application/systemtray_linux.go
@@ -537,6 +537,9 @@ func (s *linuxSystemTray) setLabel(label string) {
 		return
 	}
 
+	// The tooltip repeats the name as its title, so it follows the label.
+	s.updateToolTip()
+
 	if s.conn == nil {
 		return
 	}
@@ -548,9 +551,6 @@ func (s *linuxSystemTray) setLabel(label string) {
 		globalApplication.error("systray error: failed to emit new title signal: %w", err)
 		return
 	}
-
-	// The tooltip repeats the name as its title, so it follows the label.
-	s.updateToolTip()
 }
 
 func (s *linuxSystemTray) destroy() {

--- a/v3/pkg/application/systemtray_linux.go
+++ b/v3/pkg/application/systemtray_linux.go
@@ -449,8 +449,24 @@ func (s *linuxSystemTray) run() {
 	s.setMenu(s.menu)
 }
 
-func (s *linuxSystemTray) setTooltip(_ string) {
-	// TBD
+func (s *linuxSystemTray) setTooltip(text string) {
+	s.tooltip = text
+	s.updateToolTip()
+}
+
+// updateToolTip republishes the ToolTip property. Its title is the item's name
+// and its description is what SetTooltip was given, which is the line a desktop
+// shows under the name on hover. The property is declared with prop.EmitTrue,
+// so setting it is what tells the host to re-read it.
+func (s *linuxSystemTray) updateToolTip() {
+	if s.props == nil {
+		return
+	}
+
+	if err := s.props.Set("org.kde.StatusNotifierItem", "ToolTip",
+		dbus.MakeVariant(tooltip{V2: s.label, V3: s.tooltip})); err != nil {
+		globalApplication.error("systray error: failed to set ToolTip prop: %w", err)
+	}
 }
 
 func (s *linuxSystemTray) setIcon(icon []byte) {
@@ -533,6 +549,8 @@ func (s *linuxSystemTray) setLabel(label string) {
 		return
 	}
 
+	// The tooltip repeats the name as its title, so it follows the label.
+	s.updateToolTip()
 }
 
 func (s *linuxSystemTray) destroy() {


### PR DESCRIPTION
# Description

`SystemTray.SetTooltip()` does nothing on Linux: `linuxSystemTray.setTooltip` is an empty function marked `// TBD`. The only hover text a tray icon can have is its name, which `SetLabel` already sets, and the `ToolTip` property is published with an empty description.

StatusNotifierItem's `ToolTip` carries a description under the title — the extra line a desktop shows on hover — so `SetTooltip` fills that in.

The property is declared with `prop.EmitTrue`, so setting it is what tells the host to re-read it. `setLabel` refreshes it as well, since the title half of the tooltip follows the item's name.

No issue filed; found while building a tray-based app.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] WEP (proposal only; no implementation)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Built an app that calls `SetTooltip` on its tray item and read the exported StatusNotifierItem property over D-Bus.

Before:

```
$ busctl --user get-property <conn> /StatusNotifierItem org.kde.StatusNotifierItem ToolTip
(sa(iiay)ss) "" 0 "soundz" ""
```

After `SetTooltip("Middle-click to play or pause")`:

```
(sa(iiay)ss) "" 0 "soundz" "Middle-click to play or pause"
```

The description is also preserved across a later `SetLabel`.

- [ ] Windows
- [ ] macOS
- [x] Linux

Debian 13 (trixie), KDE Plasma 6 on Wayland.

## Test Configuration

GTK 4.18.6, WebKitGTK 2.52.3, Go 1.25.0, `org.kde.StatusNotifierWatcher` provided by plasmashell.

# Checklist:

- [ ] (v2 only) I have updated `website/src/pages/changelog.mdx` with details of this PR (v3 changelog entries are added automatically)
- [x] My code follows the general coding style of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

The behaviour is a D-Bus property on a live tray connection, which I could not see a way to cover in a unit test — happy to add one if you can point me at the right seam. `v3/UNRELEASED_CHANGELOG.md` is updated under Fixed, per CONTRIBUTING.md; drop that commit if v3 entries are generated automatically.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Linux system tray tooltips so their descriptions display correctly.
  * Updating the tray label now keeps the tooltip title synchronized.
* **Documentation**
  * Added a changelog entry documenting the Linux tooltip fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->