### PR TITLE
fix(v3/updater): restore normal startup after helper failures

### DIFF
--- a/v3/pkg/updater/helper.go
+++ b/v3/pkg/updater/helper.go
@@ -115,12 +115,21 @@ func runHelperSwap(target, newPath string, parentPID int, logPath string, wait p
 		}
 	}
 
+	// The parent has exited. Clear helper mode before backup or replacement
+	// so both the new application and any recovered original boot normally.
+	clearHelperEnv()
+
 	backup := target + ".bak"
 	_ = os.RemoveAll(backup)
 
 	lg.logf("backing up %s → %s", target, backup)
 	if err := copyAny(target, backup); err != nil {
 		lg.logf("backup failed: %v", err)
+		// The original is untouched; relaunch it instead of restoring a
+		// potentially incomplete backup.
+		if err := l.launch(target); err != nil {
+			lg.logf("relaunch original failed: %v", err)
+		}
 		return 12
 	}
 
@@ -166,15 +175,6 @@ func runHelperSwap(target, newPath string, parentPID int, logPath string, wait p
 		}
 		return 13
 	}
-
-	// Strip our helper-mode sentinels from the environment before launching
-	// the new binary. exec.Command inherits the parent's env when cmd.Env is
-	// unset, so without this the relaunched app would see WAILS_UPDATER_HELPER
-	// still set, call HandleHelperMode at start-up, try to perform another
-	// swap against a path we've already cleaned up, and exit with code 11 —
-	// the visible effect being "user clicks Restart, app dies, never reopens."
-	// Discovered against wailsapp/updater-demo on macOS arm64.
-	clearHelperEnv()
 
 	if err := l.launch(target); err != nil {
 		lg.logf("launch new failed: %v — restoring backup", err)
@@ -344,9 +344,8 @@ func (h *helperLog) Close() {
 }
 
 // clearHelperEnv unsets every WAILS_UPDATER_HELPER_* variable in the current
-// process. Called by runHelperSwap immediately before launching the new
-// binary so the launched process boots in normal mode instead of inheriting
-// our helper-mode sentinels.
+// process. Called after the parent exits and before backup or replacement,
+// so both the new application and any recovered original boot normally.
 func clearHelperEnv() {
 	for _, k := range []string{envHelperMode, envHelperTarget, envHelperNew, envHelperPID, envHelperLog} {
 		_ = os.Unsetenv(k)

--- a/v3/pkg/updater/helper_recovery_test.go
+++ b/v3/pkg/updater/helper_recovery_test.go
@@ -1,0 +1,72 @@
+package updater
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestRunHelperSwap_ReplaceFails_RelaunchesWithoutHelperEnv(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "app.bin")
+	newPath := filepath.Join(dir, "new.bin")
+	writeFile(t, target, []byte("OLD"))
+	writeFile(t, newPath, []byte("NEW"))
+	for _, key := range []string{envHelperMode, envHelperTarget, envHelperNew, envHelperPID, envHelperLog} {
+		t.Setenv(key, "1")
+	}
+	calls := 0
+	l := &funcLauncher{fn: func(path string) error {
+		calls++
+		if path != target || string(readFile(t, path)) != "OLD" {
+			t.Errorf("expected restored application, got %q", path)
+		}
+		for _, key := range []string{envHelperMode, envHelperTarget, envHelperNew, envHelperPID, envHelperLog} {
+			if value := os.Getenv(key); value != "" {
+				t.Errorf("%s leaked to restored application: %q", key, value)
+			}
+		}
+		return nil
+	}}
+	// Remove the staged file after validation to exercise failed replacement
+	// and rollback through the full helper flow.
+	wait := func(int, time.Duration) error { return os.Remove(newPath) }
+	code := runHelperSwap(target, newPath, 1234, filepath.Join(dir, "log"), wait, l)
+	if code != 13 || calls != 1 {
+		t.Fatalf("code=%d launches=%d, want 13 and 1", code, calls)
+	}
+}
+
+func TestRunHelperSwap_BackupFails_RelaunchesOriginal(t *testing.T) {
+	for _, launchFails := range []bool{false, true} {
+		t.Run(map[bool]string{false: "recovered", true: "launch_error"}[launchFails], func(t *testing.T) {
+			dir := t.TempDir()
+			// The target name fits, but adding .bak exceeds the 255-byte
+			// component limit on common filesystems.
+			target := filepath.Join(dir, strings.Repeat("a", 252))
+			newPath := filepath.Join(dir, "new.bin")
+			writeFile(t, target, []byte("OLD"))
+			writeFile(t, newPath, []byte("NEW"))
+			t.Setenv(envHelperMode, "1")
+			waited, calls := false, 0
+			wait := func(int, time.Duration) error { waited = true; return nil }
+			l := &funcLauncher{fn: func(path string) error {
+				calls++
+				if !waited || path != target || os.Getenv(envHelperMode) != "" {
+					t.Error("recovery must wait for parent and launch original without helper mode")
+				}
+				if launchFails {
+					return errors.New("launch failed")
+				}
+				return nil
+			}}
+			code := runHelperSwap(target, newPath, 1234, filepath.Join(dir, "log"), wait, l)
+			if code != 12 || calls != 1 || string(readFile(t, target)) != "OLD" {
+				t.Fatalf("code=%d launches=%d; original must remain intact", code, calls)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description

Fix two updater-helper recovery paths where the original application does not reopen normally after its parent process has exited.

When replacement retries are exhausted, `runHelperSwap` calls `restoreFromBackup` before reaching `clearHelperEnv`. The restored executable inherits `WAILS_UPDATER_HELPER=1` and re-enters helper mode instead of starting the application. When backup creation fails, the helper returns code 12 without attempting to relaunch the untouched original.

This moves helper-environment cleanup to immediately after the parent-exit wait, before backup or replacement, so it also covers recovery paths. Backup failure now attempts to relaunch the original without restoring a potentially incomplete backup. The parent-wait timeout still aborts without launching another instance. Existing exit codes are preserved.

The rollback environment leak was first reproduced against the tagged `v3.0.0-beta.16` helper source. Both regression cases were then reproduced on master before applying this fix. No separate issue is linked.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Windows
- [ ] macOS
- [ ] Linux

From `v3`: `go test ./pkg/updater` passes.

New regression tests remove the staged artifact after initial validation to exercise exhausted replacement retries and rollback, and force backup creation to fail using an overlong backup filename. They verify that the restored/original file is launched, helper variables are cleared, and the original is retained even if relaunch fails. The new tests fail before the fix and pass afterward. Existing parent-timeout, successful update, and launch-failure rollback tests also pass.

Test environment: Windows amd64 (build 26200.9168), Go 1.27.0. These are filesystem unit tests with injected launchers; no installed application was replaced and no real GUI relaunch was tested. Cross-platform runtime validation remains for CI/review.

## Checklist

- [x] My code follows the general coding style of this project
- [x] I have performed a self-review of my own code
- [x] I have commented the recovery ordering and test failure setup
- [x] I have added tests that prove my fix is effective
- [x] New and existing updater unit tests pass locally
- [x] `gofmt` and patch whitespace checks completed

No public API or user documentation change. The v3 changelog is generated from the PR on merge. `coderabbit --plain` was attempted but the CLI is not installed in the local environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved application recovery when an update replacement or backup step fails.
  * The original application now relaunches after backup failures.
  * Helper environment settings are cleared before recovery launches, preventing them from being passed to the restored application.
* **Tests**
  * Added coverage for failed replacement and backup scenarios, including unsuccessful recovery launches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->