### PR TITLE
fix(v2): free C strings allocated via Calloc.String (memory leak)

### DIFF
--- a/v2/internal/frontend/desktop/darwin/calloc.go
+++ b/v2/internal/frontend/desktop/darwin/calloc.go
@@ -13,20 +13,22 @@ type Calloc struct {
 	pool []unsafe.Pointer
 }
 
-// NewCalloc creates a new allocator
-func NewCalloc() Calloc {
-	return Calloc{}
+// NewCalloc creates a new allocator.
+// A pointer is returned so the allocation pool is shared across calls
+// instead of being copied into each method's value receiver.
+func NewCalloc() *Calloc {
+	return &Calloc{}
 }
 
 // String creates a new C string and retains a reference to it
-func (c Calloc) String(in string) *C.char {
+func (c *Calloc) String(in string) *C.char {
 	result := C.CString(in)
 	c.pool = append(c.pool, unsafe.Pointer(result))
 	return result
 }
 
 // Free frees all allocated C memory
-func (c Calloc) Free() {
+func (c *Calloc) Free() {
 	for _, str := range c.pool {
 		C.free(str)
 	}

--- a/v2/internal/frontend/desktop/linux/calloc.go
+++ b/v2/internal/frontend/desktop/linux/calloc.go
@@ -14,20 +14,22 @@ type Calloc struct {
 	pool []unsafe.Pointer
 }
 
-// NewCalloc creates a new allocator
-func NewCalloc() Calloc {
-	return Calloc{}
+// NewCalloc creates a new allocator.
+// A pointer is returned so the allocation pool is shared across calls
+// instead of being copied into each method's value receiver.
+func NewCalloc() *Calloc {
+	return &Calloc{}
 }
 
 // String creates a new C string and retains a reference to it
-func (c Calloc) String(in string) *C.char {
+func (c *Calloc) String(in string) *C.char {
 	result := C.CString(in)
 	c.pool = append(c.pool, unsafe.Pointer(result))
 	return result
 }
 
 // Free frees all allocated C memory
-func (c Calloc) Free() {
+func (c *Calloc) Free() {
 	for _, str := range c.pool {
 		C.free(str)
 	}


### PR DESCRIPTION
## Summary

`Calloc.String` used a **value receiver**, so `c.pool = append(...)` wrote to a copy of the struct that was discarded when `String` returned. The caller's `pool` stayed `nil`, and `Free()` then ranged over a nil slice — zero iterations — releasing **nothing**. Every `C.CString` handed out by this allocator leaked.

Fixes #6059
Fixes #6058

## Root cause

```go
func NewCalloc() Calloc { return Calloc{} }        // returns a value, pool == nil
func (c Calloc) String(in string) *C.char {       // value receiver → append hits a copy
    result := C.CString(in)
    c.pool = append(c.pool, unsafe.Pointer(result))
    return result
}
func (c Calloc) Free() {                           // ranges over caller's nil pool
    for _, str := range c.pool { C.free(str) }
}
```

On the linux frontend the only user is `OpenFileDialog` (`v2/internal/frontend/desktop/linux/window.go`), which allocates one string per filter display name plus one per pattern and can be opened repeatedly. The darwin frontend uses the same allocator in `menu.go`, `dialog.go`, `window.go` and `single_instance.go`.

## Fix

Return a pointer and use pointer receivers, so the pool is shared with the caller. This is exactly what v3 already does in `v3/pkg/application/linux_cgo.go`; the v2 copy never received the change.

```go
func NewCalloc() *Calloc { return &Calloc{} }
func (c *Calloc) String(in string) *C.char { ... }
func (c *Calloc) Free() { ... }
```

**No call site changes are needed** — every call site already follows `c := NewCalloc()` + `defer c.Free()` + `c.String(...)`, and none assign the allocator to a value-typed variable or struct field.

## Why actually freeing now is safe (no use-after-free)

Enabling `Free()` changes behaviour, so I verified that nothing on the C side retains the `char*` past the call — otherwise this would turn a leak into a dangling pointer:

- **linux/GTK** — `gtk_file_filter_set_name` and `gtk_file_filter_add_pattern` copy their argument, so the caller retains ownership.
- **darwin/Cocoa** — every string crossing the cgo boundary is copied into an `NSString`:
  - `Create` → `[result SetTitle:safeInit(title)]`
  - `AppendMenuItem` → `safeInit(label)` / `safeInit(shortcutKey)`
  - `Create` → `result.singleInstanceUniqueId = safeInit(singleInstanceUniqueId)`
  - `NewMenu` → `[NSString stringWithUTF8String:name]`
  - `MessageDialog` / `SendNotification*` → `safeInit(...)` / `stringWithUTF8String:`

  and `safeInit` is `result = [NSString stringWithUTF8String:input]`, which copies the bytes.

So releasing the pool when the Go function returns is correct.

## Testing

`gofmt` clean. The change is mechanical (receiver/return-type only); it could not be exercised end-to-end here because both packages are cgo/GUI code requiring the GTK and Cocoa toolchains.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved memory handling in the desktop application on macOS and Linux.
  - Fixed an issue where temporary text allocations could become disconnected from their cleanup process, helping ensure retained memory is released correctly.
  - Improved consistency when handling multiple converted strings during a single operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->