### PR TITLE
fix(v3/windows): SetMenu always redraws the menu bar

### DIFF
--- a/v3/UNRELEASED_CHANGELOG.md
+++ b/v3/UNRELEASED_CHANGELOG.md
@@ -25,6 +25,7 @@ After processing, the content will be moved to the main changelog and this file 
 ## Fixed
 - Cancel aborted Windows asset requests, including worker requests, while preserving keepalive handlers across navigation. Forward native request contexts through the application wrapper on Apple platforms. (#5963, #5969)
 <!-- Bug fixes -->
+- Fix `WebviewWindow.SetMenu` on Windows not redrawing the menu bar unless a menubar theme was configured, fixing [#6103](https://github.com/wailsapp/wails/issues/6103)
 - Preserve changelog entries across competing pushes with retries in [PR](https://github.com/wailsapp/wails/pull/6094) by @leaanthony
 - Fix `go mod vendor` failing with `pattern arm64/WebView2Loader.dll: no matching files found` on every platform, by removing the embeds that referenced binaries never shipped in the module, fixing [#5782](https://github.com/wailsapp/wails/issues/5782) and [#5376](https://github.com/wailsapp/wails/issues/5376), in [PR](https://github.com/wailsapp/wails/pull/6031) by @Grantmartin2002
 

--- a/v3/pkg/application/webview_window_windows.go
+++ b/v3/pkg/application/webview_window_windows.go
@@ -126,12 +126,15 @@ func (w *windowsWebviewWindow) setMenu(menu *Menu) {
 	if w.menubarTheme != nil {
 		globalApplication.debug("Applying menubar theme in setMenu", "window", w.parent.id)
 		w.menubarTheme.SetMenuBackground(w.menu.menu)
-		w32.DrawMenuBar(w.hwnd)
 		// Force a repaint of the menu area
 		w32.InvalidateRect(w.hwnd, nil, true)
 	} else {
 		globalApplication.debug("No menubar theme to apply in setMenu", "window", w.parent.id)
 	}
+
+	// Tell Windows the menu bar changed so it redraws, regardless of whether
+	// a menubar theme is configured.
+	w32.DrawMenuBar(w.hwnd)
 
 	// Check if using translucent background with Mica - this makes menubars invisible
 	if w.parent.options.BackgroundType == BackgroundTypeTranslucent &&


### PR DESCRIPTION
# Description

On Windows, `WebviewWindow.SetMenu` only tells the OS to redraw the menu
bar (`w32.DrawMenuBar`) when a menubar theme is configured. An application
that sets or replaces a menu at runtime without a theme gets a menu bar
that Windows was never told to redraw.

Root cause: in `windowsWebviewWindow.setMenu`
(`v3/pkg/application/webview_window_windows.go`), the only `DrawMenuBar`
call in the function lived inside the `if w.menubarTheme != nil` branch,
alongside the theme-only `SetMenuBackground` call.

Fix: move `w32.DrawMenuBar(w.hwnd)` out of the theme conditional so it
runs unconditionally after every `SetMenu`, leaving `SetMenuBackground`
and `InvalidateRect` (which are theme-specific concerns) where they were.
This matches the suggested fix in the issue.

Fixes #6103

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

`go build`, `go vet`, and the full `pkg/application` test suite pass with
no new warnings or failures (see Verification below).

I did not add a dedicated regression test for this one. `DrawMenuBar` is a
raw `user32.dll` syscall wrapper (`v3/pkg/w32/user32.go`) with no
interception seam, and its effect — asking Windows to schedule a menu bar
repaint — has no externally observable state through the public win32
query APis (`GetMenu` reports the *menu handle*, not whether a redraw was
requested) without hosting a real top-level window and a message loop,
which the package's Windows-only unit tests do not currently do anywhere.
Building that harness for a 3-line, structurally-obvious change (moving an
existing call out of an `if` branch so it runs unconditionally) felt out
of proportion and outside "minimal diff, no refactor." I verified by code
inspection that every `setMenu` call path now reaches `DrawMenuBar`
regardless of `w.menubarTheme`, confirmed via `go vet`/`go build` that
`w.hwnd` is still in scope at the call site, and ran the existing
Windows menu test suite (`go test ./pkg/application/...`) to confirm no
regressions.

- [x] Windows

### Test Configuration

Windows 11 (build 10.0.26200), go1.27.0 windows/amd64. `wails doctor` not
run; no native build/runtime required for this change.

```
$ cd v3
$ go build ./pkg/...
$ go vet ./pkg/...
$ go test ./pkg/application/...
ok  	github.com/wailsapp/wails/v3/pkg/application	1.625s
...(all sub-packages ok)
```

`go vet ./pkg/...` reports 25 pre-existing `possible misuse of
unsafe.Pointer` warnings, unrelated to this change and present identically
on `master`.

## Checklist

- [x] Added a changelog entry to `v3/UNRELEASED_CHANGELOG.md`
- [x] My code follows the general coding style of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective — see reasoning above
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed an issue on Windows where updating a webview window’s menu would not redraw the menu bar when no menu theme was configured.
  - Menu bar updates now appear correctly in this configuration.

- **Documentation**
  - Added an entry to the unreleased changelog documenting the Windows menu bar redraw fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->