### PR TITLE
docs: remove discarded proposals from macOS API guide

### DIFF
--- a/docs/src/content/docs/guides/build/private-macos-apis.mdx
+++ b/docs/src/content/docs/guides/build/private-macos-apis.mdx
@@ -104,5 +104,3 @@ go build -tags production,devtools,private_mac_apis .
 ## Maintaining this list
 
 All private native calls are isolated in `v3/pkg/application/mac_private_api_darwin.go`; default builds select `mac_public_api_darwin.go`. This inventory covers transparency, webview background colour, glass styles, glass grouping, inspector opening, and legacy inspector enablement. Changes to those implementations should update this page and the affected option documentation together.
-
-The proposed `appstore` and `noprivateapis` tags are not used. There is no `PreferPageRenderingUpdatesNear60FPS` option in this change.


### PR DESCRIPTION
Remove the paragraph about rejected build tags and an unimplemented frame-rate option from the private macOS APIs reference. Readers need the supported configuration and behavior; proposal history belongs in PR discussions.

Validation: reviewed the page, searched documentation and examples for the discarded names, and ran git diff --check. CodeRabbit completed with no findings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the private macOS APIs guide by removing outdated notes about proposed build tags and an unavailable rendering option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->