### PR TITLE
fix(ci): retry template scaffolding on transient network failures

### DIFF
--- a/.github/workflows/build-and-test-v3.yml
+++ b/.github/workflows/build-and-test-v3.yml
@@ -262,14 +262,39 @@ jobs:
           else
             RUNTIME_TGZ="$(cd wails-runtime-temp && pwd)/$(ls wails-runtime-temp/*.tgz | xargs basename)"
           fi
-          mkdir -p ./test-${{ matrix.template }}
-          cd ./test-${{ matrix.template }}
-          wails3 init -n ${{ matrix.template }} -t ${{ matrix.template }}
-          cd ${{ matrix.template }}/frontend
-          # Replace @wailsio/runtime version with local tarball
-          npm pkg set dependencies.@wailsio/runtime="file://$RUNTIME_TGZ"
-          cd ..
-          wails3 build
+          generate_and_build() (
+            set -e
+            rm -rf ./test-${{ matrix.template }}
+            mkdir -p ./test-${{ matrix.template }}
+            cd ./test-${{ matrix.template }}
+            wails3 init -n ${{ matrix.template }} -t ${{ matrix.template }}
+            cd ${{ matrix.template }}/frontend
+            # Replace @wailsio/runtime version with local tarball
+            npm pkg set dependencies.@wailsio/runtime="file://$RUNTIME_TGZ"
+            cd ..
+            wails3 build
+          )
+
+          # Each leg resolves a brand new module graph and node_modules, so one blip
+          # from the Go checksum DB or the npm registry reds the whole matrix.
+          transient='INTERNAL_ERROR|stream error|TLS handshake timeout|i/o timeout|connection reset'
+          transient="$transient|ECONNRESET|ETIMEDOUT|EAI_AGAIN|ENOTFOUND|Bad Gateway|Service Unavailable"
+          transient="$transient|Cannot find native binding"
+
+          for attempt in 1 2 3; do
+            set +e
+            generate_and_build 2>&1 | tee attempt.log
+            status=${PIPESTATUS[0]}
+            set -e
+            if [[ $status -eq 0 ]]; then
+              exit 0
+            fi
+            if [[ $attempt -eq 3 ]] || ! grep -qE "$transient" attempt.log; then
+              exit "$status"
+            fi
+            echo "::warning::Transient failure generating '${{ matrix.template }}' (attempt $attempt), retrying"
+            sleep $((attempt * 15))
+          done
 
       # GTK3 legacy template builds are covered by the Go example compilation tests above.
 


### PR DESCRIPTION
# Description

`Test Templates` scaffolds a new module on every leg, so all dependencies are re-resolved from `sum.golang.org` and the npm registry. Before this change one failed request reded the leg and the whole run. Now the scaffold-and-build step retries up to three times, gated on known transient signatures, so real breakage still fails on the first attempt.

Two classes hit this step on 2026-08-26:

```
reading https://sum.golang.org/tile/8/0/x178/138: stream error: stream ID 41; INTERNAL_ERROR; received from peer
```

```
Error: Cannot find native binding. npm has a bug related to optional dependencies
```

Warming the module cache doesn't help. The tile fetch comes from the template writing a new `go.sum`, not from the module download, and building v3 first verifies against its existing `go.sum` so it leaves the tile cache cold. `GOSUMDB=off` would work but drops verification.

Follows 55c8d9a, which hardened the same job against partial npm publishes. That doesn't cover transport errors.

Two notes for review:

- Gated rather than blanket, so a genuinely broken template doesn't cost 3x across 24 legs.
- `set +e` plus `${PIPESTATUS[0]}` is deliberate. Bash suppresses `set -e` inside a subshell called as an `if` condition, so `if generate_and_build` would run past a failing `wails3 init`.

Fixes #6038

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

CI on this PR runs the new step across all 24 legs, since the workflow triggers on changes to itself.

Locally I stubbed `generate_and_build` and drove the loop: success gives 1 attempt and exit 0; transient then success gives 2 and 0; genuine error gives 1 and 1; always transient gives 3 and 1.

Classifier checked against real output. Retried: the sumdb error above, `Cannot find native binding`, `502 Bad Gateway`, `503 Service Unavailable`, `i/o timeout`. Not retried: `added 504 packages, and audited 505 packages in 12s` (an earlier draft matched a bare `50[234]` and would have), `undefined: SomeSymbol`, `error TS2304`, `Could not resolve`.

- [ ] Windows
- [x] macOS
- [ ] Linux

macOS only because that is where the shell tests ran. The full matrix is the PR's CI run.

## Test Configuration

Not applicable. Workflow-only change with no runtime or CLI code.

# Checklist:

- [ ] (v2 only) I have updated `website/src/pages/changelog.mdx` with details of this PR (v3 changelog entries are added automatically)
- [x] My code follows the general coding style of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Docs and tests unticked on purpose: no docs describe this workflow, and CI workflows have no test harness here.

Happy to drop the gating for a plain retry if you'd prefer the simpler step.
