### PR TITLE
fix(v3/windows): show the systray label as the tooltip

### DIFF
--- a/v3/pkg/application/systemtray.go
+++ b/v3/pkg/application/systemtray.go
@@ -117,8 +117,8 @@ func newSystemTray(id uint) *SystemTray {
 }
 
 func (s *SystemTray) SetLabel(label string) {
+	s.label = label
 	if s.impl == nil {
-		s.label = label
 		return
 	}
 	InvokeSync(func() {
@@ -285,8 +285,8 @@ func (s *SystemTray) SetTemplateIcon(icon []byte) *SystemTray {
 }
 
 func (s *SystemTray) SetTooltip(tooltip string) {
+	s.tooltip = tooltip
 	if s.impl == nil {
-		s.tooltip = tooltip
 		return
 	}
 	InvokeSync(func() {

--- a/v3/pkg/application/systemtray.go
+++ b/v3/pkg/application/systemtray.go
@@ -1,6 +1,7 @@
 package application
 
 import (
+	"cmp"
 	"errors"
 	"runtime"
 	"strings"
@@ -79,6 +80,7 @@ type systemTrayImpl interface {
 
 type SystemTray struct {
 	id           uint
+	textLock     sync.RWMutex // guards label and tooltip
 	label        string
 	tooltip      string
 	icon         []byte
@@ -117,7 +119,9 @@ func newSystemTray(id uint) *SystemTray {
 }
 
 func (s *SystemTray) SetLabel(label string) {
+	s.textLock.Lock()
 	s.label = label
+	s.textLock.Unlock()
 	if s.impl == nil {
 		return
 	}
@@ -127,7 +131,17 @@ func (s *SystemTray) SetLabel(label string) {
 }
 
 func (s *SystemTray) Label() string {
+	s.textLock.RLock()
+	defer s.textLock.RUnlock()
 	return s.label
+}
+
+// tooltipOrLabel is the text Windows shows on hover: the tooltip, or the label when
+// no tooltip is set, since Windows has no text next to the tray icon.
+func (s *SystemTray) tooltipOrLabel() string {
+	s.textLock.RLock()
+	defer s.textLock.RUnlock()
+	return cmp.Or(s.tooltip, s.label)
 }
 
 func (s *SystemTray) Run() {
@@ -285,7 +299,9 @@ func (s *SystemTray) SetTemplateIcon(icon []byte) *SystemTray {
 }
 
 func (s *SystemTray) SetTooltip(tooltip string) {
+	s.textLock.Lock()
 	s.tooltip = tooltip
+	s.textLock.Unlock()
 	if s.impl == nil {
 		return
 	}

--- a/v3/pkg/application/systemtray_test.go
+++ b/v3/pkg/application/systemtray_test.go
@@ -54,3 +54,25 @@ func TestSystemTrayExplicitHandlersOverrideSmartDefaults(t *testing.T) {
 		t.Fatalf("custom handlers replaced: left calls = %d, right calls = %d", leftCalls, rightCalls)
 	}
 }
+
+// stubTrayImpl embeds the interface so only the methods a test exercises need bodies.
+type stubTrayImpl struct{ systemTrayImpl }
+
+func (stubTrayImpl) setLabel(string) {}
+
+// Label() must report the value set after the tray is running, not the one it started with.
+func TestSystemTrayLabelUpdatedAfterRun(t *testing.T) {
+	probe := &threadProbeApp{}
+	probe.onMain.Store(true)
+	prev := globalApplication
+	globalApplication = &App{impl: probe}
+	t.Cleanup(func() { globalApplication = prev })
+
+	tray := newSystemTray(1)
+	tray.SetLabel("before")
+	tray.impl = stubTrayImpl{}
+	tray.SetLabel("after")
+	if got := tray.Label(); got != "after" {
+		t.Fatalf("Label() = %q, want %q", got, "after")
+	}
+}

--- a/v3/pkg/application/systemtray_test.go
+++ b/v3/pkg/application/systemtray_test.go
@@ -58,10 +58,12 @@ func TestSystemTrayExplicitHandlersOverrideSmartDefaults(t *testing.T) {
 // stubTrayImpl embeds the interface so only the methods a test exercises need bodies.
 type stubTrayImpl struct{ systemTrayImpl }
 
-func (stubTrayImpl) setLabel(string) {}
+func (stubTrayImpl) setLabel(string)   {}
+func (stubTrayImpl) setTooltip(string) {}
 
-// Label() must report the value set after the tray is running, not the one it started with.
-func TestSystemTrayLabelUpdatedAfterRun(t *testing.T) {
+// runningTray returns a tray with a stub impl attached, as if Run had happened.
+func runningTray(t *testing.T) *SystemTray {
+	t.Helper()
 	probe := &threadProbeApp{}
 	probe.onMain.Store(true)
 	prev := globalApplication
@@ -69,10 +71,29 @@ func TestSystemTrayLabelUpdatedAfterRun(t *testing.T) {
 	t.Cleanup(func() { globalApplication = prev })
 
 	tray := newSystemTray(1)
-	tray.SetLabel("before")
 	tray.impl = stubTrayImpl{}
+	return tray
+}
+
+// Label() must report the value set after the tray is running.
+func TestSystemTrayLabelUpdatedAfterRun(t *testing.T) {
+	tray := runningTray(t)
 	tray.SetLabel("after")
 	if got := tray.Label(); got != "after" {
 		t.Fatalf("Label() = %q, want %q", got, "after")
+	}
+}
+
+// An explicit tooltip wins over the label until it is cleared, whatever the call order.
+func TestSystemTrayTooltipWinsOverLabel(t *testing.T) {
+	tray := runningTray(t)
+	tray.SetTooltip("explicit")
+	tray.SetLabel("label")
+	if got := tray.tooltipOrLabel(); got != "explicit" {
+		t.Fatalf("tooltipOrLabel() = %q, want %q", got, "explicit")
+	}
+	tray.SetTooltip("")
+	if got := tray.tooltipOrLabel(); got != "label" {
+		t.Fatalf("tooltipOrLabel() = %q, want %q", got, "label")
 	}
 }

--- a/v3/pkg/application/systemtray_test.go
+++ b/v3/pkg/application/systemtray_test.go
@@ -97,3 +97,14 @@ func TestSystemTrayTooltipWinsOverLabel(t *testing.T) {
 		t.Fatalf("tooltipOrLabel() = %q, want %q", got, "label")
 	}
 }
+
+// SetLabel then SetTooltip("") must leave the label as the hover text. The Windows
+// setTooltip reads tooltipOrLabel when it runs instead of applying the empty argument.
+func TestSystemTrayClearedTooltipFallsBackToLabel(t *testing.T) {
+	tray := runningTray(t)
+	tray.SetLabel("label")
+	tray.SetTooltip("")
+	if got := tray.tooltipOrLabel(); got != "label" {
+		t.Fatalf("tooltipOrLabel() = %q, want %q", got, "label")
+	}
+}

--- a/v3/pkg/application/systemtray_windows.go
+++ b/v3/pkg/application/systemtray_windows.go
@@ -3,7 +3,6 @@
 package application
 
 import (
-	"cmp"
 	"errors"
 	"fmt"
 	"syscall"
@@ -527,9 +526,10 @@ func (s *windowsSystemTray) setTooltip(tooltip string) {
 	}
 }
 
-// setLabel shows the label as the tooltip: Windows has no text next to the tray icon.
-func (s *windowsSystemTray) setLabel(label string) {
-	s.setTooltip(label)
+// setLabel shows the label as the tooltip unless an explicit tooltip is set,
+// the same rule show() applies when the icon is (re-)added.
+func (s *windowsSystemTray) setLabel(string) {
+	s.setTooltip(s.parent.tooltipOrLabel())
 }
 
 // ---- Unsupported ----
@@ -629,7 +629,7 @@ func (s *windowsSystemTray) show() (w32.NOTIFYICONDATA, error) {
 	s.updateIcon()
 
 	// A label set before Run has to reach the tooltip too, see setLabel.
-	if tooltip := cmp.Or(s.parent.tooltip, s.parent.label); tooltip != "" {
+	if tooltip := s.parent.tooltipOrLabel(); tooltip != "" {
 		s.setTooltip(tooltip)
 	}
 

--- a/v3/pkg/application/systemtray_windows.go
+++ b/v3/pkg/application/systemtray_windows.go
@@ -3,6 +3,7 @@
 package application
 
 import (
+	"cmp"
 	"errors"
 	"fmt"
 	"syscall"
@@ -526,9 +527,12 @@ func (s *windowsSystemTray) setTooltip(tooltip string) {
 	}
 }
 
-// ---- Unsupported ----
-func (s *windowsSystemTray) setLabel(label string) {}
+// setLabel shows the label as the tooltip: Windows has no text next to the tray icon.
+func (s *windowsSystemTray) setLabel(label string) {
+	s.setTooltip(label)
+}
 
+// ---- Unsupported ----
 func (s *windowsSystemTray) setTemplateIcon(_ []byte) {
 	// Unsupported - do nothing
 }
@@ -624,8 +628,9 @@ func (s *windowsSystemTray) show() (w32.NOTIFYICONDATA, error) {
 
 	s.updateIcon()
 
-	if s.parent.tooltip != "" {
-		s.setTooltip(s.parent.tooltip)
+	// A label set before Run has to reach the tooltip too, see setLabel.
+	if tooltip := cmp.Or(s.parent.tooltip, s.parent.label); tooltip != "" {
+		s.setTooltip(tooltip)
 	}
 
 	return nid, nil

--- a/v3/pkg/application/systemtray_windows.go
+++ b/v3/pkg/application/systemtray_windows.go
@@ -350,7 +350,7 @@ func (s *windowsSystemTray) updateIcon() {
 		// last-error is 0 that is panic(nil), which on Go 1.21+ surfaces as
 		// "panic called with nil argument" and crashes the host app.
 		//
-		// Match the other NIM_MODIFY callers (Show/Hide/setTooltip): log and
+		// Match the other NIM_MODIFY callers (Show/Hide/updateTooltip): log and
 		// return. Roll back currentIcon so the next updateIcon retries once the
 		// icon is registered again; keep the old handle (do not release it).
 		globalApplication.warning("ShellNotifyIcon NIM_MODIFY failed in updateIcon (icon not registered): %v", syscall.GetLastError())
@@ -506,14 +506,22 @@ func (s *windowsSystemTray) updateMenu(menu *Menu) {
 	s.menu.onMenuClose = s.parent.onMenuClose
 }
 
-func (s *windowsSystemTray) setTooltip(tooltip string) {
+// setTooltip and setLabel both show SystemTray.tooltipOrLabel rather than their
+// argument: an explicit tooltip wins, and clearing it falls back to the label. The
+// value is read when the dispatched call runs, so rapid SetLabel/SetTooltip calls
+// cannot leave an older value on the icon.
+func (s *windowsSystemTray) setTooltip(string) { s.updateTooltip() }
+
+func (s *windowsSystemTray) setLabel(string) { s.updateTooltip() }
+
+func (s *windowsSystemTray) updateTooltip() {
 	// Create a new NOTIFYICONDATA structure
 	nid := s.newNotifyIconData()
 	nid.UFlags = w32.NIF_TIP | w32.NIF_SHOWTIP
 
 	// Ensure the tooltip length is within the limit (128 characters including null terminate characters for szTip for Windows 2000 and later)
 	// https://learn.microsoft.com/en-us/windows/win32/api/shellapi/ns-shellapi-notifyicondataw
-	tooltipUTF16, err := w32.StringToUTF16(truncateUTF16(tooltip, 127))
+	tooltipUTF16, err := w32.StringToUTF16(truncateUTF16(s.parent.tooltipOrLabel(), 127))
 	if err != nil {
 		return
 	}
@@ -524,12 +532,6 @@ func (s *windowsSystemTray) setTooltip(tooltip string) {
 	if !w32.ShellNotifyIcon(w32.NIM_MODIFY, &nid) {
 		return
 	}
-}
-
-// setLabel shows the label as the tooltip unless an explicit tooltip is set,
-// the same rule show() applies when the icon is (re-)added.
-func (s *windowsSystemTray) setLabel(string) {
-	s.setTooltip(s.parent.tooltipOrLabel())
 }
 
 // ---- Unsupported ----
@@ -628,9 +630,9 @@ func (s *windowsSystemTray) show() (w32.NOTIFYICONDATA, error) {
 
 	s.updateIcon()
 
-	// A label set before Run has to reach the tooltip too, see setLabel.
-	if tooltip := s.parent.tooltipOrLabel(); tooltip != "" {
-		s.setTooltip(tooltip)
+	// A label set before Run has to reach the tooltip too, see updateTooltip.
+	if s.parent.tooltipOrLabel() != "" {
+		s.updateTooltip()
 	}
 
 	return nid, nil


### PR DESCRIPTION
On Windows `SetLabel` is documented to do the same thing as `SetTooltip`, but the Windows `setLabel` was an empty stub and `show()` only ever applied the tooltip, so a label set before `Run` never reached the icon. `SetLabel` and `SetTooltip` also stopped storing the value once the platform impl existed, so `Label()` kept returning the pre-`Run` text.

`setLabel` now goes through `setTooltip`, `show()` falls back to the label when no tooltip is set, and both values are stored before dispatching to the impl. The new test for `Label()` fails on master and passes here. I haven't hovered a real tray icon with this build, but the tooltip path is the existing `Shell_NotifyIcon` call.

Fixes #6045


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved system tray text handling for more consistent label and tooltip updates.
  - Explicit tooltips now take precedence over labels when both are set.
  - Clearing a tooltip correctly restores the tray label as the displayed text.
  - Tray labels and tooltips remain consistent when updated before or after the application starts, including rapid successive updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->