### PR TITLE
fix(v3/windows): SetMenu(nil) is a no-op, matching macOS

### DIFF
--- a/v3/UNRELEASED_CHANGELOG.md
+++ b/v3/UNRELEASED_CHANGELOG.md
@@ -25,6 +25,7 @@ After processing, the content will be moved to the main changelog and this file 
 ## Fixed
 - Cancel aborted Windows asset requests, including worker requests, while preserving keepalive handlers across navigation. Forward native request contexts through the application wrapper on Apple platforms. (#5963, #5969)
 <!-- Bug fixes -->
+- Fix `WebviewWindow.SetMenu(nil)` panicking on Windows instead of being a no-op like on macOS, fixing [#6104](https://github.com/wailsapp/wails/issues/6104)
 - Preserve changelog entries across competing pushes with retries in [PR](https://github.com/wailsapp/wails/pull/6094) by @leaanthony
 - Fix `go mod vendor` failing with `pattern arm64/WebView2Loader.dll: no matching files found` on every platform, by removing the embeds that referenced binaries never shipped in the module, fixing [#5782](https://github.com/wailsapp/wails/issues/5782) and [#5376](https://github.com/wailsapp/wails/issues/5376), in [PR](https://github.com/wailsapp/wails/pull/6031) by @Grantmartin2002
 

--- a/v3/pkg/application/menu_windows_internal_test.go
+++ b/v3/pkg/application/menu_windows_internal_test.go
@@ -201,3 +201,21 @@ func TestWin32MenuDestroyReleasesDetachedSubmenu(t *testing.T) {
 		t.Errorf("detached submenu remains valid after destroy: count=%d", count)
 	}
 }
+
+// TestWindowsSetMenuNilIsNoOp guards against a regression of
+// https://github.com/wailsapp/wails/issues/6104: windowsWebviewWindow.setMenu
+// used to dereference a nil *Menu via menu.Update() whenever the application
+// was running, panicking instead of behaving like the macOS no-op.
+func TestWindowsSetMenuNilIsNoOp(t *testing.T) {
+	previous := globalApplication
+	globalApplication = &App{running: true}
+	t.Cleanup(func() { globalApplication = previous })
+
+	w := &windowsWebviewWindow{parent: &WebviewWindow{}}
+
+	w.setMenu(nil)
+
+	if w.menu != nil {
+		t.Errorf("setMenu(nil) should not create a native menu, got %#v", w.menu)
+	}
+}

--- a/v3/pkg/application/webview_window_windows.go
+++ b/v3/pkg/application/webview_window_windows.go
@@ -114,6 +114,10 @@ type windowsWebviewWindow struct {
 }
 
 func (w *windowsWebviewWindow) setMenu(menu *Menu) {
+	if menu == nil {
+		// Match macOS, where SetMenu(nil) is a no-op.
+		return
+	}
 	if w.parent.options.Windows.DisableMenu {
 		return
 	}


### PR DESCRIPTION
# Description

`WebviewWindow.SetMenu(nil)` is a no-op on macOS but panics on Windows. Both
platforms share the same public API and argument, so the outcome should
match.

Root cause: `windowsWebviewWindow.setMenu` (in
`v3/pkg/application/webview_window_windows.go`) called `menu.Update()` on
the `*Menu` argument with no nil check. `Menu.Update()` only returns early
while the application is *not* running, so once the app is running and code
calls `SetMenu(nil)` (mirroring the macOS no-op), the nil receiver reaches
`m.processRadioGroups()` and panics.

Fix: guard at the top of `windowsWebviewWindow.setMenu` — `if menu == nil { return }` — matching the existing macOS no-op in
`WebviewWindow.SetMenu`. This is the minimal fix suggested in the issue.

Fixes #6104

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Added `TestWindowsSetMenuNilIsNoOp` in
`v3/pkg/application/menu_windows_internal_test.go`, which sets
`globalApplication` to a running `*App` (the condition under which the
panic previously fired) and calls `windowsWebviewWindow.setMenu(nil)`
directly. I verified the test reproduces the exact panic from the issue by
temporarily removing the new guard — it failed with the same
`processRadioGroups` nil-pointer panic reported in the issue — then
restored the fix and reran it green.

- [x] Windows

### Test Configuration

Windows 11 (build 10.0.26200), go1.27.0 windows/amd64. `wails doctor` not
run; this is a unit-test-only change, no native build/runtime required.

```
$ cd v3
$ go build ./pkg/...
$ go vet ./pkg/...
$ go test ./pkg/application/...
ok  	github.com/wailsapp/wails/v3/pkg/application	2.674s
...(all sub-packages ok)
```

`go vet ./pkg/...` reports 25 pre-existing `possible misuse of
unsafe.Pointer` warnings unrelated to this change (present identically on
`master`, none in the touched lines).

## Checklist

- [x] Added a changelog entry to `v3/UNRELEASED_CHANGELOG.md`
- [x] My code follows the general coding style of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed an issue on Windows where calling `WebviewWindow.SetMenu(nil)` could cause a panic.
  - `SetMenu(nil)` now safely performs no action, matching behavior on macOS.

- **Documentation**
  - Added a changelog entry describing the Windows fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->