### PR TITLE
fix(v3/windows): restore modal owner activation on close

### DIFF
--- a/v3/pkg/application/webview_window_modal_windows_test.go
+++ b/v3/pkg/application/webview_window_modal_windows_test.go
@@ -1,0 +1,72 @@
+//go:build windows && !server
+
+package application
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// Regression test for https://github.com/wailsapp/wails/issues/6054.
+func TestModalParentIsReleasedBeforeWindowDestruction(t *testing.T) {
+	sourceBytes, err := os.ReadFile("webview_window_windows.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	source := string(sourceBytes)
+
+	assertCallOrder(
+		t,
+		source,
+		"func (w *windowsWebviewWindow) destroy()",
+		"func (w *windowsWebviewWindow) reload()",
+		"w.releaseModalParent(w.isFocused())",
+		"w32.DestroyWindow(w.hwnd)",
+	)
+	assertCallOrder(
+		t,
+		source,
+		"case w32.WM_CLOSE:",
+		"case w32.WM_SETCURSOR:",
+		"w.releaseModalParent(restoreParentActivation)",
+		"w32.DefWindowProc(w.hwnd, w32.WM_CLOSE, 0, 0)",
+	)
+}
+
+func TestModalParentActivationIsConditional(t *testing.T) {
+	sourceBytes, err := os.ReadFile("webview_window_windows.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertCallOrder(
+		t,
+		string(sourceBytes),
+		"func (w *windowsWebviewWindow) releaseModalParent(activate bool)",
+		"func (w *windowsWebviewWindow) reload()",
+		"if activate {",
+		"w32.SetActiveWindow(w.parentHWND)",
+	)
+}
+
+func assertCallOrder(t *testing.T, source, start, end, first, second string) {
+	t.Helper()
+	startIndex := strings.Index(source, start)
+	if startIndex < 0 {
+		t.Fatalf("start marker %q not found", start)
+	}
+	section := source[startIndex:]
+	endIndex := strings.Index(section, end)
+	if endIndex < 0 {
+		t.Fatalf("end marker %q not found after %q", end, start)
+	}
+	section = section[:endIndex]
+	firstIndex := strings.Index(section, first)
+	secondIndex := strings.Index(section, second)
+	if firstIndex < 0 || secondIndex < 0 {
+		t.Fatalf("expected %q and %q between %q and %q", first, second, start, end)
+	}
+	if firstIndex > secondIndex {
+		t.Fatalf("%q must occur before %q between %q and %q", first, second, start, end)
+	}
+}

--- a/v3/pkg/application/webview_window_windows.go
+++ b/v3/pkg/application/webview_window_windows.go
@@ -854,15 +854,26 @@ func (w *windowsWebviewWindow) setRelativePosition(x int, y int) {
 }
 
 func (w *windowsWebviewWindow) destroy() {
-	// Re-enable parent window if this was a modal window
-	if w.parentHWND != 0 {
-		w32.EnableWindow(w.parentHWND, true)
-		w.parentHWND = 0
-	}
+	w.releaseModalParent(w.isFocused())
 
 	w.parent.markAsDestroyed()
 	// destroy the window
 	w32.DestroyWindow(w.hwnd)
+}
+
+// releaseModalParent makes an attached modal's owner eligible for activation
+// again. If the modal is currently foreground, activate its owner before the
+// modal is destroyed so Windows does not select the next unrelated top-level
+// window. A background modal must not steal activation from another app.
+func (w *windowsWebviewWindow) releaseModalParent(activate bool) {
+	if w.parentHWND == 0 {
+		return
+	}
+	w32.EnableWindow(w.parentHWND, true)
+	if activate {
+		w32.SetActiveWindow(w.parentHWND)
+	}
+	w.parentHWND = 0
 }
 
 func (w *windowsWebviewWindow) reload() {
@@ -1645,21 +1656,15 @@ func (w *windowsWebviewWindow) WndProc(msg uint32, wparam, lparam uintptr) uintp
 			return 0
 		}
 
-		defer func() {
-			// Re-enable parent window if this was a modal window
-			if w.parentHWND != 0 {
-				w32.EnableWindow(w.parentHWND, true)
-				w.parentHWND = 0
-			}
-
-			windowsApp := globalApplication.impl.(*windowsApp)
-			windowsApp.unregisterWindow(w)
-
-		}()
-
-		// Now do the actual close
+		// DefWindowProc destroys the modal and may select the next unrelated
+		// top-level window, so remember whether its owner should remain active.
+		restoreParentActivation := w.isFocused()
 		w.chromium.ShuttingDown()
-		return w32.DefWindowProc(w.hwnd, w32.WM_CLOSE, 0, 0)
+		w.releaseModalParent(restoreParentActivation)
+		result := w32.DefWindowProc(w.hwnd, w32.WM_CLOSE, 0, 0)
+		windowsApp := globalApplication.impl.(*windowsApp)
+		windowsApp.unregisterWindow(w)
+		return result
 	case w32.WM_SETCURSOR:
 		if w.compositionCursor != 0 && w32.LOWORD(uint32(lparam)) == w32.HTCLIENT {
 			w32.SetCursor(w.compositionCursor)


### PR DESCRIPTION
# Description

On Windows, closing a foreground attached modal can activate an unrelated application instead of returning activation to the modal owner.

The current `WM_CLOSE` path re-enables the owner only after `DefWindowProc` destroys the modal. This change records whether the modal is foreground, re-enables the owner before destruction, and activates the owner when appropriate. A background modal does not activate its owner, so closing it does not steal focus.

This also adds Windows regression tests for the required release and activation order.

Fixes #6054

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] WEP (proposal only; no implementation)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- Reproduced with a separate application using tagged `github.com/wailsapp/wails/v3 v3.0.0-beta.15`.
- Applied only this patch through a local module replacement and verified that both immediate and delayed modal closure return activation to the owner.
- Verified that an unrelated application no longer moves in front of the owner when the foreground modal closes.
- Ran `GOTOOLCHAIN=go1.25.0 go test ./pkg/application -count=1` successfully.
- Ran `GOTOOLCHAIN=go1.25.0 go test -timeout 10m ./...`; all relevant packages passed. The current upstream `internal/wake/exec` tests still fail on Windows because they invoke the POSIX `true` command through `cmd.exe`.

- [x] Windows
- [ ] macOS
- [ ] Linux

## Test Configuration

```text
Wails CLI: v3.0.0-beta.15
OS: Windows 11 Pro 25H2 (Build 26200)
Architecture: amd64
Go: go1.25.0 for tests
WebView2: 151.0.4129.107
CGO_ENABLED: 1
Diagnosis: No issues found
```

# Checklist:

- [x] (v2 only) I have updated `website/src/pages/changelog.mdx` with details of this PR (not applicable; this is a v3 fix)
- [x] My code follows the general coding style of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (not applicable; no documentation change is required)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes (blocked by the unrelated upstream Windows `internal/wake/exec` failures described above)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved modal window closing behavior on Windows.
  * Restored the modal’s owner window before destruction, preventing unrelated windows from being activated.
  * Ensured owner activation only occurs when appropriate.
* **Tests**
  * Added regression coverage for modal window release and activation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->