### PR TITLE
fix(v3/windows): raise the WebView2 embed timeout to 60s

### DIFF
--- a/v3/internal/webview2/pkg/edge/chromium.go
+++ b/v3/internal/webview2/pkg/edge/chromium.go
@@ -234,7 +234,7 @@ func (e *Chromium) Embed(hwnd uintptr) bool {
 // embedTimeout bounds how long Embed waits for CreateCoreWebView2Controller to
 // complete. Controller creation is normally well under a second; this is a
 // backstop for the case where the callback never arrives, not a budget.
-const embedTimeout = 30 * time.Second
+const embedTimeout = 60 * time.Second
 
 // pumpUntilInited runs a message loop until the controller is ready, the queue
 // receives WM_QUIT, or timeout elapses. It reports whether the controller


### PR DESCRIPTION
# Description

[This run](https://github.com/wailsapp/wails/actions/runs/32914449190/job/98015339818) failed with:

```
=== RUN   TestCookieManager
[WebView2 Error] timed out after 30s waiting for the WebView2 controller; the WebView2 runtime did not complete initialisation
FAIL	github.com/wailsapp/wails/v3/internal/webview2/pkg/edge	46.880s
```

A cold WebView2 launch creates the user data folder and spawns the browser process tree, and on CI it does that while `go test ./...` saturates the runner. Isolated on the same commit the test passes in ~10s, so 30s is simply tight rather than wrong.

`embedTimeout` is a backstop for a callback that never arrives, not a startup budget (its own comment says so), and it costs nothing when initialisation succeeds because `pumpUntilInited` returns as soon as the controller is ready. Raised to 60s.

Fixes #6042

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

`GOOS=windows go build ./internal/webview2/...` and `go vet` on the package. Vet reports two pre-existing `possible misuse of unsafe.Pointer` warnings, unchanged by this commit (confirmed by stashing it). The Windows CI leg on this PR runs `TestCookieManager` itself.

- [ ] Windows
- [x] macOS
- [ ] Linux

Cross-compiled and vetted from macOS. I have no Windows machine to run the test on, so the PR's Windows leg is the real check.

## Test Configuration

Cross-compile only, `GOOS=windows GOARCH=amd64`, Go 1.25.

# Checklist:

- [ ] (v2 only) I have updated `website/src/pages/changelog.mdx` with details of this PR (v3 changelog entries are added automatically)
- [x] My code follows the general coding style of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

The affected test is Windows-only, so I could not run it locally; no new test added since this changes a constant.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Increased the WebView2 initialization timeout to improve reliability on slower startup environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->