### PR TITLE
* [feat] Add `-appargs` CLI args to extend program arguments

### DIFF
--- a/v3/UNRELEASED_CHANGELOG.md
+++ b/v3/UNRELEASED_CHANGELOG.md
@@ -16,6 +16,7 @@ After processing, the content will be moved to the main changelog and this file 
 -->
 
 ## Added
+- Add support for `-appargs` to wails dev for extra runtime customisation
 <!-- New features, capabilities, or enhancements -->
 
 ## Changed

--- a/v3/internal/commands/build_assets/darwin/Taskfile.yml
+++ b/v3/internal/commands/build_assets/darwin/Taskfile.yml
@@ -193,7 +193,7 @@ tasks:
       - cp "{{.BIN_DIR}}/{{.APP_NAME}}" "{{.BIN_DIR}}/{{.APP_NAME}}.dev.app/Contents/MacOS"
       - cp "build/darwin/Info.dev.plist" "{{.BIN_DIR}}/{{.APP_NAME}}.dev.app/Contents/Info.plist"
       - codesign --force --deep --sign - "{{.BIN_DIR}}/{{.APP_NAME}}.dev.app"
-      - '"{{.BIN_DIR}}/{{.APP_NAME}}.dev.app/Contents/MacOS/{{.APP_NAME}}"'
+      - '"{{.BIN_DIR}}/{{.APP_NAME}}.dev.app/Contents/MacOS/{{.APP_NAME}}" {{.CLI_ARGS}}'
 
   sign:
     summary: Signs the application bundle with Developer ID

--- a/v3/internal/commands/build_assets/linux/Taskfile.yml
+++ b/v3/internal/commands/build_assets/linux/Taskfile.yml
@@ -180,7 +180,7 @@ tasks:
 
   run:
     cmds:
-      - '{{.BIN_DIR}}/{{.APP_NAME}}'
+      - '{{.BIN_DIR}}/{{.APP_NAME}} {{.CLI_ARGS}}'
 
   sign:deb:
     summary: Signs the DEB package

--- a/v3/internal/commands/build_assets/windows/Taskfile.yml
+++ b/v3/internal/commands/build_assets/windows/Taskfile.yml
@@ -162,7 +162,7 @@ tasks:
 
   run:
     cmds:
-      - '{{.BIN_DIR}}/{{.APP_NAME}}.exe'
+      - '{{.BIN_DIR}}/{{.APP_NAME}}.exe {{.CLI_ARGS}}'
 
   sign:
     summary: Signs the Windows executable

--- a/v3/internal/commands/dev.go
+++ b/v3/internal/commands/dev.go
@@ -14,8 +14,8 @@ const wailsVitePort = "WAILS_VITE_PORT"
 
 type DevOptions struct {
 	flags.Common
-
 	Config   string `description:"The config file including path" default:"./build/config.yml"`
+	AppArgs  string `name:"appargs" description:"Extra arguments to postfix to the run command"`
 	VitePort int    `name:"port" description:"Specify the vite dev server port"`
 	Secure   bool   `name:"s" description:"Enable HTTPS"`
 }
@@ -59,6 +59,7 @@ func Dev(options *DevOptions) error {
 	}
 
 	return Watcher(&WatcherOptions{
-		Config: options.Config,
+		AppArgs: options.AppArgs,
+		Config:  options.Config,
 	})
 }

--- a/v3/internal/commands/task.go
+++ b/v3/internal/commands/task.go
@@ -116,7 +116,9 @@ func RunTask(options *RunTaskOptions, otherArgs []string) error {
 			return err
 		}
 		vars := parseCLIVars(otherArgs)
-
+		if len(options.AppArgs) > 0 {
+			vars["CLI_ARGS"] = options.AppArgs
+		}
 		opts := wake.ExecuteOptions{
 			Dir:      dir,
 			Verb:     options.Name,

--- a/v3/internal/commands/task.go
+++ b/v3/internal/commands/task.go
@@ -84,6 +84,7 @@ type RunTaskOptions struct {
 	Color            bool   `name:"c" description:"colored output. Enabled by default. Set flag to false or use NO_COLOR=1 to disable" default:"true"`
 	Concurrency      int    `name:"C" description:"limit number tasks to run concurrently"`
 	Interval         int64  `name:"interval" description:"interval to watch for changes"`
+	AppArgs          string `name:"appargs" description:"Additional arguments to postfix to tasks using app_args"`
 }
 
 func RunTask(options *RunTaskOptions, otherArgs []string) error {
@@ -115,6 +116,7 @@ func RunTask(options *RunTaskOptions, otherArgs []string) error {
 			return err
 		}
 		vars := parseCLIVars(otherArgs)
+
 		opts := wake.ExecuteOptions{
 			Dir:      dir,
 			Verb:     options.Name,
@@ -127,7 +129,6 @@ func RunTask(options *RunTaskOptions, otherArgs []string) error {
 		}
 		return wake.Execute(options.Name, opts)
 	}
-
 
 	if options.Dir != "" && options.EntryPoint != "" {
 		return fmt.Errorf("task: You can't set both --dir and --taskfile")
@@ -193,41 +194,16 @@ func RunTask(options *RunTaskOptions, otherArgs []string) error {
 	}
 
 	// Parse task name and CLI variables from otherArgs or os.Args
-	var tasksAndVars []string
-
+	taskName := "default"
+	var taskVars []string
 	// Check if we have a task name specified in options
 	if options.Name != "" {
-		// If task name is provided via options, use it and treat otherArgs as CLI variables
-		tasksAndVars = append([]string{options.Name}, otherArgs...)
+		taskName = options.Name
+		taskVars = otherArgs
 	} else if len(otherArgs) > 0 {
-		// Use otherArgs directly if provided
-		tasksAndVars = otherArgs
-	} else {
-		// Fall back to parsing os.Args for backward compatibility
-		var index int
-		var arg string
-		for index, arg = range os.Args[2:] {
-			if !strings.HasPrefix(arg, "-") {
-				break
-			}
-		}
-
-		for _, taskAndVar := range os.Args[index+2:] {
-			if taskAndVar == "--" {
-				break
-			}
-			tasksAndVars = append(tasksAndVars, taskAndVar)
-		}
+		taskName = otherArgs[0]
+		taskVars = otherArgs[1:]
 	}
-
-	// Default task
-	if len(tasksAndVars) == 0 {
-		tasksAndVars = []string{"default"}
-	}
-
-	// Parse task name and CLI variables
-	taskName := tasksAndVars[0]
-	cliVars := tasksAndVars[1:]
 
 	// Create call with CLI variables
 	call := &ast.Call{
@@ -236,7 +212,7 @@ func RunTask(options *RunTaskOptions, otherArgs []string) error {
 	}
 
 	// Parse CLI variables (format: KEY=VALUE)
-	for _, v := range cliVars {
+	for _, v := range taskVars {
 		if strings.Contains(v, "=") {
 			parts := strings.SplitN(v, "=", 2)
 			if len(parts) == 2 {
@@ -249,6 +225,19 @@ func RunTask(options *RunTaskOptions, otherArgs []string) error {
 					})
 				}
 			}
+		}
+	}
+
+	// Forward passthrough args after `--` into Task's special CLI_ARGS variable.
+	if len(options.AppArgs) > 0 {
+		call.Vars.Set("CLI_ARGS", ast.Var{
+			Value: options.AppArgs,
+		})
+
+		if e.Taskfile != nil {
+			e.Taskfile.Vars.Set("CLI_ARGS", ast.Var{
+				Value: options.AppArgs,
+			})
 		}
 	}
 

--- a/v3/internal/commands/watcher.go
+++ b/v3/internal/commands/watcher.go
@@ -3,6 +3,8 @@ package commands
 import (
 	"fmt"
 	"os"
+	"runtime"
+	"strings"
 
 	"github.com/atterpac/refresh/engine"
 	"github.com/wailsapp/wails/v3/internal/signal"
@@ -50,7 +52,19 @@ func Watcher(options *WatcherOptions) error {
 		for idx, execAction := range devconfig.Config.ExecStruct {
 			if execAction.Cmd == "wails3 task run" {
 				clonedExec := execAction
-				clonedExec.Cmd = fmt.Sprintf("wails3 task run -appargs='%s'", options.AppArgs)
+
+				escapedAppArgs := options.AppArgs
+				if runtime.GOOS == "windows" {
+					escapedAppArgs = fmt.Sprintf("%q", options.AppArgs)
+				} else {
+					escapedAppArgs =
+						"'" + strings.ReplaceAll(options.AppArgs, "'", `'"'"'`) + "'"
+				}
+
+				clonedExec.Cmd = fmt.Sprintf(
+					"wails3 task run -appargs=%s",
+					escapedAppArgs,
+				)
 				devconfig.Config.ExecStruct[idx] = clonedExec
 				fmt.Printf("Executing %s\n", clonedExec.Cmd)
 			}

--- a/v3/internal/commands/watcher.go
+++ b/v3/internal/commands/watcher.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/atterpac/refresh/engine"
@@ -18,7 +19,8 @@ func ensureIgnored(list *[]string, pattern string) {
 }
 
 type WatcherOptions struct {
-	Config string `description:"The config file including path" default:"."`
+	AppArgs string `name:"appargs" description:"Extra app arguments"`
+	Config  string `description:"The config file including path" default:"."`
 }
 
 func Watcher(options *WatcherOptions) error {
@@ -42,6 +44,18 @@ func Watcher(options *WatcherOptions) error {
 	}
 
 	ensureIgnored(&devconfig.Config.Ignore.File, "*_test.go")
+
+	// If we have application arguments, append them to the wails task
+	if options.AppArgs != "" {
+		for idx, execAction := range devconfig.Config.ExecStruct {
+			if execAction.Cmd == "wails3 task run" {
+				clonedExec := execAction
+				clonedExec.Cmd = fmt.Sprintf("wails3 task run -appargs='%s'", options.AppArgs)
+				devconfig.Config.ExecStruct[idx] = clonedExec
+				fmt.Printf("Executing %s\n", clonedExec.Cmd)
+			}
+		}
+	}
 
 	watcherEngine, err := engine.NewEngineFromConfig(devconfig.Config)
 	if err != nil {


### PR DESCRIPTION
# Description

I'm currently porting my v2 app to v3 and had a nice way of testing different profiles which meant passing extra arguments to the program and would previously use appargs for this.

This is a feature missing from v3 so, i have added some base support for `-appargs` back to the dev command which, will in turn does two things:

* Modifies the `wails3 task run` command given within the watcher on the fly to add in appargs
* Gets picked up within the `task` sub command and sets the `CLI_ARGS` variable 

this means we can now do stuff like `wails3 dev -appargs="--config-path $(pwd)/testing.yaml" and it translates to running `yourapp --config-path $(pwd)/testing.yaml`

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
  
- [x] macOS
      
Customising my app startup routine during development and checking normal commands still work
  
## Test Configuration

```
# System
        
┌──────────────────────────────┐
| Name          | MacOS        |
| Version       | 26.6.2       |
| ID            | 25G83        |
| Branding      | MacOS 26.6.2 |
| Platform      | darwin       |
| Architecture  | arm64        |
| Apple Silicon | true         |
| CPU           | Apple M4 Pro |
| CPU           | Apple M4 Pro |
| GPU           | 20 cores     |
| Memory        | 64 GB        |
└──────────────────────────────┘
                   
# Build Environment
                   
┌──────────────────────────────────────────────────────────────────────┐
| Wails CLI      | v3.0.0-dev                                          |
| Go Version     | go1.26.6                                            |
| -buildmode     | exe                                                 |
| -compiler      | gc                                                  |
| CGO_CFLAGS     |                                                     |
| CGO_CPPFLAGS   |                                                     |
| CGO_CXXFLAGS   |                                                     |
| CGO_ENABLED    | 1                                                   |
| CGO_LDFLAGS    |                                                     |
| DefaultGODEBUG | cryptocustomrand=1,tlssecpmlkem=0,urlstrictcolons=0 |
| GOARCH         | arm64                                               |
| GOARM64        | v8.0                                                |
| GOOS           | darwin                                              |
| vcs            | git                                                 |
| vcs.modified   | true                                                |
| vcs.revision   | 9215c89d27237805aef1696f5e1a6e2a44cd18c0            |
| vcs.time       | 2026-08-27T18:36:41Z                                |
└──────────────────────────────────────────────────────────────────────┘
```



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added `--appargs` support to development workflows, allowing custom command-line arguments to be passed to the running application.
  - Application arguments are now forwarded consistently when launching development builds on macOS, Linux, and Windows.
  - Task execution supports passing through additional arguments to the application.

- **Documentation**
  - Updated the unreleased changelog to document the new development argument support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->