### PR TITLE
fix(linux): read dark mode from the settings portal

### DIFF
--- a/v3/UNRELEASED_CHANGELOG.md
+++ b/v3/UNRELEASED_CHANGELOG.md
@@ -24,6 +24,11 @@ After processing, the content will be moved to the main changelog and this file 
 ## Fixed
 <!-- Bug fixes -->
 
+- Fix Linux dark mode detection returning light on a dark desktop until the colour
+  scheme changed, and `linux:SystemThemeChanged` never firing on the GTK4 backend.
+  Both backends now share one implementation, backed by the
+  `org.freedesktop.appearance` portal namespace (#6072)
+
 ## Deprecated
 <!-- Soon-to-be removed features -->
 

--- a/v3/pkg/application/application_linux.go
+++ b/v3/pkg/application/application_linux.go
@@ -22,7 +22,6 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/godbus/dbus/v5"
 	"github.com/wailsapp/wails/v3/internal/operatingsystem"
 	"github.com/wailsapp/wails/v3/pkg/events"
 )
@@ -71,8 +70,6 @@ type linuxApp struct {
 	windowMap     map[windowPointer]uint
 	windowMapLock sync.Mutex
 
-	theme string
-
 	icon pointer
 }
 
@@ -116,8 +113,9 @@ func (a *linuxApp) run() error {
 		}
 	})
 	a.setupCommonEvents()
-	// Theme changes are already monitored by listenForSystemThemeChanges via init();
-	// it uses the portal-standard org.freedesktop.appearance namespace.
+	// Started here, not from init(): init() is not part of the platformApp
+	// interface and nothing calls it, so a monitor started there never runs.
+	a.monitorThemeChanges()
 	a.monitorPowerEvents()
 	return appRun(a.application)
 }
@@ -176,41 +174,6 @@ func (a *linuxApp) init(_ *App, options Options) {
 
 	if options.Icon != nil {
 		a.setIcon(options.Icon)
-	}
-
-	go listenForSystemThemeChanges(a)
-}
-
-func listenForSystemThemeChanges(a *linuxApp) {
-	conn, err := dbus.SessionBus()
-	if err != nil {
-		a.parent.error("failed to connect to session bus: %v", err)
-		return
-	}
-
-	if err = conn.AddMatchSignal(
-		dbus.WithMatchInterface("org.freedesktop.portal.Settings"),
-		dbus.WithMatchMember("SettingChanged"),
-	); err != nil {
-		return
-	}
-
-	c := make(chan *dbus.Signal, 10)
-	conn.Signal(c)
-
-	for s := range c {
-		if len(s.Body) < 3 {
-			continue
-		}
-		namespace, ok := s.Body[0].(string)
-		if !ok || namespace != "org.freedesktop.appearance" {
-			continue
-		}
-		key, ok := s.Body[1].(string)
-		if !ok || key != "color-scheme" {
-			continue
-		}
-		processApplicationEvent(C.uint(events.Linux.SystemThemeChanged), nil)
 	}
 }
 
@@ -300,35 +263,6 @@ func (a *linuxApp) getIconForFile(filename string) ([]byte, error) {
 
 func getIconBytes(iconName string) ([]byte, error) {
 	return nil, fmt.Errorf("icon lookup is not currently implemented for the GTK4 build path; build with -tags gtk3 for the legacy implementation")
-}
-
-func (a *linuxApp) isDarkMode() bool {
-	conn, err := dbus.SessionBus()
-	if err != nil {
-		return false
-	}
-
-	obj := conn.Object("org.freedesktop.portal.Desktop", "/org/freedesktop/portal/desktop")
-	call := obj.Call("org.freedesktop.portal.Settings.Read", 0, "org.freedesktop.appearance", "color-scheme")
-	if call.Err != nil {
-		return false
-	}
-
-	var result dbus.Variant
-	if err := call.Store(&result); err != nil {
-		return false
-	}
-
-	innerVariant, ok := result.Value().(dbus.Variant)
-	if !ok {
-		return false
-	}
-	colorScheme, ok := innerVariant.Value().(uint32)
-	if !ok {
-		return false
-	}
-
-	return colorScheme == 1
 }
 
 func (a *linuxApp) getAccentColor() string {

--- a/v3/pkg/application/application_linux_dbus.go
+++ b/v3/pkg/application/application_linux_dbus.go
@@ -7,6 +7,84 @@ import (
 	"github.com/wailsapp/wails/v3/pkg/events"
 )
 
+const (
+	portalBusName       = "org.freedesktop.portal.Desktop"
+	portalObjectPath    = "/org/freedesktop/portal/desktop"
+	portalSettingsIface = "org.freedesktop.portal.Settings"
+
+	// appearanceNamespace is the standardised namespace every portal
+	// implementation publishes; it is the only one read or watched. GNOME also
+	// mirrors the preference under org.gnome.desktop.interface as a string, but
+	// honouring that in the signal filter alone would be inert: the handler
+	// resolves through portalColorScheme, which speaks only this namespace.
+	appearanceNamespace = "org.freedesktop.appearance"
+	colorSchemeKey      = "color-scheme"
+
+	colorSchemePreferDark = 1
+)
+
+// isDarkMode reports the desktop colour-scheme preference, read from the
+// freedesktop Settings portal on every call.
+//
+// Read on demand rather than served from state maintained by
+// monitorThemeChanges: that monitor is started per backend, so any cache it
+// owns is only as correct as its startup wiring, and a cache fed from
+// SettingChanged payloads reports light on every desktop until the first signal
+// arrives. An on-demand read is right whether or not the monitor is running.
+// Callers that need this on a hot path should cache it themselves.
+func (a *linuxApp) isDarkMode() bool {
+	scheme, ok := portalColorScheme()
+	return ok && scheme == colorSchemePreferDark
+}
+
+// portalColorScheme reads org.freedesktop.appearance color-scheme: 0 is no
+// preference, 1 prefers dark, 2 prefers light. ok is false when the portal is
+// unreachable or the value is not the documented type.
+func portalColorScheme() (uint32, bool) {
+	conn, err := dbus.SessionBus()
+	if err != nil {
+		return 0, false
+	}
+
+	obj := conn.Object(portalBusName, portalObjectPath)
+	call := obj.Call(portalSettingsIface+".Read", 0, appearanceNamespace, colorSchemeKey)
+	if call.Err != nil {
+		return 0, false
+	}
+
+	var outer dbus.Variant
+	if err := call.Store(&outer); err != nil {
+		return 0, false
+	}
+	// Portal v1 Read double-wraps the value; other implementations, and ReadOne,
+	// return it singly wrapped. Accept both, because rejecting one shape here
+	// silently reports light -- the failure this whole path exists to remove.
+	if inner, ok := outer.Value().(dbus.Variant); ok {
+		scheme, ok := inner.Value().(uint32)
+		return scheme, ok
+	}
+	scheme, ok := outer.Value().(uint32)
+	return scheme, ok
+}
+
+// isColorSchemeChange reports whether a signal is a colour-scheme
+// SettingChanged in the standardised appearance namespace.
+func isColorSchemeChange(sig *dbus.Signal) bool {
+	if sig.Name != portalSettingsIface+".SettingChanged" {
+		return false
+	}
+	if len(sig.Body) < 2 {
+		return false
+	}
+	namespace, _ := sig.Body[0].(string)
+	key, _ := sig.Body[1].(string)
+	return namespace == appearanceNamespace && key == colorSchemeKey
+}
+
+// monitorThemeChanges emits Linux.SystemThemeChanged when the desktop colour
+// scheme changes. The portal is re-read rather than the signal payload trusted,
+// so the emitted value always agrees with isDarkMode regardless of which
+// namespace fired and what type it carried.
 func (a *linuxApp) monitorThemeChanges() {
 	go func() {
 		defer handlePanic()
@@ -21,7 +99,10 @@ func (a *linuxApp) monitorThemeChanges() {
 		defer conn.Close()
 
 		if err = conn.AddMatchSignal(
-			dbus.WithMatchObjectPath("/org/freedesktop/portal/desktop"),
+			dbus.WithMatchSender(portalBusName),
+			dbus.WithMatchObjectPath(portalObjectPath),
+			dbus.WithMatchInterface(portalSettingsIface),
+			dbus.WithMatchMember("SettingChanged"),
 		); err != nil {
 			a.parent.warning(
 				"[WARNING] Failed to subscribe to portal SettingChanged; theme changes will not fire: %v",
@@ -33,40 +114,20 @@ func (a *linuxApp) monitorThemeChanges() {
 		c := make(chan *dbus.Signal, 10)
 		conn.Signal(c)
 
-		getTheme := func(body []interface{}) (string, bool) {
-			if len(body) < 3 {
-				return "", false
-			}
-			if entry, ok := body[0].(string); !ok || entry != "org.gnome.desktop.interface" {
-				return "", false
-			}
-			if entry, ok := body[1].(string); !ok || entry != "color-scheme" {
-				return "", false
-			}
-			variant, ok := body[2].(dbus.Variant)
-			if !ok {
-				return "", false
-			}
-			value, ok := variant.Value().(string)
-			if !ok {
-				return "", false
-			}
-			return value, true
-		}
-
+		last := a.isDarkMode()
 		for v := range c {
-			theme, ok := getTheme(v.Body)
-			if !ok {
+			if !isColorSchemeChange(v) {
 				continue
 			}
-
-			if theme != a.theme {
-				a.theme = theme
-				event := newApplicationEvent(events.Linux.SystemThemeChanged)
-				event.Context().setIsDarkMode(a.isDarkMode())
-				applicationEvents <- event
+			dark := a.isDarkMode()
+			if dark == last {
+				continue
 			}
+			last = dark
 
+			event := newApplicationEvent(events.Linux.SystemThemeChanged)
+			event.Context().setIsDarkMode(dark)
+			applicationEvents <- event
 		}
 	}()
 }

--- a/v3/pkg/application/application_linux_dbus.go
+++ b/v3/pkg/application/application_linux_dbus.go
@@ -3,6 +3,9 @@
 package application
 
 import (
+	"context"
+	"time"
+
 	"github.com/godbus/dbus/v5"
 	"github.com/wailsapp/wails/v3/pkg/events"
 )
@@ -21,6 +24,14 @@ const (
 	colorSchemeKey      = "color-scheme"
 
 	colorSchemePreferDark = 1
+
+	// portalReadTimeout bounds a single Settings.Read. godbus's Object.Call
+	// passes context.Background(), so an unresponsive portal would block the
+	// caller forever, and IsDarkMode is reachable from application code on the
+	// main thread. A local IPC round-trip is sub-millisecond in practice; the
+	// budget is wide enough only to cover D-Bus activating the portal on a cold
+	// first call.
+	portalReadTimeout = 2 * time.Second
 )
 
 // isDarkMode reports the desktop colour-scheme preference, read from the
@@ -46,8 +57,13 @@ func portalColorScheme() (uint32, bool) {
 		return 0, false
 	}
 
+	ctx, cancel := context.WithTimeout(context.Background(), portalReadTimeout)
+	defer cancel()
+
 	obj := conn.Object(portalBusName, portalObjectPath)
-	call := obj.Call(portalSettingsIface+".Read", 0, appearanceNamespace, colorSchemeKey)
+	call := obj.CallWithContext(ctx, portalSettingsIface+".Read", 0, appearanceNamespace, colorSchemeKey)
+	// A deadline lands here as call.Err, so a hung portal reports the same
+	// "no preference" as an absent one.
 	if call.Err != nil {
 		return 0, false
 	}

--- a/v3/pkg/application/application_linux_gtk3.go
+++ b/v3/pkg/application/application_linux_gtk3.go
@@ -87,8 +87,6 @@ type linuxApp struct {
 	windowMap     map[windowPointer]uint
 	windowMapLock sync.Mutex
 
-	theme string
-
 	icon pointer
 }
 
@@ -214,10 +212,6 @@ func (a *linuxApp) registerWindow(window pointer, id uint) {
 	a.windowMapLock.Lock()
 	a.windowMap[windowPointer(window)] = id
 	a.windowMapLock.Unlock()
-}
-
-func (a *linuxApp) isDarkMode() bool {
-	return strings.Contains(a.theme, "dark")
 }
 
 func (a *linuxApp) getAccentColor() string {

--- a/v3/pkg/application/linux_cgo.go
+++ b/v3/pkg/application/linux_cgo.go
@@ -118,12 +118,6 @@ func activateLinux(data pointer) {
 //export processApplicationEvent
 func processApplicationEvent(eventID C.uint, data pointer) {
 	event := newApplicationEvent(events.ApplicationEventType(eventID))
-
-	switch event.Id {
-	case uint(events.Linux.SystemThemeChanged):
-		isDark := globalApplication.Env.IsDarkMode()
-		event.Context().setIsDarkMode(isDark)
-	}
 	applicationEvents <- event
 }
 

--- a/v3/pkg/application/linux_cgo_gtk3.go
+++ b/v3/pkg/application/linux_cgo_gtk3.go
@@ -598,11 +598,6 @@ func processApplicationEvent(eventID C.uint, data pointer) {
 	//	}
 	//}
 
-	switch event.Id {
-	case uint(events.Linux.SystemThemeChanged):
-		isDark := globalApplication.Env.IsDarkMode()
-		event.Context().setIsDarkMode(isDark)
-	}
 	applicationEvents <- event
 }
 


### PR DESCRIPTION
## Description

On Linux, both `Env.IsDarkMode()` and the `linux:SystemThemeChanged` event are unreliable, in a different way on each backend. This consolidates the two divergent implementations into one portal-backed pair in `application_linux_dbus.go`, shared by the GTK3 and GTK4 builds.

This change has been running in the [netbirdio/wails](https://github.com/netbirdio/wails) fork, where it was reviewed and merged as **[netbirdio/wails#4](https://github.com/netbirdio/wails/pull/4)**. I am submitting it upstream with no changes beyond the rebase and one review follow-up, noted below.

There is no existing issue for this. [#4665](https://github.com/wailsapp/wails/issues/4665) (*[v3] Window Theme API: Dark/Light/System support*) is adjacent but is a feature request for a new API, not this defect. Happy to open a bug issue if you would prefer it tracked.

Three distinct problems, all in the same subsystem:

**1. GTK3 reports light on every desktop until the first signal arrives.**

```go
// application_linux_gtk3.go
func (a *linuxApp) isDarkMode() bool {
	return strings.Contains(a.theme, "dark")
}
```

`a.theme` is only ever written by the `SettingChanged` handler, so it is `""` at launch. An app started on a dark desktop comes up light and stays light until the user toggles their colour scheme. GTK4 already reads the portal directly and does not have this problem.

**2. GTK4 never starts its theme monitor at all.**

The watcher is started from `(*linuxApp).init(_ *App, options Options)`. That method is not part of the `platformApp` interface (`application.go`), and the only `.init(` call sites in the repo are the zero-argument `(*App).init()` in `application_production.go` and `application_debug.go`. Nothing calls the two-argument `linuxApp.init`, so on GTK4 `linux:SystemThemeChanged` never fires. It is now started from `run()`, which is how the GTK3 path already does it (`application_linux_gtk3.go`).

**3. The shared watcher matches the wrong namespace.**

`monitorThemeChanges` filters on GNOME's `org.gnome.desktop.interface` rather than the standardised `org.freedesktop.appearance`, and trusts the signal body's value instead of re-reading the portal.

## What this changes

`application_linux_dbus.go` becomes the single source of truth for both backends — it carries no `gtk3` build constraint (`//go:build linux && cgo && !android && !server`), so one copy serves both:

- `isDarkMode()` reads `org.freedesktop.appearance` / `color-scheme` from the Settings portal on demand. This is deliberately not cached: the value is correct whether or not the monitor is running, which matters given problem 2 above went unnoticed.
- `portalColorScheme()` returns `(uint32, bool)` so "portal unreachable" is distinguishable from "prefers light", and accepts both a doubly-wrapped `v{v{u}}` reply (portal v1 `Read`) and a singly-wrapped `v{u}` one (`ReadOne` and some implementations). Rejecting either shape would silently report light, which is the failure this change exists to remove.
- `monitorThemeChanges()` filters on sender, object path, interface and member, then re-reads the portal rather than trusting the signal body, and de-duplicates on the resolved boolean.

The per-backend copies (`isDarkMode` in both platform files, `listenForSystemThemeChanges` in the GTK4 file) and the now-unused `theme` struct field are removed. `monitorThemeChanges` is consequently the sole emitter of `linux:SystemThemeChanged`, which makes the `case uint(events.Linux.SystemThemeChanged)` arm in `processApplicationEvent` unreachable in both `linux_cgo.go` and `linux_cgo_gtk3.go`; those are deleted too. No Linux C source calls `processApplicationEvent`, so there is no remaining producer. Removing them also drops an `Env.IsDarkMode()` call that ran on the GTK main thread.

## Review follow-up

`portalColorScheme` now bounds its `Settings.Read` with `CallWithContext` and a
2s deadline. godbus's `Object.Call` passes `context.Background()`, so an
unresponsive portal would have blocked the caller indefinitely, and
`Env.IsDarkMode()` is reachable from application code on the main thread. A
deadline surfaces as `call.Err`, which the existing fallback already treats as
"no preference", so a hung portal now reports exactly what an absent one does.
The budget is wide enough only to cover D-Bus activating the portal on a cold
first call; a local round-trip is sub-millisecond.

## One point for maintainers on WEP scope

I have filed this as a bug fix rather than a WEP, because every case it changes was returning a wrong answer. There is one observable behaviour change worth your call:

GTK4 previously emitted `SystemThemeChanged` on **every** appearance `color-scheme` signal. It now emits only when the resolved dark/light value actually changes, so `no-preference` ↔ `prefer-light` transitions no longer produce an event. I believe this is safe because the event's entire payload is the `isDarkMode` boolean, so a suppressed event carried no information a consumer could act on. If you consider that public behaviour, say so and I will split it out or raise a WEP.

## Changelog entry

Added to `v3/UNRELEASED_CHANGELOG.md` under `## Fixed`. That makes
`auto-changelog-v3.yml` take its `skip=true` path on merge rather than
auto-filling, so this is the wording that ships:

```markdown
- Fix Linux dark mode detection returning light on a dark desktop until the colour
  scheme changed, and `linux:SystemThemeChanged` never firing on the GTK4 backend.
  Both backends now share one implementation, backed by the
  `org.freedesktop.appearance` portal namespace (#6072)
```

Happy to reword it if you would rather it read differently.

# Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] WEP (proposal only; no implementation)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

No public API surface changes. Everything added is unexported, and both removed symbols (`listenForSystemThemeChanges`, the `theme` field) were unexported.

# How Has This Been Tested?

- [ ] Windows
- [ ] macOS
- [x] Linux

Windows and macOS are unaffected; every changed file is behind a `linux` build tag.

## Provenance of these results, and what has not been re-run

Being explicit about this, because it bears on how much the matrices below are worth:

The runtime and toolchain verification was carried out against a **`v3.0.0-beta.3`** base while developing the fix, and the change then shipped in the fork off `v3.0.0-beta.9` as netbirdio/wails#4. This branch is that same commit cherry-picked onto current `master`. The cherry-pick is conflict-free, and of the five files, the three carrying the substance of the fix — `application_linux_dbus.go`, `application_linux_gtk3.go`, `linux_cgo_gtk3.go` — are byte-identical between the fork base and `master`; `application_linux.go` and `linux_cgo.go` auto-merged against unrelated upstream edits. `gofmt -l` is clean on all five on `master`.

**The runtime matrices below were not re-run on the current `master` tree.** If you would like them repeated against the tip before merge, say so and I will do that.

## Test matrix

Tested on **three desktops covering three portal backends and both Linux backends**, all Wayland sessions:

| distro | desktop | portal backend | GTK3 / GTK4 | WebKit 4.1 / 6.0 |
| --- | --- | --- | --- | --- |
| Omarchy 4.0.1 (Arch) | Hyprland | `xdg-desktop-portal-hyprland` 1.4.1 | 3.24.52 / 4.22.4 | 2.52.6 / 2.52.6 |
| Ubuntu 24.04.4 LTS | GNOME 46 | `xdg-desktop-portal-gnome` 46.2 | 3.24.41 / 4.14.5 | 2.52.6 / 2.52.6 |
| Fedora 44 | KDE Plasma 6 | `xdg-desktop-portal-kde` 6.7.4 | 3.24.52 / 4.22.4 | 2.52.5 / 2.52.5 |

## Compile, vet and unit tests

Both tag combinations, on Linux:

```sh
cd v3
CGO_ENABLED=1 go build       ./pkg/application/        # ok
CGO_ENABLED=1 go build -tags gtk3 ./pkg/application/   # ok
CGO_ENABLED=1 go vet         ./pkg/application/        # clean
CGO_ENABLED=1 go vet  -tags gtk3 ./pkg/application/    # clean
CGO_ENABLED=1 go test        ./pkg/application/        # ok
CGO_ENABLED=1 go test -tags gtk3 ./pkg/application/    # ok
```

`gofmt -l` clean on all five files. The only `vet` output is the pre-existing `possible misuse of unsafe.Pointer` in `dialogs_linux.go`, and the only build warnings are the pre-existing GTK4 `gdk_x11_*` deprecations in `linux_cgo.c`. No new warnings. Both variants were additionally compiled on all three distros above.

## Runtime: the bug, before the change

A real Wails app set to follow the system theme, launched on a **dark** desktop, then toggled light and back. On stock `v3.0.0-beta.3`:

| desktop | backend | at startup | desktop → light | desktop → dark |
| --- | --- | --- | --- | --- |
| Hyprland | GTK3 | **light — wrong** | light | dark (recovers) |
| GNOME 46 | GTK3 | **light — wrong** | light | dark (recovers) |
| GNOME 46 | GTK4 | dark — correct | **dark — never followed** | dark |
| KDE Plasma 6 | GTK3 | **light — wrong** | light | dark (recovers) |
| KDE Plasma 6 | GTK4 | dark — correct | **dark — never followed** | dark |

Both failure modes reproduce on every desktop tested, which is what convinced me these are two independent defects rather than one desktop-specific quirk. GTK3 recovers after a toggle because it does call `monitorThemeChanges` from `run()`; GTK4 never recovers because of problem 2.

## Runtime: after the change

Same procedure, same desktops:

| desktop | backend | at startup | desktop → light | desktop → dark |
| --- | --- | --- | --- | --- |
| Hyprland | GTK3 | dark ✅ | light ✅ | dark ✅ |
| Hyprland | GTK4 | dark ✅ | light ✅ | dark ✅ |
| GNOME 46 | GTK3 | dark ✅ | light ✅ | dark ✅ |
| GNOME 46 | GTK4 | dark ✅ | light ✅ | dark ✅ |
| KDE Plasma 6 | GTK4 | dark ✅ | light ✅ | dark ✅ |

## Portal values observed

Worth recording, because the three backends disagree about how they express "light" and the fix has to treat all of them as not-dark:

| desktop | `org.freedesktop.appearance` when light | when dark |
| --- | --- | --- |
| GNOME 46 | `uint32 0` (no preference) | `uint32 1` |
| KDE Plasma 6 | `uint32 2` (prefer light) | `uint32 1` |
| Hyprland | — | `uint32 1` |

All three also publish GNOME's `org.gnome.desktop.interface` `color-scheme` as a string. That is why dropping it from the signal filter is safe here: every backend tested serves the standardised namespace, so nothing depended on the GNOME-specific one.

## How the verdicts were measured

Light/dark was decided by counting pixels matching the app's known surface colours in each screenshot, not by overall image brightness. That matters: two runs were silently invalidated by the VM blanking its screen mid-test, and this method reports them as "no app surface found" instead of producing a confident wrong answer.

## Reproducing the original bug

On a GTK3 build: set your desktop to prefer dark, launch an app that resolves its theme from `Env.IsDarkMode()`, and observe it come up light. On a GTK4 build: launch it, then change your desktop colour scheme and observe that nothing happens. Confirm the desktop preference independently with:

```sh
gdbus call --session --dest org.freedesktop.portal.Desktop \
  --object-path /org/freedesktop/portal/desktop \
  --method org.freedesktop.portal.Settings.Read \
  org.freedesktop.appearance color-scheme
# expect (<<uint32 1>>,) when the desktop prefers dark
```

## Not covered

- **The current `master` tree at runtime** — see the provenance note above.
- **X11 sessions.** All three desktops were tested under Wayland only.
- **A portal-less desktop** (no `xdg-desktop-portal` at all). The unreachable path is exercised only by inspection, where it returns light — matching the previous GTK4 behaviour.
- **KDE with GTK3 after the change** — the before case was measured there, the after case was measured on the other two desktops.
- **Architectures other than amd64.**

## Test Configuration

`wails3 doctor` on the Arch host, where the build and vet runs above were done:

```
# System
Name                 Omarchy
Version              4.0.1
ID                   omarchy
Platform             linux
Architecture         amd64
Desktop Environment  Hyprland (Wayland session; doctor reports "unset" over SSH)
CPU                  QEMU Virtual CPU version 2.5+
GPU                  unknown
Memory               8GB

# Build Environment
Wails CLI      v3.0.0-beta.3
Go Version     go1.27.0-X:nodwarf5
-buildmode     exe
-compiler      gc
CGO_ENABLED    1
GOARCH         amd64
GOOS           linux

# Dependencies
gcc                  16.2.1
gtk3 (legacy)        1:3.24.52-1
gtk4                 1:4.22.4-1
webkit2gtk (legacy)  2.52.6-1
webkitgtk-6.0        2.52.6-1
pkg-config           3.0.5-1
npm                  11.19.0

# Checking for issues
No issues found
```

The other two hosts ran Go 1.27.0 with their distro toolchains: Ubuntu 24.04.4
(gcc 13.3.0, GTK 3.24.41 / 4.14.5) and Fedora 44 (gcc 16.2.1, GTK 3.24.52 /
4.22.4). Between them the GTK4 runtimes exercised end-to-end are 4.14.5 and
4.22.4, eight releases apart, and the GTK3 runtimes are 3.24.41 and 3.24.52.

### Note for anyone reproducing this on a VM

All three hosts are GPU-less QEMU guests, and **GTK4 segfaults there under its default renderer** — in `gtk_window_present` on Ubuntu (preceded by `MESA: ZINK: failed to choose pdev`) and in `g_application_run` on Fedora. This is unrelated to the change; the GTK4 runs above needed:

```sh
export GSK_RENDERER=cairo LIBGL_ALWAYS_SOFTWARE=1
export WEBKIT_DISABLE_COMPOSITING_MODE=1 WEBKIT_DISABLE_DMABUF_RENDERER=1
```

# Checklist:

- [x] (v2 only) I have updated `website/src/pages/changelog.mdx` with details of this PR (v3 changelog entries are added automatically) — n/a, this is v3; entry added to `v3/UNRELEASED_CHANGELOG.md` instead, which suppresses the auto-fill
- [x] My code follows the general coding style of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation — none required, no public API change
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

On the unchecked box: the fix is verified at runtime across the matrices above but not yet by an automated test. `isColorSchemeChange` is a pure function over a `*dbus.Signal` and is straightforwardly unit-testable without a session bus, alongside the existing `*_linux_test.go` files in this package. Happy to add that before merge — say the word.

## Licence and provenance

No third-party code is included in this change. It is offered under the project's MIT Licence. It was previously merged into the netbirdio/wails fork as netbirdio/wails#4; I am the author of the contribution in both places.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Linux dark-mode detection using the freedesktop Settings portal.
  * Added support for wrapped and unwrapped portal color-scheme values.
  * Unified dark-mode handling across Linux GTK3 and GTK4 environments.
  * Improved theme-change filtering to respond only to relevant system setting updates.
  * Prevented redundant theme-change events when the dark-mode state remains unchanged.
  * Fixed theme monitoring so it starts reliably when the application runs.
  * Fixed initial detection when the desktop is already using dark mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
