### PR TITLE
fix(v3): wait for standard dev frontend before app startup

### DIFF
--- a/v3/go.mod
+++ b/v3/go.mod
@@ -6,7 +6,7 @@ require (
 	git.sr.ht/~jackmordaunt/go-toast/v2 v2.0.3
 	github.com/adrg/xdg v0.5.3
 	github.com/atotto/clipboard v0.1.4
-	github.com/atterpac/refresh v1.0.0
+	github.com/atterpac/refresh v1.1.3
 	github.com/charmbracelet/bubbles v0.21.1-0.20250623103423-23b8fd6302d7
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/glamour v0.10.0

--- a/v3/go.sum
+++ b/v3/go.sum
@@ -63,6 +63,8 @@ github.com/atotto/clipboard v0.1.4 h1:EH0zSVneZPSuFR11BlR9YppQTVDbh5+16AmcJi4g1z
 github.com/atotto/clipboard v0.1.4/go.mod h1:ZY9tmq7sm5xIbd9bOK4onWV4S6X0u6GY7Vn0Yu86PYI=
 github.com/atterpac/refresh v1.0.0 h1:IK/rh3w5cD7nb6GuqzfScIdNuAz/E0sZz10k1pioIFE=
 github.com/atterpac/refresh v1.0.0/go.mod h1:+vQ8OHgGmZ7wwoZfxxkT6Nr/gKA8j78Rbt+qcLLDEoc=
+github.com/atterpac/refresh v1.1.3 h1:pwvhX6CNQpbDpyaAYK1EQSfsAJCZBZr8n7rQtTGqG5U=
+github.com/atterpac/refresh v1.1.3/go.mod h1:+vQ8OHgGmZ7wwoZfxxkT6Nr/gKA8j78Rbt+qcLLDEoc=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiErDT4WkJ2k=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1/go.mod h1:uYgXzlJ7ZpABp8OJ+exZzJJhRNQ2ASbcXHWsFqH8hp8=
 github.com/aymanbagabas/go-udiff v0.3.1 h1:LV+qyBQ2pqe0u42ZsUEtPiCaUoqgA9gYRDs3vj1nolY=

--- a/v3/internal/commands/build_assets/config.yml
+++ b/v3/internal/commands/build_assets/config.yml
@@ -54,6 +54,11 @@ dev_mode:
   executes:
     - cmd: wails3 build DEV=true
       type: blocking
+    # wails3 dev waits up to 60s for this standard frontend task to open the
+    # selected dev port before starting the app. Custom commands can opt in:
+    # readiness:
+    #   tcp: "localhost:5173"
+    #   timeout: "60s"
     - cmd: wails3 task common:dev:frontend
       type: background
     - cmd: wails3 task run

--- a/v3/internal/commands/watcher.go
+++ b/v3/internal/commands/watcher.go
@@ -1,10 +1,14 @@
 package commands
 
 import (
+	"fmt"
+	"net"
+	"net/url"
 	"os"
+	"strings"
 
 	"github.com/atterpac/refresh/engine"
-	"github.com/wailsapp/wails/v3/internal/signal"
+	"github.com/atterpac/refresh/process"
 	"gopkg.in/yaml.v3"
 )
 
@@ -22,8 +26,6 @@ type WatcherOptions struct {
 }
 
 func Watcher(options *WatcherOptions) error {
-	stopChan := make(chan struct{})
-
 	// Parse the config file
 	type devConfig struct {
 		Config engine.Config `yaml:"dev_mode"`
@@ -42,36 +44,43 @@ func Watcher(options *WatcherOptions) error {
 	}
 
 	ensureIgnored(&devconfig.Config.Ignore.File, "*_test.go")
+	if err := applyFrontendReadiness(&devconfig.Config, os.Getenv("FRONTEND_DEVSERVER_URL")); err != nil {
+		return err
+	}
 
 	watcherEngine, err := engine.NewEngineFromConfig(devconfig.Config)
 	if err != nil {
 		return err
 	}
 
-	// Setup cleanup function that stops the engine
-	cleanup := func() {
-		watcherEngine.Stop()
-	}
-	defer cleanup()
+	// Refresh owns signal handling and blocks until the development session ends.
+	defer watcherEngine.Stop()
+	return watcherEngine.Start()
+}
 
-	// Signal handler needs to notify when to stop
-	signalCleanup := func() {
-		cleanup()
-		stopChan <- struct{}{}
+// Standard projects get startup ordering without rewriting their Taskfiles.
+// Custom commands and explicitly configured readiness remain user-owned.
+func applyFrontendReadiness(config *engine.Config, frontendURL string) error {
+	if frontendURL == "" {
+		return nil
 	}
-
-	signalHandler := signal.NewSignalHandler(signalCleanup)
-	signalHandler.ExitMessage = func(sig os.Signal) string {
-		return ""
+	for i := range config.ExecStruct {
+		step := &config.ExecStruct[i]
+		if step.Type != process.Background || step.Readiness != nil || len(step.Command) != 0 || strings.Join(strings.Fields(step.Cmd), " ") != "wails3 task common:dev:frontend" {
+			continue
+		}
+		target, err := url.Parse(frontendURL)
+		if err != nil || target.Hostname() == "" || (target.Scheme != "http" && target.Scheme != "https") {
+			return fmt.Errorf("invalid frontend development server URL %q", frontendURL)
+		}
+		port := target.Port()
+		if port == "" {
+			port = "80"
+			if target.Scheme == "https" {
+				port = "443"
+			}
+		}
+		step.Readiness = &process.Readiness{TCP: net.JoinHostPort(target.Hostname(), port), Timeout: "60s"}
 	}
-	signalHandler.Start()
-
-	// Start the engine
-	err = watcherEngine.Start()
-	if err != nil {
-		return err
-	}
-
-	<-stopChan
 	return nil
 }

--- a/v3/internal/commands/watcher_test.go
+++ b/v3/internal/commands/watcher_test.go
@@ -3,7 +3,10 @@ package commands
 import (
 	"testing"
 
+	"github.com/atterpac/refresh/engine"
+	"github.com/atterpac/refresh/process"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestEnsureIgnored(t *testing.T) {
@@ -26,5 +29,49 @@ func TestEnsureIgnored(t *testing.T) {
 		ensureIgnored(&list, "*_test.go")
 		assert.Contains(t, list, "*_test.go")
 		assert.Len(t, list, 1)
+	})
+}
+
+func TestFrontendReadiness(t *testing.T) {
+	for _, tc := range []struct{ name, frontendURL, address string }{
+		{"default", "http://localhost:9245", "localhost:9245"},
+		{"custom port", "http://localhost:17321", "localhost:17321"},
+		{"secure", "https://localhost:17322", "localhost:17322"},
+		{"IPv6", "http://[::1]:17323", "[::1]:17323"},
+		{"HTTP default port", "http://localhost", "localhost:80"},
+		{"HTTPS default port", "https://localhost", "localhost:443"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			config := engine.Config{ExecStruct: []process.Execute{{Cmd: "wails3 task common:dev:frontend", Type: process.Background}}}
+			require.NoError(t, applyFrontendReadiness(&config, tc.frontendURL))
+			require.NotNil(t, config.ExecStruct[0].Readiness)
+			assert.Equal(t, tc.address, config.ExecStruct[0].Readiness.TCP)
+			assert.Equal(t, "60s", config.ExecStruct[0].Readiness.Timeout)
+		})
+	}
+	t.Run("preserve custom configuration", func(t *testing.T) {
+		explicit := &process.Readiness{TCP: "custom:8000", Timeout: "2m"}
+		config := engine.Config{ExecStruct: []process.Execute{
+			{Cmd: "wails3 task common:dev:frontend", Type: process.Background, Readiness: explicit},
+			{Cmd: "npm run dev", Type: process.Background},
+			{Cmd: "wails3 task common:dev:frontend && echo ready", Type: process.Background},
+			{Cmd: "wails3 task common:dev:frontend", Type: process.Primary},
+		}}
+		require.NoError(t, applyFrontendReadiness(&config, "http://localhost:9245"))
+		assert.Same(t, explicit, config.ExecStruct[0].Readiness)
+		for _, step := range config.ExecStruct[1:] {
+			assert.Nil(t, step.Readiness)
+		}
+	})
+	t.Run("no frontend", func(t *testing.T) {
+		config := engine.Config{ExecStruct: []process.Execute{{Cmd: "wails3 task common:dev:frontend", Type: process.Background}}}
+		require.NoError(t, applyFrontendReadiness(&config, ""))
+		assert.Nil(t, config.ExecStruct[0].Readiness)
+	})
+	t.Run("invalid URL", func(t *testing.T) {
+		for _, target := range []string{"not-a-url", "file:///tmp/frontend", "http://localhost:bad"} {
+			config := engine.Config{ExecStruct: []process.Execute{{Cmd: "wails3 task common:dev:frontend", Type: process.Background}}}
+			assert.Error(t, applyFrontendReadiness(&config, target))
+		}
 	})
 }

--- a/v3/test/manual/frontend-readiness/check.py
+++ b/v3/test/manual/frontend-readiness/check.py
@@ -1,0 +1,55 @@
+# Linux/macOS orchestration regression: python3 check.py /absolute/path/to/wails3
+# Uses lightweight task stand-ins to check launch ordering without a GUI/npm.
+import os,pathlib,signal,socket,subprocess,sys,tempfile,time
+timeout_case = len(sys.argv) > 2 and sys.argv[2] == 'timeout'
+with tempfile.TemporaryDirectory(prefix='wails-readiness-') as d:
+ root=pathlib.Path(d)
+ with socket.socket() as s:s.bind(('127.0.0.1',0));port=s.getsockname()[1]
+ fake=root/'wails3'
+ fake.write_text('''#!/usr/bin/env python3
+import os,socket,sys,time,pathlib
+if sys.argv[1:]==['task','common:dev:frontend']:
+ time.sleep(6)
+ s=socket.socket();s.bind(('127.0.0.1',int(os.environ['WAILS_VITE_PORT'])));s.listen()
+ while True:
+  c,_=s.accept();c.close()
+elif sys.argv[1:]==['task','run']:
+ try:
+  with socket.create_connection(('localhost',int(os.environ['WAILS_VITE_PORT'])),timeout=1):pass
+  pathlib.Path('result').write_text('READY')
+ except OSError:pathlib.Path('result').write_text('STARTED BEFORE FRONTEND')
+ while True:time.sleep(1)
+''');fake.chmod(0o755)
+ (root/'config.yml').write_text('''dev_mode:
+  root_path: .
+  log_level: error
+  ignore:
+    watched_extension: ["*.go"]
+  executes:
+    - cmd: wails3 build DEV=true
+      type: blocking
+    - cmd: wails3 task common:dev:frontend
+      type: background
+    - cmd: wails3 task run
+      type: primary
+''')
+ if timeout_case:
+  config=root/'config.yml'
+  config.write_text(config.read_text().replace('      type: background', '      type: background\n      readiness:\n        tcp: localhost:'+str(port)+'\n        timeout: 200ms'))
+ with open(root/'log','w') as log:
+  p=subprocess.Popen([sys.argv[1],'dev','--config',str(root/'config.yml'),'--port',str(port)],cwd=root,env={**os.environ,'PATH':str(root)+':'+os.environ['PATH']},stdout=log,stderr=log,start_new_session=True)
+  try:
+   deadline=time.monotonic()+15
+   while not (root/'result').exists() and p.poll() is None and time.monotonic()<deadline:time.sleep(.05)
+   result=(root/'result').read_text() if (root/'result').exists() else 'NO APP RESULT'
+   exit_code=p.poll()
+  finally:
+   if p.poll() is None:os.killpg(p.pid,signal.SIGTERM)
+   try:p.wait(timeout=3)
+   except subprocess.TimeoutExpired:os.killpg(p.pid,signal.SIGKILL);p.wait()
+ if timeout_case:
+  if result=='NO APP RESULT' and exit_code not in (None,0) and 'did not become ready' in (root/'log').read_text():
+   print('TIMEOUT: app correctly not started');sys.exit(0)
+  print(result);print((root/'log').read_text());sys.exit(1)
+ print(result)
+ if result!='READY':print((root/'log').read_text());sys.exit(1)


### PR DESCRIPTION
A standard `wails3 dev` project can launch its native app while frontend dependency installation is still running; the app then exhausts its short startup retry window. Wait for the standard frontend task to open the selected development port before starting the app.

Uses the published `github.com/atterpac/refresh` v1.1.3 readiness gate, following the upstream-orchestration direction discussed on #5828. Existing standard configurations work without Taskfile edits; custom commands and explicit readiness settings are preserved. The default gate is 60 seconds and follows `--port` and HTTPS settings. Refresh now owns signal handling, and Wails returns when its blocking supervisor finishes.

Fixes #4905. Related: #5828 and #6049. This overlaps #6049's refresh dependency/supervisor changes and needs coordination when either lands; it does not add that PR's primary-process exit policy.

Validation:
- The same CLI harness reports `STARTED BEFORE FRONTEND` on master and `READY` with this change after a six-second delayed frontend.
- Explicit readiness timeout exits without starting the app.
- `go test -race ./internal/commands -count=1` and `go vet ./internal/commands` pass on Linux.
- Windows amd64 command-package test binary cross-compiles; native Windows/macOS execution is unverified.
- Added configuration tests for ports, HTTPS, IPv6, invalid URLs and preserved custom settings, plus `v3/test/manual/frontend-readiness/check.py` for the process-ordering regression.
- `git diff --check` passes. Required `coderabbit --plain` was attempted but is unsupported by the installed CLI; supported `coderabbit review --uncommitted` was attempted and blocked by the free OSS review limit.

The readiness gate checks TCP connectivity, as supported by the published refresh release; it does not assert HTTP status. Runtime frontend checks remain in place. Draft pending review and native platform validation.
