### PR TITLE
fix(v3): offer the Fn/Globe key to the input method on macOS

### DIFF
--- a/v3/pkg/application/application_darwin.go
+++ b/v3/pkg/application/application_darwin.go
@@ -19,10 +19,49 @@ extern void registerListener(unsigned int event);
 
 static AppDelegate *appDelegate = nil;
 
+// kVK_Function from Carbon's Events.h, spelled out so that header is not
+// needed for one number.
+static const unsigned short kWailsFunctionKeyCode = 63;
+
+
 static void init(void) {
     [NSApplication sharedApplication];
     appDelegate = [[AppDelegate alloc] init];
     [NSApp setDelegate:appDelegate];
+
+	// The Fn/Globe key arrives as a modifier change rather than a key press,
+	// and WebKit drops keyCode 63 in WebViewImpl::flagsChanged() before it
+	// reaches interpretKeyEvent(), so the current input method never sees it.
+	// Input methods that bind a shortcut to holding Fn - push-to-talk voice
+	// input is the common one - therefore do nothing at all inside a Wails
+	// window, while working in native and Chromium applications.
+	//
+	// Offer the event to the first responder's input context here instead. The
+	// event is returned unchanged either way, so AppKit's own handling is
+	// untouched and no DOM keyboard event is synthesised: the page still does
+	// not see Fn, which is the existing behaviour and the correct one.
+	[NSEvent addLocalMonitorForEventsMatchingMask:NSEventMaskFlagsChanged handler:^NSEvent * _Nullable(NSEvent * _Nonnull event) {
+		if ([event keyCode] != kWailsFunctionKeyCode) {
+			return event;
+		}
+		NSWindow* eventWindow = [event window];
+		if (eventWindow == nil) {
+			return event;
+		}
+		if (![[eventWindow delegate] isKindOfClass:[WebviewWindowDelegate class]]) {
+			return event;
+		}
+		// inputContext is declared on NSView, not on NSResponder, and the
+		// first responder is not necessarily a view.
+		NSResponder* responder = [eventWindow firstResponder];
+		if ([responder isKindOfClass:[NSView class]]) {
+			NSTextInputContext* inputContext = [(NSView*)responder inputContext];
+			if (inputContext != nil) {
+				[inputContext handleEvent:event];
+			}
+		}
+		return event;
+	}];
 
 	[NSEvent addLocalMonitorForEventsMatchingMask:NSEventMaskLeftMouseDown handler:^NSEvent * _Nullable(NSEvent * _Nonnull event) {
 		NSWindow* eventWindow = [event window];


### PR DESCRIPTION
Fixes #6033 — **pending confirmation from the reporter**, see Testing.

## The problem

The Fn/Globe key arrives as a *modifier change*, not a key press. WebKit drops `keyCode 63` in `WebViewImpl::flagsChanged()` before it reaches `interpretKeyEvent()`, so the current input method never sees it. An input method that binds a shortcut to holding Fn — push-to-talk voice input is the common one, and hardware remappers produce the same event — does nothing at all inside a Wails window, while working in native and Chromium apps.

Nothing in Wails handled `flagsChanged` at all, so there was no existing code path to correct; this adds one.

## The change

A local event monitor, alongside the two `application_darwin.go` already installs for mouse events, offers a keyCode 63 modifier change to the first responder's input context:

```objc
[NSEvent addLocalMonitorForEventsMatchingMask:NSEventMaskFlagsChanged handler:^NSEvent *(NSEvent *event) {
    if ([event keyCode] != kWailsFunctionKeyCode) { return event; }
    ...
    [inputContext handleEvent:event];
    return event;   // always
}];
```

The event is **returned unchanged either way**, so AppKit's own handling is untouched and no DOM keyboard event is synthesised — the page still doesn't see Fn, which is both the existing behaviour and the right one. The monitor ignores every other key code, and events belonging to windows that aren't ours.

This is the approach @1939869736luosi proposed in the issue, citing [`NSTextInputContext.handleEvent`](https://developer.apple.com/documentation/appkit/nstextinputcontext/handleevent(_:)).

`inputContext` is declared on `NSView`, not `NSResponder`, and the first responder isn't necessarily a view — hence the `isKindOfClass:` check, which also keeps the cgo build free of warnings.

## Testing

**Verified:** build and `go vet` clean, `pkg/application` tests pass, and sending real Fn presses to a running application changes nothing else — key bindings fire before and after, and nothing crashes. So the regression risk (swallowing events, or breaking normal keyboard handling) is covered.

**Not verified:** the symptom itself. Reproducing it needs an input method with a hold-Fn voice shortcut bound, which I don't have. Synthesising the event proves *delivery*, not that the input method acts on it.

@1939869736luosi — would you be able to build this branch and confirm your IME's Fn voice shortcut now works inside a Wails window? I'd rather not have this merged on the strength of reasoning alone.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved macOS keyboard handling for the Fn/Globe key in desktop windows.
  - Preserves text input behavior while preventing unintended web-based keyboard events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->