### PR TITLE
fix(v3): bound non-chunked runtime request bodies

### DIFF
--- a/docs/src/content/docs/guides/server-build.mdx
+++ b/docs/src/content/docs/guides/server-build.mdx
@@ -348,3 +348,12 @@ These take precedence over the `ServerOptions` in your code, which is why the Do
 - [Custom Transport](/guides/custom-transport) - For advanced IPC customization
 - [Services](/features/bindings/services) - Service binding documentation
 - [Events](/guides/events-reference) - Event system documentation
+
+
+### Runtime request size
+
+Requests to `/wails/runtime` are limited to 64 MiB before JSON processing. An
+ordinary request above this limit receives HTTP 413, including requests without
+`Content-Length`. Chunked runtime uploads retain their separate 1 MiB per-chunk
+and 64 MiB assembled-payload limits. Use application middleware or a reverse proxy
+to impose a lower limit where appropriate.

--- a/v3/pkg/application/transport_http.go
+++ b/v3/pkg/application/transport_http.go
@@ -187,7 +187,7 @@ func (t *HTTPTransport) handleRuntimeRequest(rw http.ResponseWriter, r *http.Req
 	if _, err := io.Copy(buf, r.Body); err != nil {
 		var sizeErr *http.MaxBytesError
 		if errors.As(err, &sizeErr) {
-			http.Error(rw, "runtime request body exceeds 64 MiB", http.StatusRequestEntityTooLarge)
+			http.Error(rw, "runtime request body exceeds "+strconv.FormatInt(sizeErr.Limit/(1024*1024), 10)+" MiB", http.StatusRequestEntityTooLarge)
 			return
 		}
 		t.httpError(rw, errs.WrapInvalidRuntimeCallErrorf(err, "Unable to read request body"))

--- a/v3/pkg/application/transport_http.go
+++ b/v3/pkg/application/transport_http.go
@@ -21,6 +21,9 @@ import (
 // to prevent memory bloat from occasional large requests (e.g., images).
 const maxPooledBufferSize = 512 * 1024 // 512KB
 
+// Ordinary requests have the same payload ceiling as assembled chunked requests.
+const maxRuntimeBodyBytes = maxAssembledBytes
+
 var bufferPool = sync.Pool{
 	New: func() any {
 		return bytes.NewBuffer(make([]byte, 0, 4096))
@@ -180,7 +183,13 @@ func (t *HTTPTransport) handleRuntimeRequest(rw http.ResponseWriter, r *http.Req
 		}
 	}()
 
+	r.Body = http.MaxBytesReader(rw, r.Body, int64(maxRuntimeBodyBytes))
 	if _, err := io.Copy(buf, r.Body); err != nil {
+		var sizeErr *http.MaxBytesError
+		if errors.As(err, &sizeErr) {
+			http.Error(rw, "runtime request body exceeds 64 MiB", http.StatusRequestEntityTooLarge)
+			return
+		}
 		t.httpError(rw, errs.WrapInvalidRuntimeCallErrorf(err, "Unable to read request body"))
 		return
 	}

--- a/v3/pkg/application/transport_http_test.go
+++ b/v3/pkg/application/transport_http_test.go
@@ -2,6 +2,11 @@ package application
 
 import (
 	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -52,5 +57,60 @@ func TestHTTPTransportCleanupLifecycle(t *testing.T) {
 		case <-time.After(time.Second):
 			t.Fatalf("cycle %d: cleanup goroutine did not stop", cycle)
 		}
+	}
+}
+
+// Supply JSON followed by a streamed padding body so the fixture itself does not
+// allocate tens of megabytes. Missing object/method keeps accepted requests from
+// needing a live application; oversized requests must fail before JSON parsing.
+func TestHTTPTransportRuntimeBodyLimit(t *testing.T) {
+	for _, size := range []int64{maxRuntimeBodyBytes - 1, maxRuntimeBodyBytes, maxRuntimeBodyBytes + 1} {
+		for _, knownLength := range []bool{false, true} {
+			t.Run(fmt.Sprintf("size=%d/knownLength=%t", size, knownLength), func(t *testing.T) {
+				padding := &runtimeBodyPadding{remaining: size - 2}
+				body := io.MultiReader(strings.NewReader("{}"), padding)
+				req := httptest.NewRequest(http.MethodPost, "/wails/runtime", body)
+				if knownLength {
+					req.ContentLength = size
+				}
+				rec := httptest.NewRecorder()
+				transport := NewHTTPTransport()
+				transport.handleRuntimeRequest(rec, req)
+				want := http.StatusUnprocessableEntity
+				if size > maxRuntimeBodyBytes {
+					want = http.StatusRequestEntityTooLarge
+				}
+				if rec.Code != want {
+					t.Fatalf("status = %d, want %d: %s", rec.Code, want, rec.Body.String())
+				}
+			})
+		}
+	}
+}
+
+type runtimeBodyPadding struct{ remaining int64 }
+
+func (p *runtimeBodyPadding) Read(buf []byte) (int, error) {
+	if p.remaining == 0 {
+		return 0, io.EOF
+	}
+	n := int(min(int64(len(buf)), p.remaining))
+	for i := range buf[:n] {
+		buf[i] = ' '
+	}
+	p.remaining -= int64(n)
+	return n, nil
+}
+
+func TestHTTPTransportRuntimeBodyStopsReadingAtLimit(t *testing.T) {
+	padding := &runtimeBodyPadding{remaining: 2 * maxRuntimeBodyBytes}
+	req := httptest.NewRequest(http.MethodPost, "/wails/runtime", padding)
+	rec := httptest.NewRecorder()
+	NewHTTPTransport().handleRuntimeRequest(rec, req)
+	if rec.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("status = %d, want 413", rec.Code)
+	}
+	if padding.remaining != maxRuntimeBodyBytes-1 {
+		t.Fatalf("read beyond limit probe: %d bytes remain", padding.remaining)
 	}
 }


### PR DESCRIPTION
Ordinary `/wails/runtime` requests now stop reading at 64 MiB and return HTTP 413 instead of buffering an unlimited body before JSON validation. This matches the existing assembled chunk payload ceiling; chunked requests retain their existing limits.

Fixes #6090.

Validation:
- `GOWORK=off go test -tags server ./pkg/application -run TestHTTPTransport -count=1` passed, covering below/at/above the limit, known and unknown Content-Length, and stopping the reader at the limit probe.
- CodeRabbit local review: no findings.
- Ripwire contract check: unchanged; quality delta: no gating regressions (new Go tests are classified as dead code by its static graph).
- `git diff --check` passed.

Compatibility: ordinary requests larger than 64 MiB now fail explicitly. Documented this limit in the server-build guide. No deliberate OOM test was performed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Runtime requests exceeding 64 MiB are rejected with an HTTP 413 response.
  - Oversized requests are detected even when their total size is not provided in advance.
  - Request processing stops when the enforced size limit is reached, preventing unnecessary reads.
  - Requests at or below the limit continue to be processed normally.

- **Documentation**
  - Added guidance on runtime request size limits, existing chunked-upload limits, and configuring lower limits through middleware or a reverse proxy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->