### PR TITLE
fix(v3): cancel aborted Windows asset requests

### DIFF
--- a/v3/UNRELEASED_CHANGELOG.md
+++ b/v3/UNRELEASED_CHANGELOG.md
@@ -22,6 +22,7 @@ After processing, the content will be moved to the main changelog and this file 
 <!-- Changes in existing functionality -->
 
 ## Fixed
+- Cancel aborted Windows asset requests, including worker requests, while preserving keepalive handlers across navigation. Forward native request contexts through the application wrapper on Apple platforms. (#5963, #5969)
 <!-- Bug fixes -->
 
 ## Deprecated

--- a/v3/internal/assetserver/webview/request_tracker.go
+++ b/v3/internal/assetserver/webview/request_tracker.go
@@ -1,0 +1,171 @@
+package webview
+
+import (
+	"context"
+	"crypto/rand"
+	"sync"
+)
+
+// RequestIDHeader is a private bridge marker, removed before calling handlers.
+const RequestIDHeader = "X-Wails-Request-Id"
+
+// Keepalive registration precedes native interception. Bound these hints so
+// scripts cannot accumulate unlimited registrations without issuing requests.
+const maxKeepaliveRequests = 1024
+
+// RequestTracker connects browser request identities to Go contexts. A tracker
+// belongs to one WebView; neither URLs nor native pointers identify requests.
+type RequestTracker struct {
+	mu         sync.Mutex
+	ctx        context.Context
+	cancel     context.CancelFunc
+	byID       map[string]*trackedRequest
+	byToken    map[string]*trackedRequest
+	keepalives int
+}
+
+type trackedRequest struct {
+	id, token  string
+	ctx        context.Context
+	cancel     context.CancelFunc
+	claimed    bool
+	persistent bool
+	active     int
+	failed     bool
+}
+
+func NewRequestTracker(parent context.Context) *RequestTracker {
+	ctx, cancel := context.WithCancel(parent)
+	return &RequestTracker{ctx: ctx, cancel: cancel, byID: make(map[string]*trackedRequest), byToken: make(map[string]*trackedRequest)}
+}
+
+// Start runs before the browser resumes an intercepted request. Redirects may
+// reuse a network ID, so each interception receives a fresh, unguessable token.
+func (t *RequestTracker) Start(id string) string { return t.start(id, false) }
+
+// StartKeepalive spans redirects and outlives the JavaScript response consumer.
+func (t *RequestTracker) StartKeepalive(id string) string { return t.start(id, true) }
+
+func (t *RequestTracker) start(id string, persistent bool) string {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if id == "" || t.ctx.Err() != nil {
+		return ""
+	}
+	t.remove(t.byID[id])
+	if persistent && t.keepalives >= maxKeepaliveRequests {
+		return ""
+	}
+	if persistent {
+		t.keepalives++
+	}
+	ctx, cancel := context.WithCancel(t.ctx)
+	r := &trackedRequest{id: id, token: rand.Text(), ctx: ctx, cancel: cancel, persistent: persistent}
+	t.byID[id], t.byToken[r.token] = r, r
+	return r.token
+}
+
+// Cancel also removes unclaimed requests: an abort can arrive before the
+// WebResourceRequested callback, or prevent that callback entirely.
+func (t *RequestTracker) Cancel(id string) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.remove(t.byID[id])
+}
+
+// FailKeepalive releases failed delivery once all dispatched handlers finish.
+func (t *RequestTracker) FailKeepalive(id string) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if entry := t.byID[id]; entry != nil {
+		entry.failed = true
+		if entry.active == 0 {
+			t.remove(entry)
+		}
+	}
+}
+
+// Token returns the marker for a request registered before interception.
+func (t *RequestTracker) Token(id string) string {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if entry := t.byID[id]; entry != nil {
+		return entry.token
+	}
+	return ""
+}
+
+// Close cancels all requests, including requests lacking a browser identity.
+func (t *RequestTracker) Close() {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.cancel()
+	clear(t.byID)
+	clear(t.byToken)
+	t.keepalives = 0
+}
+
+func (t *RequestTracker) remove(r *trackedRequest) {
+	if r == nil {
+		return
+	}
+	r.cancel()
+	delete(t.byToken, r.token)
+	if t.byID[r.id] == r {
+		delete(t.byID, r.id)
+		if r.persistent {
+			t.keepalives--
+		}
+	}
+}
+
+// Wrap consumes the marker and transfers context ownership to the request.
+// A missing nonempty token means an earlier abort (or an invalid marker), and
+// must not resurrect the request. Closing an old redirect cannot remove its successor.
+func (t *RequestTracker) Wrap(r Request) Request {
+	header, _ := r.Header()
+	token := header.Get(RequestIDHeader)
+	header.Del(RequestIDHeader)
+	t.mu.Lock()
+	entry := t.byToken[token]
+	ctx, release := context.WithCancel(t.ctx)
+	if entry != nil && entry.persistent {
+		release()
+		entry.active++
+		ctx, release = context.WithCancel(entry.ctx)
+		cancel := release
+		release = func() {
+			cancel()
+			t.mu.Lock()
+			defer t.mu.Unlock()
+			entry.active--
+			if entry.failed && entry.active == 0 {
+				t.remove(entry)
+			}
+		}
+	} else if entry != nil && !entry.claimed {
+		entry.claimed = true
+		release()
+		ctx = entry.ctx
+		release = func() { t.mu.Lock(); defer t.mu.Unlock(); t.remove(entry) }
+	} else if token != "" {
+		release()
+	}
+	t.mu.Unlock()
+	return &contextRequest{Request: r, ctx: ctx, release: release}
+}
+
+type contextRequest struct {
+	Request
+	ctx     context.Context
+	release context.CancelFunc
+	once    sync.Once
+	err     error
+}
+
+func (r *contextRequest) Context() context.Context { return r.ctx }
+
+func (r *contextRequest) Close() error {
+	r.once.Do(func() { r.release(); r.err = r.Request.Close() })
+	return r.err
+}

--- a/v3/internal/assetserver/webview/request_tracker_test.go
+++ b/v3/internal/assetserver/webview/request_tracker_test.go
@@ -1,0 +1,211 @@
+package webview
+
+import (
+	"context"
+	"net/http"
+	"strconv"
+	"sync"
+	"testing"
+)
+
+type trackerTestRequest struct {
+	finalizerTestRequest
+	headers http.Header
+}
+
+func (r *trackerTestRequest) Header() (http.Header, error) { return r.headers, nil }
+func trackedTestRequest(token string) *trackerTestRequest {
+	return &trackerTestRequest{headers: http.Header{RequestIDHeader: {token}, "Content-Type": {"application/json"}}}
+}
+
+func TestRequestTrackerIdenticalURLsAreIndependent(t *testing.T) {
+	tracker := NewRequestTracker(context.Background())
+	defer tracker.Close()
+	a := trackedTestRequest(tracker.Start("a"))
+	b := trackedTestRequest(tracker.Start("b"))
+	first, second := tracker.Wrap(a), tracker.Wrap(b)
+	defer first.Close()
+	defer second.Close()
+	tracker.Cancel("a")
+	if requestContext(first).Err() != context.Canceled {
+		t.Fatal("aborted request not cancelled")
+	}
+	if requestContext(second).Err() != nil {
+		t.Fatal("unrelated same-URL request cancelled")
+	}
+	if a.headers.Get(RequestIDHeader) != "" || a.headers.Get("Content-Type") != "application/json" {
+		t.Fatal("internal header leaked or application headers lost")
+	}
+}
+
+func TestRequestTrackerAbortBeforeClaim(t *testing.T) {
+	tracker := NewRequestTracker(context.Background())
+	defer tracker.Close()
+	token := tracker.Start("request")
+	tracker.Cancel("request")
+	if len(tracker.byID) != 0 || len(tracker.byToken) != 0 {
+		t.Fatal("unclaimed abort leaked")
+	}
+	r := tracker.Wrap(trackedTestRequest(token))
+	defer r.Close()
+	if requestContext(r).Err() != context.Canceled {
+		t.Fatal("late callback resurrected an aborted request")
+	}
+}
+
+func TestRequestTrackerRedirectReusesNetworkID(t *testing.T) {
+	tracker := NewRequestTracker(context.Background())
+	defer tracker.Close()
+	old := tracker.Wrap(trackedTestRequest(tracker.Start("redirect")))
+	current := tracker.Wrap(trackedTestRequest(tracker.Start("redirect")))
+	defer current.Close()
+	old.Close()
+	if requestContext(current).Err() != nil {
+		t.Fatal("old response cleanup cancelled its successor")
+	}
+	tracker.Cancel("redirect")
+	if requestContext(current).Err() != context.Canceled {
+		t.Fatal("successor lost cancellation registration")
+	}
+}
+
+func TestRequestTrackerWindowCloseAndLateRequests(t *testing.T) {
+	tracker := NewRequestTracker(context.Background())
+	unmarked := tracker.Wrap(trackedTestRequest(""))
+	marked := tracker.Wrap(trackedTestRequest(tracker.Start("active")))
+	tracker.Start("unclaimed")
+	tracker.Close()
+	defer unmarked.Close()
+	defer marked.Close()
+	for _, r := range []Request{unmarked, marked} {
+		if requestContext(r).Err() != context.Canceled {
+			t.Fatal("window close missed a request")
+		}
+	}
+	if len(tracker.byID) != 0 || len(tracker.byToken) != 0 {
+		t.Fatal("window close leaked requests")
+	}
+	if tracker.Start("late") != "" {
+		t.Fatal("closed tracker accepted a request")
+	}
+	late := tracker.Wrap(trackedTestRequest(""))
+	defer late.Close()
+	if requestContext(late).Err() != context.Canceled {
+		t.Fatal("late request escaped window cancellation")
+	}
+}
+
+func TestRequestTrackerConcurrentCompletionAndAbort(t *testing.T) {
+	for range 100 {
+		tracker := NewRequestTracker(context.Background())
+		raw := trackedTestRequest(tracker.Start("request"))
+		r := tracker.Wrap(raw)
+		var workers sync.WaitGroup
+		for range 8 {
+			workers.Go(func() { tracker.Cancel("request") })
+			workers.Go(func() { r.Close() })
+			workers.Go(func() { tracker.Close() })
+		}
+		workers.Wait()
+		if raw.closeCount.Load() != 1 {
+			t.Fatal("request closed more than once")
+		}
+		if len(tracker.byID) != 0 || len(tracker.byToken) != 0 {
+			t.Fatal("completed request leaked")
+		}
+	}
+}
+
+func TestRequestTrackerRejectsDuplicateAndForeignMarkers(t *testing.T) {
+	tracker := NewRequestTracker(context.Background())
+	defer tracker.Close()
+	token := tracker.Start("request")
+	owner := tracker.Wrap(trackedTestRequest(token))
+	defer owner.Close()
+	for _, marker := range []string{token, "untrusted"} {
+		r := tracker.Wrap(trackedTestRequest(marker))
+		defer r.Close()
+		if requestContext(r).Err() != context.Canceled {
+			t.Fatal("invalid marker acquired a live context")
+		}
+	}
+	if requestContext(owner).Err() != nil {
+		t.Fatal("invalid marker cancelled another request")
+	}
+}
+
+func TestRequestTrackerParentCancellation(t *testing.T) {
+	parent, cancel := context.WithCancel(context.Background())
+	tracker := NewRequestTracker(parent)
+	defer tracker.Close()
+	r := tracker.Wrap(trackedTestRequest(tracker.Start("active")))
+	defer r.Close()
+	cancel()
+	if requestContext(r).Err() != context.Canceled || tracker.Start("late") != "" {
+		t.Fatal("application shutdown did not cancel requests")
+	}
+}
+
+func TestRequestTrackerKeepaliveRedirectAndFailedDelivery(t *testing.T) {
+	tracker := NewRequestTracker(context.Background())
+	defer tracker.Close()
+	token := tracker.StartKeepalive("keepalive")
+	redirect := tracker.Wrap(trackedTestRequest(token))
+	redirect.Close()
+	if tracker.Token("keepalive") != token {
+		t.Fatal("redirect retired keepalive identity")
+	}
+	handler := tracker.Wrap(trackedTestRequest(token))
+	tracker.FailKeepalive("keepalive")
+	if requestContext(handler).Err() != nil {
+		t.Fatal("page teardown cancelled running keepalive")
+	}
+	handler.Close()
+	if tracker.Token("keepalive") != "" {
+		t.Fatal("failed delivery leaked a completed keepalive")
+	}
+}
+
+func TestRequestTrackerKeepaliveAbortAndFailureBeforeDispatch(t *testing.T) {
+	tracker := NewRequestTracker(context.Background())
+	defer tracker.Close()
+	token := tracker.StartKeepalive("active")
+	handler := tracker.Wrap(trackedTestRequest(token))
+	defer handler.Close()
+	tracker.Cancel("active")
+	if requestContext(handler).Err() != context.Canceled {
+		t.Fatal("explicit abort missed keepalive")
+	}
+	tracker.StartKeepalive("failed")
+	tracker.FailKeepalive("failed")
+	if tracker.Token("failed") != "" {
+		t.Fatal("failed fetch leaked before dispatch")
+	}
+}
+
+func TestRequestTrackerBoundsKeepaliveRegistrations(t *testing.T) {
+	tracker := NewRequestTracker(context.Background())
+	defer tracker.Close()
+	for i := range maxKeepaliveRequests {
+		if tracker.StartKeepalive(strconv.Itoa(i)) == "" {
+			t.Fatal("registration rejected below capacity")
+		}
+	}
+	if tracker.StartKeepalive("overflow") != "" {
+		t.Fatal("unbounded keepalive registration")
+	}
+	old := tracker.Wrap(trackedTestRequest(tracker.Token("0")))
+	tracker.Cancel("0")
+	tracker.Cancel("unknown")
+	if tracker.StartKeepalive("replacement") == "" {
+		t.Fatal("cancellation did not release capacity")
+	}
+	old.Close()
+	if tracker.keepalives != maxKeepaliveRequests {
+		t.Fatal("old close released capacity twice")
+	}
+	tracker.Close()
+	if tracker.keepalives != 0 {
+		t.Fatal("window close retained registrations")
+	}
+}

--- a/v3/internal/webview2/pkg/edge/devtools.go
+++ b/v3/internal/webview2/pkg/edge/devtools.go
@@ -1,0 +1,190 @@
+//go:build windows
+
+package edge
+
+import (
+	"syscall"
+	"unsafe"
+
+	"github.com/wailsapp/wails/v3/internal/webview2/pkg/combridge"
+	"golang.org/x/sys/windows"
+)
+
+// These callbacks use combridge so COM reference ownership also keeps their Go
+// closures alive. All methods and callbacks run on the WebView's UI thread.
+type devToolsCompletion interface{ Complete(int32, *uint16) }
+type devToolsEvent interface{ Receive(*devToolsEventArgs) }
+type devToolsCompletionFunc func(int32, *uint16)
+
+func (f devToolsCompletionFunc) Complete(hr int32, result *uint16) { f(hr, result) }
+
+type devToolsEventFunc func(*devToolsEventArgs)
+
+func (f devToolsEventFunc) Receive(args *devToolsEventArgs) { f(args) }
+
+func init() {
+	combridge.RegisterVTable[combridge.IUnknown, devToolsCompletion]("{5c4889f0-5ef6-4c5a-952c-d8f1b92d0574}",
+		func(this uintptr, hr int32, result *uint16) uintptr {
+			combridge.Resolve[devToolsCompletion](this).Complete(hr, result)
+			return 0
+		})
+	combridge.RegisterVTable[combridge.IUnknown, devToolsEvent]("{e2fda4be-5456-406c-a261-3d452138362c}",
+		func(this uintptr, _ *ICoreWebView2, args *devToolsEventArgs) uintptr {
+			combridge.Resolve[devToolsEvent](this).Receive(args)
+			return 0
+		})
+}
+
+type devToolsEventArgs struct {
+	vtbl *struct {
+		_IUnknownVtbl
+		GetJSON ComProc
+	}
+}
+type devToolsEventReceiver struct {
+	vtbl *struct {
+		_IUnknownVtbl
+		Add, Remove ComProc
+	}
+}
+
+func (a *devToolsEventArgs) json() (string, error) {
+	var value *uint16
+	hr, _, _ := a.vtbl.GetJSON.Call(uintptr(unsafe.Pointer(a)), uintptr(unsafe.Pointer(&value)))
+	if int32(hr) < 0 {
+		return "", syscall.Errno(hr)
+	}
+	defer windows.CoTaskMemFree(unsafe.Pointer(value))
+	return windows.UTF16PtrToString(value), nil
+}
+
+// CallDevTools invokes CDP in process; it does not enable a remote debugging port.
+// done receives asynchronous protocol errors as well as the result JSON.
+func (e *Chromium) CallDevTools(method, params string, done func(string, error)) error {
+	return e.CallDevToolsForSession("", method, params, done)
+}
+
+// CallDevToolsForSession addresses a worker or frame session attached with Target.setAutoAttach.
+func (e *Chromium) CallDevToolsForSession(session, method, params string, done func(string, error)) error {
+	m, err := windows.UTF16PtrFromString(method)
+	if err != nil {
+		return err
+	}
+	p, err := windows.UTF16PtrFromString(params)
+	if err != nil {
+		return err
+	}
+	callback := combridge.New[devToolsCompletion](devToolsCompletionFunc(func(hr int32, result *uint16) {
+		if hr < 0 {
+			done("", syscall.Errno(uint32(hr)))
+			return
+		}
+		done(windows.UTF16PtrToString(result), nil)
+	}))
+	defer callback.Close()
+	var hr uintptr
+	if session == "" {
+		hr, _, _ = e.webview.vtbl.CallDevToolsProtocolMethod.Call(uintptr(unsafe.Pointer(e.webview)), uintptr(unsafe.Pointer(m)), uintptr(unsafe.Pointer(p)), callback.Ref())
+	} else {
+		sid, err := windows.UTF16PtrFromString(session)
+		if err != nil {
+			return err
+		}
+		guid := windows.GUID{Data1: 0x0be78e56, Data2: 0xc193, Data3: 0x4051, Data4: [8]byte{0xb9, 0x43, 0x23, 0xb4, 0x60, 0xc0, 0x8b, 0xdb}}
+		var view *devToolsWebView11
+		hr, _, _ = e.webview.vtbl.QueryInterface.Call(uintptr(unsafe.Pointer(e.webview)), uintptr(unsafe.Pointer(&guid)), uintptr(unsafe.Pointer(&view)))
+		if int32(hr) < 0 {
+			return syscall.Errno(hr)
+		}
+		defer view.vtbl.Release.Call(uintptr(unsafe.Pointer(view)))
+		hr, _, _ = view.vtbl.CallForSession.Call(uintptr(unsafe.Pointer(view)), uintptr(unsafe.Pointer(sid)), uintptr(unsafe.Pointer(m)), uintptr(unsafe.Pointer(p)), callback.Ref())
+	}
+	if int32(hr) < 0 {
+		return syscall.Errno(hr)
+	}
+	return nil
+}
+
+// OnDevTools subscribes to one CDP event. The returned cleanup must run on the UI thread.
+func (e *Chromium) OnDevTools(event string, receive func(string, string, error)) (func() error, error) {
+	name, err := windows.UTF16PtrFromString(event)
+	if err != nil {
+		return nil, err
+	}
+	var receiver *devToolsEventReceiver
+	hr, _, _ := e.webview.vtbl.GetDevToolsProtocolEventReceiver.Call(uintptr(unsafe.Pointer(e.webview)), uintptr(unsafe.Pointer(name)), uintptr(unsafe.Pointer(&receiver)))
+	if int32(hr) < 0 {
+		return nil, syscall.Errno(hr)
+	}
+	callback := combridge.New[devToolsEvent](devToolsEventFunc(func(args *devToolsEventArgs) {
+		session, err := args.session()
+		if err != nil {
+			receive("", "", err)
+			return
+		}
+		data, err := args.json()
+		receive(session, data, err)
+	}))
+	defer callback.Close()
+	var token _EventRegistrationToken
+	hr, _, _ = receiver.vtbl.Add.Call(uintptr(unsafe.Pointer(receiver)), callback.Ref(), uintptr(unsafe.Pointer(&token)))
+	if int32(hr) < 0 {
+		receiver.vtbl.Release.Call(uintptr(unsafe.Pointer(receiver)))
+		return nil, syscall.Errno(hr)
+	}
+	return func() error {
+		if receiver == nil {
+			return nil
+		}
+		var hr uintptr
+		if unsafe.Sizeof(uintptr(0)) == 4 {
+			hr, _, _ = receiver.vtbl.Remove.Call(uintptr(unsafe.Pointer(receiver)), uintptr(uint32(token.value)), uintptr(uint64(token.value)>>32))
+		} else {
+			hr, _, _ = receiver.vtbl.Remove.Call(uintptr(unsafe.Pointer(receiver)), uintptr(token.value))
+		}
+		receiver.vtbl.Release.Call(uintptr(unsafe.Pointer(receiver)))
+		receiver = nil
+		if int32(hr) < 0 {
+			return syscall.Errno(hr)
+		}
+		return nil
+	}, nil
+}
+
+// ICoreWebView2_2 through _10 add 38 methods in WebView2.1.0.2903.40.idl.
+// _11 starts with CallDevToolsProtocolMethodForSession. This layout is shared by
+// x86, x64 and arm64; every slot is one COM procedure pointer.
+type devToolsWebView11 struct {
+	vtbl *struct {
+		iCoreWebView2Vtbl
+		versions2Through10 [38]ComProc
+		CallForSession     ComProc
+	}
+}
+
+type devToolsEventArgs2 struct {
+	vtbl *struct {
+		_IUnknownVtbl
+		GetJSON, GetSession ComProc
+	}
+}
+
+func (a *devToolsEventArgs) session() (string, error) {
+	guid := windows.GUID{Data1: 0x2dc4959d, Data2: 0x1494, Data3: 0x4393, Data4: [8]byte{0x95, 0xba, 0xbe, 0xa4, 0xcb, 0x9e, 0xbd, 0x1b}}
+	var extended *devToolsEventArgs2
+	hr, _, _ := a.vtbl.QueryInterface.Call(uintptr(unsafe.Pointer(a)), uintptr(unsafe.Pointer(&guid)), uintptr(unsafe.Pointer(&extended)))
+	if uint32(hr) == uint32(windows.E_NOINTERFACE) {
+		return "", nil
+	}
+	if int32(hr) < 0 {
+		return "", syscall.Errno(hr)
+	}
+	defer extended.vtbl.Release.Call(uintptr(unsafe.Pointer(extended)))
+	var value *uint16
+	hr, _, _ = extended.vtbl.GetSession.Call(uintptr(unsafe.Pointer(extended)), uintptr(unsafe.Pointer(&value)))
+	if int32(hr) < 0 {
+		return "", syscall.Errno(hr)
+	}
+	defer windows.CoTaskMemFree(unsafe.Pointer(value))
+	return windows.UTF16PtrToString(value), nil
+}

--- a/v3/pkg/application/application.go
+++ b/v3/pkg/application/application.go
@@ -375,6 +375,14 @@ func (r *webViewAssetRequest) Method() (string, error) {
 	return r.Request.Method()
 }
 
+// Context preserves native request cancellation through the header-injecting wrapper.
+func (r *webViewAssetRequest) Context() context.Context {
+	if contextual, ok := r.Request.(interface{ Context() context.Context }); ok {
+		return contextual.Context()
+	}
+	return nil
+}
+
 func (r *webViewAssetRequest) Header() (http.Header, error) {
 	h, err := r.Request.Header()
 	if err != nil {

--- a/v3/pkg/application/asset_request_context_test.go
+++ b/v3/pkg/application/asset_request_context_test.go
@@ -1,0 +1,39 @@
+package application
+
+import (
+	"context"
+	"testing"
+
+	"github.com/wailsapp/wails/v3/internal/assetserver/webview"
+)
+
+type contextualAssetRequest struct {
+	webview.Request
+	ctx context.Context
+}
+
+func (r contextualAssetRequest) Context() context.Context { return r.ctx }
+
+func TestAssetRequestPreservesNativeContext(t *testing.T) {
+	ctx, abort := context.WithCancel(context.Background())
+	defer abort()
+	r := &webViewAssetRequest{Request: contextualAssetRequest{ctx: ctx}}
+	actual, release := webview.RequestContext(r)
+	defer release()
+	abort()
+	if actual.Err() != context.Canceled {
+		t.Fatal("application wrapper discarded native cancellation")
+	}
+}
+
+func TestAssetRequestWithoutNativeContext(t *testing.T) {
+	r := &webViewAssetRequest{}
+	ctx, release := webview.RequestContext(r)
+	if ctx.Err() != nil {
+		t.Fatal("fallback context starts cancelled")
+	}
+	release()
+	if ctx.Err() != context.Canceled {
+		t.Fatal("fallback context cannot be released")
+	}
+}

--- a/v3/pkg/application/request_cancellation_windows.go
+++ b/v3/pkg/application/request_cancellation_windows.go
@@ -1,0 +1,372 @@
+//go:build windows && !server
+
+package application
+
+import (
+	_ "embed"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/wailsapp/wails/v3/internal/assetserver/webview"
+)
+
+//go:embed request_keepalive_windows.js
+var requestKeepaliveScript string
+
+const keepaliveBinding = "__wailsAssetKeepalive"
+const keepaliveFragment = "&__wails_keepalive="
+
+type requestCancellationDevTools interface {
+	CallDevTools(string, string, func(string, error)) error
+	CallDevToolsForSession(string, string, string, func(string, error)) error
+	OnDevTools(string, func(string, string, error)) (func() error, error)
+}
+
+// windowsRequestCancellation owns the CDP sessions for one WebView.
+// Fetch provides a network ID before WebResourceRequested; Network reports aborts
+// while the HTTP handler is still running. Requests are matched by identity, never URL.
+// Except for tracker operations, all access is confined to the UI thread.
+type windowsRequestCancellation struct {
+	chromium        requestCancellationDevTools
+	tracker         *webview.RequestTracker
+	unsubscribe     []func() error
+	closed          bool
+	owners          map[string]string
+	scriptID        string
+	keepaliveOwners map[string]keepaliveOwner
+}
+
+func (w *windowsWebviewWindow) startRequestCancellation(ready func()) {
+	if globalApplication.assets == nil {
+		ready()
+		return
+	}
+	c := &windowsRequestCancellation{chromium: w.chromium, tracker: webview.NewRequestTracker(globalApplication.Context())}
+	w.requestCancellation = c
+	done := func(err error) {
+		if c.closed {
+			return
+		}
+		if err != nil {
+			globalApplication.error("Windows request cancellation unavailable: %v", err)
+			c.close()
+		}
+		if !w.parent.isDestroyed() {
+			ready()
+		}
+	}
+	if err := c.subscribe(); err != nil {
+		done(err)
+		return
+	}
+	c.enableSession("", done)
+}
+
+type keepaliveOwner struct {
+	session string
+	context int64
+}
+
+type cancellationCommand struct {
+	method string
+	params any
+}
+
+func (c *windowsRequestCancellation) enableSession(session string, done func(error)) {
+	commands := []cancellationCommand{
+		{"Network.enable", struct{}{}},
+		{"Runtime.enable", struct{}{}},
+		{"Runtime.addBinding", map[string]string{"name": keepaliveBinding}},
+	}
+	if session == "" {
+		commands = append(commands,
+			cancellationCommand{"Page.enable", struct{}{}},
+			cancellationCommand{"Page.addScriptToEvaluateOnNewDocument", map[string]string{"source": requestKeepaliveScript}},
+			cancellationCommand{"Fetch.enable", map[string]any{"patterns": []map[string]string{
+				{"urlPattern": "http://wails.localhost/*", "requestStage": "Request"},
+				{"urlPattern": "http://wails.localhost:*/*", "requestStage": "Request"},
+			}}},
+		)
+	} else {
+		// WebView2 intercepts worker requests on the root Fetch session. Only the
+		// worker's Network domain must be enabled to observe its terminal events.
+		commands = append(commands, cancellationCommand{"Runtime.evaluate", map[string]string{"expression": requestKeepaliveScript}})
+	}
+	commands = append(commands, cancellationCommand{"Target.setAutoAttach", map[string]any{"autoAttach": true, "waitForDebuggerOnStart": true, "flatten": true}})
+	c.configure(session, commands, done)
+}
+
+func (c *windowsRequestCancellation) configure(session string, commands []cancellationCommand, done func(error)) {
+	if len(commands) == 0 {
+		done(nil)
+		return
+	}
+	c.call(session, commands[0].method, commands[0].params, func(err error) {
+		if err != nil {
+			done(err)
+			return
+		}
+		c.configure(session, commands[1:], done)
+	})
+}
+
+func (c *windowsRequestCancellation) subscribe() error {
+	for _, event := range []string{"Network.requestWillBeSent", "Runtime.bindingCalled", "Runtime.executionContextDestroyed", "Runtime.executionContextsCleared", "Fetch.requestPaused", "Network.loadingFailed", "Network.loadingFinished", "Target.attachedToTarget", "Target.detachedFromTarget"} {
+		unsubscribe, err := c.chromium.OnDevTools(event, func(session, data string, err error) {
+			if c.closed {
+				return
+			}
+			if err == nil {
+				err = c.event(session, event, data)
+			}
+			if err != nil {
+				globalApplication.error("Windows request cancellation (%s): %v", event, err)
+			}
+		})
+		if err != nil {
+			return err
+		}
+		c.unsubscribe = append(c.unsubscribe, unsubscribe)
+	}
+	return nil
+}
+
+func (c *windowsRequestCancellation) call(session, method string, params any, done func(error)) {
+	if c.closed {
+		return
+	}
+	data, err := json.Marshal(params)
+	if err != nil {
+		done(err)
+		return
+	}
+	err = c.chromium.CallDevToolsForSession(session, method, string(data), func(result string, err error) {
+		if method == "Page.addScriptToEvaluateOnNewDocument" && err == nil {
+			var script struct{ Identifier string }
+			err = json.Unmarshal([]byte(result), &script)
+			c.scriptID = script.Identifier
+		}
+		if !c.closed {
+			done(err)
+		}
+	})
+	if err != nil {
+		done(err)
+	}
+}
+
+type pausedWebRequest struct {
+	RequestID string `json:"requestId"`
+	NetworkID string `json:"networkId"`
+	Request   struct {
+		Headers     map[string]string `json:"headers"`
+		URLFragment string            `json:"urlFragment"`
+	} `json:"request"`
+}
+
+type requestHeader struct {
+	Name  string `json:"name"`
+	Value string `json:"value"`
+}
+
+func (c *windowsRequestCancellation) event(session, event, data string) error {
+	switch event {
+	case "Runtime.bindingCalled":
+		return c.keepaliveEvent(session, data)
+	case "Target.attachedToTarget", "Target.detachedFromTarget":
+		return c.targetEvent(event, data)
+	case "Runtime.executionContextDestroyed":
+		var context struct {
+			ExecutionContextID int64 `json:"executionContextId"`
+		}
+		if err := json.Unmarshal([]byte(data), &context); err != nil {
+			return err
+		}
+		c.retireKeepalives(session, context.ExecutionContextID)
+		return nil
+	case "Runtime.executionContextsCleared":
+		c.retireKeepalives(session, 0)
+		return nil
+	case "Fetch.requestPaused":
+		return c.resumeRequest(session, data)
+	}
+	var request struct {
+		RequestID string `json:"requestId"`
+	}
+	if err := json.Unmarshal([]byte(data), &request); err != nil {
+		return err
+	}
+	if event == "Network.requestWillBeSent" {
+		if session != "" {
+			if c.owners == nil {
+				c.owners = make(map[string]string)
+			}
+			c.owners[request.RequestID] = session
+		}
+	} else {
+		// WebView2's root Fetch and child Network sessions share network IDs.
+		// Keepalive contexts have a separate identity and ignore consumer teardown.
+		c.tracker.Cancel(request.RequestID)
+		delete(c.owners, request.RequestID)
+	}
+	return nil
+}
+
+func (c *windowsRequestCancellation) requestToken(paused pausedWebRequest) string {
+	pos := strings.LastIndex(paused.Request.URLFragment, keepaliveFragment)
+	if pos < 0 {
+		return c.tracker.Start(paused.NetworkID)
+	}
+	id := paused.Request.URLFragment[pos+len(keepaliveFragment):]
+	token := c.tracker.Token("keepalive:" + id)
+	if token == "" {
+		return "cancelled-keepalive"
+	}
+	return token
+}
+
+func (c *windowsRequestCancellation) resumeRequest(session, data string) error {
+	var paused pausedWebRequest
+	if err := json.Unmarshal([]byte(data), &paused); err != nil {
+		return err
+	}
+	if paused.RequestID == "" {
+		return fmt.Errorf("missing Fetch request ID")
+	}
+	token := c.requestToken(paused)
+	headers := make([]requestHeader, 0, len(paused.Request.Headers)+1)
+	for name, value := range paused.Request.Headers {
+		if !strings.EqualFold(name, webview.RequestIDHeader) {
+			headers = append(headers, requestHeader{name, value})
+		}
+	}
+	if token != "" {
+		headers = append(headers, requestHeader{webview.RequestIDHeader, token})
+	}
+	c.call(session, "Fetch.continueRequest", map[string]any{"requestId": paused.RequestID, "headers": headers}, func(err error) {
+		if err != nil {
+			c.tracker.Cancel(paused.NetworkID)
+			globalApplication.error("Resuming Windows asset request: %v", err)
+		}
+	})
+	return nil
+}
+
+func (c *windowsRequestCancellation) close() {
+	if c == nil || c.closed {
+		return
+	}
+	c.closed = true
+	c.tracker.Close()
+	if c.scriptID != "" {
+		params, _ := json.Marshal(map[string]string{"identifier": c.scriptID})
+		_ = c.chromium.CallDevTools("Page.removeScriptToEvaluateOnNewDocument", string(params), func(string, error) {})
+	}
+	_ = c.chromium.CallDevTools("Runtime.removeBinding", `{"name":"__wailsAssetKeepalive"}`, func(string, error) {})
+	// Detaching also releases workers paused during setup.
+	_ = c.chromium.CallDevTools("Target.setAutoAttach", `{"autoAttach":false,"waitForDebuggerOnStart":false,"flatten":true}`, func(string, error) {})
+	// Disabling Fetch releases paused requests even when setup failed halfway.
+	if err := c.chromium.CallDevTools("Fetch.disable", "{}", func(_ string, err error) {
+		if err != nil {
+			globalApplication.error("Disabling Windows request interception: %v", err)
+		}
+	}); err != nil {
+		globalApplication.error("Disabling Windows request interception: %v", err)
+	}
+	for _, unsubscribe := range c.unsubscribe {
+		if err := unsubscribe(); err != nil {
+			globalApplication.error("Removing Windows request cancellation callback: %v", err)
+		}
+	}
+	c.unsubscribe = nil
+	clear(c.owners)
+	clear(c.keepaliveOwners)
+}
+
+func (c *windowsRequestCancellation) targetEvent(event, data string) error {
+	var target struct {
+		SessionID string `json:"sessionId"`
+	}
+	if err := json.Unmarshal([]byte(data), &target); err != nil {
+		return err
+	}
+	if target.SessionID == "" {
+		return fmt.Errorf("missing target session ID")
+	}
+	if event == "Target.detachedFromTarget" {
+		c.retireKeepalives(target.SessionID, 0)
+		for id, session := range c.owners {
+			if session == target.SessionID {
+				c.tracker.Cancel(id)
+				delete(c.owners, id)
+			}
+		}
+		return nil
+	}
+	c.enableSession(target.SessionID, func(err error) {
+		if err != nil {
+			globalApplication.error("Worker request cancellation setup: %v", err)
+		}
+		// Always release the startup pause, even if a runtime does not support an API.
+		c.call(target.SessionID, "Runtime.runIfWaitingForDebugger", struct{}{}, func(err error) {
+			if err != nil {
+				globalApplication.error("Resuming attached WebView target: %v", err)
+				params, _ := json.Marshal(map[string]string{"sessionId": target.SessionID})
+				// The root session can detach and release a paused worker even when
+				// the runtime cannot address that child session directly.
+				_ = c.chromium.CallDevTools("Target.detachFromTarget", string(params), func(string, error) {})
+			}
+		})
+	})
+	return nil
+}
+
+func (c *windowsRequestCancellation) keepaliveEvent(session, data string) error {
+	var event struct {
+		Name, Payload      string
+		ExecutionContextID int64 `json:"executionContextId"`
+	}
+	if err := json.Unmarshal([]byte(data), &event); err != nil {
+		return err
+	}
+	if event.Name != keepaliveBinding {
+		return nil
+	}
+	var state struct{ ID, State string }
+	if err := json.Unmarshal([]byte(event.Payload), &state); err != nil {
+		return err
+	}
+	if len(state.ID) != 36 {
+		return fmt.Errorf("invalid keepalive request identity")
+	}
+	id := "keepalive:" + state.ID
+	switch state.State {
+	case "start":
+		if c.tracker.StartKeepalive(id) != "" {
+			if c.keepaliveOwners == nil {
+				c.keepaliveOwners = make(map[string]keepaliveOwner)
+			}
+			c.keepaliveOwners[id] = keepaliveOwner{session, event.ExecutionContextID}
+		}
+	case "failed":
+		c.tracker.FailKeepalive(id)
+		delete(c.keepaliveOwners, id)
+	case "abort", "end":
+		c.tracker.Cancel(id)
+		delete(c.keepaliveOwners, id)
+	default:
+		return fmt.Errorf("invalid keepalive request state")
+	}
+	return nil
+}
+
+// Losing a JavaScript context ends delivery, not an active keepalive handler.
+func (c *windowsRequestCancellation) retireKeepalives(session string, context int64) {
+	for id, owner := range c.keepaliveOwners {
+		if owner.session == session && (context == 0 || owner.context == context) {
+			c.tracker.FailKeepalive(id)
+			delete(c.keepaliveOwners, id)
+		}
+	}
+}

--- a/v3/pkg/application/request_cancellation_windows_test.go
+++ b/v3/pkg/application/request_cancellation_windows_test.go
@@ -1,0 +1,211 @@
+//go:build windows && !server
+
+package application
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"log/slog"
+	"net/http"
+	"testing"
+
+	"github.com/wailsapp/wails/v3/internal/assetserver/webview"
+)
+
+type cancellationCall struct{ session, method, params string }
+type cancellationTestCDP struct {
+	calls   []cancellationCall
+	events  map[string]func(string, string, error)
+	fail    string
+	removed int
+}
+
+func (f *cancellationTestCDP) CallDevTools(method, params string, done func(string, error)) error {
+	return f.CallDevToolsForSession("", method, params, done)
+}
+func (f *cancellationTestCDP) CallDevToolsForSession(session, method, params string, done func(string, error)) error {
+	f.calls = append(f.calls, cancellationCall{session, method, params})
+	if method == f.fail {
+		done("", errors.New("unsupported"))
+	} else {
+		done("{}", nil)
+	}
+	return nil
+}
+func (f *cancellationTestCDP) OnDevTools(event string, receive func(string, string, error)) (func() error, error) {
+	f.events[event] = receive
+	return func() error { f.removed++; return nil }, nil
+}
+func cancellationFixture(t *testing.T) (*windowsRequestCancellation, *cancellationTestCDP) {
+	t.Helper()
+	previous := globalApplication
+	globalApplication = &App{Logger: slog.New(slog.NewTextHandler(io.Discard, nil))}
+	fake := &cancellationTestCDP{events: make(map[string]func(string, string, error))}
+	c := &windowsRequestCancellation{chromium: fake, tracker: webview.NewRequestTracker(context.Background())}
+	t.Cleanup(func() { c.close(); globalApplication = previous })
+	if err := c.subscribe(); err != nil {
+		t.Fatal(err)
+	}
+	return c, fake
+}
+func emitCancellation(t *testing.T, c *windowsRequestCancellation, session, event string, payload any) {
+	t.Helper()
+	data, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := c.event(session, event, string(data)); err != nil {
+		t.Fatal(err)
+	}
+}
+func keepaliveState(t *testing.T, c *windowsRequestCancellation, id, state string) {
+	t.Helper()
+	payload, _ := json.Marshal(map[string]string{"ID": id, "State": state})
+	emitCancellation(t, c, "", "Runtime.bindingCalled", map[string]string{"name": keepaliveBinding, "payload": string(payload)})
+}
+
+type cancellationTestRequest struct {
+	webview.Request
+	header http.Header
+}
+
+func (r *cancellationTestRequest) Header() (http.Header, error) { return r.header, nil }
+func (r *cancellationTestRequest) Close() error                 { return nil }
+func pauseCancellation(t *testing.T, c *windowsRequestCancellation, f *cancellationTestCDP, id string, extra map[string]string) webview.Request {
+	t.Helper()
+	headers := map[string]string{"Accept": "application/json"}
+	for k, v := range extra {
+		if k != "fragment" {
+			headers[k] = v
+		}
+	}
+	emitCancellation(t, c, "", "Fetch.requestPaused", map[string]any{"requestId": "pause-" + id, "networkId": id, "request": map[string]any{"headers": headers, "urlFragment": extra["fragment"]}})
+	var continued struct{ Headers []requestHeader }
+	if err := json.Unmarshal([]byte(f.calls[len(f.calls)-1].params), &continued); err != nil {
+		t.Fatal(err)
+	}
+	header := make(http.Header)
+	for _, h := range continued.Headers {
+		header.Add(h.Name, h.Value)
+	}
+	if header.Get("fragment") != "" {
+		t.Fatal("fragment leaked into headers")
+	}
+	r := c.tracker.Wrap(&cancellationTestRequest{header: header})
+	t.Cleanup(func() { r.Close() })
+	return r
+}
+func isCancelled(r webview.Request) bool {
+	ctx, _ := webview.RequestContext(r)
+	return ctx.Err() == context.Canceled
+}
+
+func TestWindowsCancellationWorkerUsesRootInterceptionIdentity(t *testing.T) {
+	c, f := cancellationFixture(t)
+	emitCancellation(t, c, "worker", "Network.requestWillBeSent", map[string]string{"requestId": "42.1"})
+	worker := pauseCancellation(t, c, f, "42.1", nil)
+	control := pauseCancellation(t, c, f, "42.2", nil)
+	emitCancellation(t, c, "worker", "Network.loadingFailed", map[string]string{"requestId": "42.1"})
+	if !isCancelled(worker) || isCancelled(control) {
+		t.Fatal("worker abort was lost or cancelled another request")
+	}
+}
+
+func TestWindowsCancellationWorkerDetach(t *testing.T) {
+	c, f := cancellationFixture(t)
+	emitCancellation(t, c, "worker", "Network.requestWillBeSent", map[string]string{"requestId": "42.1"})
+	worker := pauseCancellation(t, c, f, "42.1", nil)
+	control := pauseCancellation(t, c, f, "42.2", nil)
+	emitCancellation(t, c, "", "Target.detachedFromTarget", map[string]string{"sessionId": "worker"})
+	if !isCancelled(worker) || isCancelled(control) {
+		t.Fatal("detachment cancelled the wrong requests")
+	}
+}
+
+func TestWindowsCancellationKeepaliveSurvivesNavigation(t *testing.T) {
+	c, f := cancellationFixture(t)
+	id := "11111111-1111-1111-1111-111111111111"
+	keepaliveState(t, c, id, "start")
+	redirect := pauseCancellation(t, c, f, "42.1", map[string]string{"fragment": "#" + keepaliveFragment + id})
+	redirect.Close()
+	handler := pauseCancellation(t, c, f, "42.1", map[string]string{"fragment": "#" + keepaliveFragment + id})
+	emitCancellation(t, c, "", "Network.loadingFailed", map[string]string{"requestId": "42.1"})
+	keepaliveState(t, c, id, "failed")
+	if isCancelled(handler) {
+		t.Fatal("navigation cancelled keepalive handler")
+	}
+	keepaliveState(t, c, id, "abort")
+	if !isCancelled(handler) {
+		t.Fatal("explicit abort did not cancel keepalive")
+	}
+}
+
+func TestWindowsCancellationKeepaliveAbortBeforeInterception(t *testing.T) {
+	c, f := cancellationFixture(t)
+	id := "11111111-1111-1111-1111-111111111111"
+	keepaliveState(t, c, id, "start")
+	keepaliveState(t, c, id, "abort")
+	r := pauseCancellation(t, c, f, "42.1", map[string]string{"fragment": "#" + keepaliveFragment + id})
+	if !isCancelled(r) {
+		t.Fatal("late interception resurrected keepalive")
+	}
+}
+
+func TestWindowsCancellationSetupAndFailedWorkerResume(t *testing.T) {
+	c, f := cancellationFixture(t)
+	var setupErr error
+	c.enableSession("", func(err error) { setupErr = err })
+	if setupErr != nil {
+		t.Fatal(setupErr)
+	}
+	foundFetch := false
+	for _, call := range f.calls {
+		if call.method == "Fetch.enable" {
+			foundFetch = true
+		}
+	}
+	if !foundFetch {
+		t.Fatal("root interception missing")
+	}
+	f.calls = nil
+	f.fail = "Network.enable"
+	emitCancellation(t, c, "", "Target.attachedToTarget", map[string]string{"sessionId": "worker"})
+	last := f.calls[len(f.calls)-1]
+	if last.session != "worker" || last.method != "Runtime.runIfWaitingForDebugger" {
+		t.Fatal("failed setup left worker paused")
+	}
+}
+
+func TestWindowsCancellationCloseReleasesRequestsAndSubscriptions(t *testing.T) {
+	c, f := cancellationFixture(t)
+	r := pauseCancellation(t, c, f, "42.1", nil)
+	c.close()
+	c.close()
+	if !isCancelled(r) || f.removed != len(f.events) {
+		t.Fatal("close leaked request or event callback")
+	}
+	calls := len(f.calls)
+	for _, receive := range f.events {
+		receive("", "invalid late event", nil)
+	}
+	if len(f.calls) != calls {
+		t.Fatal("late event accessed closed WebView")
+	}
+}
+
+func TestWindowsCancellationKeepaliveContextLossReleasesAfterHandler(t *testing.T) {
+	c, f := cancellationFixture(t)
+	id := "11111111-1111-1111-1111-111111111111"
+	keepaliveState(t, c, id, "start")
+	handler := pauseCancellation(t, c, f, "42.1", map[string]string{"fragment": "#" + keepaliveFragment + id})
+	emitCancellation(t, c, "", "Runtime.executionContextsCleared", struct{}{})
+	if isCancelled(handler) {
+		t.Fatal("context loss cancelled a running keepalive")
+	}
+	handler.Close()
+	if c.tracker.Token("keepalive:"+id) != "" || len(c.keepaliveOwners) != 0 {
+		t.Fatal("context loss leaked keepalive registration")
+	}
+}

--- a/v3/pkg/application/request_keepalive_windows.js
+++ b/v3/pkg/application/request_keepalive_windows.js
@@ -1,0 +1,51 @@
+// DevTools reports page teardown as ERR_ABORTED even for keepalive fetches.
+// Preserve those requests until completion or explicit AbortSignal cancellation.
+// This script runs before page/worker scripts and only marks local keepalive calls.
+(() => {
+    const notify = globalThis.__wailsAssetKeepalive;
+    const nativeFetch = globalThis.fetch;
+    if (typeof notify !== 'function' || typeof nativeFetch !== 'function') return;
+    globalThis.fetch = function(input, init) {
+        // Leave the usual fetch path untouched, including external requests.
+        if (!(init && init.keepalive) && !(input instanceof Request && input.keepalive)) {
+            return Reflect.apply(nativeFetch, this, arguments);
+        }
+        let request;
+        try { request = new Request(input, init); }
+        catch (error) { return Promise.reject(error); }
+        const url = new URL(request.url);
+        if (!request.keepalive || request.signal.aborted || url.protocol !== 'http:' || url.hostname !== 'wails.localhost') {
+            return nativeFetch.call(this, request);
+        }
+        const id = crypto.randomUUID();
+        const send = state => notify(JSON.stringify({ ID: id, State: state }));
+        const abort = () => send('abort');
+        url.hash += '&__wails_keepalive=' + id;
+        send('start');
+        request.signal.addEventListener('abort', abort, { once: true });
+        const dispatch = async () => {
+            const options = {
+                method: request.method, headers: request.headers, mode: request.mode,
+                credentials: request.credentials, cache: request.cache, redirect: request.redirect,
+                referrer: request.referrer, referrerPolicy: request.referrerPolicy,
+                integrity: request.integrity, keepalive: true, signal: request.signal,
+            };
+            // A Request body is exposed as a stream, which keepalive forbids as
+            // input. Materialise it before rebuilding the URL; native fetch
+            // still enforces its keepalive body-size limit.
+            if (request.body !== null) options.body = await request.arrayBuffer();
+            return nativeFetch.call(this, url, options);
+        };
+        return dispatch().then(response => {
+            request.signal.removeEventListener('abort', abort);
+            send('end');
+            return response;
+        }, error => {
+            request.signal.removeEventListener('abort', abort);
+            // WebView2 rejects the promise on navigation even though keepalive
+            // permits an already dispatched Go handler to finish its work.
+            send(request.signal.aborted ? 'abort' : 'failed');
+            throw error;
+        });
+    };
+})();

--- a/v3/pkg/application/request_keepalive_windows_test.mjs
+++ b/v3/pkg/application/request_keepalive_windows_test.mjs
@@ -1,0 +1,85 @@
+import assert from 'node:assert/strict';
+import { webcrypto } from 'node:crypto';
+import { readFileSync } from 'node:fs';
+import vm from 'node:vm';
+import test from 'node:test';
+
+const source = readFileSync(new URL('./request_keepalive_windows.js', import.meta.url), 'utf8');
+function fixture(fetch) {
+    const events = [];
+    const context = { Request, URL, crypto: webcrypto, fetch,
+        __wailsAssetKeepalive: payload => events.push(JSON.parse(payload)) };
+    vm.runInNewContext(source, context);
+    return { fetch: context.fetch, events };
+}
+
+test('ordinary fetch forwards the original arguments', async () => {
+    const options = { signal: new AbortController().signal };
+    const f = fixture((input, init) => {
+        assert.equal(input, 'http://wails.localhost/data');
+        assert.equal(init, options);
+        return Promise.resolve('response');
+    });
+    assert.equal(await f.fetch('http://wails.localhost/data', options), 'response');
+    assert.deepEqual(f.events, []);
+});
+
+test('local keepalive preserves POST body, headers and request options', async () => {
+    const original = new Request('http://wails.localhost/data#original', {
+        method: 'POST', body: 'body', headers: { 'X-Test': 'preserved' },
+        credentials: 'include', cache: 'no-store', redirect: 'error', keepalive: true,
+    });
+    const f = fixture(async (input, init) => {
+        const request = new Request(input, init);
+        assert.equal(await request.text(), 'body');
+        assert.equal(request.headers.get('X-Test'), 'preserved');
+        assert.equal(request.headers.has('X-Wails-Keepalive-Id'), false);
+        assert.equal(request.credentials, 'include');
+        assert.equal(request.cache, 'no-store');
+        assert.equal(request.redirect, 'error');
+        assert.equal(request.keepalive, true);
+        assert.match(request.url, /#original&__wails_keepalive=[\da-f-]{36}$/);
+        return 'response';
+    });
+    assert.equal(await f.fetch(original), 'response');
+    assert.equal(original.url, 'http://wails.localhost/data#original');
+    assert.deepEqual(f.events.map(e => e.State), ['start', 'end']);
+    assert.equal(f.events[0].ID, f.events[1].ID);
+});
+
+test('external keepalive requests gain no marker or binding events', async () => {
+    const f = fixture(request => {
+        assert.equal(request.url, 'https://example.org/data');
+        return Promise.resolve('response');
+    });
+    await f.fetch('https://example.org/data', { keepalive: true });
+    assert.deepEqual(f.events, []);
+});
+
+test('explicit abort retains AbortSignal behaviour', async () => {
+    const controller = new AbortController();
+    const f = fixture((input, init) => new Promise((resolve, reject) => {
+        init.signal.addEventListener('abort', () => reject(init.signal.reason));
+    }));
+    const promise = f.fetch('http://wails.localhost/data', { keepalive: true, signal: controller.signal });
+    controller.abort('cancelled');
+    await assert.rejects(promise, reason => reason === 'cancelled');
+    assert.equal(f.events[0].State, 'start');
+    assert.ok(f.events.slice(1).every(e => e.State === 'abort'));
+});
+
+test('failed delivery is distinct from explicit abort', async () => {
+    const f = fixture(() => Promise.reject(new TypeError('Failed to fetch')));
+    await assert.rejects(f.fetch('http://wails.localhost/data', { keepalive: true }), /Failed to fetch/);
+    assert.deepEqual(f.events.map(e => e.State), ['start', 'failed']);
+});
+
+test('Request keepalive can be overridden by init', async () => {
+    const f = fixture(request => {
+        assert.equal(request.keepalive, false);
+        assert.equal(request.url, 'http://wails.localhost/data');
+        return Promise.resolve();
+    });
+    await f.fetch(new Request('http://wails.localhost/data', { keepalive: true }), { keepalive: false });
+    assert.deepEqual(f.events, []);
+});

--- a/v3/pkg/application/testdata/request-cancellation/README.md
+++ b/v3/pkg/application/testdata/request-cancellation/README.md
@@ -1,0 +1,29 @@
+# Windows asset request cancellation regression probe
+
+This probe exercises the Wails v3 application path for issue [#5963](https://github.com/wailsapp/wails/issues/5963), including the shared `webViewAssetRequest` wrapper. It launches hidden WebView2 windows and a loopback HTTP control server, runs for 15 seconds, writes `request-cancellation-results.json` and `native.log`, and exits nonzero on a failed assertion.
+
+Build from `v3`:
+
+```sh
+go build -o cancellation-probe.exe ./pkg/application/testdata/request-cancellation
+```
+
+Run the executable in an interactive Windows desktop session. An SSH service session cannot initialise WebView2; use an interactive scheduled task or run from the desktop. No remote debugging port or external CDP client is required.
+
+The probe checks fetch/XHR aborts, POST bodies and headers, redirects, identical URLs, iframe requests, worker aborts and termination, navigation, window closure, and 40 concurrent aborts. Controls verify normal completion, local and HTTP keepalive navigation, keepalive redirects and uploads, external redirects without added CORS preflights, and unchanged response URLs.
+
+Additional automated checks:
+
+```sh
+go test ./pkg/application -run 'TestWindowsCancellation|TestAssetRequest'
+go test ./internal/assetserver/...
+node --test pkg/application/request_keepalive_windows_test.mjs
+```
+
+## Implementation notes
+
+WebView2 does not expose an early cancellation event on `WebResourceRequested`. The Windows implementation uses its in-process DevTools API: root `Fetch.requestPaused` events associate an opaque marker with a network request ID, and `Network` terminal events cancel that request's Go context. Worker network events arrive on child sessions while their interceptions arrive on the root session. Window/application teardown also cancels pending contexts.
+
+DevTools reports `ERR_ABORTED` when a page disappears even for keepalive fetches. A script installed before page and worker code gives local keepalive requests an independent identity and reports explicit aborts separately. This identity travels in the URL fragment, which HTTP does not send to handlers or external redirect targets; adding a header here would cause unwanted CORS preflights. Native request markers are stripped before application handlers run. Failed JavaScript response delivery lets an already dispatched keepalive handler finish, then releases its context.
+
+The shared application wrapper forwards native contexts on every platform. Apple platforms already provide native cancellation contexts; their forwarding is covered by the application regression tests. Linux's native abort wiring is outside this Windows change.

--- a/v3/pkg/application/testdata/request-cancellation/main.go
+++ b/v3/pkg/application/testdata/request-cancellation/main.go
@@ -1,0 +1,183 @@
+//go:build windows
+
+// Native regression probe: build and run in an interactive Windows session.
+// It requires no debugging port or external CDP client.
+package main
+
+import (
+	_ "embed"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"log/slog"
+	"net"
+	"net/http"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/wailsapp/wails/v3/pkg/application"
+)
+
+//go:embed page.html
+var page string
+
+type result struct {
+	Name, Outcome string
+	Milliseconds  int64
+}
+type probe struct {
+	mu          sync.Mutex
+	inflight    sync.WaitGroup
+	results     map[string]result
+	closing     *application.WebviewWindow
+	externalURL string
+}
+
+func (p *probe) record(name, outcome string, elapsed int64) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.results[name] = result{name, outcome, elapsed}
+}
+func privateMarker(r *http.Request) bool {
+	return r.Header.Get("X-Wails-Request-Id") != "" || strings.Contains(r.URL.String(), "__wails_keepalive")
+}
+func (p *probe) slow(w http.ResponseWriter, r *http.Request) {
+	p.inflight.Add(1)
+	defer p.inflight.Done()
+	name := r.URL.Query().Get("name")
+	if r.Header.Get("X-Case") != "" {
+		name = r.Header.Get("X-Case")
+	}
+	start := time.Now()
+	outcome := "complete"
+	if privateMarker(r) {
+		outcome = "marker leaked"
+	}
+	if name == "post" || name == "keepalive-post" {
+		body, _ := io.ReadAll(r.Body)
+		if string(body) != "upload body" || r.Header.Get("X-Probe") != "preserved" {
+			outcome = "body/header changed"
+		}
+	}
+	if name == "close" {
+		go func() { time.Sleep(700 * time.Millisecond); p.closing.Close() }()
+	}
+	duration := 4 * time.Second
+	if name == "app-shutdown" {
+		duration = 30 * time.Second
+	}
+	select {
+	case <-r.Context().Done():
+		if outcome == "complete" {
+			outcome = "cancelled"
+		}
+	case <-time.After(duration):
+	}
+	p.record(name, outcome, time.Since(start).Milliseconds())
+	fmt.Fprint(w, "done")
+}
+func (p *probe) external(w http.ResponseWriter, r *http.Request) {
+	outcome := "complete"
+	if privateMarker(r) {
+		outcome = "marker leaked"
+	}
+	if r.Method == "OPTIONS" {
+		outcome = "unexpected preflight"
+	}
+	p.record(r.URL.Query().Get("name"), outcome, 0)
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+	fmt.Fprint(w, "external response")
+}
+func (p *probe) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	switch r.URL.Path {
+	case "/slow":
+		p.slow(w, r)
+	case "/external":
+		p.external(w, r)
+	case "/redirect":
+		name := r.URL.Query().Get("name")
+		if name == "" {
+			name = "redirect"
+		}
+		http.Redirect(w, r, "/slow?name="+name, http.StatusTemporaryRedirect)
+	case "/external-redirect":
+		http.Redirect(w, r, p.externalURL+"/external?name="+r.URL.Query().Get("name"), http.StatusTemporaryRedirect)
+	case "/client":
+		p.record(r.URL.Query().Get("name"), r.URL.Query().Get("outcome"), 0)
+	case "/worker.js":
+		w.Header().Set("Content-Type", "text/javascript")
+		fmt.Fprint(w, `const name=new URL(location).searchParams.get('name')||'worker';const c=new AbortController();fetch('/slow?name='+name,{signal:c.signal,keepalive:name.includes('keepalive')}).catch(()=>{});if(!name.endsWith('terminated'))setTimeout(()=>c.abort(),700);`)
+	case "/done":
+		fmt.Fprint(w, "navigated")
+	default:
+		w.Header().Set("Content-Type", "text/html")
+		fmt.Fprint(w, page)
+	}
+}
+func (p *probe) validate() error {
+	expected := map[string][]string{
+		"cancelled": {"fetch", "xhr", "post", "redirect", "same-abort", "frame", "navigation", "close", "worker", "worker-keepalive", "keepalive-abort", "keepalive-redirect-abort", "worker-terminated", "keepalive-post", "app-shutdown"},
+		"complete":  {"same-control", "normal", "keepalive", "http-keepalive", "keepalive-redirect", "external", "external-client", "external-keepalive", "external-keepalive-client", "keepalive-url", "worker-keepalive-terminated"},
+	}
+	for i := range 20 {
+		for _, prefix := range []string{"stress-", "stress-keepalive-"} {
+			expected["cancelled"] = append(expected["cancelled"], fmt.Sprintf("%s%d", prefix, i))
+		}
+	}
+	for outcome, names := range expected {
+		for _, name := range names {
+			if p.results[name].Outcome != outcome {
+				return fmt.Errorf("%s: got %q, want %s", name, p.results[name].Outcome, outcome)
+			}
+		}
+	}
+	return nil
+}
+func (p *probe) windows(app *application.App) {
+	app.Window.NewWithOptions(application.WebviewWindowOptions{Title: "HTTP keepalive", URL: p.externalURL + "/?scenario=http-keepalive", Hidden: true})
+	for _, scenario := range []string{"main", "navigation", "keepalive", "close"} {
+		window := app.Window.NewWithOptions(application.WebviewWindowOptions{Title: "Cancellation probe: " + scenario, URL: "/?scenario=" + scenario, Width: 400, Height: 200, Hidden: true})
+		if scenario == "close" {
+			p.closing = window
+		}
+	}
+}
+func run() error {
+	logs, err := os.Create("native.log")
+	if err != nil {
+		return err
+	}
+	defer logs.Close()
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return err
+	}
+	defer listener.Close()
+	p := &probe{results: make(map[string]result), externalURL: "http://" + listener.Addr().String()}
+	go http.Serve(listener, p)
+	app := application.New(application.Options{Name: "RequestCancellationRegression", Logger: slog.New(slog.NewTextHandler(logs, nil)), Windows: application.WindowsOptions{DisableQuitOnLastWindowClosed: true}, Assets: application.AssetOptions{Handler: p}})
+	p.windows(app)
+	go func() { time.Sleep(15 * time.Second); app.Quit() }()
+	if err := app.Run(); err != nil {
+		return err
+	}
+	p.inflight.Wait()
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	data, err := json.MarshalIndent(p.results, "", "  ")
+	if err != nil {
+		return err
+	}
+	if err := os.WriteFile("request-cancellation-results.json", data, 0600); err != nil {
+		return err
+	}
+	return p.validate()
+}
+func main() {
+	if err := run(); err != nil {
+		log.Fatal(err)
+	}
+}

--- a/v3/pkg/application/testdata/request-cancellation/page.html
+++ b/v3/pkg/application/testdata/request-cancellation/page.html
@@ -1,0 +1,37 @@
+<!doctype html><script>
+const scenario=new URLSearchParams(location.search).get('scenario');
+const slow=(name,options={})=>fetch('/slow?name='+name,options);
+const abort=(name,url='/slow?name='+name,options={})=>{const c=new AbortController();fetch(url,{...options,signal:c.signal}).catch(()=>{});setTimeout(()=>c.abort(),700)};
+setTimeout(()=>{
+ if(scenario==='main'){
+  abort('fetch');
+  const x=new XMLHttpRequest();x.open('GET','/slow?name=xhr');x.send();setTimeout(()=>x.abort(),700);
+  abort('redirect','/redirect');
+  abort('post',undefined,{method:'POST',headers:{'X-Probe':'preserved'},body:'upload body'});
+  abort('same-abort','/slow?name=same',{headers:{'X-Case':'same-abort'}});
+  slow('same',{headers:{'X-Case':'same-control'}});
+  slow('normal');
+  slow('app-shutdown').catch(()=>{});
+  new Worker('/worker.js');
+  const keptWorker=new Worker('/worker.js?name=worker-keepalive-terminated');setTimeout(()=>keptWorker.terminate(),1500);
+  const terminated=new Worker('/worker.js?name=worker-terminated');setTimeout(()=>terminated.terminate(),1500);
+  for(let i=0;i<20;i++){
+   abort('stress-'+i);
+   abort('stress-keepalive-'+i,undefined,{keepalive:true});
+  }
+  fetch('/external-redirect?name=external-keepalive',{keepalive:true}).then(r=>r.text()).then(()=>fetch('/client?name=external-keepalive-client&outcome=complete'),()=>fetch('/client?name=external-keepalive-client&outcome=failed'));
+
+  new Worker('/worker.js?name=worker-keepalive');
+  abort('keepalive-abort',undefined,{keepalive:true});
+  abort('keepalive-post',undefined,{keepalive:true,method:'POST',headers:{'X-Probe':'preserved'},body:'upload body'});
+  abort('keepalive-redirect-abort','/redirect?name=keepalive-redirect-abort',{keepalive:true});
+  fetch(new Request('/redirect?name=keepalive-redirect',{keepalive:true})).then(r=>fetch('/client?name=keepalive-url&outcome='+(r.url.includes('__wails_keepalive')?'marker-leaked':'complete'))).catch(()=>{});
+  fetch('/external-redirect?name=external').then(r=>r.text()).then(()=>fetch('/client?name=external-client&outcome=complete'),()=>fetch('/client?name=external-client&outcome=failed'));
+
+  const frame=document.createElement('iframe');frame.src='/?scenario=frame';document.body.append(frame);
+ }else if(scenario==='frame'){abort('frame')}
+ else if(scenario==='navigation'||scenario==='keepalive'||scenario==='http-keepalive'){
+  slow(scenario,{keepalive:scenario!=='navigation'}).catch(()=>{});setTimeout(()=>location.href='/done',700);
+ }else if(scenario==='close'){slow('close').catch(()=>{})}
+},500);
+</script><body>Windows request cancellation regression probe</body>

--- a/v3/pkg/application/webview_window_windows.go
+++ b/v3/pkg/application/webview_window_windows.go
@@ -22,9 +22,9 @@ import (
 	"github.com/wailsapp/wails/v3/internal/sliceutil"
 	"github.com/wailsapp/wails/v3/internal/webview2/webviewloader"
 
+	"github.com/wailsapp/wails/v3/internal/webview2/pkg/edge"
 	"github.com/wailsapp/wails/v3/pkg/events"
 	"github.com/wailsapp/wails/v3/pkg/w32"
-	"github.com/wailsapp/wails/v3/internal/webview2/pkg/edge"
 )
 
 var edgeMap = map[string]uintptr{
@@ -39,6 +39,7 @@ var edgeMap = map[string]uintptr{
 }
 
 type windowsWebviewWindow struct {
+	requestCancellation      *windowsRequestCancellation
 	windowImpl               unsafe.Pointer
 	parent                   *WebviewWindow
 	hwnd                     w32.HWND
@@ -854,6 +855,7 @@ func (w *windowsWebviewWindow) setRelativePosition(x int, y int) {
 }
 
 func (w *windowsWebviewWindow) destroy() {
+	w.requestCancellation.close()
 	// Re-enable parent window if this was a modal window
 	if w.parentHWND != 0 {
 		w32.EnableWindow(w.parentHWND, true)
@@ -1658,6 +1660,7 @@ func (w *windowsWebviewWindow) WndProc(msg uint32, wparam, lparam uintptr) uintp
 		}()
 
 		// Now do the actual close
+		w.requestCancellation.close()
 		w.chromium.ShuttingDown()
 		return w32.DefWindowProc(w.hwnd, w32.WM_CLOSE, 0, 0)
 	case w32.WM_SETCURSOR:
@@ -2359,6 +2362,9 @@ func (w *windowsWebviewWindow) processRequest(
 		return
 	}
 
+	if w.requestCancellation != nil && !w.requestCancellation.closed {
+		webviewRequest = w.requestCancellation.tracker.Wrap(webviewRequest)
+	}
 	webviewRequests <- &webViewAssetRequest{
 		Request:    webviewRequest,
 		windowId:   w.parent.id,
@@ -2600,6 +2606,12 @@ func (w *windowsWebviewWindow) setupChromium() {
 		chromium.SetGlobalPermission(edge.CoreWebView2PermissionStateAllow)
 	}
 	chromium.AddWebResourceRequestedFilter("*", edge.COREWEBVIEW2_WEB_RESOURCE_CONTEXT_ALL)
+
+	w.startRequestCancellation(w.navigateInitialPage)
+}
+
+func (w *windowsWebviewWindow) navigateInitialPage() {
+	chromium := w.chromium
 
 	if w.parent.options.HTML != "" {
 		var script string


### PR DESCRIPTION
# Description

Aborting an asset request in a Windows WebView currently leaves its Go handler running. This change connects WebView2 request identities to handler contexts so fetch/XHR aborts, worker termination, navigation, and window/application shutdown can cancel the corresponding work. Concurrent requests to the same URL remain independent.

Use WebView2's in-process DevTools API to associate intercepted requests with cancellation events, including events from worker sessions. Preserve local keepalive handlers across page/worker teardown while still honouring explicit aborts. Bound keepalive registrations and clean them up when delivery or handlers finish. No remote debugging port or new dependency is required.

Also forward native contexts through `webViewAssetRequest`: the shared wrapper currently drops the contexts supplied by the Apple implementation in #5969. A native macOS comparison reproduced the problem and verified the forwarding fix.

Addresses the **v3 Windows** portion of #5963 and completes shared context forwarding for the Apple implementation. This PR does not implement v2 or Linux native cancellation, so it should not automatically close the broader issue.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] WEP (proposal only; no implementation)
- [ ] Breaking change
- [x] This change requires a documentation update

# How Has This Been Tested?

- [x] Windows
- [x] macOS
- [ ] Linux native desktop

On win-node1, all **66 production scenarios passed**: 55 expected cancellations and 11 completion controls. Coverage includes fetch/XHR, uploads and headers, internal/external redirects, identical URLs, iframes, workers, page/window/application teardown, keepalive behavior, 40 concurrent aborts, CORS preflight isolation, and response URLs. The earlier debug run also passed its 64 scenarios.

Additional validation:

- Full Windows and macOS application test suites passed.
- Windows request tracker/wrapper tests and asset-server race tests passed.
- Six JavaScript helper tests passed.
- Windows x64, x86, and ARM64 builds passed; only x64 was executed natively.
- Linux server-mode compilation passed; Linux desktop and iOS were not run.
- CodeRabbit review completed. Its finding about unbounded keepalive registration was fixed and covered by a regression test.

Reproduce from `v3`:

```sh
go test ./pkg/application
go test -race ./internal/assetserver/...
node --test pkg/application/request_keepalive_windows_test.mjs
go build -tags production -o cancellation-probe.exe ./pkg/application/testdata/request-cancellation
```

Run the probe in an interactive Windows session. It writes JSON results and exits nonzero on failure. See `v3/pkg/application/testdata/request-cancellation/README.md` for details. Native application test binaries must run from the application source directory because some existing tests inspect source files.

## Test Configuration

Recorded from the native probe rather than `wails doctor`: win-node1, Windows 11 Pro 25H2, build 26200, x64; WebView2 152.0.4191.66; Go 1.26.2. macOS tests ran on the local Apple Silicon host. The native macOS comparison showed aborted fetch/XHR handlers reaching a four-second timeout on master and cancelling at approximately 704 ms with context forwarding; normal requests completed in both runs.

# Checklist

- [ ] (v2 only) Updated the v2 changelog — not applicable
- [x] My code follows the general coding style of this project
- [x] I have performed a self-review of my own code
- [x] I have commented hard-to-understand areas
- [x] I have made corresponding documentation changes
- [ ] My changes generate no new warnings — macOS linking emits existing SDK/deployment-target warnings
- [x] I have added tests that prove the fix is effective
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows request cancellation for fetch, XHR, redirects, workers, navigation, and window closure.
  * Keepalive requests now complete or cancel more reliably during navigation and application shutdown.
  * Preserved native request cancellation contexts on Apple platforms.
  * Improved handling of request bodies, headers, redirects, and external navigation during cancellation.

* **Developer Features**
  * Added Windows WebView2 DevTools Protocol support for invoking commands and receiving events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->