### PR TITLE
fix(v3): harden application MCP origins and remote access

### DIFF
--- a/docs/src/content/docs/guides/mcp-service.mdx
+++ b/docs/src/content/docs/guides/mcp-service.mdx
@@ -201,7 +201,8 @@ All configuration is via environment variables — no code changes required.
 | Environment variable   | Default     | Description |
 |------------------------|-------------|-------------|
 | `WAILS_MCP`            | (unset)     | Set to `1`, `true`, `on` or `yes` to add the `mcp` build tag automatically when using the Wails CLI. |
-| `WAILS_MCP_HOST`       | `127.0.0.1` | Interface to bind to. Change only in trusted, isolated networks. |
+| `WAILS_MCP_HOST`       | `127.0.0.1` | Interface to bind to. Non-loopback binds require `WAILS_MCP_TOKEN`. |
+| `WAILS_MCP_TOKEN` | unset | Optional bearer token on loopback; required on other bind addresses. Clients send `Authorization: Bearer <token>`. |
 | `WAILS_MCP_PORT`       | `9099`      | Port to listen on. Set to `0` for a randomly assigned free port (printed in the log). |
 | `WAILS_MCP_TIMEOUT`    | `30000`     | Default JS evaluation timeout in **milliseconds**. |
 | `WAILS_MCP_HIDE_CURSOR`| (unset)     | Set to `1` or `true` to disable the animated cursor overlay. |
@@ -258,15 +259,23 @@ Drag from selector: ".card" to selector: ".dropzone"
 
 <Aside type="caution">
 The MCP server gives full programmatic control over your application. Anyone who can
-reach the port can read the DOM, evaluate JavaScript, click buttons, and call Go methods.
+access its tools can read the DOM, evaluate JavaScript, click buttons, and call Go methods.
 </Aside>
 
-- The server binds to `127.0.0.1` by default and rejects non-local browser origins
-  (DNS-rebinding protection per the MCP spec).
+- The server binds to `127.0.0.1` by default. Browser origins must be HTTP(S)
+  loopback origins; opaque (`null`), malformed, and foreign origins are rejected.
+- Headerless native MCP clients remain supported. Without `WAILS_MCP_TOKEN`, local
+  processes and permitted local browser origins are trusted; origin checks are not
+  authentication. Set a high-entropy token to require bearer authentication for all
+  `/mcp` calls. Configure the same token in the client's `Authorization: Bearer <token>` header. Preflight requests do not require the token.
+- The `/eval-result` callback uses unpredictable per-evaluation IDs rather than
+  the client bearer token, so webview result delivery remains compatible.
 - Production builds should **not** include the `mcp` tag. The Wails CLI only adds it when
   `WAILS_MCP=1` is explicitly set, and the default `wails3 build` has none of the server code.
 - If you need to expose the server on a non-loopback interface (e.g. LAN testing), set
-  `WAILS_MCP_HOST=0.0.0.0` and ensure your network is trusted.
+  `WAILS_MCP_HOST=0.0.0.0` and a high-entropy `WAILS_MCP_TOKEN`; startup fails
+  without a token. Use an encrypted tunnel or TLS-terminating proxy on untrusted
+  networks because the built-in listener uses HTTP.
 
 ## Example application
 

--- a/v3/pkg/application/mcp_enabled.go
+++ b/v3/pkg/application/mcp_enabled.go
@@ -8,6 +8,7 @@ package application
 // no user code changes are required. Configure with environment variables:
 //
 //	WAILS_MCP_HOST       bind address (default 127.0.0.1)
+//	WAILS_MCP_TOKEN      bearer token (required for non-loopback binds)
 //	WAILS_MCP_PORT       port number  (default 9099; 0 = free port)
 //	WAILS_MCP_TIMEOUT    JS eval timeout in milliseconds (default 30000)
 //	WAILS_MCP_HIDE_CURSOR  set to 1/true to disable the animated cursor overlay
@@ -28,6 +29,7 @@ import (
 
 const (
 	mcpHostEnvVar       = "WAILS_MCP_HOST"
+	mcpTokenEnvVar      = "WAILS_MCP_TOKEN"
 	mcpPortEnvVar       = "WAILS_MCP_PORT"
 	mcpTimeoutEnvVar    = "WAILS_MCP_TIMEOUT"
 	mcpHideCursorEnvVar = "WAILS_MCP_HIDE_CURSOR"
@@ -44,6 +46,7 @@ type mcpServer struct {
 	hideCursor  bool
 	evalTimeout time.Duration
 	addr        string
+	authToken   string
 
 	httpServer *http.Server
 
@@ -89,6 +92,11 @@ func startMCPServer(a *App) error {
 		hideCursor = true
 	}
 
+	token := os.Getenv(mcpTokenEnvVar)
+	if err := validateMCPBind(host, token); err != nil {
+		return err
+	}
+
 	listener, err := net.Listen("tcp", net.JoinHostPort(host, strconv.Itoa(port)))
 	if err != nil {
 		return fmt.Errorf("failed to listen: %w", err)
@@ -100,6 +108,7 @@ func startMCPServer(a *App) error {
 		hideCursor:  hideCursor,
 		evalTimeout: evalTimeout,
 		addr:        listener.Addr().String(),
+		authToken:   token,
 		pending:     make(map[string]chan mcpEvalResult),
 	}
 	server.registerTools()
@@ -187,4 +196,13 @@ func (m *mcpServer) mcpEvalTimeout(args map[string]any) time.Duration {
 		return time.Duration(ms) * time.Millisecond
 	}
 	return m.evalTimeout
+}
+
+// Headerless local clients retain the existing development workflow. Any bind
+// that can accept non-loopback clients requires an explicit bearer token.
+func validateMCPBind(host, token string) error {
+	if token != "" || host == "localhost" || net.ParseIP(host).IsLoopback() {
+		return nil
+	}
+	return fmt.Errorf("%s is required when %s is not a loopback address", mcpTokenEnvVar, mcpHostEnvVar)
 }

--- a/v3/pkg/application/mcp_enabled_test.go
+++ b/v3/pkg/application/mcp_enabled_test.go
@@ -203,12 +203,17 @@ func TestMCPOriginAllowed(t *testing.T) {
 		allowed bool
 	}{
 		{"", true},
-		{"null", true},
+		{"null", false},
 		{"http://localhost:3000", true},
 		{"http://127.0.0.1:8080", true},
 		{"http://[::1]:0", true},
 		{"http://evil.com", false},
 		{"https://attacker.com", false},
+		{"file://localhost", false},
+		{"http://localhost/path", false},
+		{"http://user@localhost", false},
+		{"http://localhost?query", false},
+		{"http://localhost#fragment", false},
 	}
 	for _, tc := range cases {
 		req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
@@ -273,5 +278,79 @@ func TestMCPEnvVarDefaults(t *testing.T) {
 	}
 	if mcpDefaultTimeout != 30*time.Second {
 		t.Errorf("unexpected default timeout: %v", mcpDefaultTimeout)
+	}
+}
+
+func TestMCPRejectsOpaqueOriginsBeforeToolDispatch(t *testing.T) {
+	for _, method := range []string{http.MethodOptions, http.MethodPost} {
+		t.Run(method, func(t *testing.T) {
+			m := newTestMCPServer()
+			called := false
+			m.tools = []*mcpTool{{Name: "probe", Handler: func(map[string]any) (any, error) { called = true; return nil, nil }}}
+			req := httptest.NewRequest(method, "/mcp", strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"probe"}}`))
+			req.Header.Set("Origin", "null")
+			rec := httptest.NewRecorder()
+			m.handleMCP(rec, req)
+			if rec.Code != http.StatusForbidden || called {
+				t.Fatalf("status=%d, dispatched=%v", rec.Code, called)
+			}
+			if rec.Header().Get("Access-Control-Allow-Origin") != "" {
+				t.Fatal("rejected origin received CORS permission")
+			}
+		})
+	}
+}
+
+func TestMCPBearerAuthentication(t *testing.T) {
+	for _, tc := range []struct {
+		name, authorization string
+		want                int
+	}{
+		{"missing", "", http.StatusUnauthorized},
+		{"wrong", "Bearer wrong", http.StatusUnauthorized},
+		{"scheme", "Basic test-token", http.StatusUnauthorized},
+		{"valid", "Bearer test-token", http.StatusOK},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			m := newTestMCPServer()
+			m.authToken = "test-token"
+			called := false
+			m.tools = []*mcpTool{{Name: "probe", Handler: func(map[string]any) (any, error) { called = true; return nil, nil }}}
+			req := httptest.NewRequest(http.MethodPost, "/mcp", strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"probe"}}`))
+			req.Header.Set("Authorization", tc.authorization)
+			rec := httptest.NewRecorder()
+			m.handleMCP(rec, req)
+			if rec.Code != tc.want || called != (tc.want == http.StatusOK) {
+				t.Fatalf("status=%d, dispatched=%v", rec.Code, called)
+			}
+		})
+	}
+}
+
+func TestMCPAuthenticatedPreflight(t *testing.T) {
+	m := newTestMCPServer()
+	m.authToken = "test-token"
+	req := httptest.NewRequest(http.MethodOptions, "/mcp", nil)
+	req.Header.Set("Origin", "http://localhost:3000")
+	rec := httptest.NewRecorder()
+	m.handleMCP(rec, req)
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("status=%d", rec.Code)
+	}
+}
+
+func TestMCPBindRequiresTokenOutsideLoopback(t *testing.T) {
+	for _, host := range []string{"localhost", "127.0.0.1", "::1"} {
+		if err := validateMCPBind(host, ""); err != nil {
+			t.Errorf("%s: %v", host, err)
+		}
+	}
+	for _, host := range []string{"0.0.0.0", "::", "192.0.2.1", "example.com"} {
+		if err := validateMCPBind(host, ""); err == nil {
+			t.Errorf("%s allowed without token", host)
+		}
+		if err := validateMCPBind(host, "test-token"); err != nil {
+			t.Errorf("%s: %v", host, err)
+		}
 	}
 }

--- a/v3/pkg/application/mcp_protocol_enabled.go
+++ b/v3/pkg/application/mcp_protocol_enabled.go
@@ -3,6 +3,8 @@
 package application
 
 import (
+	"crypto/sha256"
+	"crypto/subtle"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -40,9 +42,9 @@ type mcpJSONRPCError struct {
 }
 
 type mcpJSONRPCResponse struct {
-	JSONRPC string          `json:"jsonrpc"`
-	ID      json.RawMessage `json:"id"`
-	Result  any             `json:"result,omitempty"`
+	JSONRPC string           `json:"jsonrpc"`
+	ID      json.RawMessage  `json:"id"`
+	Result  any              `json:"result,omitempty"`
 	Error   *mcpJSONRPCError `json:"error,omitempty"`
 }
 
@@ -63,11 +65,11 @@ func mcpResultResponse(id json.RawMessage, result any) *mcpJSONRPCResponse {
 // are always allowed; browser contexts must originate from localhost.
 func mcpOriginAllowed(r *http.Request) bool {
 	origin := r.Header.Get("Origin")
-	if origin == "" || origin == "null" {
+	if origin == "" {
 		return true
 	}
 	u, err := url.Parse(origin)
-	if err != nil {
+	if err != nil || (u.Scheme != "http" && u.Scheme != "https") || u.User != nil || u.Path != "" || u.RawQuery != "" || u.Fragment != "" {
 		return false
 	}
 	host := u.Hostname()
@@ -85,9 +87,14 @@ func mcpSetCORSHeaders(w http.ResponseWriter) {
 // handleMCP implements the server side of the MCP streamable HTTP transport.
 // Responses are always plain JSON (the spec allows this in place of SSE).
 func (m *mcpServer) handleMCP(w http.ResponseWriter, r *http.Request) {
-	mcpSetCORSHeaders(w)
 	if !mcpOriginAllowed(r) {
 		http.Error(w, "forbidden origin", http.StatusForbidden)
+		return
+	}
+	mcpSetCORSHeaders(w)
+	if r.Method != http.MethodOptions && !m.authorizedMCPRequest(r) {
+		w.Header().Set("WWW-Authenticate", "Bearer")
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
 		return
 	}
 
@@ -290,4 +297,18 @@ func mcpToolError(message string) map[string]any {
 		"content": []map[string]any{{"type": "text", "text": message}},
 		"isError": true,
 	}
+}
+
+func (m *mcpServer) authorizedMCPRequest(r *http.Request) bool {
+	if m.authToken == "" {
+		return true
+	}
+	header := r.Header.Get("Authorization")
+	scheme, token, ok := strings.Cut(header, " ")
+	if !ok || !strings.EqualFold(scheme, "Bearer") {
+		return false
+	}
+	supplied := sha256.Sum256([]byte(token))
+	expected := sha256.Sum256([]byte(m.authToken))
+	return subtle.ConstantTimeCompare(supplied[:], expected[:]) == 1
 }


### PR DESCRIPTION
The built-in application MCP endpoint now rejects opaque (`Origin: null`), malformed, and non-HTTP(S) browser origins before CORS permission or tool dispatch. Native headerless MCP clients keep the loopback development workflow.

Adds `WAILS_MCP_TOKEN`: when set, `/mcp` calls require a bearer token; non-loopback binds now refuse to start without one. Approved-origin preflights remain supported, and evaluation callbacks retain their existing unpredictable per-evaluation IDs so the token is not injected into the webview. The guide documents the local trust boundary, client header, and encrypted transport requirements for remote access.

Fixes #6089.

Validation:
- `GOWORK=off go test -tags mcp ./pkg/application -run TestMCP -count=1` passed on macOS.
- `GOWORK=off go test -tags 'server mcp' ./pkg/application -run TestMCP -count=1` passed.
- Handler tests cover rejecting null POST/preflight before dispatch, missing/wrong/valid bearer credentials, authenticated preflight, and non-loopback bind policy.
- CodeRabbit local review: no findings. `git diff --check` passed.
- Ripwire reports unchanged function contracts. Its quality delta flags test-scaffolding duplication (two gating rows), newly discovered Go tests as dead code, and two minor function-length increases; these are retained explicitly rather than weakening coverage to satisfy structural metrics.

Compatibility: existing non-loopback MCP setups must now configure `WAILS_MCP_TOKEN` and the matching client Authorization header. No real-browser exploit test was performed; regression tests exercise the HTTP handler directly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added optional bearer-token authentication for MCP requests.
  - Non-loopback MCP bindings now require a configured token; loopback bindings may remain unauthenticated.
  - Added stricter origin validation for MCP requests, including rejection of opaque or malformed origins.
  - Preflight requests remain supported while protected tool calls require valid authentication.

- **Documentation**
  - Updated MCP configuration and security guidance, including token setup and recommendations for TLS or encrypted tunnels when externally exposed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->