### PR TITLE
fix(v3): release InvokeSync* callers when the callback panics

### DIFF
--- a/v3/UNRELEASED_CHANGELOG.md
+++ b/v3/UNRELEASED_CHANGELOG.md
@@ -25,6 +25,7 @@ After processing, the content will be moved to the main changelog and this file 
 ## Fixed
 - Cancel aborted Windows asset requests, including worker requests, while preserving keepalive handlers across navigation. Forward native request contexts through the application wrapper on Apple platforms. (#5963, #5969)
 <!-- Bug fixes -->
+- Fix all five `InvokeSync*` variants blocking their caller forever when the dispatched callback panics, fixing [#6107](https://github.com/wailsapp/wails/issues/6107), in [PR](https://github.com/wailsapp/wails/pull/6108) by @RALIST
 - Preserve changelog entries across competing pushes with retries in [PR](https://github.com/wailsapp/wails/pull/6094) by @leaanthony
 - Fix `go mod vendor` failing with `pattern arm64/WebView2Loader.dll: no matching files found` on every platform, by removing the embeds that referenced binaries never shipped in the module, fixing [#5782](https://github.com/wailsapp/wails/issues/5782) and [#5376](https://github.com/wailsapp/wails/issues/5376), in [PR](https://github.com/wailsapp/wails/pull/6031) by @Grantmartin2002
 

--- a/v3/pkg/application/mainthread.go
+++ b/v3/pkg/application/mainthread.go
@@ -24,9 +24,13 @@ func InvokeSync(fn func()) {
 	var wg sync.WaitGroup
 	wg.Add(1)
 	globalApplication.dispatchOnMainThread(func() {
+		// handlePanic recovers and returns normally, so releasing the caller
+		// from the closure's last statement would skip it on a panic and leave
+		// wg.Wait() blocked forever. Deferred first, LIFO still runs
+		// handlePanic to completion before the caller is let go.
+		defer wg.Done()
 		defer handlePanic()
 		fn()
-		wg.Done()
 	})
 	wg.Wait()
 }
@@ -35,9 +39,9 @@ func InvokeSyncWithResult[T any](fn func() T) (res T) {
 	var wg sync.WaitGroup
 	wg.Add(1)
 	globalApplication.dispatchOnMainThread(func() {
+		defer wg.Done()
 		defer handlePanic()
 		res = fn()
-		wg.Done()
 	})
 	wg.Wait()
 	return res
@@ -47,9 +51,9 @@ func InvokeSyncWithError(fn func() error) (err error) {
 	var wg sync.WaitGroup
 	wg.Add(1)
 	globalApplication.dispatchOnMainThread(func() {
+		defer wg.Done()
 		defer handlePanic()
 		err = fn()
-		wg.Done()
 	})
 	wg.Wait()
 	return
@@ -59,9 +63,9 @@ func InvokeSyncWithResultAndError[T any](fn func() (T, error)) (res T, err error
 	var wg sync.WaitGroup
 	wg.Add(1)
 	globalApplication.dispatchOnMainThread(func() {
+		defer wg.Done()
 		defer handlePanic()
 		res, err = fn()
-		wg.Done()
 	})
 	wg.Wait()
 	return res, err
@@ -71,9 +75,9 @@ func InvokeSyncWithResultAndOther[T any, U any](fn func() (T, U)) (res T, other 
 	var wg sync.WaitGroup
 	wg.Add(1)
 	globalApplication.dispatchOnMainThread(func() {
+		defer wg.Done()
 		defer handlePanic()
 		res, other = fn()
-		wg.Done()
 	})
 	wg.Wait()
 	return res, other

--- a/v3/pkg/application/mainthread_panic_test.go
+++ b/v3/pkg/application/mainthread_panic_test.go
@@ -1,0 +1,331 @@
+package application
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+)
+
+// dispatchWait bounds how long a test will wait for the caller of an
+// InvokeSync* variant to come back. The bug under test wedges it forever, so
+// the only alternative to a bound is a package-wide timeout that fails every
+// other test in the run as collateral.
+const dispatchWait = 5 * time.Second
+
+// panicProbe records what the panic handler saw. The default handler ends in
+// os.Exit(1), so a test that lets a panic reach it takes the whole binary with
+// it: every test here has to install one of these.
+type panicProbe struct {
+	mu       sync.Mutex
+	handled  int
+	released chan struct{} // closed by the caller once its InvokeSync* returns
+
+	// earlyRelease is set when the caller was already released at the moment
+	// the panic reached the handler.
+	earlyRelease bool
+	// observeRelease makes the handler wait for the caller instead of only
+	// glancing at it. Only the ordering test needs that.
+	observeRelease bool
+}
+
+func (p *panicProbe) handle(*PanicDetails) {
+	early := false
+	if p.observeRelease {
+		// A correctly ordered closure cannot release the caller from in here:
+		// wg.Done() is deferred first, so it runs only after this returns, and
+		// the wait always expires. A reversed closure releases the caller
+		// before this runs, so the wait fires instead. Holding here is also
+		// what keeps handled at 0 until the caller has read it.
+		select {
+		case <-p.released:
+			early = true
+		case <-time.After(250 * time.Millisecond):
+		}
+	} else {
+		select {
+		case <-p.released:
+			early = true
+		default:
+		}
+	}
+
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.handled++
+	p.earlyRelease = p.earlyRelease || early
+}
+
+func (p *panicProbe) counts() (handled int, earlyRelease bool) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.handled, p.earlyRelease
+}
+
+// newPanicProbe installs a controllable platform layer plus a recording panic
+// handler, and hands back the restore func for globalApplication.
+func newPanicProbe(t *testing.T) (*threadProbeApp, *panicProbe, func()) {
+	t.Helper()
+
+	dispatcher := &threadProbeApp{}
+	probe := &panicProbe{released: make(chan struct{})}
+
+	prev := globalApplication
+	globalApplication = &App{
+		impl:    dispatcher,
+		options: Options{PanicHandler: probe.handle},
+	}
+
+	// Off the main thread by default, so the work is queued rather than run
+	// inline and the caller genuinely parks in wg.Wait().
+	dispatcher.onMain.Store(false)
+
+	return dispatcher, probe, func() { globalApplication = prev }
+}
+
+// runQueuedWork releases the UI thread once the caller has reached it, and
+// fails rather than hangs if the work never arrives.
+func runQueuedWork(t *testing.T, dispatcher *threadProbeApp) {
+	t.Helper()
+
+	deadline := time.Now().Add(dispatchWait)
+	for dispatcher.pendingCount() == 0 {
+		if time.Now().After(deadline) {
+			t.Fatal("the dispatched work never reached the main-thread queue")
+		}
+		time.Sleep(time.Millisecond)
+	}
+	dispatcher.runPending()
+}
+
+// waitForCaller fails instead of hanging when the caller is never released,
+// which is the whole symptom being tested. Every caller here closes released
+// from a defer, so returning from this also means the calling goroutine has
+// finished and whatever it assigned is safe to read.
+func waitForCaller(t *testing.T, probe *panicProbe, name string) {
+	t.Helper()
+
+	select {
+	case <-probe.released:
+	case <-time.After(dispatchWait):
+		t.Fatalf("%s never returned", name)
+	}
+}
+
+// A recovered panic in the callback must release the caller of every
+// InvokeSync* variant. The closures used to call wg.Done() as their last
+// statement, below `defer handlePanic()`: handlePanic recovers and returns
+// normally, so the panic is swallowed, the closure unwinds cleanly, wg.Done()
+// is skipped and wg.Wait() blocks for the life of the process.
+//
+// The variants that assign a result hand back the zero value in that case.
+// That is a deliberate consequence of releasing the caller at all: before this
+// there was no value to observe because there was no return.
+func TestInvokeSyncReleasesCallerWhenCallbackPanics(t *testing.T) {
+	tests := []struct {
+		name string
+		// call reports a wrong result rather than asserting, so nothing in the
+		// goroutine touches *testing.T: on unfixed code that goroutine is still
+		// parked when the test gives up on it.
+		call func() error
+	}{
+		{
+			name: "InvokeSync",
+			call: func() error {
+				InvokeSync(func() { panic("boom") })
+				return nil
+			},
+		},
+		{
+			name: "InvokeSyncWithResult",
+			call: func() error {
+				if got := InvokeSyncWithResult(func() string { panic("boom") }); got != "" {
+					return fmt.Errorf("result = %q, want the zero value", got)
+				}
+				return nil
+			},
+		},
+		{
+			name: "InvokeSyncWithError",
+			call: func() error {
+				if err := InvokeSyncWithError(func() error { panic("boom") }); err != nil {
+					return fmt.Errorf("error = %v, want the zero value", err)
+				}
+				return nil
+			},
+		},
+		{
+			name: "InvokeSyncWithResultAndError",
+			call: func() error {
+				got, err := InvokeSyncWithResultAndError(func() (string, error) { panic("boom") })
+				if got != "" || err != nil {
+					return fmt.Errorf("result = %q, error = %v, want the zero values", got, err)
+				}
+				return nil
+			},
+		},
+		{
+			name: "InvokeSyncWithResultAndOther",
+			call: func() error {
+				got, other := InvokeSyncWithResultAndOther(func() (string, int) { panic("boom") })
+				if got != "" || other != 0 {
+					return fmt.Errorf("result = %q, other = %d, want the zero values", got, other)
+				}
+				return nil
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dispatcher, probe, restore := newPanicProbe(t)
+			defer restore()
+
+			// The call has to run somewhere other than here: on unfixed code it
+			// never returns, and this goroutine is the one that has to release
+			// the UI thread and then declare the failure.
+			var callErr error
+			go func() {
+				defer close(probe.released)
+				callErr = tt.call()
+			}()
+
+			runQueuedWork(t, dispatcher)
+			waitForCaller(t, probe, tt.name)
+
+			if callErr != nil {
+				t.Error(callErr)
+			}
+			if handled, _ := probe.counts(); handled != 1 {
+				t.Errorf("panic handler ran %d times, want 1: the panic must still be recovered and reported", handled)
+			}
+		})
+	}
+}
+
+// When the caller is already on the main thread, dispatchOnMainThread runs the
+// closure inline — so the callback and wg.Wait() sit on the same goroutine and
+// an unreleased WaitGroup freezes the main thread itself, with nobody left to
+// release it. That is the shape behind a panic handler that can no longer draw
+// its dialog.
+func TestInvokeSyncReleasesInlineCallerWhenCallbackPanics(t *testing.T) {
+	dispatcher, probe, restore := newPanicProbe(t)
+	defer restore()
+	dispatcher.onMain.Store(true)
+
+	go func() {
+		defer close(probe.released)
+		InvokeSync(func() { panic("boom") })
+	}()
+
+	// Nothing to drain: the closure runs on the calling goroutine.
+	waitForCaller(t, probe, "InvokeSync")
+
+	if handled, _ := probe.counts(); handled != 1 {
+		t.Errorf("panic handler ran %d times, want 1", handled)
+	}
+	if queued := dispatcher.pendingCount(); queued != 0 {
+		t.Errorf("%d items were queued; the inline path was not the one exercised", queued)
+	}
+}
+
+// The caller must be released only after the panic has been processed.
+//
+// Deferred calls run LIFO, so `defer wg.Done()` has to come first and
+// `defer handlePanic()` second. Reversing them also releases the caller, and
+// also passes the test above — but it releases it while the panic is still
+// being handled, which is what a panic handler that wants to draw a dialog on
+// the main thread races against.
+func TestInvokeSyncReleasesCallerAfterPanicIsProcessed(t *testing.T) {
+	dispatcher, probe, restore := newPanicProbe(t)
+	defer restore()
+	probe.observeRelease = true
+
+	// Read from the caller's own goroutine the instant it is released. With
+	// the release deferred first, the handler has finished by then and the
+	// wg.Done()/wg.Wait() pair publishes that to this goroutine, so a correct
+	// closure always reports 1 here — no timing assumption involved. The
+	// reversed closure releases the caller before the handler has even been
+	// entered, and reports 0.
+	var handledAtRelease int
+
+	go func() {
+		defer close(probe.released)
+		InvokeSync(func() { panic("boom") })
+		handledAtRelease, _ = probe.counts()
+	}()
+
+	runQueuedWork(t, dispatcher)
+	waitForCaller(t, probe, "InvokeSync")
+
+	handled, earlyRelease := probe.counts()
+	if handled != 1 {
+		t.Fatalf("panic handler ran %d times, want 1", handled)
+	}
+	if handledAtRelease != 1 {
+		t.Errorf("the panic handler had not finished when the caller was released (saw %d handled): wg.Done() must be deferred before handlePanic()", handledAtRelease)
+	}
+	if earlyRelease {
+		t.Error("the caller was released while the panic was still being processed: wg.Done() must be deferred before handlePanic()")
+	}
+}
+
+// The variants must keep behaving normally when nothing panics: this is the
+// control for the tests above, which would all pass against a closure that
+// released the caller unconditionally and never ran the callback.
+//
+// One call per subtest, because runPending drains until empty and reports the
+// UI thread as current while it does: a second call issued by a caller it just
+// released would either be swept up by the same drain or run inline, and
+// either way nothing would be left to release.
+func TestInvokeSyncPassesThroughWhenCallbackDoesNotPanic(t *testing.T) {
+	t.Run("InvokeSync", func(t *testing.T) {
+		dispatcher, probe, restore := newPanicProbe(t)
+		defer restore()
+
+		var ran bool
+		go func() {
+			defer close(probe.released)
+			InvokeSync(func() { ran = true })
+		}()
+
+		runQueuedWork(t, dispatcher)
+		waitForCaller(t, probe, "InvokeSync")
+
+		if !ran {
+			t.Error("the callback never ran")
+		}
+		if handled, _ := probe.counts(); handled != 0 {
+			t.Errorf("panic handler ran %d times, want 0", handled)
+		}
+	})
+
+	t.Run("InvokeSyncWithResultAndError", func(t *testing.T) {
+		dispatcher, probe, restore := newPanicProbe(t)
+		defer restore()
+
+		wantErr := errors.New("callback error")
+
+		var (
+			gotRes string
+			gotErr error
+		)
+		go func() {
+			defer close(probe.released)
+			gotRes, gotErr = InvokeSyncWithResultAndError(func() (string, error) {
+				return "value", wantErr
+			})
+		}()
+
+		runQueuedWork(t, dispatcher)
+		waitForCaller(t, probe, "InvokeSyncWithResultAndError")
+
+		if gotRes != "value" || !errors.Is(gotErr, wantErr) {
+			t.Errorf("result = %q, error = %v; want %q, %v", gotRes, gotErr, "value", wantErr)
+		}
+		if handled, _ := probe.counts(); handled != 0 {
+			t.Errorf("panic handler ran %d times, want 0", handled)
+		}
+	})
+}


### PR DESCRIPTION
# Description

All five `InvokeSync*` variants in `v3/pkg/application/mainthread.go` called `wg.Done()` as the last statement of the dispatched closure, with `defer handlePanic()` above it:

```go
globalApplication.dispatchOnMainThread(func() {
	defer handlePanic()
	fn()
	wg.Done()      // skipped when fn() panics
})
wg.Wait()          // blocks forever
```

`handlePanic` calls `recover()` and returns normally, so a panic inside `fn` is swallowed and the closure unwinds cleanly — but `wg.Done()` never runs and `wg.Wait()` blocks for the life of the process. The recovery is what makes it hard to spot: the panic is handled, so there is no crash to point at, and the application looks healthy around a caller that is simply wedged. `InvokeAsync` is unaffected and is left alone — it has no `WaitGroup`.

Application code cannot work around this. The `sync.WaitGroup` is a local inside the Wails function, so there is no handle a caller could use to release it.

This came out of a Linux crash dialog that never renders: `linuxDialog.show` wraps its work in `gtkDispatch`, and `runQuestionDialog` marshals to the main thread and blocks on its result channel. A panic anywhere on that path parks the GTK main thread in `wg.Wait()`, and no dialog can be drawn again — so a panic produces no crash report and no visible explanation.

The fix defers the release. `wg.Done()` is deferred **first** so that, deferred calls being LIFO, `handlePanic` still runs to completion *before* the caller is released — a panic handler that wants to draw UI on the main thread must not race the caller it just let go. `recover()` still reaches the panic from that position: both calls are deferred directly by the closure that panics.

```go
globalApplication.dispatchOnMainThread(func() {
	defer wg.Done()
	defer handlePanic()
	fn()
})
```

**One behavioural consequence, stated up front.** For the variants that assign a result, a callback that panics before its assignment completes now hands the caller the zero value instead of never returning. I do not think this needs a WEP: the behaviour it replaces is an unrecoverable hang with no caller-side handle and no way to observe a value, so there is no usable public behaviour being changed — but I would rather flag it here than have it found in review.

Nothing else is touched: no shared helper extracted across the five functions, no re-panic on the caller's goroutine, no change to `InvokeAsync`.

**Considered and left out**, both deliberately:

- Reporting the panic through `InvokeSyncWithError`'s return value. Three of the five variants have no error channel, so a panic-derived error would be inconsistent across the family — and the panic is still recovered and passed to the `PanicHandler` either way. That is a design question for a WEP, not for this fix.
- `v3/pkg/application/screen_linux.go:9-18` has the same shape one frame out: `processAndCacheScreens` wraps `InvokeSync` in its own `WaitGroup` and calls `wg.Done()` as the callback's last statement. With this fix in place, a panic in `getScreens` is recovered, `InvokeSync` correctly returns, and `processAndCacheScreens` then blocks forever on its own `wg.Wait()`. It hung before this change too, one frame deeper, so it is not a regression — and the outer `WaitGroup` is redundant anyway, since `InvokeSync` is synchronous by construction. It is Linux-only and needs xvfb+dbus to exercise, so I have left it out rather than bolt an untestable platform change onto an otherwise platform-neutral PR. Happy to open it as a separate issue, or fold it in here if you would rather.

Fixes #6107

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] WEP (proposal only; no implementation)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

New regression test `v3/pkg/application/mainthread_panic_test.go`. It has no platform-specific code — it drives the existing `threadProbeApp` from `event_ordering_test.go`, which stands in for the platform layer, so both dispatch paths are exercised identically everywhere. Four tests:

- `TestInvokeSyncReleasesCallerWhenCallbackPanics` — table over all five variants on the queued path: the caller is released, the panic is still recovered and reported exactly once, and the result variants hand back the zero value.
- `TestInvokeSyncReleasesInlineCallerWhenCallbackPanics` — the inline path, where `isOnMainThread()` is true and the callback and `wg.Wait()` share a goroutine. This is the more severe symptom: the main thread freezes with nobody left to release it.
- `TestInvokeSyncReleasesCallerAfterPanicIsProcessed` — pins the defer *order*, not just the presence of the defer.
- `TestInvokeSyncPassesThroughWhenCallbackDoesNotPanic` — control: a non-panicking callback still runs and its results and errors still come back. It passes on unfixed code, which is what makes it a control rather than a fourth copy of the same assertion.

Each call is made from a goroutine and bounded by a timeout, so unfixed code fails the test rather than hanging the package run.

**Before the fix** (`go test ./pkg/application/ -run TestInvokeSync -count=1 -v`):

```
--- FAIL: TestInvokeSyncReleasesCallerWhenCallbackPanics (25.02s)
    --- FAIL: TestInvokeSyncReleasesCallerWhenCallbackPanics/InvokeSync (5.00s)
    --- FAIL: TestInvokeSyncReleasesCallerWhenCallbackPanics/InvokeSyncWithResult (5.00s)
    --- FAIL: TestInvokeSyncReleasesCallerWhenCallbackPanics/InvokeSyncWithError (5.00s)
    --- FAIL: TestInvokeSyncReleasesCallerWhenCallbackPanics/InvokeSyncWithResultAndError (5.00s)
    --- FAIL: TestInvokeSyncReleasesCallerWhenCallbackPanics/InvokeSyncWithResultAndOther (5.00s)
--- FAIL: TestInvokeSyncReleasesInlineCallerWhenCallbackPanics (5.00s)
--- FAIL: TestInvokeSyncReleasesCallerAfterPanicIsProcessed (5.26s)
--- PASS: TestInvokeSyncPassesThroughWhenCallbackDoesNotPanic (0.00s)
```

**After the fix:** all pass, including `-race -count=20 -shuffle=on`, plus the whole package (`go test ./pkg/application/ -count=1` → `ok`) and `go vet ./pkg/application/` clean. The new tests add about 250 ms to the package.

**The ordering test has teeth.** With the two defers swapped (`defer handlePanic()` first) — applied non-destructively via `go test -overlay` — the caller is still released, so the table test passes, and exactly the ordering test fails, 20 runs out of 20:

```
--- FAIL: TestInvokeSyncReleasesCallerAfterPanicIsProcessed (0.00s)
    mainthread_panic_test.go:267: the panic handler had not finished when the caller was released (saw 0 handled): wg.Done() must be deferred before handlePanic()
    mainthread_panic_test.go:270: the caller was released while the panic was still being processed: wg.Done() must be deferred before handlePanic()
```

That first assertion is made by the caller's own goroutine at the moment it is released, so it rests on the `wg.Done()`/`wg.Wait()` happens-before rather than on a timer: correct code always reports the handler as finished there.

- [ ] Windows
- [x] macOS
- [ ] Linux

Run on macOS only; the test is platform-independent Go with a stubbed platform layer, so CI covers the other two.

## Test Configuration

```
Wails CLI      v3.0.0-beta.19
Go             go1.27.1
OS             macOS 26.6.2 (darwin/arm64, Apple M1 Pro)
CGO_ENABLED    1
```

# Checklist:

- [ ] (v2 only) I have updated `website/src/pages/changelog.mdx` with details of this PR (v3 changelog entries are added automatically) — n/a, this is a v3 change; I added an entry to `v3/UNRELEASED_CHANGELOG.md` so the wording is mine rather than auto-filled
- [x] My code follows the general coding style of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed an issue where synchronous main-thread operations could leave callers waiting indefinitely if a callback encountered a panic.
  - Ensured callers are released after panic handling completes across all synchronous invocation variants.

- **Tests**
  - Added coverage for panic recovery, normal execution, inline calls, queued calls, and completion timing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->