### PR TITLE
fix(dev): stop watcher when primary process exits

### DIFF
--- a/v3/UNRELEASED_CHANGELOG.md
+++ b/v3/UNRELEASED_CHANGELOG.md
@@ -23,6 +23,7 @@ After processing, the content will be moved to the main changelog and this file 
 
 ## Fixed
 <!-- Bug fixes -->
+- Stop `wails3 dev` and its background processes when the primary application exits (#6048)
 
 ## Deprecated
 <!-- Soon-to-be removed features -->

--- a/v3/go.mod
+++ b/v3/go.mod
@@ -6,7 +6,7 @@ require (
 	git.sr.ht/~jackmordaunt/go-toast/v2 v2.0.3
 	github.com/adrg/xdg v0.5.3
 	github.com/atotto/clipboard v0.1.4
-	github.com/atterpac/refresh v1.0.0
+	github.com/atterpac/refresh v1.1.3
 	github.com/charmbracelet/bubbles v0.21.1-0.20250623103423-23b8fd6302d7
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/glamour v0.10.0

--- a/v3/go.sum
+++ b/v3/go.sum
@@ -61,8 +61,8 @@ github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkY
 github.com/atomicgo/cursor v0.0.1/go.mod h1:cBON2QmmrysudxNBFthvMtN32r3jxVRIvzkUiF/RuIk=
 github.com/atotto/clipboard v0.1.4 h1:EH0zSVneZPSuFR11BlR9YppQTVDbh5+16AmcJi4g1z4=
 github.com/atotto/clipboard v0.1.4/go.mod h1:ZY9tmq7sm5xIbd9bOK4onWV4S6X0u6GY7Vn0Yu86PYI=
-github.com/atterpac/refresh v1.0.0 h1:IK/rh3w5cD7nb6GuqzfScIdNuAz/E0sZz10k1pioIFE=
-github.com/atterpac/refresh v1.0.0/go.mod h1:+vQ8OHgGmZ7wwoZfxxkT6Nr/gKA8j78Rbt+qcLLDEoc=
+github.com/atterpac/refresh v1.1.3 h1:pwvhX6CNQpbDpyaAYK1EQSfsAJCZBZr8n7rQtTGqG5U=
+github.com/atterpac/refresh v1.1.3/go.mod h1:+vQ8OHgGmZ7wwoZfxxkT6Nr/gKA8j78Rbt+qcLLDEoc=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiErDT4WkJ2k=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1/go.mod h1:uYgXzlJ7ZpABp8OJ+exZzJJhRNQ2ASbcXHWsFqH8hp8=
 github.com/aymanbagabas/go-udiff v0.3.1 h1:LV+qyBQ2pqe0u42ZsUEtPiCaUoqgA9gYRDs3vj1nolY=

--- a/v3/internal/commands/build_assets/config.yml
+++ b/v3/internal/commands/build_assets/config.yml
@@ -58,6 +58,7 @@ dev_mode:
       type: background
     - cmd: wails3 task run
       type: primary
+      exit_policy: shutdown
 
 # File Associations
 # More information at: https://v3.wails.io/noit/done/yet

--- a/v3/internal/commands/watcher.go
+++ b/v3/internal/commands/watcher.go
@@ -1,10 +1,13 @@
 package commands
 
 import (
+	"errors"
+	"log/slog"
 	"os"
+	"os/exec"
 
 	"github.com/atterpac/refresh/engine"
-	"github.com/wailsapp/wails/v3/internal/signal"
+	"github.com/atterpac/refresh/process"
 	"gopkg.in/yaml.v3"
 )
 
@@ -17,13 +20,25 @@ func ensureIgnored(list *[]string, pattern string) {
 	*list = append(*list, pattern)
 }
 
+func ensurePrimaryExitPolicy(executes []process.Execute) {
+	for index := range executes {
+		execute := &executes[index]
+		if execute.Type == process.Primary && execute.ExitPolicy == "" {
+			execute.ExitPolicy = process.ExitPolicyShutdown
+		}
+	}
+}
+
+func isInterruptError(err error) bool {
+	var exitErr *exec.ExitError
+	return errors.As(err, &exitErr) && isInterruptProcessState(exitErr.ProcessState)
+}
+
 type WatcherOptions struct {
 	Config string `description:"The config file including path" default:"."`
 }
 
 func Watcher(options *WatcherOptions) error {
-	stopChan := make(chan struct{})
-
 	// Parse the config file
 	type devConfig struct {
 		Config engine.Config `yaml:"dev_mode"`
@@ -42,36 +57,18 @@ func Watcher(options *WatcherOptions) error {
 	}
 
 	ensureIgnored(&devconfig.Config.Ignore.File, "*_test.go")
+	ensurePrimaryExitPolicy(devconfig.Config.ExecStruct)
 
 	watcherEngine, err := engine.NewEngineFromConfig(devconfig.Config)
 	if err != nil {
 		return err
 	}
-
-	// Setup cleanup function that stops the engine
-	cleanup := func() {
-		watcherEngine.Stop()
-	}
-	defer cleanup()
-
-	// Signal handler needs to notify when to stop
-	signalCleanup := func() {
-		cleanup()
-		stopChan <- struct{}{}
-	}
-
-	signalHandler := signal.NewSignalHandler(signalCleanup)
-	signalHandler.ExitMessage = func(sig os.Signal) string {
-		return ""
-	}
-	signalHandler.Start()
-
-	// Start the engine
-	err = watcherEngine.Start()
-	if err != nil {
+	if err := watcherEngine.Start(); err != nil {
+		if isInterruptError(err) {
+			slog.Warn("graceful exit requested", "signal", os.Interrupt)
+			return nil
+		}
 		return err
 	}
-
-	<-stopChan
 	return nil
 }

--- a/v3/internal/commands/watcher_interrupt_other.go
+++ b/v3/internal/commands/watcher_interrupt_other.go
@@ -1,0 +1,9 @@
+//go:build !darwin && !linux && !windows
+
+package commands
+
+import "os"
+
+func isInterruptProcessState(*os.ProcessState) bool {
+	return false
+}

--- a/v3/internal/commands/watcher_interrupt_unix.go
+++ b/v3/internal/commands/watcher_interrupt_unix.go
@@ -1,0 +1,13 @@
+//go:build darwin || linux
+
+package commands
+
+import (
+	"os"
+	"syscall"
+)
+
+func isInterruptProcessState(state *os.ProcessState) bool {
+	status, ok := state.Sys().(syscall.WaitStatus)
+	return ok && status.Signal() == syscall.SIGINT
+}

--- a/v3/internal/commands/watcher_interrupt_unix_test.go
+++ b/v3/internal/commands/watcher_interrupt_unix_test.go
@@ -1,0 +1,22 @@
+//go:build darwin || linux
+
+package commands
+
+import (
+	"fmt"
+	"os/exec"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsInterruptError(t *testing.T) {
+	interruptErr := exec.Command("sh", "-c", "kill -INT $$").Run()
+	require.Error(t, interruptErr)
+	assert.True(t, isInterruptError(fmt.Errorf("process exited: %w", interruptErr)))
+
+	exitErr := exec.Command("sh", "-c", "exit 1").Run()
+	require.Error(t, exitErr)
+	assert.False(t, isInterruptError(exitErr))
+}

--- a/v3/internal/commands/watcher_interrupt_windows.go
+++ b/v3/internal/commands/watcher_interrupt_windows.go
@@ -1,0 +1,11 @@
+//go:build windows
+
+package commands
+
+import "os"
+
+const statusControlCExit = 0xC000013A
+
+func isInterruptProcessState(state *os.ProcessState) bool {
+	return uint32(state.ExitCode()) == statusControlCExit
+}

--- a/v3/internal/commands/watcher_interrupt_windows_test.go
+++ b/v3/internal/commands/watcher_interrupt_windows_test.go
@@ -1,0 +1,22 @@
+//go:build windows
+
+package commands
+
+import (
+	"fmt"
+	"os/exec"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsInterruptError(t *testing.T) {
+	interruptErr := exec.Command("cmd", "/c", "exit /b -1073741510").Run()
+	require.Error(t, interruptErr)
+	assert.True(t, isInterruptError(fmt.Errorf("process exited: %w", interruptErr)))
+
+	exitErr := exec.Command("cmd", "/c", "exit /b 1").Run()
+	require.Error(t, exitErr)
+	assert.False(t, isInterruptError(exitErr))
+}

--- a/v3/internal/commands/watcher_test.go
+++ b/v3/internal/commands/watcher_test.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"testing"
 
+	"github.com/atterpac/refresh/process"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -26,5 +27,25 @@ func TestEnsureIgnored(t *testing.T) {
 		ensureIgnored(&list, "*_test.go")
 		assert.Contains(t, list, "*_test.go")
 		assert.Len(t, list, 1)
+	})
+}
+
+func TestEnsurePrimaryExitPolicy(t *testing.T) {
+	t.Run("defaults primary process to shutdown", func(t *testing.T) {
+		executes := []process.Execute{{Type: process.Primary}}
+		ensurePrimaryExitPolicy(executes)
+		assert.Equal(t, process.ExitPolicyShutdown, executes[0].ExitPolicy)
+	})
+
+	t.Run("preserves explicit policy", func(t *testing.T) {
+		executes := []process.Execute{{Type: process.Primary, ExitPolicy: process.ExitPolicyIgnore}}
+		ensurePrimaryExitPolicy(executes)
+		assert.Equal(t, process.ExitPolicyIgnore, executes[0].ExitPolicy)
+	})
+
+	t.Run("ignores non-primary process", func(t *testing.T) {
+		executes := []process.Execute{{Type: process.Background}}
+		ensurePrimaryExitPolicy(executes)
+		assert.Empty(t, executes[0].ExitPolicy)
 	})
 }


### PR DESCRIPTION
<!--

*********************************************************************
*               PLEASE READ BEFORE SUBMITTING YOUR PR               *
*     YOUR PR MAY BE REJECTED IF IT DOES NOT FOLLOW THESE STEPS     *
*********************************************************************

- *DO NOT* submit bugs for a source install of v3, ONLY tagged versions, e.g. v3.0.0-beta.1
- For a new capability or change to public behaviour, submit a draft **WEP (Wails Enhancement Proposal)** PR first. Do not start implementation until it is accepted.
  The feedback guide for v3 is here: https://v3.wails.io/feedback/

- For a bug fix, link the bug issue where one exists. For an enhancement implementation, link the accepted WEP PR.
- Please fill in the checklists.

-->

# Description

Fix `wails3 dev` remaining alive after Ctrl+C terminates the primary application but does not deliver SIGINT to the watcher process group.

This change upgrades `github.com/atterpac/refresh` from v1.0.0 to v1.1.3 and defaults primary development processes to its `shutdown` exit policy. Explicit user-configured exit policies are preserved. It also removes the redundant Wails signal wait after the refresh supervisor returns, so the watcher exits together with its managed background processes.

When the primary process receives SIGINT directly, refresh reports the resulting process exit as an error. Wails now identifies that exit using structured platform process state and reports it as the same graceful interrupt used when the watcher receives SIGINT itself. Other signals and non-zero exits remain errors. Unix SIGINT and Windows `STATUS_CONTROL_C_EXIT` are handled separately.

Newly generated project configurations include `exit_policy: shutdown`. Existing configurations receive the same default at runtime, so no migration is required.

Fixes #6048

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] WEP (proposal only; no implementation)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [ ] Windows
- [x] macOS
- [ ] Linux


https://github.com/user-attachments/assets/08d5af65-57d9-4f09-a84c-a0be8823d6ad

Runtime reproduction was performed on macOS using the repository and revision from #6048:

```shell
git clone https://github.com/Paulkm2006/wails.git /tmp/wails-pr-6048
cd /tmp/wails-pr-6048
git checkout codex/fix-dev-ctrl-c
cd v3
GOTOOLCHAIN=go1.25.0 go build -o /tmp/wails3 ./cmd/wails3

git clone https://github.com/MaimoryLab/codeoff-server.git /tmp/codeoff-server-6048
cd /tmp/codeoff-server-6048
git checkout 7f1325a48d493673058add6f4b2a1ca75c443854

PATH="/tmp:$PATH" /tmp/wails3 dev -config ./build/config.yml -port 9258
```

After the native application and Vite started, pressing Ctrl+C once:

- printed `WRN graceful exit requested signal=interrupt`;
- returned control to the shell without an error;
- stopped the watcher, native application, and Vite process; and
- released port 9258.

Additional verification:

```shell
GOTOOLCHAIN=go1.25.0 go test ./...
GOTOOLCHAIN=go1.25.0 go vet ./internal/commands
staticcheck -checks=inherit,-ST1005,-U1000,-S1017 ./internal/commands
CGO_ENABLED=0 GOOS=windows GOARCH=amd64 GOTOOLCHAIN=go1.25.0 go test -c -o /tmp/wails-commands.test.exe ./internal/commands
```

The Windows command package and platform-specific test compile successfully, but the runtime behavior has not been tested on Windows. Linux has not been tested.

## Test Configuration

```text
Wails v3.0.0-dev › Wails Doctor

# System

┌──────────────────────────────┐
| Name          | MacOS        |
| Version       | 26.6.2       |
| ID            | 25G83        |
| Branding      | MacOS 26.6.2 |
| Platform      | darwin       |
| Architecture  | arm64        |
| Apple Silicon | true         |
| CPU           | Apple M2 Pro |
| CPU           | Apple M2 Pro |
| GPU           | 16 cores     |
| Memory        | 16 GB        |
└──────────────────────────────┘

# Build Environment

┌───────────────────────────┐
| Wails CLI    | v3.0.0-dev |
| Go Version   | go1.25.0   |
| -buildmode   | exe        |
| -compiler    | gc         |
| CGO_CFLAGS   |            |
| CGO_CPPFLAGS |            |
| CGO_CXXFLAGS |            |
| CGO_ENABLED  | 1          |
| CGO_LDFLAGS  |            |
| GOARCH       | arm64      |
| GOARM64      | v8.0       |
| GOOS         | darwin     |
└───────────────────────────┘

# Dependencies

┌─────────────────────────────────────────────────────────────────────────────────────────────────────┐
| *Android NDK            | /Users/ppio/Library/Android/sdk/ndk/28.2.13676358                         |
| *Android SDK            | /Users/ppio/Library/Android/sdk                                           |
| *Android platform-tools | Installed                                                                 |
| *Java (Android)         | Not found. Install a JDK (e.g. brew install openjdk@21) or set JAVA_HOME. |
| *NSIS                   | Not Installed. Install with `brew install makensis`.                      |
| *Xcode (iOS)            | Xcode 26.6, Build version 17F113                                          |
| *iOS Device SDK         | 26.5                                                                      |
| *iOS Simulator SDK      | 26.5                                                                      |
| Xcode cli tools         | 2416                                                                      |
| npm                     | 12.0.2                                                                    |
| docker                  | *Docker version 29.7.2, build a7dcaa6fdb (cross-compilation ready)        |
|                                                                                                     |
└────────────────────────────────────── * - Optional Dependency ──────────────────────────────────────┘

# Signing

┌───────────────────────────────────────────────────────────────────┐
| macOS Signing   | Developer ID Application: steve li (F2VC757B28) |
| Windows Signing | Not configured                                  |
| Linux Signing   | Not configured (GPG)                            |
└───────────────────────────────────────────────────────────────────┘

# Checking for issues

SUCCESS  No issues found

# Diagnosis

SUCCESS  Your system is ready for Wails development!
```

# Checklist:

- [ ] (v2 only) I have updated `website/src/pages/changelog.mdx` with details of this PR (not applicable: this is a v3 change)
- [x] My code follows the general coding style of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (not applicable: no public API or documented configuration changes)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * `wails3 dev` and its background processes now shut down automatically when the main application exits.
  * Interrupt-based exits are handled as graceful shutdowns instead of being reported as errors.
  * Explicit process shutdown settings continue to be respected.
* **Documentation**
  * Added a changelog entry documenting the improved shutdown behavior.
* **Tests**
  * Added coverage for shutdown policies and interrupt handling across supported platforms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->