### PR TITLE
fix(v3): start default signal handler during App.Run

### DIFF
--- a/v3/pkg/application/application.go
+++ b/v3/pkg/application/application.go
@@ -64,9 +64,6 @@ func New(appOptions Options) *App {
 		}
 	}
 
-	// Set up signal handling (platform-specific)
-	result.setupSignalHandler(appOptions)
-
 	result.logStartup()
 	result.logPlatformInfo()
 
@@ -763,6 +760,9 @@ func (a *App) Run() error {
 	if err := startup(); err != nil {
 		return err
 	}
+	// Handle signals only after the application is ready to quit.
+	a.setupSignalHandler(a.options)
+
 	return a.impl.run()
 }
 

--- a/v3/pkg/application/signal_handler_android.go
+++ b/v3/pkg/application/signal_handler_android.go
@@ -9,7 +9,7 @@ import (
 // setupSignalHandler sets up signal handling for Android
 // On Android, we don't handle Unix signals directly as the app lifecycle
 // is managed by the Android runtime
-func setupSignalHandler() {
+func (a *App) setupSignalHandler(options Options) {
 	// No-op on Android - lifecycle managed by Android framework
 }
 

--- a/v3/pkg/application/signal_handler_desktop.go
+++ b/v3/pkg/application/signal_handler_desktop.go
@@ -1,4 +1,4 @@
-//go:build !ios
+//go:build !ios && !android
 
 package application
 

--- a/v3/pkg/application/signal_handler_desktop.go
+++ b/v3/pkg/application/signal_handler_desktop.go
@@ -16,5 +16,6 @@ func (a *App) setupSignalHandler(options Options) {
 		a.signalHandler.ExitMessage = func(sig os.Signal) string {
 			return "Quitting application..."
 		}
+		a.signalHandler.Start()
 	}
 }

--- a/v3/pkg/application/signal_handler_desktop_test.go
+++ b/v3/pkg/application/signal_handler_desktop_test.go
@@ -1,0 +1,82 @@
+//go:build !windows && !ios && !android
+
+package application
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"os"
+	"os/exec"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// signalQuitApp observes Quit without starting a native event loop.
+type signalQuitApp struct {
+	platformApp
+	quit chan struct{}
+}
+
+func (a *signalQuitApp) isOnMainThread() bool { return true }
+func (a *signalQuitApp) destroy()             { close(a.quit) }
+
+func TestDefaultSignalHandler(t *testing.T) {
+	for _, sig := range []syscall.Signal{syscall.SIGINT, syscall.SIGTERM} {
+		for _, disabled := range []string{"false", "true"} {
+			t.Run(sig.String()+"/disabled="+disabled, func(t *testing.T) {
+				ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+				defer cancel()
+				cmd := exec.CommandContext(ctx, os.Args[0], "-test.run=^TestDefaultSignalHandlerProcess$")
+				cmd.Env = append(os.Environ(), "WAILS_TEST_SIGNAL="+sig.String(), "WAILS_TEST_SIGNAL_DISABLED="+disabled)
+				output, err := cmd.CombinedOutput()
+				if disabled == "false" {
+					if err != nil {
+						t.Fatalf("signal did not reach Quit: %v\n%s", err, output)
+					}
+					return
+				}
+				var exitErr *exec.ExitError
+				if !errors.As(err, &exitErr) {
+					t.Fatalf("expected default signal termination, got %v\n%s", err, output)
+				}
+				status, ok := exitErr.Sys().(syscall.WaitStatus)
+				if !ok || !status.Signaled() || status.Signal() != sig {
+					t.Fatalf("expected termination by %v, got %v\n%s", sig, err, output)
+				}
+			})
+		}
+	}
+}
+
+func TestDefaultSignalHandlerProcess(t *testing.T) {
+	name := os.Getenv("WAILS_TEST_SIGNAL")
+	if name == "" {
+		return
+	}
+	var sig syscall.Signal
+	switch name {
+	case syscall.SIGINT.String():
+		sig = syscall.SIGINT
+	case syscall.SIGTERM.String():
+		sig = syscall.SIGTERM
+	default:
+		t.Fatalf("unexpected signal %q", name)
+	}
+
+	impl := &signalQuitApp{quit: make(chan struct{})}
+	app := &App{impl: impl, Logger: slog.Default()}
+	globalApplication = app
+	app.setupSignalHandler(Options{
+		DisableDefaultSignalHandler: os.Getenv("WAILS_TEST_SIGNAL_DISABLED") == "true",
+	})
+	if err := syscall.Kill(os.Getpid(), sig); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-impl.quit:
+	case <-time.After(5 * time.Second):
+		t.Fatal("signal did not call App.Quit")
+	}
+}

--- a/v3/pkg/application/signal_handler_test.go
+++ b/v3/pkg/application/signal_handler_test.go
@@ -1,0 +1,36 @@
+package application
+
+import (
+	"go/build"
+	"testing"
+)
+
+// TestSignalHandlerBuildVariants keeps mobile lifecycle handling separate from
+// the desktop/server Unix signal handler.
+func TestSignalHandlerBuildVariants(t *testing.T) {
+	for _, platform := range []string{"darwin", "linux", "windows", "ios", "android"} {
+		for _, mode := range []string{"desktop", "server"} {
+			t.Run(platform+"/"+mode, func(t *testing.T) {
+				ctx := build.Default
+				ctx.GOOS, ctx.GOARCH, ctx.CgoEnabled = platform, "arm64", true
+				ctx.BuildTags = nil
+				if mode == "server" {
+					ctx.BuildTags = []string{"server"}
+				}
+				for file, want := range map[string]bool{
+					"signal_handler_desktop.go": platform != "ios" && platform != "android",
+					"signal_handler_ios.go":     platform == "ios",
+					"signal_handler_android.go": platform == "android",
+				} {
+					got, err := ctx.MatchFile(".", file)
+					if err != nil {
+						t.Fatal(err)
+					}
+					if got != want {
+						t.Errorf("%s selected = %v, want %v", file, got, want)
+					}
+				}
+			})
+		}
+	}
+}


### PR DESCRIPTION
## Description

SIGINT and SIGTERM previously terminated v3 desktop apps without calling `App.Quit()`, so service shutdown and other cleanup hooks were skipped. Move signal-handler setup from `New()` to `Run()`, after successful startup, and start the handler there. `DisableDefaultSignalHandler` remains respected, and both iOS and Android use no-op setup managed by their platform lifecycle.

Adds subprocess regression tests for SIGINT and SIGTERM with the handler enabled and disabled. The tests verify dispatch to `App.Quit()` and normal OS termination when disabled.

Fixes #6096.

## Validation

- `go test ./pkg/application ./internal/signal -count=1`: passed on macOS arm64.
- Signal regression tests fail with the `Start()` call removed and pass with it restored.
- `go test -race ./pkg/application -run '^TestDefaultSignalHandler' -count=1`: passed.
- Focused server-mode signal and server lifecycle tests: passed.
- Real macOS app: both SIGINT and SIGTERM invoke `ServiceShutdown` and `PostShutdown` and exit successfully; disabling the handler preserves OS signal termination.
- Platform-selection regression tests cover Darwin, Linux, Windows, iOS, and Android, with and without the server tag. The Android cases fail when its exclusion is removed.
- `GOOS=android GOARCH=arm64 CGO_ENABLED=0 go build ./pkg/application`: passed.
- `git diff --check`: passed. CodeRabbit reviewed all three changed files with zero findings.

The full server-mode application suite fails `TestSystemModes` and `TestIsPlatform`, which assume desktop mode; both failures reproduce on the unchanged base. Windows and Linux runtime behavior was not exercised locally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved application shutdown handling so interrupt and termination signals are processed correctly after startup.
  * Ensured enabled signal handlers trigger a graceful application quit, while disabled handlers retain standard operating-system behavior.
  * Improved signal-handling behavior across desktop, iOS, and Android platforms.

* **Tests**
  * Added coverage for desktop interrupt and termination scenarios.
  * Added verification for platform-specific signal-handler selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
