### PR TITLE
feat(linux): allow the GTK application ID to be set

### DIFF
--- a/v3/UNRELEASED_CHANGELOG.md
+++ b/v3/UNRELEASED_CHANGELOG.md
@@ -17,7 +17,7 @@ After processing, the content will be moved to the main changelog and this file 
 
 ## Added
 <!-- New features, capabilities, or enhancements -->
-- Add `LinuxOptions.ApplicationID` to override the GTK application ID, which Flatpak and Snap require to be a domain the publisher controls
+- Add `LinuxOptions.ApplicationID` to override the GTK application ID, which Flatpak and Snap require to be a domain the publisher controls (#6020)
 
 ## Changed
 <!-- Changes in existing functionality -->

--- a/v3/UNRELEASED_CHANGELOG.md
+++ b/v3/UNRELEASED_CHANGELOG.md
@@ -17,6 +17,7 @@ After processing, the content will be moved to the main changelog and this file 
 
 ## Added
 <!-- New features, capabilities, or enhancements -->
+- Add `LinuxOptions.ApplicationID` to override the GTK application ID, which Flatpak and Snap require to be a domain the publisher controls
 
 ## Changed
 <!-- Changes in existing functionality -->

--- a/v3/pkg/application/application_linux.go
+++ b/v3/pkg/application/application_linux.go
@@ -233,9 +233,16 @@ func (a *linuxApp) unregisterWindow(window windowPointer) {
 
 func newPlatformApp(parent *App) *linuxApp {
 	name := sanitizeAppName(parent.options.Name)
+	application := pointer(nil)
+	if id := parent.options.Linux.ApplicationID; id != "" {
+		application = appNewWithID(id)
+	}
+	if application == nil {
+		application = appNew(name)
+	}
 	app := &linuxApp{
 		parent:      parent,
-		application: appNew(name),
+		application: application,
 		activated:   make(chan struct{}),
 		windowMap:   map[windowPointer]uint{},
 	}

--- a/v3/pkg/application/application_options.go
+++ b/v3/pkg/application/application_options.go
@@ -329,6 +329,16 @@ type LinuxOptions struct {
 	//
 	//[see the docs]: https://docs.gtk.org/glib/func.set_prgname.html
 	ProgramName string
+
+	// ApplicationID overrides the GTK application ID, which defaults to
+	// org.wails.<name>.
+	//
+	// It is the app ID a Wayland compositor sees, and a desktop entry is found
+	// by matching it, so a window's icon and its grouping both hang off it.
+	// Flatpak and Snap go further and require the ID to be a domain the
+	// publisher controls, which the default cannot be. Must be a valid GTK
+	// application ID; an invalid one is ignored in favour of the default.
+	ApplicationID string
 }
 
 /********* iOS Options *********/

--- a/v3/pkg/application/linux_cgo.go
+++ b/v3/pkg/application/linux_cgo.go
@@ -144,12 +144,22 @@ func appName() string {
 }
 
 func appNew(name string) pointer {
+	return appNewWithID(fmt.Sprintf("org.wails.%s", name))
+}
+
+// appNewWithID creates the GtkApplication under an explicit ID. GTK refuses an
+// invalid one, so it is checked first and the caller's default used instead —
+// an application that fails to construct has no window to report the problem
+// in.
+func appNewWithID(appID string) pointer {
 	C.install_signal_handlers()
 
-	appId := fmt.Sprintf("org.wails.%s", name)
-	nameC := C.CString(appId)
-	defer C.free(unsafe.Pointer(nameC))
-	return pointer(C.gtk_application_new(nameC, C.APPLICATION_DEFAULT_FLAGS))
+	idC := C.CString(appID)
+	defer C.free(unsafe.Pointer(idC))
+	if C.g_application_id_is_valid(idC) == 0 {
+		return nil
+	}
+	return pointer(C.gtk_application_new(idC, C.APPLICATION_DEFAULT_FLAGS))
 }
 
 func setProgramName(prgName string) {

--- a/v3/pkg/application/linux_cgo.go
+++ b/v3/pkg/application/linux_cgo.go
@@ -144,6 +144,13 @@ func appName() string {
 }
 
 func appNew(name string) pointer {
+	// A GApplication ID is capped at 255 characters and the prefix takes ten,
+	// so a long enough app name would otherwise build an ID GTK refuses,
+	// leaving no application at all.
+	const maxNameLength = 245
+	if len(name) > maxNameLength {
+		name = name[:maxNameLength]
+	}
 	return appNewWithID(fmt.Sprintf("org.wails.%s", name))
 }
 


### PR DESCRIPTION
# Description

**Process note up front:** the template asks for a WEP before an enhancement is implemented, and there is no WEP behind this one. I had the patch already — I needed it to package a Wails app for Flathub — so I am opening it as a concrete proposal rather than leaving it sitting in a fork. Happy to convert it into a WEP and park the code until that is accepted, or to close it, whichever you prefer.

The GTK application ID is always `org.wails.<name>`. It is the app ID a Wayland compositor sees, and a desktop entry is found by matching it, so a window's icon and its grouping both hang off it — and Flatpak and Snap require it to be a domain the publisher controls, which `org.wails` cannot be. An app packaged for either currently has no way to be identified correctly.

`LinuxOptions.ApplicationID` sets it. GTK aborts on an invalid ID, so it is checked with `g_application_id_is_valid` first and the old default used instead — an application that fails to construct has no window to report the problem in.

Default behaviour is unchanged when the option is left empty.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] WEP (proposal only; no implementation)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

Built an app with `Linux: application.LinuxOptions{ApplicationID: "ch.znipp.violette"}` and asked the compositor what app ID it sees. Under KWin, `workspace.windowList()` reports the Wayland `app_id` as `resourceClass`:

```
resourceClass      | resourceName | caption
ch.znipp.violette  | violette     | Violette
```

Without the option that first column is `org.wails.violette`.

With a matching `~/.local/share/applications/ch.znipp.violette.desktop` in place, the window then picks up the icon from that entry — which is what it could not do before, since GTK4 dropped `gtk_window_set_icon` and the entry is found by matching the app ID.

Also ran with `ApplicationID` empty and confirmed the ID stays `org.wails.<name>`.

The invalid-ID path I have only reasoned through rather than exercised: `g_application_id_is_valid` fails, `appNewWithID` returns nil, and `newPlatformApp` falls back to `appNew(name)`. Worth a look from someone who knows whether silently falling back is the behaviour you want here, or whether it should be a hard error at startup instead — I picked the quiet fallback because the alternative is a `g_error` abort with no window to report it in, but that is a judgement call and yours to make.

- [ ] Windows
- [ ] macOS
- [x] Linux

Debian 13 (trixie), KDE Plasma 6 on Wayland.

## Test Configuration

GTK 4.18.6, WebKitGTK 2.52.3, Go 1.25.0.

# Checklist:

- [ ] (v2 only) I have updated `website/src/pages/changelog.mdx` with details of this PR (v3 changelog entries are added automatically)
- [x] My code follows the general coding style of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

Documentation is unticked deliberately — the option is documented on the struct field, but if this is accepted it should also be mentioned wherever Linux packaging is covered, and I did not want to guess at the right page. `v3/UNRELEASED_CHANGELOG.md` is updated under Added, per CONTRIBUTING.md; drop that commit if v3 entries are generated automatically.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Linux application ID option for configuring GTK, Flatpak, Snap, Wayland, and desktop-entry integration.
  * Applications can now use a custom ID, with automatic fallback to the default ID if the configured value is invalid or unavailable.

* **Documentation**
  * Added changelog documentation for the new Linux application ID option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->