### PR TITLE
fix(v3): serve /wails/* assets with their real MIME type on Android

### DIFF
--- a/v3/UNRELEASED_CHANGELOG.md
+++ b/v3/UNRELEASED_CHANGELOG.md
@@ -23,6 +23,7 @@ After processing, the content will be moved to the main changelog and this file 
 
 ## Fixed
 <!-- Bug fixes -->
+- Serve `/wails/*` assets on Android with their real MIME type instead of a hardcoded `application/json`, so ES modules such as `/wails/runtime.js` are no longer rejected by the WebView and the runtime initialises correctly (#6014)
 
 ## Deprecated
 <!-- Soon-to-be removed features -->

--- a/v3/examples/android/build/android/app/src/main/java/com/wails/app/MainActivity.java
+++ b/v3/examples/android/build/android/app/src/main/java/com/wails/app/MainActivity.java
@@ -106,16 +106,28 @@ public class MainActivity extends AppCompatActivity {
                         }
                         if (DEBUG) Log.d(TAG, "Wails API call: " + fullPath);
 
+                        // Resolve the real MIME type for this path. Everything under
+                        // /wails/ used to be served as application/json, which makes
+                        // WebView refuse to execute ES modules such as
+                        // /wails/runtime.js ("Failed to load module script").
+                        // The bridge reports application/octet-stream for paths
+                        // without a known extension, so extension-less RPC calls
+                        // (/wails/runtime?...) keep their previous JSON type.
+                        String mimeType = bridge.getAssetMimeType(path);
+                        if ("application/octet-stream".equals(mimeType)) {
+                            mimeType = "application/json";
+                        }
+
                         byte[] data = bridge.serveAsset(fullPath, request.getMethod(), "{}");
                         if (data != null && data.length > 0) {
                             java.io.InputStream inputStream = new java.io.ByteArrayInputStream(data);
                             java.util.Map<String, String> headers = new java.util.HashMap<>();
                             headers.put("Access-Control-Allow-Origin", "*");
                             headers.put("Cache-Control", "no-cache");
-                            headers.put("Content-Type", "application/json");
+                            headers.put("Content-Type", mimeType);
 
                             return new WebResourceResponse(
-                                "application/json",
+                                mimeType,
                                 "UTF-8",
                                 200,
                                 "OK",

--- a/v3/examples/mobile/build/android/app/src/main/java/com/wails/app/MainActivity.java
+++ b/v3/examples/mobile/build/android/app/src/main/java/com/wails/app/MainActivity.java
@@ -143,16 +143,28 @@ public class MainActivity extends AppCompatActivity {
                         }
                         if (DEBUG) Log.d(TAG, "Wails API call: " + fullPath);
 
+                        // Resolve the real MIME type for this path. Everything under
+                        // /wails/ used to be served as application/json, which makes
+                        // WebView refuse to execute ES modules such as
+                        // /wails/runtime.js ("Failed to load module script").
+                        // The bridge reports application/octet-stream for paths
+                        // without a known extension, so extension-less RPC calls
+                        // (/wails/runtime?...) keep their previous JSON type.
+                        String mimeType = bridge.getAssetMimeType(path);
+                        if ("application/octet-stream".equals(mimeType)) {
+                            mimeType = "application/json";
+                        }
+
                         byte[] data = bridge.serveAsset(fullPath, request.getMethod(), "{}");
                         if (data != null && data.length > 0) {
                             java.io.InputStream inputStream = new java.io.ByteArrayInputStream(data);
                             java.util.Map<String, String> headers = new java.util.HashMap<>();
                             headers.put("Access-Control-Allow-Origin", "*");
                             headers.put("Cache-Control", "no-cache");
-                            headers.put("Content-Type", "application/json");
+                            headers.put("Content-Type", mimeType);
 
                             return new WebResourceResponse(
-                                "application/json",
+                                mimeType,
                                 "UTF-8",
                                 200,
                                 "OK",

--- a/v3/internal/commands/build_assets/android/app/src/main/java/com/wails/app/MainActivity.java
+++ b/v3/internal/commands/build_assets/android/app/src/main/java/com/wails/app/MainActivity.java
@@ -143,16 +143,28 @@ public class MainActivity extends AppCompatActivity {
                         }
                         if (DEBUG) Log.d(TAG, "Wails API call: " + fullPath);
 
+                        // Resolve the real MIME type for this path. Everything under
+                        // /wails/ used to be served as application/json, which makes
+                        // WebView refuse to execute ES modules such as
+                        // /wails/runtime.js ("Failed to load module script").
+                        // The bridge reports application/octet-stream for paths
+                        // without a known extension, so extension-less RPC calls
+                        // (/wails/runtime?...) keep their previous JSON type.
+                        String mimeType = bridge.getAssetMimeType(path);
+                        if ("application/octet-stream".equals(mimeType)) {
+                            mimeType = "application/json";
+                        }
+
                         byte[] data = bridge.serveAsset(fullPath, request.getMethod(), "{}");
                         if (data != null && data.length > 0) {
                             java.io.InputStream inputStream = new java.io.ByteArrayInputStream(data);
                             java.util.Map<String, String> headers = new java.util.HashMap<>();
                             headers.put("Access-Control-Allow-Origin", "*");
                             headers.put("Cache-Control", "no-cache");
-                            headers.put("Content-Type", "application/json");
+                            headers.put("Content-Type", mimeType);
 
                             return new WebResourceResponse(
-                                "application/json",
+                                mimeType,
                                 "UTF-8",
                                 200,
                                 "OK",


### PR DESCRIPTION
## Summary

On Android, every response served through the `/wails/*` interception path is returned with a hardcoded `Content-Type: application/json`. WebView enforces strict MIME type checking for module scripts, so `/wails/runtime.js` is rejected outright and the Wails runtime never initialises. The frontend stays dead: bindings are unavailable, and native form submits fall back to a page reload.

Fixes #6014.

## Root cause

`MainActivity.shouldInterceptRequest` has two paths: the `/wails/*` branch, which hardcoded `application/json` for every response, and `WailsPathHandler`, which already resolves the real MIME type via `bridge.getAssetMimeType(path)` (`WailsPathHandler.java:50`). Only the first one is wrong — it applies a JSON content type to JavaScript modules as well.

Observed on device:

```
I/chromium: [INFO:CONSOLE:0] "Failed to load module script: Expected a
  JavaScript-or-Wasm module script but the server responded with a MIME type of
  "application/json". Strict MIME type checking is enforced for module scripts
  per HTML spec.", source: https://wails.localhost/wails/runtime.js (0)
```

## The fix

Reuse the same MIME resolution the non-intercepted path already uses, and fall back to `application/json` for paths without a known extension, so extension-less RPC calls (such as `/wails/runtime?...`) keep their previous content type:

```java
String mimeType = bridge.getAssetMimeType(path);
if ("application/octet-stream".equals(mimeType)) {
    mimeType = "application/json";
}
```

`getAssetMimeType` delegates to `getMimeTypeForPath` in `pkg/application/application_android.go`, which maps `.js`/`.mjs` to `application/javascript` and returns `application/octet-stream` otherwise. This change introduces no new MIME logic; it makes the interception path agree with `WailsPathHandler`.

No public API and no behaviour outside the Android asset interception path changes.

## Verification

Tested on a physical Android device (Android 16 / API 36, arm64-v8a) with a Wails v3 app whose frontend imports `/wails/runtime.js`.

With the fix:

```
I/chromium: [INFO:CONSOLE:792] "%c wails3 %c Wails Runtime Loaded ...",
              source: https://wails.localhost/wails/runtime.js (792)
D/WailsJSBridge: InvokeAsync called: { ... "methodName":"main.App.Greet" ... }
```

16 consecutive Go-JS bridge calls succeed.

Without the fix (patch neutralised, same build otherwise):

```
D/WailsBridge: Serving asset: /wails/runtime.js
I/chromium: [INFO:CONSOLE:0] "Failed to load module script: Expected a
  JavaScript-or-Wasm module script but the server responded with a MIME type of
  "application/json". Strict MIME type checking is enforced for module scripts
  per HTML spec.", source: https://wails.localhost/wails/runtime.js (0)
```

Every binding call fails afterwards, because the runtime never initialises.

Log excerpts come from a test application; app-specific identifiers are genericised.

## Notes

- The same hardcoded `application/json` existed in all three Android `MainActivity` copies (the build template and both examples); all three are updated.
- Changelog entry added to `v3/UNRELEASED_CHANGELOG.md`.
- No Go unit test is added: the change is confined to the Android Java template, which has no test harness in this repository.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Android-served assets now use their correct MIME types.
  - ES modules, including runtime scripts, load successfully in the Android WebView.
  - Extensionless API requests continue to be served as JSON for compatibility.
  - Resolved MIME types are consistently applied to response headers and WebView responses.

- **Documentation**
  - Added an unreleased changelog entry documenting the Android MIME type fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->