### PR TITLE
fix(v3/windows): free the replaced menu, redraw the bar, and ignore a nil menu

### DIFF
--- a/v3/pkg/application/menu_windows_test.go
+++ b/v3/pkg/application/menu_windows_test.go
@@ -1,0 +1,109 @@
+//go:build windows && !server && !cef
+
+package application
+
+import (
+	"testing"
+
+	"github.com/wailsapp/wails/v3/pkg/w32"
+)
+
+// These cover three defects in the shipping Windows backend's setMenu, found
+// while porting it to the CEF frontend and filed as #6102, #6103 and #6104.
+//
+// Two of the three are testable here because setMenu does its own bookkeeping
+// before it touches the window: a window handle of zero makes SetMenu and
+// DrawMenuBar no-ops without changing anything this asserts on. The redraw
+// (#6103) is a repaint side effect with nothing to assert on and is not
+// covered here.
+
+// withTestApplication gives the package a global application to log through,
+// since setMenu debug-logs on a path these tests take, and puts back whatever
+// was there.
+func withTestApplication(t *testing.T) {
+	t.Helper()
+	previous := globalApplication
+	globalApplication = nil
+	app := New(Options{Name: "menu test"})
+	// Marked as running, because that is the only state in which any of this
+	// misbehaves: Menu.Update returns before touching its receiver otherwise,
+	// so a nil menu would not panic and a real one would not be rebuilt.
+	app.runLock.Lock()
+	app.running = true
+	app.runLock.Unlock()
+	t.Cleanup(func() { globalApplication = previous })
+}
+
+// A nil menu means "no menu", which is what macOS makes of it. Menu.Update
+// dereferences its receiver once the application is running, so this used to
+// panic rather than do nothing (#6104).
+func TestWindowsSetMenuIgnoresANilMenu(t *testing.T) {
+	withTestApplication(t)
+
+	w := &windowsWebviewWindow{parent: &WebviewWindow{}}
+	w.setMenu(nil)
+
+	if w.menu != nil {
+		t.Fatalf("a nil menu left one on the window: %#v", w.menu)
+	}
+}
+
+// setMenu builds a new Win32Menu, so the one it replaces is dropped. Nothing
+// else ever frees it - Win32Menu.Update only frees the previous handle of the
+// same object - so its HMENU leaked (#6102).
+func TestWindowsSetMenuFreesTheMenuItReplaces(t *testing.T) {
+	withTestApplication(t)
+
+	w := &windowsWebviewWindow{parent: &WebviewWindow{}}
+
+	first := NewMenu()
+	first.Add("First")
+	w.setMenu(first)
+
+	if w.menu == nil {
+		t.Fatal("setMenu built no menu")
+	}
+	replaced := w.menu.menu
+	if !w32.IsMenu(replaced) {
+		t.Fatalf("the first menu was not a live HMENU: %v", replaced)
+	}
+
+	second := NewMenu()
+	second.Add("Second")
+	w.setMenu(second)
+
+	if w.menu.menu == replaced {
+		t.Fatal("setMenu reused the previous HMENU rather than building one")
+	}
+	if w32.IsMenu(replaced) {
+		t.Error("the replaced menu's HMENU is still live, so it leaked (#6102)")
+	}
+	if !w32.IsMenu(w.menu.menu) {
+		t.Error("setMenu destroyed the menu it had just put on the window")
+	}
+}
+
+// The same Menu twice is the case where freeing the old Win32Menu can reach
+// state the new one now owns: both mappings hold the same *MenuItem values,
+// whose impl the second build has reassigned. The old menu must still go, and
+// the new one must survive.
+func TestWindowsSetMenuWithTheSameMenuTwice(t *testing.T) {
+	withTestApplication(t)
+
+	w := &windowsWebviewWindow{parent: &WebviewWindow{}}
+
+	menu := NewMenu()
+	menu.Add("Only")
+
+	w.setMenu(menu)
+	replaced := w.menu.menu
+
+	w.setMenu(menu)
+
+	if w32.IsMenu(replaced) {
+		t.Error("the replaced menu's HMENU is still live, so it leaked (#6102)")
+	}
+	if !w32.IsMenu(w.menu.menu) {
+		t.Error("setMenu destroyed the menu it had just put on the window")
+	}
+}

--- a/v3/pkg/application/popupmenu_windows.go
+++ b/v3/pkg/application/popupmenu_windows.go
@@ -94,6 +94,23 @@ func (p *Win32Menu) freeBitmaps() {
 	p.bitmaps = nil
 }
 
+// takeRuntimeBitmaps moves the HBITMAP handles MenuItem.SetBitmap allocated
+// after the build off the item impls and into the menu's own list.
+//
+// It exists for the same reason Update does the equivalent inline: building a
+// menu reassigns item.impl, so any handle still hanging off the old impl
+// becomes unreachable through this menu's mapping and would never be freed.
+// A caller replacing one Win32Menu with another has to take them before the
+// new build, and can then Destroy the old one afterwards.
+func (p *Win32Menu) takeRuntimeBitmaps() {
+	for _, item := range p.menuMapping {
+		if impl, ok := item.impl.(*windowsMenuItem); ok && impl.bitmap != 0 {
+			p.bitmaps = append(p.bitmaps, impl.bitmap)
+			impl.bitmap = 0
+		}
+	}
+}
+
 func (p *Win32Menu) newMenu() w32.HMENU {
 	if p.isPopup {
 		return w32.NewPopupMenu()

--- a/v3/pkg/application/webview_window_windows.go
+++ b/v3/pkg/application/webview_window_windows.go
@@ -117,21 +117,50 @@ func (w *windowsWebviewWindow) setMenu(menu *Menu) {
 	if w.parent.options.Windows.DisableMenu {
 		return
 	}
+	// A nil menu means "no menu", which is what macOS makes of it. Update
+	// dereferences its receiver once the application is running, so without
+	// this the call panicked rather than doing nothing (#6104).
+	if menu == nil {
+		return
+	}
 	menu.Update()
+
+	// The menu being replaced owns an HMENU, the HBITMAPs SetMenuIcons
+	// allocated while building it, and the submenu handles detached for hidden
+	// rows. Win32Menu.Update frees those, but only for the same object, and
+	// this builds a new one - so without freeing it here nothing ever does
+	// (#6102). Its runtime bitmaps are taken first, because building the
+	// replacement reassigns item.impl and would put them out of reach.
+	previous := w.menu
+	if previous != nil {
+		previous.takeRuntimeBitmaps()
+	}
+
 	w.menu = NewApplicationMenu(w, menu)
 	w.menu.parentWindow = w
 	w32.SetMenu(w.hwnd, w.menu.menu)
+
+	// Only once the window has been given the new menu: destroying one that is
+	// still assigned to a window leaves it pointing at a freed handle.
+	if previous != nil {
+		previous.Destroy()
+	}
 
 	// Set menu background if theme is active
 	if w.menubarTheme != nil {
 		globalApplication.debug("Applying menubar theme in setMenu", "window", w.parent.id)
 		w.menubarTheme.SetMenuBackground(w.menu.menu)
-		w32.DrawMenuBar(w.hwnd)
 		// Force a repaint of the menu area
 		w32.InvalidateRect(w.hwnd, nil, true)
 	} else {
 		globalApplication.debug("No menubar theme to apply in setMenu", "window", w.parent.id)
 	}
+
+	// Outside the branch above: the bar has to be redrawn whenever the menu
+	// changes, not only when a menubar theme happens to be set, or the window
+	// goes on showing the old one until something else forces a repaint
+	// (#6103).
+	w32.DrawMenuBar(w.hwnd)
 
 	// Check if using translucent background with Mica - this makes menubars invisible
 	if w.parent.options.BackgroundType == BackgroundTypeTranslucent &&

--- a/v3/pkg/w32/user32.go
+++ b/v3/pkg/w32/user32.go
@@ -102,6 +102,7 @@ var (
 	procRemoveMenu                    = moduser32.NewProc("RemoveMenu")
 	procGetMenuItemPosition           = moduser32.NewProc("GetMenuItemPosition")
 	procDestroyMenu                   = moduser32.NewProc("DestroyMenu")
+	procIsMenu                        = moduser32.NewProc("IsMenu")
 	procCreatePopupMenu               = moduser32.NewProc("CreatePopupMenu")
 	procCheckMenuRadioItem            = moduser32.NewProc("CheckMenuRadioItem")
 	procCreateIconFromResourceEx      = moduser32.NewProc("CreateIconFromResourceEx")
@@ -1484,6 +1485,14 @@ func GetKeyState(nVirtKey int32) int16 {
 
 func DestroyMenu(hMenu HMENU) bool {
 	ret, _, _ := procDestroyMenu.Call(uintptr(hMenu))
+	return ret != 0
+}
+
+// IsMenu reports whether the handle is still a menu. A destroyed menu handle
+// is not, which is what makes it possible to tell that a menu was actually
+// freed rather than merely dropped.
+func IsMenu(hMenu HMENU) bool {
+	ret, _, _ := procIsMenu.Call(uintptr(hMenu))
 	return ret != 0
 }
 


### PR DESCRIPTION
Fixes #6102, fixes #6103, fixes #6104.

Three defects in `windowsWebviewWindow.setMenu`, each with a test confirmed to fail without its fix.

## #6102 — the replaced menu's handles are never freed

`setMenu` builds a **new** `Win32Menu` via `NewApplicationMenu` and drops the previous one without freeing its `HMENU`, the `HBITMAP`s allocated while building it, or the submenu handles detached for hidden rows.

`Win32Menu.Update()` does free all three — but only for the *same object*, and this constructs a new one, so that path never reaches the outgoing menu. `DestroyMenu` is used 13 times across the menu implementation and zero times in the file that replaces menus.

Two ordering constraints matter, neither obvious:

- The runtime bitmaps must be taken off the item impls **before** the replacement is built. Building reassigns `item.impl`, putting them beyond the mapping walk that would free them. Factored out as `takeRuntimeBitmaps` so `Update` and `setMenu` share it.
- The outgoing menu must be destroyed **after** `SetMenu`, not before — destroying one still assigned to a window leaves the window pointing at a freed handle.

There is a test for replacing a window's menu with the *same* `*Menu` object, since that is where the ownership hazard lives.

## #6103 — the menu bar is not redrawn without a menubar theme

`DrawMenuBar` appeared exactly once in the function, inside `if w.menubarTheme != nil`. An application setting a menu at runtime without a theme never told Windows the bar had changed. It now runs after every `SetMenu`; `SetMenuBackground` and `InvalidateRect` stay where they were.

## #6104 — `SetMenu(nil)` panics on Windows, no-ops on macOS

`setMenu` dereferenced its argument with no nil check. `Menu.Update()` returns early when the application is not running, so the panic only fires on a running application — which is when `SetMenu` would be called. Past those guards it reaches `processRadioGroups()` and `m.impl` on a nil receiver. It now returns, matching macOS.

## `w32.IsMenu`

Added because without it a freed handle cannot be distinguished from a dropped one. That is what makes the leak assertable, and plausibly why it survived this long.

## Testing

Run on Windows, not type-checked:

```
TestWindowsSetMenuIgnoresANilMenu         PASS
TestWindowsSetMenuFreesTheMenuItReplaces  PASS
TestWindowsSetMenuWithTheSameMenuTwice    PASS
./pkg/application  ok          ./pkg/w32  ok
```

Each was confirmed to fail with its fix backed out: without `Destroy()` both leak assertions report the replaced `HMENU` still live; without the nil check it panics in `processRadioGroups`.

`go vet ./pkg/application/ ./pkg/w32/` reports **25 findings on this branch and 25 on master at `0cb402470`** — identical once line numbers are normalised. All are pre-existing `possible misuse of unsafe.Pointer`, most of them in `w32`. Unchanged rather than clean.

`go build ./pkg/...` is clean. `go build ./...` fails in `internal/commands/build_assets/ios` with `function main is undeclared in the main package`, which reproduces on `0cb402470` and is unrelated to this change.

## How they were found

By sharing the Windows menu implementation with a second frontend. Writing the same logic a second time, with different questions in mind, surfaced what reviewing it had not — the destroy-before-`SetMenu` ordering in particular had already passed review and run in a live application.

https://claude.ai/code/session_01WP7MWnMpQDT2WB7CPLWbqr

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows menu handling when menus are absent, replaced, or fail to apply.
  * Prevented crashes when clearing a window’s menu.
  * Preserved the existing menu when a replacement cannot be applied.
  * Ensured replaced menus and associated resources are properly released without leaks.
  * Preserved existing menu items when updates fail.
  * Refreshed the Windows menubar consistently after menu changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->