### PR TITLE
fix: start default signal handler in App.Run

### DIFF
--- a/v3/pkg/application/application.go
+++ b/v3/pkg/application/application.go
@@ -647,6 +647,15 @@ func (a *App) Run() error {
 	a.starting = true
 	a.runLock.Unlock()
 
+	// Start the default signal handler, when one was set up at creation, so
+	// that Ctrl+C and SIGTERM go through App.Quit and the application's
+	// shutdown hooks instead of the OS default disposition. It is a no-op
+	// when DisableDefaultSignalHandler was requested or on platforms that
+	// carry no signal handler.
+	if a.signalHandler != nil {
+		a.signalHandler.Start()
+	}
+
 	// Ensure application context is cancelled in case of failures.
 	defer a.cancel()
 


### PR DESCRIPTION
## Summary

Fixes #6096. In v3.0.0-beta.19 the default application signal handler was constructed in `setupSignalHandler` (`pkg/application/signal_handler_desktop.go`) but never started, so SIGINT/SIGTERM bypassed `App.Quit()`: the OS default disposition killed the process and none of the app's cleanup ran (service `ServiceShutdown`, window/tray teardown, `PostShutdown`, etc.).

`App.Run()` now starts the handler right after the run lock is taken, so the first Ctrl+C / SIGTERM goes through `App.Quit()` and the shutdown hooks. The start is guarded by `a.signalHandler` being non-nil, so:

- `DisableDefaultSignalHandler: true` stays a no-op (the handler is never constructed),
- platforms without a desktop signal handler (iOS, where `platformSignalHandler` is empty) stay a no-op.

## Tests

- `go build ./internal/signal/... ./pkg/application/...` — passes
- `go test ./pkg/application/...` — passes (including the service lifecycle suites)
- `go test ./...` — passes except four pre-existing environment-dependent failures (`internal/generator`, `internal/wake`, `internal/wake/exec`, `internal/webview2/pkg/edge`), which fail identically on a clean `master` checkout in this environment
- `go vet ./pkg/application/...` — no findings on the changed lines (the `unsafe.Pointer` findings are pre-existing Windows-only files, identical on clean `master`)
- `golangci-lint run --new-from-rev=origin/master --new ./pkg/application/...` — 0 issues (the repository ships no lint configuration and its CI does not run golangci-lint, so this used the default profile)

## Verification

The change is a two-step platform-independent sequence: forward the first signal into the already-existing `internal/signal.SignalHandler` goroutine, which logs the configured exit message and calls `a.Quit()` (the same path `wails3 dev` and the watcher already use). A full GUI signal round-trip needs an interactive desktop session and could not be executed in this environment; the handler and its wiring are covered by the package tests above.

Fixes #6096

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Applications now handle Ctrl+C and SIGTERM through the application shutdown flow, allowing registered shutdown hooks to run before exiting.
  - Signal handling remains unchanged when disabled or unavailable on the current platform.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->