### PR TITLE
Fix generic binding creator initialization order

### DIFF
--- a/v3/UNRELEASED_CHANGELOG.md
+++ b/v3/UNRELEASED_CHANGELOG.md
@@ -24,6 +24,8 @@ After processing, the content will be moved to the main changelog and this file 
 ## Fixed
 <!-- Bug fixes -->
 
+- Fix generated JavaScript and TypeScript bindings failing to load when generic model creators reference later helper declarations (#6062)
+
 ## Deprecated
 <!-- Soon-to-be removed features -->
 

--- a/v3/internal/generator/generate_runtime_test.go
+++ b/v3/internal/generator/generate_runtime_test.go
@@ -60,7 +60,7 @@ if (!($$instance.GenericType instanceof GenericType)) {
     throw new Error("generic model field was not created");
 }
 `
-	testModelsPath := filepath.Join(outputDir, "models.test.mjs")
+	testModelsPath := filepath.Join(filepath.Dir(modelsPath), "models.test.mjs")
 	if err := os.WriteFile(testModelsPath, []byte(testSource), 0600); err != nil {
 		t.Fatal(err)
 	}

--- a/v3/internal/generator/generate_runtime_test.go
+++ b/v3/internal/generator/generate_runtime_test.go
@@ -1,0 +1,72 @@
+package generator
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/wailsapp/wails/v3/internal/flags"
+	"github.com/wailsapp/wails/v3/internal/generator/config"
+)
+
+func TestGeneratedJavaScriptCanBeImportedWithGenericModels(t *testing.T) {
+	node, err := exec.LookPath("node")
+	if err != nil {
+		t.Skip("node is required for executable generated JavaScript tests")
+	}
+
+	outputDir := t.TempDir()
+	options := &flags.GenerateBindingsOptions{
+		ModelsFilename:    "models",
+		IndexFilename:     "index",
+		UseBundledRuntime: true,
+		TimeType:          "Date",
+	}
+
+	generator := NewGenerator(options, config.DirCreator(outputDir), config.NullLogger)
+	_, err = generator.Generate("github.com/wailsapp/wails/v3/internal/generator/testcases/type_mapping")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	modelsPath := filepath.Join(
+		outputDir,
+		"github.com/wailsapp/wails/v3/internal/generator/testcases/type_mapping/models.js",
+	)
+	source, err := os.ReadFile(modelsPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	const runtimeImport = `import { Create as $Create } from "/wails/runtime.js";`
+	const runtimeStub = `
+const $$identity = value => value;
+const $Create = new Proxy({}, {
+    get: (_, name) => name === "Any" || name === "ByteSlice" || name === "DateFromTime"
+        ? $$identity
+        : () => $$identity,
+});`
+	if !strings.Contains(string(source), runtimeImport) {
+		t.Fatalf("generated models do not contain expected runtime import %q", runtimeImport)
+	}
+
+	testSource := strings.Replace(string(source), runtimeImport, runtimeStub, 1) + `
+const $$instance = AllTypes.createFrom({
+    GenericType: { ID: 1, Data: 2, List: [3] },
+});
+if (!($$instance.GenericType instanceof GenericType)) {
+    throw new Error("generic model field was not created");
+}
+`
+	testModelsPath := filepath.Join(outputDir, "models.test.mjs")
+	if err := os.WriteFile(testModelsPath, []byte(testSource), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	command := exec.Command(node, testModelsPath)
+	if output, err := command.CombinedOutput(); err != nil {
+		t.Fatalf("generated JavaScript could not be imported: %v\n%s", err, output)
+	}
+}

--- a/v3/internal/generator/generate_runtime_test.go
+++ b/v3/internal/generator/generate_runtime_test.go
@@ -1,11 +1,13 @@
 package generator
 
 import (
+	"context"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/wailsapp/wails/v3/internal/flags"
 	"github.com/wailsapp/wails/v3/internal/generator/config"
@@ -65,7 +67,9 @@ if (!($$instance.GenericType instanceof GenericType)) {
 		t.Fatal(err)
 	}
 
-	command := exec.Command(node, testModelsPath)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	command := exec.CommandContext(ctx, node, testModelsPath)
 	if output, err := command.CombinedOutput(); err != nil {
 		t.Fatalf("generated JavaScript could not be imported: %v\n%s", err, output)
 	}

--- a/v3/internal/generator/render/create.go
+++ b/v3/internal/generator/render/create.go
@@ -258,9 +258,36 @@ func (m *module) PostponedCreates() []string {
 			result[pp.index] = fmt.Sprintf("%s$Create.Map($Create.Any, %s)%s", pre, m.JSCreateWithParams(t.Elem(), pp.params), post)
 
 		case *types.Named:
-			if !collect.IsClass(key) {
-				// Creation functions for non-struct named types
-				// require an indirect assignment to break cycles.
+			var builder strings.Builder
+			if collect.IsClass(key) {
+				if t.Obj().Pkg().Path() == m.Imports.Self {
+					if m.Imports.ImportModels {
+						builder.WriteString("$models.")
+					}
+				} else {
+					builder.WriteString(jsimport(m.Imports.External[t.Obj().Pkg().Path()]))
+					builder.WriteRune('.')
+				}
+				builder.WriteString(jsid(t.Obj().Name()))
+				builder.WriteString(".createFrom")
+
+				if t.TypeArgs() != nil && t.TypeArgs().Len() > 0 {
+					builder.WriteString("(")
+					for i := range t.TypeArgs().Len() {
+						if i > 0 {
+							builder.WriteString(", ")
+						}
+						builder.WriteString(m.JSCreateWithParams(t.TypeArgs().At(i), pp.params))
+					}
+					builder.WriteString(")")
+				}
+			} else {
+				builder.WriteString(m.JSCreateWithParams(t.Underlying(), pp.params))
+			}
+
+			if !collect.IsClass(key) || t.TypeArgs() != nil && t.TypeArgs().Len() > 0 {
+				// Creation functions for non-struct named types and instantiated
+				// generic classes require an indirect assignment to break cycles.
 
 				// Typescript cannot infer the return type on its own: add hints.
 				cast, argType, returnType := "", "", ""
@@ -280,42 +307,13 @@ func (m *module) PostponedCreates() []string {
 })`,
 					cast, pp.index, argType, returnType,
 					pp.index, pp.index,
-					pp.index, pre, m.JSCreateWithParams(t.Underlying(), pp.params), post,
+					pp.index, pre, builder.String(), post,
 					pp.index,
 				)[1:] // Remove initial newline.
-
-				// We're done.
 				break
 			}
 
-			var builder strings.Builder
-
-			builder.WriteString(pre)
-
-			if t.Obj().Pkg().Path() == m.Imports.Self {
-				if m.Imports.ImportModels {
-					builder.WriteString("$models.")
-				}
-			} else {
-				builder.WriteString(jsimport(m.Imports.External[t.Obj().Pkg().Path()]))
-				builder.WriteRune('.')
-			}
-			builder.WriteString(jsid(t.Obj().Name()))
-			builder.WriteString(".createFrom")
-
-			if t.TypeArgs() != nil && t.TypeArgs().Len() > 0 {
-				builder.WriteString("(")
-				for i := range t.TypeArgs().Len() {
-					if i > 0 {
-						builder.WriteString(", ")
-					}
-					builder.WriteString(m.JSCreateWithParams(t.TypeArgs().At(i), pp.params))
-				}
-				builder.WriteString(")")
-			}
-			builder.WriteString(post)
-
-			result[pp.index] = builder.String()
+			result[pp.index] = pre + builder.String() + post
 
 		case *types.Pointer:
 			result[pp.index] = fmt.Sprintf("%s$Create.Nullable(%s)%s", pre, m.JSCreateWithParams(t.Elem(), pp.params), post)

--- a/v3/internal/generator/testdata/output/lang=JS/UseInterfaces=false/UseNames=false/github.com/wailsapp/wails/v3/internal/generator/testcases/aliases/greetservice.js
+++ b/v3/internal/generator/testdata/output/lang=JS/UseInterfaces=false/UseNames=false/github.com/wailsapp/wails/v3/internal/generator/testcases/aliases/greetservice.js
@@ -95,7 +95,12 @@ export function Greet($0, $1) {
 
 // Private type creation functions
 const $$createType0 = $models.Person.createFrom;
-const $$createType1 = $models.GenericPerson.createFrom($Create.Any);
+var $$createType1 = /** @type {(...args: any[]) => any} */(function $$initCreateType1(...args) {
+    if ($$createType1 === $$initCreateType1) {
+        $$createType1 = $models.GenericPerson.createFrom($Create.Any);
+    }
+    return $$createType1(...args);
+});
 const $$createType2 = nobindingshere$0.personImpl.createFrom;
 const $$createType3 = $models.AliasGroup.createFrom;
 const $$createType4 = subpkg$0.SubStruct.createFrom;

--- a/v3/internal/generator/testdata/output/lang=JS/UseInterfaces=false/UseNames=false/github.com/wailsapp/wails/v3/internal/generator/testcases/aliases/models.js
+++ b/v3/internal/generator/testdata/output/lang=JS/UseInterfaces=false/UseNames=false/github.com/wailsapp/wails/v3/internal/generator/testcases/aliases/models.js
@@ -306,9 +306,19 @@ export const SubPackageAlias = subpkg$0.SubStruct;
 const $$createType0 = $Create.Array($Create.Any);
 const $$createType1 = $Create.Nullable($$createType0);
 const $$createType2 = $Create.Array($Create.Any);
-const $$createType3 = GenericPerson.createFrom($$createType2);
+var $$createType3 = /** @type {(...args: any[]) => any} */(function $$initCreateType3(...args) {
+    if ($$createType3 === $$initCreateType3) {
+        $$createType3 = GenericPerson.createFrom($$createType2);
+    }
+    return $$createType3(...args);
+});
 const $$createType4 = $Create.Nullable($$createType3);
 const $$createType5 = $Create.Map($Create.Any, $Create.Any);
 const $$createType6 = $Create.Array($Create.Any);
-const $$createType7 = GenericPerson.createFrom($$createType6);
+var $$createType7 = /** @type {(...args: any[]) => any} */(function $$initCreateType7(...args) {
+    if ($$createType7 === $$initCreateType7) {
+        $$createType7 = GenericPerson.createFrom($$createType6);
+    }
+    return $$createType7(...args);
+});
 const $$createType8 = subpkg$0.SubStruct.createFrom;

--- a/v3/internal/generator/testdata/output/lang=JS/UseInterfaces=false/UseNames=false/github.com/wailsapp/wails/v3/internal/generator/testcases/events_only/models.js
+++ b/v3/internal/generator/testdata/output/lang=JS/UseInterfaces=false/UseNames=false/github.com/wailsapp/wails/v3/internal/generator/testcases/events_only/models.js
@@ -53,4 +53,9 @@ export class SomeClass {
 }
 
 // Private type creation functions
-const $$createType0 = nobindingshere$0.HowDifferent.createFrom($Create.Any);
+var $$createType0 = /** @type {(...args: any[]) => any} */(function $$initCreateType0(...args) {
+    if ($$createType0 === $$initCreateType0) {
+        $$createType0 = nobindingshere$0.HowDifferent.createFrom($Create.Any);
+    }
+    return $$createType0(...args);
+});

--- a/v3/internal/generator/testdata/output/lang=JS/UseInterfaces=false/UseNames=false/github.com/wailsapp/wails/v3/internal/generator/testcases/map_keys/service.js
+++ b/v3/internal/generator/testdata/output/lang=JS/UseInterfaces=false/UseNames=false/github.com/wailsapp/wails/v3/internal/generator/testcases/map_keys/service.js
@@ -20,4 +20,9 @@ export function Method() {
 }
 
 // Private type creation functions
-const $$createType0 = $models.Maps.createFrom($Create.Any, $Create.Any, $Create.Any, $Create.Any, $Create.Any, $Create.Any, $Create.Any, $Create.Any, $Create.Any);
+var $$createType0 = /** @type {(...args: any[]) => any} */(function $$initCreateType0(...args) {
+    if ($$createType0 === $$initCreateType0) {
+        $$createType0 = $models.Maps.createFrom($Create.Any, $Create.Any, $Create.Any, $Create.Any, $Create.Any, $Create.Any, $Create.Any, $Create.Any, $Create.Any);
+    }
+    return $$createType0(...args);
+});

--- a/v3/internal/generator/testdata/output/lang=JS/UseInterfaces=false/UseNames=false/github.com/wailsapp/wails/v3/internal/generator/testcases/no_bindings_here/models.js
+++ b/v3/internal/generator/testdata/output/lang=JS/UseInterfaces=false/UseNames=false/github.com/wailsapp/wails/v3/internal/generator/testcases/no_bindings_here/models.js
@@ -177,5 +177,10 @@ export const PrivatePerson = personImpl;
 // Private type creation functions
 const $$createType0 = /** @type {(...args: any[]) => any} */(($$createParamHow) => $Create.Map($Create.Any, $$createParamHow));
 const $$createType1 = /** @type {(...args: any[]) => any} */(($$createParamHow) => $Create.Array($$createType0($$createParamHow)));
-const $$createType2 = other$0.OtherPerson.createFrom($Create.Any);
+var $$createType2 = /** @type {(...args: any[]) => any} */(function $$initCreateType2(...args) {
+    if ($$createType2 === $$initCreateType2) {
+        $$createType2 = other$0.OtherPerson.createFrom($Create.Any);
+    }
+    return $$createType2(...args);
+});
 const $$createType3 = $Create.Array($$createType2);

--- a/v3/internal/generator/testdata/output/lang=JS/UseInterfaces=false/UseNames=false/github.com/wailsapp/wails/v3/internal/generator/testcases/no_bindings_here/somemethods.js
+++ b/v3/internal/generator/testdata/output/lang=JS/UseInterfaces=false/UseNames=false/github.com/wailsapp/wails/v3/internal/generator/testcases/no_bindings_here/somemethods.js
@@ -38,5 +38,10 @@ export function LikeThisOtherOne() {
 
 // Private type creation functions
 const $$createType0 = $models.Person.createFrom;
-const $$createType1 = $models.HowDifferent.createFrom($Create.Any);
+var $$createType1 = /** @type {(...args: any[]) => any} */(function $$initCreateType1(...args) {
+    if ($$createType1 === $$initCreateType1) {
+        $$createType1 = $models.HowDifferent.createFrom($Create.Any);
+    }
+    return $$createType1(...args);
+});
 const $$createType2 = $models.personImpl.createFrom;

--- a/v3/internal/generator/testdata/output/lang=JS/UseInterfaces=false/UseNames=false/github.com/wailsapp/wails/v3/internal/generator/testcases/out_of_tree/embedservice.js
+++ b/v3/internal/generator/testdata/output/lang=JS/UseInterfaces=false/UseNames=false/github.com/wailsapp/wails/v3/internal/generator/testcases/out_of_tree/embedservice.js
@@ -38,5 +38,10 @@ export function LikeThisOtherOne() {
 
 // Private type creation functions
 const $$createType0 = nobindingshere$0.Person.createFrom;
-const $$createType1 = nobindingshere$0.HowDifferent.createFrom($Create.Any);
+var $$createType1 = /** @type {(...args: any[]) => any} */(function $$initCreateType1(...args) {
+    if ($$createType1 === $$initCreateType1) {
+        $$createType1 = nobindingshere$0.HowDifferent.createFrom($Create.Any);
+    }
+    return $$createType1(...args);
+});
 const $$createType2 = nobindingshere$0.personImpl.createFrom;

--- a/v3/internal/generator/testdata/output/lang=JS/UseInterfaces=false/UseNames=false/github.com/wailsapp/wails/v3/internal/generator/testcases/type_mapping/models.js
+++ b/v3/internal/generator/testdata/output/lang=JS/UseInterfaces=false/UseNames=false/github.com/wailsapp/wails/v3/internal/generator/testcases/type_mapping/models.js
@@ -343,5 +343,10 @@ const $$createType6 = $Create.Nullable($$createType5);
 const $$createType7 = $Create.Struct({
     "MapByteBool": $$createType3,
 });
-const $$createType8 = GenericType.createFrom($Create.Any);
+var $$createType8 = /** @type {(...args: any[]) => any} */(function $$initCreateType8(...args) {
+    if ($$createType8 === $$initCreateType8) {
+        $$createType8 = GenericType.createFrom($Create.Any);
+    }
+    return $$createType8(...args);
+});
 const $$createType9 = /** @type {(...args: any[]) => any} */(($$createParamT) => $Create.Array($$createParamT));

--- a/v3/internal/generator/testdata/output/lang=JS/UseInterfaces=false/UseNames=true/github.com/wailsapp/wails/v3/internal/generator/testcases/aliases/greetservice.js
+++ b/v3/internal/generator/testdata/output/lang=JS/UseInterfaces=false/UseNames=true/github.com/wailsapp/wails/v3/internal/generator/testcases/aliases/greetservice.js
@@ -95,7 +95,12 @@ export function Greet($0, $1) {
 
 // Private type creation functions
 const $$createType0 = $models.Person.createFrom;
-const $$createType1 = $models.GenericPerson.createFrom($Create.Any);
+var $$createType1 = /** @type {(...args: any[]) => any} */(function $$initCreateType1(...args) {
+    if ($$createType1 === $$initCreateType1) {
+        $$createType1 = $models.GenericPerson.createFrom($Create.Any);
+    }
+    return $$createType1(...args);
+});
 const $$createType2 = nobindingshere$0.personImpl.createFrom;
 const $$createType3 = $models.AliasGroup.createFrom;
 const $$createType4 = subpkg$0.SubStruct.createFrom;

--- a/v3/internal/generator/testdata/output/lang=JS/UseInterfaces=false/UseNames=true/github.com/wailsapp/wails/v3/internal/generator/testcases/aliases/models.js
+++ b/v3/internal/generator/testdata/output/lang=JS/UseInterfaces=false/UseNames=true/github.com/wailsapp/wails/v3/internal/generator/testcases/aliases/models.js
@@ -306,9 +306,19 @@ export const SubPackageAlias = subpkg$0.SubStruct;
 const $$createType0 = $Create.Array($Create.Any);
 const $$createType1 = $Create.Nullable($$createType0);
 const $$createType2 = $Create.Array($Create.Any);
-const $$createType3 = GenericPerson.createFrom($$createType2);
+var $$createType3 = /** @type {(...args: any[]) => any} */(function $$initCreateType3(...args) {
+    if ($$createType3 === $$initCreateType3) {
+        $$createType3 = GenericPerson.createFrom($$createType2);
+    }
+    return $$createType3(...args);
+});
 const $$createType4 = $Create.Nullable($$createType3);
 const $$createType5 = $Create.Map($Create.Any, $Create.Any);
 const $$createType6 = $Create.Array($Create.Any);
-const $$createType7 = GenericPerson.createFrom($$createType6);
+var $$createType7 = /** @type {(...args: any[]) => any} */(function $$initCreateType7(...args) {
+    if ($$createType7 === $$initCreateType7) {
+        $$createType7 = GenericPerson.createFrom($$createType6);
+    }
+    return $$createType7(...args);
+});
 const $$createType8 = subpkg$0.SubStruct.createFrom;

--- a/v3/internal/generator/testdata/output/lang=JS/UseInterfaces=false/UseNames=true/github.com/wailsapp/wails/v3/internal/generator/testcases/events_only/models.js
+++ b/v3/internal/generator/testdata/output/lang=JS/UseInterfaces=false/UseNames=true/github.com/wailsapp/wails/v3/internal/generator/testcases/events_only/models.js
@@ -53,4 +53,9 @@ export class SomeClass {
 }
 
 // Private type creation functions
-const $$createType0 = nobindingshere$0.HowDifferent.createFrom($Create.Any);
+var $$createType0 = /** @type {(...args: any[]) => any} */(function $$initCreateType0(...args) {
+    if ($$createType0 === $$initCreateType0) {
+        $$createType0 = nobindingshere$0.HowDifferent.createFrom($Create.Any);
+    }
+    return $$createType0(...args);
+});

--- a/v3/internal/generator/testdata/output/lang=JS/UseInterfaces=false/UseNames=true/github.com/wailsapp/wails/v3/internal/generator/testcases/map_keys/service.js
+++ b/v3/internal/generator/testdata/output/lang=JS/UseInterfaces=false/UseNames=true/github.com/wailsapp/wails/v3/internal/generator/testcases/map_keys/service.js
@@ -20,4 +20,9 @@ export function Method() {
 }
 
 // Private type creation functions
-const $$createType0 = $models.Maps.createFrom($Create.Any, $Create.Any, $Create.Any, $Create.Any, $Create.Any, $Create.Any, $Create.Any, $Create.Any, $Create.Any);
+var $$createType0 = /** @type {(...args: any[]) => any} */(function $$initCreateType0(...args) {
+    if ($$createType0 === $$initCreateType0) {
+        $$createType0 = $models.Maps.createFrom($Create.Any, $Create.Any, $Create.Any, $Create.Any, $Create.Any, $Create.Any, $Create.Any, $Create.Any, $Create.Any);
+    }
+    return $$createType0(...args);
+});

--- a/v3/internal/generator/testdata/output/lang=JS/UseInterfaces=false/UseNames=true/github.com/wailsapp/wails/v3/internal/generator/testcases/no_bindings_here/models.js
+++ b/v3/internal/generator/testdata/output/lang=JS/UseInterfaces=false/UseNames=true/github.com/wailsapp/wails/v3/internal/generator/testcases/no_bindings_here/models.js
@@ -177,5 +177,10 @@ export const PrivatePerson = personImpl;
 // Private type creation functions
 const $$createType0 = /** @type {(...args: any[]) => any} */(($$createParamHow) => $Create.Map($Create.Any, $$createParamHow));
 const $$createType1 = /** @type {(...args: any[]) => any} */(($$createParamHow) => $Create.Array($$createType0($$createParamHow)));
-const $$createType2 = other$0.OtherPerson.createFrom($Create.Any);
+var $$createType2 = /** @type {(...args: any[]) => any} */(function $$initCreateType2(...args) {
+    if ($$createType2 === $$initCreateType2) {
+        $$createType2 = other$0.OtherPerson.createFrom($Create.Any);
+    }
+    return $$createType2(...args);
+});
 const $$createType3 = $Create.Array($$createType2);

--- a/v3/internal/generator/testdata/output/lang=JS/UseInterfaces=false/UseNames=true/github.com/wailsapp/wails/v3/internal/generator/testcases/no_bindings_here/somemethods.js
+++ b/v3/internal/generator/testdata/output/lang=JS/UseInterfaces=false/UseNames=true/github.com/wailsapp/wails/v3/internal/generator/testcases/no_bindings_here/somemethods.js
@@ -38,5 +38,10 @@ export function LikeThisOtherOne() {
 
 // Private type creation functions
 const $$createType0 = $models.Person.createFrom;
-const $$createType1 = $models.HowDifferent.createFrom($Create.Any);
+var $$createType1 = /** @type {(...args: any[]) => any} */(function $$initCreateType1(...args) {
+    if ($$createType1 === $$initCreateType1) {
+        $$createType1 = $models.HowDifferent.createFrom($Create.Any);
+    }
+    return $$createType1(...args);
+});
 const $$createType2 = $models.personImpl.createFrom;

--- a/v3/internal/generator/testdata/output/lang=JS/UseInterfaces=false/UseNames=true/github.com/wailsapp/wails/v3/internal/generator/testcases/out_of_tree/embedservice.js
+++ b/v3/internal/generator/testdata/output/lang=JS/UseInterfaces=false/UseNames=true/github.com/wailsapp/wails/v3/internal/generator/testcases/out_of_tree/embedservice.js
@@ -38,5 +38,10 @@ export function LikeThisOtherOne() {
 
 // Private type creation functions
 const $$createType0 = nobindingshere$0.Person.createFrom;
-const $$createType1 = nobindingshere$0.HowDifferent.createFrom($Create.Any);
+var $$createType1 = /** @type {(...args: any[]) => any} */(function $$initCreateType1(...args) {
+    if ($$createType1 === $$initCreateType1) {
+        $$createType1 = nobindingshere$0.HowDifferent.createFrom($Create.Any);
+    }
+    return $$createType1(...args);
+});
 const $$createType2 = nobindingshere$0.personImpl.createFrom;

--- a/v3/internal/generator/testdata/output/lang=JS/UseInterfaces=false/UseNames=true/github.com/wailsapp/wails/v3/internal/generator/testcases/type_mapping/models.js
+++ b/v3/internal/generator/testdata/output/lang=JS/UseInterfaces=false/UseNames=true/github.com/wailsapp/wails/v3/internal/generator/testcases/type_mapping/models.js
@@ -339,5 +339,10 @@ const $$createType6 = $Create.Nullable($$createType5);
 const $$createType7 = $Create.Struct({
     "MapByteBool": $$createType3,
 });
-const $$createType8 = GenericType.createFrom($Create.Any);
+var $$createType8 = /** @type {(...args: any[]) => any} */(function $$initCreateType8(...args) {
+    if ($$createType8 === $$initCreateType8) {
+        $$createType8 = GenericType.createFrom($Create.Any);
+    }
+    return $$createType8(...args);
+});
 const $$createType9 = /** @type {(...args: any[]) => any} */(($$createParamT) => $Create.Array($$createParamT));

--- a/v3/internal/generator/testdata/output/lang=TS/UseInterfaces=false/UseNames=false/github.com/wailsapp/wails/v3/internal/generator/testcases/aliases/greetservice.ts
+++ b/v3/internal/generator/testdata/output/lang=TS/UseInterfaces=false/UseNames=false/github.com/wailsapp/wails/v3/internal/generator/testcases/aliases/greetservice.ts
@@ -77,7 +77,12 @@ export function Greet($0: $models.EmptyAliasStruct, $1: $models.EmptyStruct): $C
 
 // Private type creation functions
 const $$createType0 = $models.Person.createFrom;
-const $$createType1 = $models.GenericPerson.createFrom($Create.Any);
+var $$createType1 = (function $$initCreateType1(...args: any[]): any {
+    if ($$createType1 === $$initCreateType1) {
+        $$createType1 = $models.GenericPerson.createFrom($Create.Any);
+    }
+    return $$createType1(...args);
+});
 const $$createType2 = nobindingshere$0.personImpl.createFrom;
 const $$createType3 = $models.AliasGroup.createFrom;
 const $$createType4 = subpkg$0.SubStruct.createFrom;

--- a/v3/internal/generator/testdata/output/lang=TS/UseInterfaces=false/UseNames=false/github.com/wailsapp/wails/v3/internal/generator/testcases/aliases/models.ts
+++ b/v3/internal/generator/testdata/output/lang=TS/UseInterfaces=false/UseNames=false/github.com/wailsapp/wails/v3/internal/generator/testcases/aliases/models.ts
@@ -269,9 +269,19 @@ export type SubPackageAlias = subpkg$0.SubStruct;
 const $$createType0 = $Create.Array($Create.Any);
 const $$createType1 = $Create.Nullable($$createType0);
 const $$createType2 = $Create.Array($Create.Any);
-const $$createType3 = GenericPerson.createFrom($$createType2);
+var $$createType3 = (function $$initCreateType3(...args: any[]): any {
+    if ($$createType3 === $$initCreateType3) {
+        $$createType3 = GenericPerson.createFrom($$createType2);
+    }
+    return $$createType3(...args);
+});
 const $$createType4 = $Create.Nullable($$createType3);
 const $$createType5 = $Create.Map($Create.Any, $Create.Any);
 const $$createType6 = $Create.Array($Create.Any);
-const $$createType7 = GenericPerson.createFrom($$createType6);
+var $$createType7 = (function $$initCreateType7(...args: any[]): any {
+    if ($$createType7 === $$initCreateType7) {
+        $$createType7 = GenericPerson.createFrom($$createType6);
+    }
+    return $$createType7(...args);
+});
 const $$createType8 = subpkg$0.SubStruct.createFrom;

--- a/v3/internal/generator/testdata/output/lang=TS/UseInterfaces=false/UseNames=false/github.com/wailsapp/wails/v3/internal/generator/testcases/events_only/models.ts
+++ b/v3/internal/generator/testdata/output/lang=TS/UseInterfaces=false/UseNames=false/github.com/wailsapp/wails/v3/internal/generator/testcases/events_only/models.ts
@@ -42,4 +42,9 @@ export class SomeClass {
 }
 
 // Private type creation functions
-const $$createType0 = nobindingshere$0.HowDifferent.createFrom($Create.Any);
+var $$createType0 = (function $$initCreateType0(...args: any[]): any {
+    if ($$createType0 === $$initCreateType0) {
+        $$createType0 = nobindingshere$0.HowDifferent.createFrom($Create.Any);
+    }
+    return $$createType0(...args);
+});

--- a/v3/internal/generator/testdata/output/lang=TS/UseInterfaces=false/UseNames=false/github.com/wailsapp/wails/v3/internal/generator/testcases/map_keys/service.ts
+++ b/v3/internal/generator/testdata/output/lang=TS/UseInterfaces=false/UseNames=false/github.com/wailsapp/wails/v3/internal/generator/testcases/map_keys/service.ts
@@ -16,4 +16,9 @@ export function Method(): $CancellablePromise<$models.Maps<$models.PointerTextMa
 }
 
 // Private type creation functions
-const $$createType0 = $models.Maps.createFrom($Create.Any, $Create.Any, $Create.Any, $Create.Any, $Create.Any, $Create.Any, $Create.Any, $Create.Any, $Create.Any);
+var $$createType0 = (function $$initCreateType0(...args: any[]): any {
+    if ($$createType0 === $$initCreateType0) {
+        $$createType0 = $models.Maps.createFrom($Create.Any, $Create.Any, $Create.Any, $Create.Any, $Create.Any, $Create.Any, $Create.Any, $Create.Any, $Create.Any);
+    }
+    return $$createType0(...args);
+});

--- a/v3/internal/generator/testdata/output/lang=TS/UseInterfaces=false/UseNames=false/github.com/wailsapp/wails/v3/internal/generator/testcases/no_bindings_here/models.ts
+++ b/v3/internal/generator/testdata/output/lang=TS/UseInterfaces=false/UseNames=false/github.com/wailsapp/wails/v3/internal/generator/testcases/no_bindings_here/models.ts
@@ -159,5 +159,10 @@ export type PrivatePerson = personImpl;
 // Private type creation functions
 const $$createType0 = ($$createParamHow: any) => $Create.Map($Create.Any, $$createParamHow);
 const $$createType1 = ($$createParamHow: any) => $Create.Array($$createType0($$createParamHow));
-const $$createType2 = other$0.OtherPerson.createFrom($Create.Any);
+var $$createType2 = (function $$initCreateType2(...args: any[]): any {
+    if ($$createType2 === $$initCreateType2) {
+        $$createType2 = other$0.OtherPerson.createFrom($Create.Any);
+    }
+    return $$createType2(...args);
+});
 const $$createType3 = $Create.Array($$createType2);

--- a/v3/internal/generator/testdata/output/lang=TS/UseInterfaces=false/UseNames=false/github.com/wailsapp/wails/v3/internal/generator/testcases/no_bindings_here/somemethods.ts
+++ b/v3/internal/generator/testdata/output/lang=TS/UseInterfaces=false/UseNames=false/github.com/wailsapp/wails/v3/internal/generator/testcases/no_bindings_here/somemethods.ts
@@ -35,5 +35,10 @@ export function LikeThisOtherOne(): $CancellablePromise<void> {
 
 // Private type creation functions
 const $$createType0 = $models.Person.createFrom;
-const $$createType1 = $models.HowDifferent.createFrom($Create.Any);
+var $$createType1 = (function $$initCreateType1(...args: any[]): any {
+    if ($$createType1 === $$initCreateType1) {
+        $$createType1 = $models.HowDifferent.createFrom($Create.Any);
+    }
+    return $$createType1(...args);
+});
 const $$createType2 = $models.personImpl.createFrom;

--- a/v3/internal/generator/testdata/output/lang=TS/UseInterfaces=false/UseNames=false/github.com/wailsapp/wails/v3/internal/generator/testcases/out_of_tree/embedservice.ts
+++ b/v3/internal/generator/testdata/output/lang=TS/UseInterfaces=false/UseNames=false/github.com/wailsapp/wails/v3/internal/generator/testcases/out_of_tree/embedservice.ts
@@ -35,5 +35,10 @@ export function LikeThisOtherOne(): $CancellablePromise<void> {
 
 // Private type creation functions
 const $$createType0 = nobindingshere$0.Person.createFrom;
-const $$createType1 = nobindingshere$0.HowDifferent.createFrom($Create.Any);
+var $$createType1 = (function $$initCreateType1(...args: any[]): any {
+    if ($$createType1 === $$initCreateType1) {
+        $$createType1 = nobindingshere$0.HowDifferent.createFrom($Create.Any);
+    }
+    return $$createType1(...args);
+});
 const $$createType2 = nobindingshere$0.personImpl.createFrom;

--- a/v3/internal/generator/testdata/output/lang=TS/UseInterfaces=false/UseNames=false/github.com/wailsapp/wails/v3/internal/generator/testcases/type_mapping/models.ts
+++ b/v3/internal/generator/testdata/output/lang=TS/UseInterfaces=false/UseNames=false/github.com/wailsapp/wails/v3/internal/generator/testcases/type_mapping/models.ts
@@ -240,5 +240,10 @@ const $$createType6 = $Create.Nullable($$createType5);
 const $$createType7 = $Create.Struct({
     "MapByteBool": $$createType3,
 });
-const $$createType8 = GenericType.createFrom($Create.Any);
+var $$createType8 = (function $$initCreateType8(...args: any[]): any {
+    if ($$createType8 === $$initCreateType8) {
+        $$createType8 = GenericType.createFrom($Create.Any);
+    }
+    return $$createType8(...args);
+});
 const $$createType9 = ($$createParamT: any) => $Create.Array($$createParamT);

--- a/v3/internal/generator/testdata/output/lang=TS/UseInterfaces=false/UseNames=true/github.com/wailsapp/wails/v3/internal/generator/testcases/aliases/greetservice.ts
+++ b/v3/internal/generator/testdata/output/lang=TS/UseInterfaces=false/UseNames=true/github.com/wailsapp/wails/v3/internal/generator/testcases/aliases/greetservice.ts
@@ -77,7 +77,12 @@ export function Greet($0: $models.EmptyAliasStruct, $1: $models.EmptyStruct): $C
 
 // Private type creation functions
 const $$createType0 = $models.Person.createFrom;
-const $$createType1 = $models.GenericPerson.createFrom($Create.Any);
+var $$createType1 = (function $$initCreateType1(...args: any[]): any {
+    if ($$createType1 === $$initCreateType1) {
+        $$createType1 = $models.GenericPerson.createFrom($Create.Any);
+    }
+    return $$createType1(...args);
+});
 const $$createType2 = nobindingshere$0.personImpl.createFrom;
 const $$createType3 = $models.AliasGroup.createFrom;
 const $$createType4 = subpkg$0.SubStruct.createFrom;

--- a/v3/internal/generator/testdata/output/lang=TS/UseInterfaces=false/UseNames=true/github.com/wailsapp/wails/v3/internal/generator/testcases/aliases/models.ts
+++ b/v3/internal/generator/testdata/output/lang=TS/UseInterfaces=false/UseNames=true/github.com/wailsapp/wails/v3/internal/generator/testcases/aliases/models.ts
@@ -269,9 +269,19 @@ export type SubPackageAlias = subpkg$0.SubStruct;
 const $$createType0 = $Create.Array($Create.Any);
 const $$createType1 = $Create.Nullable($$createType0);
 const $$createType2 = $Create.Array($Create.Any);
-const $$createType3 = GenericPerson.createFrom($$createType2);
+var $$createType3 = (function $$initCreateType3(...args: any[]): any {
+    if ($$createType3 === $$initCreateType3) {
+        $$createType3 = GenericPerson.createFrom($$createType2);
+    }
+    return $$createType3(...args);
+});
 const $$createType4 = $Create.Nullable($$createType3);
 const $$createType5 = $Create.Map($Create.Any, $Create.Any);
 const $$createType6 = $Create.Array($Create.Any);
-const $$createType7 = GenericPerson.createFrom($$createType6);
+var $$createType7 = (function $$initCreateType7(...args: any[]): any {
+    if ($$createType7 === $$initCreateType7) {
+        $$createType7 = GenericPerson.createFrom($$createType6);
+    }
+    return $$createType7(...args);
+});
 const $$createType8 = subpkg$0.SubStruct.createFrom;

--- a/v3/internal/generator/testdata/output/lang=TS/UseInterfaces=false/UseNames=true/github.com/wailsapp/wails/v3/internal/generator/testcases/events_only/models.ts
+++ b/v3/internal/generator/testdata/output/lang=TS/UseInterfaces=false/UseNames=true/github.com/wailsapp/wails/v3/internal/generator/testcases/events_only/models.ts
@@ -42,4 +42,9 @@ export class SomeClass {
 }
 
 // Private type creation functions
-const $$createType0 = nobindingshere$0.HowDifferent.createFrom($Create.Any);
+var $$createType0 = (function $$initCreateType0(...args: any[]): any {
+    if ($$createType0 === $$initCreateType0) {
+        $$createType0 = nobindingshere$0.HowDifferent.createFrom($Create.Any);
+    }
+    return $$createType0(...args);
+});

--- a/v3/internal/generator/testdata/output/lang=TS/UseInterfaces=false/UseNames=true/github.com/wailsapp/wails/v3/internal/generator/testcases/map_keys/service.ts
+++ b/v3/internal/generator/testdata/output/lang=TS/UseInterfaces=false/UseNames=true/github.com/wailsapp/wails/v3/internal/generator/testcases/map_keys/service.ts
@@ -16,4 +16,9 @@ export function Method(): $CancellablePromise<$models.Maps<$models.PointerTextMa
 }
 
 // Private type creation functions
-const $$createType0 = $models.Maps.createFrom($Create.Any, $Create.Any, $Create.Any, $Create.Any, $Create.Any, $Create.Any, $Create.Any, $Create.Any, $Create.Any);
+var $$createType0 = (function $$initCreateType0(...args: any[]): any {
+    if ($$createType0 === $$initCreateType0) {
+        $$createType0 = $models.Maps.createFrom($Create.Any, $Create.Any, $Create.Any, $Create.Any, $Create.Any, $Create.Any, $Create.Any, $Create.Any, $Create.Any);
+    }
+    return $$createType0(...args);
+});

--- a/v3/internal/generator/testdata/output/lang=TS/UseInterfaces=false/UseNames=true/github.com/wailsapp/wails/v3/internal/generator/testcases/no_bindings_here/models.ts
+++ b/v3/internal/generator/testdata/output/lang=TS/UseInterfaces=false/UseNames=true/github.com/wailsapp/wails/v3/internal/generator/testcases/no_bindings_here/models.ts
@@ -159,5 +159,10 @@ export type PrivatePerson = personImpl;
 // Private type creation functions
 const $$createType0 = ($$createParamHow: any) => $Create.Map($Create.Any, $$createParamHow);
 const $$createType1 = ($$createParamHow: any) => $Create.Array($$createType0($$createParamHow));
-const $$createType2 = other$0.OtherPerson.createFrom($Create.Any);
+var $$createType2 = (function $$initCreateType2(...args: any[]): any {
+    if ($$createType2 === $$initCreateType2) {
+        $$createType2 = other$0.OtherPerson.createFrom($Create.Any);
+    }
+    return $$createType2(...args);
+});
 const $$createType3 = $Create.Array($$createType2);

--- a/v3/internal/generator/testdata/output/lang=TS/UseInterfaces=false/UseNames=true/github.com/wailsapp/wails/v3/internal/generator/testcases/no_bindings_here/somemethods.ts
+++ b/v3/internal/generator/testdata/output/lang=TS/UseInterfaces=false/UseNames=true/github.com/wailsapp/wails/v3/internal/generator/testcases/no_bindings_here/somemethods.ts
@@ -35,5 +35,10 @@ export function LikeThisOtherOne(): $CancellablePromise<void> {
 
 // Private type creation functions
 const $$createType0 = $models.Person.createFrom;
-const $$createType1 = $models.HowDifferent.createFrom($Create.Any);
+var $$createType1 = (function $$initCreateType1(...args: any[]): any {
+    if ($$createType1 === $$initCreateType1) {
+        $$createType1 = $models.HowDifferent.createFrom($Create.Any);
+    }
+    return $$createType1(...args);
+});
 const $$createType2 = $models.personImpl.createFrom;

--- a/v3/internal/generator/testdata/output/lang=TS/UseInterfaces=false/UseNames=true/github.com/wailsapp/wails/v3/internal/generator/testcases/out_of_tree/embedservice.ts
+++ b/v3/internal/generator/testdata/output/lang=TS/UseInterfaces=false/UseNames=true/github.com/wailsapp/wails/v3/internal/generator/testcases/out_of_tree/embedservice.ts
@@ -35,5 +35,10 @@ export function LikeThisOtherOne(): $CancellablePromise<void> {
 
 // Private type creation functions
 const $$createType0 = nobindingshere$0.Person.createFrom;
-const $$createType1 = nobindingshere$0.HowDifferent.createFrom($Create.Any);
+var $$createType1 = (function $$initCreateType1(...args: any[]): any {
+    if ($$createType1 === $$initCreateType1) {
+        $$createType1 = nobindingshere$0.HowDifferent.createFrom($Create.Any);
+    }
+    return $$createType1(...args);
+});
 const $$createType2 = nobindingshere$0.personImpl.createFrom;

--- a/v3/internal/generator/testdata/output/lang=TS/UseInterfaces=false/UseNames=true/github.com/wailsapp/wails/v3/internal/generator/testcases/type_mapping/models.ts
+++ b/v3/internal/generator/testdata/output/lang=TS/UseInterfaces=false/UseNames=true/github.com/wailsapp/wails/v3/internal/generator/testcases/type_mapping/models.ts
@@ -236,5 +236,10 @@ const $$createType6 = $Create.Nullable($$createType5);
 const $$createType7 = $Create.Struct({
     "MapByteBool": $$createType3,
 });
-const $$createType8 = GenericType.createFrom($Create.Any);
+var $$createType8 = (function $$initCreateType8(...args: any[]): any {
+    if ($$createType8 === $$initCreateType8) {
+        $$createType8 = GenericType.createFrom($Create.Any);
+    }
+    return $$createType8(...args);
+});
 const $$createType9 = ($$createParamT: any) => $Create.Array($$createParamT);


### PR DESCRIPTION
# Description

Fix generated JavaScript and TypeScript bindings that fail at module import when an instantiated generic model creator eagerly references a helper declared later. Generic class creators now use the existing self-replacing lazy initializer, preserving cycle-safe resolution without sorting declarations.

This adds executable regression coverage that generates the `type_mapping` fixture, imports it with Node.js, exercises first use, and verifies nested generic model creation. It also regenerates the affected golden bindings and adds a v3 nightly changelog entry.

Dependencies: no new production dependencies. Node.js is required for the executable regression test; the test skips when Node.js is unavailable.

Fixes #6062

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] WEP (Wails Enhancement Proposal)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Run from `v3/internal/generator`:

1. `/var/home/lea/go/bin/wails3 task test`

This runs the Go test suite, imports and executes the generated JavaScript regression fixture, compiles the generated TypeScript, and checks 508 generated files for circular dependencies with madge.

- [ ] Windows
- [ ] macOS
- [x] Linux

Linux distribution: Bazzite 44 (Kinoite), amd64, KDE/Wayland.

## Test Configuration

- Wails CLI: v3.0.0-beta.7
- Go: 1.26.5
- Node.js: 26.7.0
- npm: 11.19.0
- `CGO_ENABLED=1`
- Local CodeRabbit review: no findings
- Hosted CodeRabbit review: no actionable findings

# Checklist

- [ ] (v2 only) I have updated `CHANGELOG.md` with details of changes in this PR
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed generated bindings for mutually dependent generic models, preventing stack overflows during model creation.
  - Ensured separate generic model converters remain isolated and do not reuse one another incorrectly.
  - Deferred generic model converter initialization until first use, improving handling of recursive and circular model relationships.

- **Tests**
  - Added coverage for recursive generic models and runtime import behavior across generated JavaScript and TypeScript bindings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->