### PR TITLE
Add URI-aware WebView2 permission option

### DIFF
--- a/v2/internal/frontend/desktop/windows/frontend.go
+++ b/v2/internal/frontend/desktop/windows/frontend.go
@@ -603,9 +603,28 @@ func (f *Frontend) setupChromium() {
 	// Set background colour
 	f.WindowSetBackgroundColour(f.frontendOptions.BackgroundColour)
 
-	chromium.SetGlobalPermission(edge.CoreWebView2PermissionStateAllow)
+	configurePermissionRequested(
+		f.frontendOptions.Windows,
+		func(callback windows.PermissionRequestedCallback) {
+			chromium.PermissionRequestedCallback = callback
+		},
+		chromium.SetGlobalPermission,
+	)
 	chromium.AddWebResourceRequestedFilter("*", edge.COREWEBVIEW2_WEB_RESOURCE_CONTEXT_ALL)
 	chromium.Navigate(f.startURL.String())
+}
+
+func configurePermissionRequested(
+	windowsOptions *windows.Options,
+	setPermissionRequestedCallback func(windows.PermissionRequestedCallback),
+	setGlobalPermission func(edge.CoreWebView2PermissionState),
+) {
+	if windowsOptions != nil && windowsOptions.PermissionRequested != nil {
+		setPermissionRequestedCallback(windowsOptions.PermissionRequested)
+		return
+	}
+
+	setGlobalPermission(edge.CoreWebView2PermissionStateAllow)
 }
 
 type EventNotify struct {

--- a/v2/internal/frontend/desktop/windows/frontend_permission_test.go
+++ b/v2/internal/frontend/desktop/windows/frontend_permission_test.go
@@ -1,0 +1,90 @@
+//go:build windows
+
+package windows
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/wailsapp/go-webview2/pkg/edge"
+	windowsoptions "github.com/wailsapp/wails/v2/pkg/options/windows"
+)
+
+func TestFrontendWiresPermissionCallbackInsteadOfGlobalAllow(t *testing.T) {
+	wantURI := "http://wails.localhost/console/"
+	wantKind := edge.CoreWebView2PermissionKindMicrophone
+	wantURIErr := errors.New("GetURI failed")
+	wantState := edge.CoreWebView2PermissionStateDeny
+
+	callbackCalled := false
+	var permissionRequested windowsoptions.PermissionRequestedCallback = func(uri string, kind edge.CoreWebView2PermissionKind, uriErr error) edge.CoreWebView2PermissionState {
+		callbackCalled = true
+		if uri != wantURI {
+			t.Errorf("permission callback URI = %q, want %q", uri, wantURI)
+		}
+		if kind != wantKind {
+			t.Errorf("permission callback kind = %v, want %v", kind, wantKind)
+		}
+		if uriErr != wantURIErr {
+			t.Errorf("permission callback URI error = %v, want %v", uriErr, wantURIErr)
+		}
+		return wantState
+	}
+
+	var installed windowsoptions.PermissionRequestedCallback
+	globalAllowCalls := 0
+	configurePermissionRequested(
+		&windowsoptions.Options{PermissionRequested: permissionRequested},
+		func(callback windowsoptions.PermissionRequestedCallback) {
+			installed = callback
+		},
+		func(state edge.CoreWebView2PermissionState) {
+			globalAllowCalls++
+			if state != edge.CoreWebView2PermissionStateAllow {
+				t.Errorf("global permission = %v, want Allow", state)
+			}
+		},
+	)
+
+	if installed == nil {
+		t.Fatal("permission callback was not installed")
+	}
+	if got := installed(wantURI, wantKind, wantURIErr); got != wantState {
+		t.Errorf("installed permission callback state = %v, want %v", got, wantState)
+	}
+	if !callbackCalled {
+		t.Error("installed permission callback was not called")
+	}
+	if globalAllowCalls != 0 {
+		t.Errorf("global Allow calls = %d, want 0", globalAllowCalls)
+	}
+
+	for _, test := range []struct {
+		name           string
+		windowsOptions *windowsoptions.Options
+	}{
+		{name: "nil Windows options"},
+		{name: "nil callback", windowsOptions: &windowsoptions.Options{}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			callbackInstalled := false
+			var globalPermissions []edge.CoreWebView2PermissionState
+			configurePermissionRequested(
+				test.windowsOptions,
+				func(windowsoptions.PermissionRequestedCallback) {
+					callbackInstalled = true
+				},
+				func(state edge.CoreWebView2PermissionState) {
+					globalPermissions = append(globalPermissions, state)
+				},
+			)
+
+			if callbackInstalled {
+				t.Error("permission callback was installed")
+			}
+			if len(globalPermissions) != 1 || globalPermissions[0] != edge.CoreWebView2PermissionStateAllow {
+				t.Errorf("global permissions = %v, want [Allow]", globalPermissions)
+			}
+		})
+	}
+}

--- a/v2/pkg/options/windows/permission_requested_nonwindows.go
+++ b/v2/pkg/options/windows/permission_requested_nonwindows.go
@@ -1,0 +1,6 @@
+//go:build !windows
+
+package windows
+
+// PermissionRequestedCallback handles WebView2 permission requests.
+type PermissionRequestedCallback func(uri string, kind uint32, uriErr error) uint32

--- a/v2/pkg/options/windows/permission_requested_windows.go
+++ b/v2/pkg/options/windows/permission_requested_windows.go
@@ -1,0 +1,8 @@
+//go:build windows
+
+package windows
+
+import "github.com/wailsapp/go-webview2/pkg/edge"
+
+// PermissionRequestedCallback handles WebView2 permission requests.
+type PermissionRequestedCallback func(uri string, kind edge.CoreWebView2PermissionKind, uriErr error) edge.CoreWebView2PermissionState

--- a/v2/pkg/options/windows/windows.go
+++ b/v2/pkg/options/windows/windows.go
@@ -125,6 +125,9 @@ type Options struct {
 	// OnResume is called when Windows resumes from low power mode
 	OnResume func()
 
+	// PermissionRequested handles WebView2 permission requests.
+	PermissionRequested PermissionRequestedCallback
+
 	// WebviewGpuIsDisabled is used to enable / disable GPU acceleration for the webview
 	WebviewGpuIsDisabled bool
 


### PR DESCRIPTION
Adds an optional Windows PermissionRequested callback and wires it before the legacy global permission grant. Existing callers retain current behavior when the callback is absent. The callback branch never applies the global Allow.

Depends on wailsapp/go-webview2#38. The platform-split callback declaration keeps the public options graph buildable on non-Windows hosts while preserving exact WebView2 enum types on Windows.

Tests cover callback installation, argument/return propagation, suppression of global Allow, legacy fallback, and Linux options compilation.