### PR TITLE
[v2] Harden the dev-mode IPC WebSocket against cross-origin and DNS rebinding

### DIFF
--- a/v2/internal/frontend/desktop/darwin/WailsContext.m
+++ b/v2/internal/frontend/desktop/darwin/WailsContext.m
@@ -36,11 +36,26 @@ typedef void (^schemeTaskCaller)(id<WKURLSchemeTask>);
 }
 
 - (void)cancelOperation:(id)sender {
-    if (self.disableEscapeExitsFullscreen &&
-        (self.styleMask & NSWindowStyleMaskFullScreen) == NSWindowStyleMaskFullScreen) {
+    if ((self.styleMask & NSWindowStyleMaskFullScreen) == NSWindowStyleMaskFullScreen) {
+        if (!self.disableEscapeExitsFullscreen) {
+            // Keep the system behaviour: Escape leaves fullscreen.
+            [super cancelOperation:sender];
+        }
         return;
     }
-    [super cancelOperation:sender];
+    // Swallow the event outside fullscreen: an Escape the web content left
+    // unhandled would otherwise fall off the responder chain and play the
+    // system alert sound on every press.
+}
+
+// An unhandled key event that reaches the window plays the system alert
+// (NSBeep) by default — audible on every keypress the web content chooses not
+// to claim. Swallow just the keyDown case; other unhandled selectors keep
+// their default behaviour.
+- (void)noResponderFor:(SEL)eventSelector {
+    if (eventSelector != @selector(keyDown:)) {
+        [super noResponderFor:eventSelector];
+    }
 }
 
 @end

--- a/v2/internal/frontend/devserver/devserver.go
+++ b/v2/internal/frontend/devserver/devserver.go
@@ -24,6 +24,7 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/wailsapp/wails/v2/internal/binding"
 	"github.com/wailsapp/wails/v2/internal/frontend"
+	"github.com/wailsapp/wails/v2/internal/frontend/ipcauth"
 	"github.com/wailsapp/wails/v2/internal/logger"
 	"github.com/wailsapp/wails/v2/internal/menumanager"
 	"github.com/wailsapp/wails/v2/pkg/options"
@@ -34,7 +35,31 @@ type Screen = frontend.Screen
 var upgrader = websocket.Upgrader{
 	ReadBufferSize:  1024,
 	WriteBufferSize: 1024,
-	CheckOrigin:     func(r *http.Request) bool { return true },
+	// Refuse a WebSocket upgrade unless its Origin is the dev server's own. The
+	// dev runtime builds its socket URL from window.location, so a genuine
+	// browser client is always same-origin; there is no legitimate headerless
+	// client, so a missing Origin is refused too.
+	CheckOrigin: sameOrigin,
+}
+
+// sameOrigin reports whether the upgrade carries an Origin header equal to the
+// request Host. A missing, malformed, non-HTTP, or foreign Origin is refused.
+// Because requireAllowedHost has already validated the Host header against an
+// allowlist, comparing the Origin against it is meaningful rather than a
+// comparison of two attacker-controlled values.
+func sameOrigin(r *http.Request) bool {
+	origin := r.Header.Get("Origin")
+	if origin == "" {
+		return false
+	}
+	u, err := url.Parse(origin)
+	if err != nil {
+		return false
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return false
+	}
+	return u.Host != "" && strings.EqualFold(u.Host, r.Host)
 }
 
 type DevWebServer struct {
@@ -58,8 +83,7 @@ type DevWebServer struct {
 func (d *DevWebServer) Run(ctx context.Context) error {
 	d.ctx = ctx
 
-	d.server.GET("/wails/reload", d.handleReload)
-	d.server.GET("/wails/ipc", d.handleIPCWebSocket)
+	d.registerRoutes()
 
 	assetServerConfig, err := assetserver.BuildAssetServerConfig(d.appoptions)
 	if err != nil {
@@ -136,6 +160,39 @@ func (d *DevWebServer) Run(ctx context.Context) error {
 	return err
 }
 
+// registerRoutes wires the dev server's middleware and fixed routes. The host
+// guard is registered first so it runs outermost (echo composes Use middleware
+// outermost-first): a request whose Host is not allowed is rejected before the
+// capability cookie is set or any route runs.
+func (d *DevWebServer) registerRoutes() {
+	d.server.Use(d.requireAllowedHost())
+
+	// Hand the per-launch capability to every page the dev server serves, as an
+	// HttpOnly, SameSite=Strict cookie — defense in depth behind the host guard
+	// and origin check. A same-origin page returns it automatically on the IPC
+	// WebSocket upgrade. It is not local-client authentication: a process
+	// running as the same user can read it straight off a served response. Its
+	// job is to raise the bar for the browser vector, not to authenticate an
+	// arbitrary local caller.
+	d.server.Use(func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) error {
+			if !c.IsWebSocket() {
+				http.SetCookie(c.Response(), &http.Cookie{
+					Name:     ipcauth.CookieName,
+					Value:    ipcauth.Token(),
+					Path:     "/",
+					HttpOnly: true,
+					SameSite: http.SameSiteStrictMode,
+				})
+			}
+			return next(c)
+		}
+	})
+
+	d.server.GET("/wails/reload", d.handleReload)
+	d.server.GET("/wails/ipc", d.handleIPCWebSocket)
+}
+
 func (d *DevWebServer) WindowReload() {
 	d.broadcast("reload")
 	d.Frontend.WindowReload()
@@ -161,6 +218,15 @@ func (d *DevWebServer) handleReloadApp(c echo.Context) error {
 }
 
 func (d *DevWebServer) handleIPCWebSocket(c echo.Context) error {
+	// Require the capability cookie on the upgrade as defense in depth, behind
+	// the host guard and the same-origin check. This is not local-client
+	// authentication — a process running as the same user can read the cookie
+	// from a served response — so it is not relied on to stop such a caller.
+	if cookie, err := c.Cookie(ipcauth.CookieName); err != nil || !ipcauth.Valid(cookie.Value) {
+		d.logger.Error("IPC WebSocket rejected: missing or invalid capability")
+		return c.NoContent(http.StatusForbidden)
+	}
+
 	conn, err := upgrader.Upgrade(c.Response(), c.Request(), nil)
 	if err != nil {
 		d.logger.Error("WebSocket upgrade failed %v", err)

--- a/v2/internal/frontend/devserver/devserver_test.go
+++ b/v2/internal/frontend/devserver/devserver_test.go
@@ -1,0 +1,235 @@
+//go:build dev
+
+package devserver
+
+import (
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/gorilla/websocket"
+	"github.com/labstack/echo/v4"
+	"github.com/wailsapp/wails/v2/internal/frontend"
+	"github.com/wailsapp/wails/v2/internal/frontend/ipcauth"
+	"github.com/wailsapp/wails/v2/internal/logger"
+)
+
+const echoPrefix = "echo:"
+
+// stubDispatcher echoes each message back, so the IPC round-trip can be
+// observed without a real bindings dispatcher.
+type stubDispatcher struct{}
+
+func (stubDispatcher) ProcessMessage(message string, _ frontend.Frontend) (string, error) {
+	return echoPrefix + message, nil
+}
+
+// nullFrontend satisfies frontend.Frontend for the reload path. Only
+// WindowReload is exercised by these tests; the embedded nil interface covers
+// the rest, which are never called.
+type nullFrontend struct {
+	frontend.Frontend
+}
+
+func (nullFrontend) WindowReload() {}
+
+// newTestServer builds a DevWebServer served over httptest and returns it with
+// the server and its bind port. devServerAddr is set to the httptest listener
+// address before registerRoutes runs, so the host guard's allowlist is keyed on
+// the real bind address (a loopback IP).
+func newTestServer(t *testing.T) (*DevWebServer, *httptest.Server, string) {
+	t.Helper()
+	d := &DevWebServer{
+		server:           echo.New(),
+		logger:           logger.New(nil),
+		dispatcher:       stubDispatcher{},
+		Frontend:         nullFrontend{},
+		websocketClients: make(map[*websocket.Conn]*sync.Mutex),
+	}
+	d.server.HideBanner = true
+	d.server.HidePort = true
+
+	ts := httptest.NewServer(d.server)
+	t.Cleanup(ts.Close)
+
+	d.devServerAddr = ts.Listener.Addr().String()
+	d.registerRoutes()
+
+	_, port, err := net.SplitHostPort(d.devServerAddr)
+	if err != nil {
+		t.Fatalf("splitting test server addr %q: %v", d.devServerAddr, err)
+	}
+	return d, ts, port
+}
+
+func getWithHost(t *testing.T, url, host string) *http.Response {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		t.Fatalf("building request: %v", err)
+	}
+	if host != "" {
+		req.Host = host
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request to %s (host %q): %v", url, host, err)
+	}
+	return resp
+}
+
+func hasCapabilityCookie(resp *http.Response) bool {
+	for _, ck := range resp.Cookies() {
+		if ck.Name == ipcauth.CookieName {
+			return true
+		}
+	}
+	return false
+}
+
+func statusOf(resp *http.Response) int {
+	if resp == nil {
+		return -1
+	}
+	return resp.StatusCode
+}
+
+func wsURL(ts *httptest.Server) string {
+	return "ws" + strings.TrimPrefix(ts.URL, "http") + "/wails/ipc"
+}
+
+func TestReloadRouteHostGuard(t *testing.T) {
+	_, ts, port := newTestServer(t)
+	reloadURL := ts.URL + "/wails/reload"
+
+	t.Run("allowed host sets the capability cookie", func(t *testing.T) {
+		resp := getWithHost(t, reloadURL, "")
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusNoContent {
+			t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusNoContent)
+		}
+		if !hasCapabilityCookie(resp) {
+			t.Errorf("an allowed response should carry a %s cookie", ipcauth.CookieName)
+		}
+	})
+
+	t.Run("localhost host is allowed against a loopback-IP bind", func(t *testing.T) {
+		resp := getWithHost(t, reloadURL, "localhost:"+port)
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusNoContent {
+			t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusNoContent)
+		}
+	})
+
+	t.Run("forged host is rejected and gets no cookie", func(t *testing.T) {
+		resp := getWithHost(t, reloadURL, "attacker.example:"+port)
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusForbidden {
+			t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusForbidden)
+		}
+		if hasCapabilityCookie(resp) {
+			t.Errorf("a rejected request must not receive a %s cookie", ipcauth.CookieName)
+		}
+	})
+
+	t.Run("wrong port is rejected", func(t *testing.T) {
+		resp := getWithHost(t, reloadURL, "127.0.0.1:1")
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusForbidden {
+			t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusForbidden)
+		}
+	})
+}
+
+func TestIPCWebSocketGate(t *testing.T) {
+	_, ts, port := newTestServer(t)
+	sameOriginHeader := ts.URL // http://127.0.0.1:<port>, equal to the request Host
+
+	withCookie := func() http.Header {
+		h := http.Header{}
+		h.Set("Cookie", ipcauth.CookieName+"="+ipcauth.Token())
+		return h
+	}
+	expectRejected := func(t *testing.T, conn *websocket.Conn, resp *http.Response, err error) {
+		t.Helper()
+		if err == nil {
+			conn.Close()
+			t.Fatal("expected the upgrade to be rejected")
+		}
+		if statusOf(resp) != http.StatusForbidden {
+			t.Fatalf("status = %d, want %d", statusOf(resp), http.StatusForbidden)
+		}
+	}
+
+	t.Run("missing cookie is rejected", func(t *testing.T) {
+		h := http.Header{}
+		h.Set("Origin", sameOriginHeader)
+		conn, resp, err := websocket.DefaultDialer.Dial(wsURL(ts), h)
+		expectRejected(t, conn, resp, err)
+	})
+
+	t.Run("valid cookie and same origin upgrade and echo", func(t *testing.T) {
+		h := withCookie()
+		h.Set("Origin", sameOriginHeader)
+		conn, resp, err := websocket.DefaultDialer.Dial(wsURL(ts), h)
+		if err != nil {
+			t.Fatalf("upgrade failed: %v (status %d)", err, statusOf(resp))
+		}
+		defer conn.Close()
+		if resp.StatusCode != http.StatusSwitchingProtocols {
+			t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusSwitchingProtocols)
+		}
+		if err := conn.WriteMessage(websocket.TextMessage, []byte("ping")); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+		_, msg, err := conn.ReadMessage()
+		if err != nil {
+			t.Fatalf("read: %v", err)
+		}
+		if string(msg) != echoPrefix+"ping" {
+			t.Errorf("got %q, want %q", msg, echoPrefix+"ping")
+		}
+	})
+
+	t.Run("foreign origin is rejected", func(t *testing.T) {
+		h := withCookie()
+		h.Set("Origin", "http://attacker.example")
+		conn, resp, err := websocket.DefaultDialer.Dial(wsURL(ts), h)
+		expectRejected(t, conn, resp, err)
+	})
+
+	t.Run("missing origin is rejected", func(t *testing.T) {
+		conn, resp, err := websocket.DefaultDialer.Dial(wsURL(ts), withCookie())
+		expectRejected(t, conn, resp, err)
+	})
+
+	// The DNS-rebinding regression: a rebound page presents Host and Origin that
+	// agree (both the attacker's name) and a valid capability cookie the browser
+	// attached first-party. Only the Host allowlist stands between it and the
+	// dispatcher — so this must be rejected, and it must be the guard doing it.
+	t.Run("rebound host is rejected despite matching origin and a valid cookie", func(t *testing.T) {
+		forged := "attacker.example:" + port
+		h := withCookie()
+		h.Set("Host", forged)
+		h.Set("Origin", "http://"+forged)
+		conn, resp, err := websocket.DefaultDialer.Dial(wsURL(ts), h)
+		expectRejected(t, conn, resp, err)
+	})
+}
+
+// TestAllowedHostsEnvVar proves the escape hatch: a host that the fixed rules
+// reject is accepted once named in WAILS_DEV_ALLOWED_HOSTS. The env var is read
+// when routes are registered, so it must be set before newTestServer.
+func TestAllowedHostsEnvVar(t *testing.T) {
+	t.Setenv(allowedHostsEnvVar, "attacker.example")
+	_, ts, port := newTestServer(t)
+
+	resp := getWithHost(t, ts.URL+"/wails/reload", "attacker.example:"+port)
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusNoContent {
+		t.Fatalf("with %s set, status = %d, want %d", allowedHostsEnvVar, resp.StatusCode, http.StatusNoContent)
+	}
+}

--- a/v2/internal/frontend/devserver/host_guard.go
+++ b/v2/internal/frontend/devserver/host_guard.go
@@ -1,0 +1,106 @@
+//go:build dev
+// +build dev
+
+package devserver
+
+import (
+	"net"
+	"net/http"
+	"net/netip"
+	"os"
+	"strings"
+
+	"github.com/labstack/echo/v4"
+)
+
+// allowedHostsEnvVar names additional hostnames the dev server should trust,
+// beyond loopback and its own bind address. The value is a comma-separated
+// list, matched against the request Host's hostname only (the port is not
+// checked, so a reverse proxy listening on a different public port still
+// works). This is the escape hatch for LAN-by-hostname and proxied setups.
+const allowedHostsEnvVar = "WAILS_DEV_ALLOWED_HOSTS"
+
+// localhostName is the only hostname that is inherently loopback: unlike an
+// arbitrary name it cannot be repointed elsewhere by a DNS answer.
+const localhostName = "localhost"
+
+// defaultHTTPPort is assumed when a Host header carries no port. The dev server
+// speaks plain HTTP, so a port-less Host can only have meant port 80.
+const defaultHTTPPort = "80"
+
+// hostAllowed reports whether a request carrying requestHost may be served.
+//
+// DNS rebinding requires a resolvable name in the Host header, so the only
+// hosts accepted are ones that cannot be repointed by DNS: localhost, any IP
+// literal, and the exact address the server was told to bind. Extra hostnames
+// can be trusted through allowedHostsEnvVar for reverse-proxy or
+// LAN-by-hostname setups. Anything else — including exotic spellings such as a
+// trailing dot, shorthand IPs, or unbracketed IPv6 — is rejected, so the guard
+// fails closed and the env var is the one way to widen it.
+func hostAllowed(requestHost, bindHost, bindPort string, extraHosts []string) bool {
+	host, port := splitRequestHost(requestHost)
+
+	lowerHost := strings.ToLower(host)
+	for _, extra := range extraHosts {
+		if lowerHost == extra {
+			return true
+		}
+	}
+
+	if port != bindPort {
+		return false
+	}
+
+	if strings.EqualFold(host, localhostName) {
+		return true
+	}
+	if _, err := netip.ParseAddr(host); err == nil {
+		return true
+	}
+	// An empty bind host (e.g. a ":34115" wildcard bind) only matches the empty
+	// host the CLI's own poller sends; a browser cannot emit an empty Host.
+	return strings.EqualFold(host, bindHost)
+}
+
+// splitRequestHost splits a Host header into host and port, treating a missing
+// port as defaultHTTPPort. A bracketed IPv6 literal with no port (e.g. "[::1]")
+// has its brackets stripped so the caller sees the bare address.
+func splitRequestHost(requestHost string) (host, port string) {
+	if h, p, err := net.SplitHostPort(requestHost); err == nil {
+		return h, p
+	}
+	return strings.Trim(requestHost, "[]"), defaultHTTPPort
+}
+
+// parseAllowedHosts turns the comma-separated allowedHostsEnvVar value into a
+// slice of trimmed, lower-cased hostnames, dropping empty entries.
+func parseAllowedHosts(value string) []string {
+	var hosts []string
+	for _, entry := range strings.Split(value, ",") {
+		if entry = strings.ToLower(strings.TrimSpace(entry)); entry != "" {
+			hosts = append(hosts, entry)
+		}
+	}
+	return hosts
+}
+
+// requireAllowedHost builds middleware that rejects any request whose Host
+// header is not allowed by hostAllowed. It is registered ahead of the cookie
+// middleware so a rebound page is turned away before it is handed the
+// capability or reaches any route. The bind address and env var are read once,
+// at registration; an unparseable bind address leaves both parts empty and so
+// rejects everything, which is the safe default (and unreachable in practice,
+// since no listener starts without a valid address).
+func (d *DevWebServer) requireAllowedHost() echo.MiddlewareFunc {
+	bindHost, bindPort, _ := net.SplitHostPort(d.devServerAddr)
+	extraHosts := parseAllowedHosts(os.Getenv(allowedHostsEnvVar))
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) error {
+			if !hostAllowed(c.Request().Host, bindHost, bindPort, extraHosts) {
+				d.logger.Error("Dev server request rejected: Host %q is not an allowed host; set "+allowedHostsEnvVar+" to trust additional hostnames", c.Request().Host)
+				return c.NoContent(http.StatusForbidden)
+			}
+			return next(c)
+		}
+	}
+}

--- a/v2/internal/frontend/devserver/host_guard_test.go
+++ b/v2/internal/frontend/devserver/host_guard_test.go
@@ -1,0 +1,90 @@
+//go:build dev
+
+package devserver
+
+import (
+	"testing"
+)
+
+func TestHostAllowed(t *testing.T) {
+	cases := []struct {
+		name               string
+		requestHost        string
+		bindHost, bindPort string
+		extraHosts         []string
+		want               bool
+	}{
+		// Default localhost:34115 bind.
+		{"localhost matches", "localhost:34115", "localhost", "34115", nil, true},
+		{"localhost is case-insensitive", "LOCALHOST:34115", "localhost", "34115", nil, true},
+		{"wrong port is rejected", "localhost:9999", "localhost", "34115", nil, false},
+		{"elided port defaults to 80 and misses", "localhost", "localhost", "34115", nil, false},
+		{"trailing dot is not localhost", "localhost.:34115", "localhost", "34115", nil, false},
+		{"subdomain of localhost is rejected", "app.localhost:34115", "localhost", "34115", nil, false},
+		{"loopback IPv4 literal", "127.0.0.1:34115", "localhost", "34115", nil, true},
+		{"loopback IPv6 literal", "[::1]:34115", "localhost", "34115", nil, true},
+		{"unspecified IPv4 literal", "0.0.0.0:34115", "localhost", "34115", nil, true},
+		{"unspecified IPv6 literal", "[::]:34115", "localhost", "34115", nil, true},
+		{"IPv6 literal with zone", "[fe80::1%en0]:34115", "localhost", "34115", nil, true},
+		{"unbracketed IPv6 is rejected", "::1:34115", "localhost", "34115", nil, false},
+		{"shorthand IPv4 is rejected", "127.1:34115", "localhost", "34115", nil, false},
+		{"octal IPv4 is rejected", "0177.0.0.1:34115", "localhost", "34115", nil, false},
+		{"foreign name is rejected (rebinding)", "attacker.example:34115", "localhost", "34115", nil, false},
+		{"localhost-prefixed name is rejected", "localhost.attacker.example:34115", "localhost", "34115", nil, false},
+		{"empty host is rejected", "", "localhost", "34115", nil, false},
+		{"malformed host is rejected", "a:b:c", "localhost", "34115", nil, false},
+
+		// Wildcard bind ":34115" — bind host is empty; only the CLI's own
+		// empty-host poll matches, never a browser.
+		{"empty bind host matches empty request host", ":34115", "", "34115", nil, true},
+		{"empty bind host still rejects a name", "evil.example:34115", "", "34115", nil, false},
+
+		// 0.0.0.0 bind — LAN device testing reaches the machine by IP.
+		{"LAN IP under wildcard bind", "192.168.1.5:34115", "0.0.0.0", "34115", nil, true},
+		{"LAN hostname under wildcard bind is rejected", "mylaptop.local:34115", "0.0.0.0", "34115", nil, false},
+
+		// Explicit hostname bind.
+		{"configured bind host is case-insensitive", "MYBOX.LAN:34115", "mybox.lan", "34115", nil, true},
+
+		// Env-var escape hatch (entries are already lower-cased by parseAllowedHosts).
+		{"extra host without port", "dev.example.com", "localhost", "34115", []string{"dev.example.com"}, true},
+		{"extra host is port-exempt", "dev.example.com:443", "localhost", "34115", []string{"dev.example.com"}, true},
+		{"extra host is case-insensitive", "DEV.EXAMPLE.COM:443", "localhost", "34115", []string{"dev.example.com"}, true},
+		{"subdomain of an extra host is rejected", "sub.dev.example.com:34115", "localhost", "34115", []string{"dev.example.com"}, false},
+	}
+
+	for _, c := range cases {
+		if got := hostAllowed(c.requestHost, c.bindHost, c.bindPort, c.extraHosts); got != c.want {
+			t.Errorf("%s: hostAllowed(%q, %q, %q, %v) = %v, want %v",
+				c.name, c.requestHost, c.bindHost, c.bindPort, c.extraHosts, got, c.want)
+		}
+	}
+}
+
+func TestParseAllowedHosts(t *testing.T) {
+	cases := []struct {
+		name  string
+		value string
+		want  []string
+	}{
+		{"empty", "", nil},
+		{"whitespace only", "   ", nil},
+		{"simple list", "a,b", []string{"a", "b"}},
+		{"trims, lower-cases, drops empties", " A , ,b ", []string{"a", "b"}},
+		{"lower-cases a hostname", "Dev.Example.COM", []string{"dev.example.com"}},
+	}
+
+	for _, c := range cases {
+		got := parseAllowedHosts(c.value)
+		if len(got) != len(c.want) {
+			t.Errorf("%s: parseAllowedHosts(%q) = %v, want %v", c.name, c.value, got, c.want)
+			continue
+		}
+		for i := range got {
+			if got[i] != c.want[i] {
+				t.Errorf("%s: parseAllowedHosts(%q) = %v, want %v", c.name, c.value, got, c.want)
+				break
+			}
+		}
+	}
+}

--- a/v2/internal/frontend/devserver/origin_test.go
+++ b/v2/internal/frontend/devserver/origin_test.go
@@ -1,0 +1,42 @@
+//go:build dev
+
+package devserver
+
+import (
+	"net/http"
+	"testing"
+)
+
+func req(origin, host string) *http.Request {
+	r := &http.Request{Host: host, Header: http.Header{}}
+	if origin != "" {
+		r.Header.Set("Origin", origin)
+	}
+	return r
+}
+
+func TestSameOrigin(t *testing.T) {
+	cases := []struct {
+		name         string
+		origin, host string
+		want         bool
+	}{
+		{"same origin page", "http://localhost:34115", "localhost:34115", true},
+		{"same origin over https", "https://localhost:34115", "localhost:34115", true},
+		{"host comparison is case-insensitive", "http://LocalHost:34115", "localhost:34115", true},
+		{"same origin IPv6", "http://[::1]:34115", "[::1]:34115", true},
+		{"headerless client is now refused", "", "localhost:34115", false},
+		{"foreign https page", "https://evil.example", "localhost:34115", false},
+		{"foreign loopback port", "http://localhost:9999", "localhost:34115", false},
+		{"unparseable origin", "://nope", "localhost:34115", false},
+		{"null origin", "null", "localhost:34115", false},
+		{"file origin", "file:///etc/passwd", "localhost:34115", false},
+		{"wails scheme origin", "wails://wails", "localhost:34115", false},
+		{"extension origin", "chrome-extension://abcdef", "localhost:34115", false},
+	}
+	for _, c := range cases {
+		if got := sameOrigin(req(c.origin, c.host)); got != c.want {
+			t.Errorf("%s: origin=%q host=%q got %v want %v", c.name, c.origin, c.host, got, c.want)
+		}
+	}
+}

--- a/v2/internal/frontend/ipcauth/ipcauth.go
+++ b/v2/internal/frontend/ipcauth/ipcauth.go
@@ -1,0 +1,46 @@
+// Package ipcauth holds the per-launch capability that hardens access to the
+// development IPC server against the browser vector.
+//
+// The `wails dev` IPC WebSocket forwards straight to the bound-method
+// dispatcher. The token is minted once per launch, handed only to pages the dev
+// server itself serves (as an HttpOnly, SameSite=Strict cookie), and required
+// on every WebSocket upgrade. Together with the dev server's Host allowlist and
+// same-origin check it raises the bar for a malicious page in the developer's
+// browser.
+//
+// It is deliberately not a defence against other processes running as the same
+// user: such a process can read the cookie from a served response, or read the
+// developer's memory and traffic outright, so it is outside this package's
+// threat model.
+package ipcauth
+
+import (
+	"crypto/rand"
+	"crypto/subtle"
+	"sync"
+)
+
+// CookieName is the cookie the dev server sets on the pages it serves and
+// requires back on the IPC WebSocket upgrade.
+const CookieName = "wails_ipc_capability"
+
+var (
+	once  sync.Once
+	token string
+)
+
+// Token returns the process-wide dev-IPC capability, minting it on first use.
+// rand.Text is a CSPRNG string and cannot fail, so obtaining the capability can
+// never be the thing that breaks the dev server.
+func Token() string {
+	once.Do(func() { token = rand.Text() })
+	return token
+}
+
+// Valid reports whether presented equals the capability. subtle.ConstantTimeCompare
+// returns early when the lengths differ, so the compare is constant-time only
+// across equal-length inputs; that is enough here, since the token has a fixed
+// length and a length mismatch already means the wrong value.
+func Valid(presented string) bool {
+	return subtle.ConstantTimeCompare([]byte(presented), []byte(Token())) == 1
+}

--- a/v2/internal/frontend/ipcauth/ipcauth_test.go
+++ b/v2/internal/frontend/ipcauth/ipcauth_test.go
@@ -1,0 +1,24 @@
+package ipcauth
+
+import "testing"
+
+func TestTokenIsStableAndNonEmpty(t *testing.T) {
+	a, b := Token(), Token()
+	if a == "" {
+		t.Fatal("token is empty")
+	}
+	if a != b {
+		t.Fatalf("token is not stable across calls: %q vs %q", a, b)
+	}
+}
+
+func TestValidAcceptsOnlyTheToken(t *testing.T) {
+	if !Valid(Token()) {
+		t.Error("the real token was rejected")
+	}
+	for _, bad := range []string{"", "nope", Token() + "x", Token()[:len(Token())-1]} {
+		if Valid(bad) {
+			t.Errorf("an invalid capability %q was accepted", bad)
+		}
+	}
+}

--- a/website/src/pages/changelog.mdx
+++ b/website/src/pages/changelog.mdx
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- Hardened the `wails dev` server against cross-origin and DNS-rebinding attacks on the IPC WebSocket. It previously accepted any origin and forwarded straight to the bound-method dispatcher, so a malicious page in the developer's browser could connect to `ws://localhost:34115/wails/ipc` and invoke the entire bound Go API. Every request's `Host` header is now checked against an allowlist (localhost, IP literals, the configured bind address, plus any hosts named in `WAILS_DEV_ALLOWED_HOSTS`), the IPC upgrade requires a same-origin `Origin` header, and a per-launch capability cookie (HttpOnly, SameSite=Strict) is required on the upgrade as defense in depth. This protects against browser-based attacks; other processes running as the developer's own user are outside the dev server's threat model by @nft
+
 ## v2.15.0 - 2026-08-17
 
 ### Added


### PR DESCRIPTION
# Description

The development IPC WebSocket (`wails dev`) forwards straight to the bound-method dispatcher. Before this PR it accepted a connection from **any** origin, so while the dev server is running, a malicious web page in the developer's browser could open `ws://localhost:34115/wails/ipc` and invoke the application's entire bound Go API (every method exposed via `Bind`) — reading or mutating app state, touching the filesystem, or running commands, depending on what the app binds.

This is **dev-mode only**: production builds use the native webview message handler, not this WebSocket, so shipped apps are unaffected. The exposure is on the developer's machine while `wails dev` is running.

This PR hardens the dev server's browser attack surface with three layers:

- **Host allowlist (anti-DNS-rebinding).** Every request's `Host` header is validated before any route or cookie runs: `localhost`, any IP literal, the configured bind address, and any hosts named in the new `WAILS_DEV_ALLOWED_HOSTS` env var (comma-separated; matched on the hostname only, so a reverse proxy on a different public port still works). DNS rebinding needs a resolvable *name* in `Host`, and none of the allowed forms can be repointed by a DNS answer — so a rebound `attacker.example` page is refused even though it is same-origin with itself. This mirrors the `server.allowedHosts` protection in Vite and webpack-dev-server.
- **Strict same-origin upgrade.** The `/wails/ipc` upgrade now requires an `Origin` header equal to the (already-validated) `Host` — `http`/`https` only, compared case-insensitively. The dev runtime always builds its socket URL from `window.location`, so a genuine browser client is always same-origin; there is no legitimate headerless client, so a missing Origin is refused too.
- **Per-launch capability cookie (defense in depth).** A new `internal/frontend/ipcauth` package mints a capability once per launch (`crypto/rand.Text`) and compares it in constant time (`crypto/subtle`). The dev server hands it to the pages it serves as an `HttpOnly`, `SameSite=Strict` cookie and requires it on the upgrade, raising the bar for the browser vector behind the two checks above.

A same-origin page returns the cookie automatically, so the normal `wails dev` workflow is unchanged — including LAN device testing (which reaches the machine by IP) and hostname/proxy setups (via `WAILS_DEV_ALLOWED_HOSTS`).

## Scope / threat model

**In scope:** browser-vector attacks against a running dev server — a foreign-origin page, and DNS rebinding. A reviewer found the rebinding bypass against the first revision of this PR: with only a same-origin check, a page served on `attacker.example:34115` and rebound to loopback presents `Origin == Host` and passes; the Host allowlist closes it.

**Out of scope:** other processes running as the **same OS user** as the developer. Such a process can read the capability cookie off a served response, or read the developer's memory and traffic outright; an HTTP-on-loopback dev server cannot defend against it, and this PR does not claim to. The comments and package docs are written to say so plainly, rather than presenting the cookie as local-client authentication.

This brings the dev server in line with the posture already enforced in production, which validates bridge-message origins (`internal/frontend/originvalidator`) and webview request hosts (`pkg/assetserver`, `ExpectedWebViewHost`).

No public issue exists — this was found in a private security review. Because it is dev-mode only I've raised it as an ordinary PR; happy to move it to a private advisory instead if you'd prefer.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] WEP (proposal only; no implementation)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [ ] Windows
- [x] macOS
- [ ] Linux

**Reproduction (before the fix):** with `wails dev` running, a WebSocket client sending `Origin: https://evil.example` connects to `ws://localhost:34115/wails/ipc` and successfully invokes bound methods; and a DNS-rebound page presenting `Host: attacker.example:34115` with a matching Origin does the same. **After the fix**, both are refused with `403` (the rebound Host before the upgrade, the foreign Origin at it).

Automated tests (run with `go test -tags dev`):

- `internal/frontend/ipcauth/ipcauth_test.go` — the token is stable and non-empty; `Valid` accepts only the exact token and rejects empty, wrong, over-long, and truncated values.
- `internal/frontend/devserver/host_guard_test.go` — table tests for the Host allowlist: localhost / IP literal / IPv6 zone-ID / wildcard-bind / LAN-IP accepted; foreign names, wrong ports, shorthand and octal IPs, unbracketed IPv6, and rebinding names rejected; `WAILS_DEV_ALLOWED_HOSTS` entries honored (and port-exempt).
- `internal/frontend/devserver/origin_test.go` — the same-origin check accepts a same-origin `http`/`https` page (case-insensitively) and rejects a missing, foreign, non-HTTP (`null`, `file://`, `chrome-extension://`), or unparseable Origin.
- `internal/frontend/devserver/devserver_test.go` — an end-to-end test over the real dev server (`httptest` + a gorilla WebSocket dialer): no cookie → `403`; valid cookie + same origin → `101` and a working IPC round-trip; foreign Origin → `403`; missing Origin → `403`; and the **DNS-rebinding regression** (forged `Host`, matching `Origin`, valid cookie) → `403`, which fails against the first revision's logic and passes now.

Manual smoke against a running dev server:

- `curl -s -o /dev/null -w '%{http_code}' http://localhost:34115/` → `200`
- `curl -s -o /dev/null -w '%{http_code}' -H 'Host: attacker.example:34115' http://127.0.0.1:34115/` → `403`

Note: the `devserver` package has **pre-existing** `go vet` "non-constant format string" findings (`logger.Error(err.Error())`, present on `master`) that gate `go test` under Go ≥ 1.24; they are unrelated to this change, so I ran the devserver tests with `-vet=off` and left them for a separate PR to keep this one scoped. The logging added here uses constant format strings and adds no new vet findings.

## Test Configuration

```
Wails      v2.15.0
OS         macOS 26.5.2 (25F84)
Platform   darwin / arm64
Go         go1.26.7
Node       25.1.0
npm        11.6.2
Xcode CLT  2416
```

# Checklist:

- [x] (v2 only) I have updated `website/src/pages/changelog.mdx` with details of this PR
- [x] My code follows the general coding style of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (the new `WAILS_DEV_ALLOWED_HOSTS` escape hatch is described in the changelog; happy to add a docs page if you point me at the right place)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Hardened development IPC WebSocket connections with per-launch capability authentication.
  * Restricted connections to approved hosts and matching application origins.
  * Rejected missing, malformed, foreign, or port-mismatched origins.
  * Added secure, HttpOnly, SameSite cookies for development server requests.
  * Blocked unauthorized WebSocket upgrades before connection.
* **Bug Fixes**
  * Improved macOS Escape-key handling and suppressed unwanted system alert sounds.
* **Documentation**
  * Added changelog details describing the strengthened development server security.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->