### PR TITLE
fix(v3): restore MSIX packaging for fresh projects

### DIFF
--- a/.github/workflows/msix-smoke-v3.yml
+++ b/.github/workflows/msix-smoke-v3.yml
@@ -1,0 +1,33 @@
+name: MSIX packaging v3
+
+on:
+  pull_request:
+    branches: [master]
+    paths:
+      - 'v3/**'
+      - '.github/workflows/msix-smoke-v3.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  package:
+    runs-on: windows-latest
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: [amd64, arm64]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: v3/go.mod
+          cache-dependency-path: v3/go.sum
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - name: Initialize, build and validate MSIX package
+        shell: pwsh
+        run: ./v3/scripts/test-msix.ps1 -Arch '${{ matrix.arch }}' -WorkDir '${{ runner.temp }}/msix smoke'

--- a/v3/cmd/wails3/main.go
+++ b/v3/cmd/wails3/main.go
@@ -98,6 +98,8 @@ func main() {
 	plugin.NewSubCommandFunction("init", "Initialise a new service", commands.ServiceInit)
 
 	tool := app.NewSubCommand("tool", "Various tools")
+	tool.NewSubCommandFunction("msix", "Create a Windows MSIX package", commands.ToolMSIX)
+	tool.NewSubCommand("msix-install-tools", "Install Windows MSIX packaging tools").Action(commands.InstallMSIXTools)
 	tool.NewSubCommandFunction("checkport", "Checks if a port is open. Useful for testing if vite is running.", commands.ToolCheckPort)
 	tool.NewSubCommandFunction("watcher", "Watches files and runs a command when they change", commands.Watcher)
 	tool.NewSubCommandFunction("cp", "Copy files", commands.Cp)

--- a/v3/internal/commands/build_assets/windows/Taskfile.yml
+++ b/v3/internal/commands/build_assets/windows/Taskfile.yml
@@ -141,14 +141,14 @@ tasks:
     cmds:
       - |-
         wails3 tool msix \
-          --config "{{.ROOT_DIR}}/wails.json" \
-          --name "{{.APP_NAME}}" \
+          --config "{{.ROOT_DIR}}/build/config.yml" \
+          --name "{{.APP_NAME}}.exe" \
           --executable "{{.ROOT_DIR}}/{{.BIN_DIR}}/{{.APP_NAME}}.exe" \
           --arch "{{.ARCH}}" \
           --out "{{.ROOT_DIR}}/{{.BIN_DIR}}/{{.APP_NAME}}-{{.ARCH}}.msix" \
           {{if .CERT_PATH}}--cert "{{.CERT_PATH}}"{{end}} \
           {{if .PUBLISHER}}--publisher "{{.PUBLISHER}}"{{end}} \
-          {{if .USE_MSIX_TOOL}}--use-msix-tool{{else}}--use-makeappx{{end}}
+          {{if eq .USE_MSIX_TOOL "true"}}--use-msix-tool{{else}}--use-makeappx{{end}}
     vars:
       ARCH: '{{.ARCH | default ARCH}}'
       CERT_PATH: '{{.CERT_PATH | default ""}}'

--- a/v3/internal/commands/build_assets/windows/msix/app_manifest.xml.tmpl
+++ b/v3/internal/commands/build_assets/windows/msix/app_manifest.xml.tmpl
@@ -9,7 +9,7 @@
   
   <Identity 
     Name="{{.ProductIdentifier}}"
-    Publisher="{{.Publisher}}"
+    Publisher="{{.Publisher | html}}"
     Version="{{.ProductVersion}}.0" 
     ProcessorArchitecture="{{.ProcessorArchitecture}}" />
   

--- a/v3/internal/commands/build_assets/windows/msix/template.xml.tmpl
+++ b/v3/internal/commands/build_assets/windows/msix/template.xml.tmpl
@@ -15,7 +15,7 @@
     <PackageInformation
         PackageName="{{.ProductName}}"
         PackageDisplayName="{{.ProductName}}"
-        PublisherName="CN={{.ProductCompany}}"
+        PublisherName="{{.Publisher | html}}"
         PublisherDisplayName="{{.ProductCompany}}"
         Version="{{.ProductVersion}}.0"
         PackageDescription="{{.ProductDescription}}">

--- a/v3/internal/commands/msix.go
+++ b/v3/internal/commands/msix.go
@@ -102,7 +102,7 @@ func checkMSIXTools(options *flags.ToolMSIX) error {
 	// The Packaging Tool is opt-in; MakeAppx is the default.
 	if options.UseMsixPackagingTool {
 		if _, err := exec.LookPath("MsixPackagingTool.exe"); err != nil {
-			return fmt.Errorf("Microsoft MSIX Packaging Tool is not found in PATH: %w", err)
+			return fmt.Errorf("cannot find Microsoft MSIX Packaging Tool in PATH: %w", err)
 		}
 	} else if _, err := findWindowsSDKTool("MakeAppx.exe"); err != nil {
 		return err
@@ -176,6 +176,12 @@ func validateMSIXOptions(options *MSIXOptions) error {
 	}
 
 	options.ProcessorArchitecture = archToMSIX(options.ProcessorArchitecture)
+	// Validate against the MSIX Identity schema after translating Go names.
+	switch options.ProcessorArchitecture {
+	case "x64", "x86", "arm", "arm64", "x86a64", "neutral":
+	default:
+		return fmt.Errorf("unsupported MSIX processor architecture %q: expected x64, x86, arm, arm64, x86a64, or neutral", options.ProcessorArchitecture)
+	}
 
 	// Set default publisher if not provided
 	if options.Publisher == "" {

--- a/v3/internal/commands/msix.go
+++ b/v3/internal/commands/msix.go
@@ -1,16 +1,20 @@
 package commands
 
 import (
+	"bytes"
 	"embed"
-	"encoding/json"
 	"fmt"
+	"image"
+	"image/png"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"sort"
 	"text/template"
 
 	"github.com/wailsapp/wails/v3/internal/flags"
+	"gopkg.in/yaml.v3"
 )
 
 //go:embed build_assets/windows/msix/*
@@ -18,25 +22,7 @@ var msixAssets embed.FS
 
 // MSIXOptions represents the configuration for MSIX packaging
 type MSIXOptions struct {
-	// Info from project config
-	Info struct {
-		CompanyName       string `json:"companyName"`
-		ProductName       string `json:"productName"`
-		ProductVersion    string `json:"version"`
-		ProductIdentifier string `json:"productIdentifier"`
-		Description       string `json:"description"`
-		Copyright         string `json:"copyright"`
-		Comments          string `json:"comments"`
-	}
-	// File associations
-	FileAssociations []struct {
-		Ext         string `json:"ext"`
-		Name        string `json:"name"`
-		Description string `json:"description"`
-		IconName    string `json:"iconName"`
-		Role        string `json:"role"`
-		MimeType    string `json:"mimeType,omitempty"`
-	} `json:"fileAssociations"`
+	WailsConfig
 	// MSIX specific options
 	Publisher             string `json:"publisher"`
 	CertificatePath       string `json:"certificatePath"`
@@ -65,7 +51,7 @@ func ToolMSIX(options *flags.ToolMSIX) error {
 	// Load project configuration
 	configPath := options.ConfigPath
 	if configPath == "" {
-		configPath = "wails.json"
+		configPath = "build/config.yml"
 	}
 
 	// Read the config file
@@ -75,16 +61,15 @@ func ToolMSIX(options *flags.ToolMSIX) error {
 	}
 
 	// Parse the config
-	var config struct {
-		Info             map[string]interface{}   `json:"info"`
-		FileAssociations []map[string]interface{} `json:"fileAssociations"`
-	}
-	if err := json.Unmarshal(configData, &config); err != nil {
+	var config WailsConfig
+	// YAML also accepts legacy JSON configuration files.
+	if err := yaml.Unmarshal(configData, &config); err != nil {
 		return fmt.Errorf("error parsing config file: %w", err)
 	}
 
 	// Create MSIX options
 	msixOptions := MSIXOptions{
+		WailsConfig:           config,
 		Publisher:             options.Publisher,
 		CertificatePath:       options.CertificatePath,
 		CertificatePassword:   options.CertificatePassword,
@@ -94,26 +79,6 @@ func ToolMSIX(options *flags.ToolMSIX) error {
 		OutputPath:            options.OutputPath,
 		UseMsixPackagingTool:  options.UseMsixPackagingTool,
 		UseMakeAppx:           options.UseMakeAppx,
-	}
-
-	// Copy info from config
-	infoBytes, err := json.Marshal(config.Info)
-	if err != nil {
-		return fmt.Errorf("error marshaling info: %w", err)
-	}
-	if err := json.Unmarshal(infoBytes, &msixOptions.Info); err != nil {
-		return fmt.Errorf("error unmarshaling info: %w", err)
-	}
-
-	// Copy file associations from config
-	if len(config.FileAssociations) > 0 {
-		faBytes, err := json.Marshal(config.FileAssociations)
-		if err != nil {
-			return fmt.Errorf("error marshaling file associations: %w", err)
-		}
-		if err := json.Unmarshal(faBytes, &msixOptions.FileAssociations); err != nil {
-			return fmt.Errorf("error unmarshaling file associations: %w", err)
-		}
 	}
 
 	// Validate options
@@ -134,39 +99,44 @@ func ToolMSIX(options *flags.ToolMSIX) error {
 
 // checkMSIXTools checks if the required tools for MSIX packaging are installed
 func checkMSIXTools(options *flags.ToolMSIX) error {
-	// Check if MsixPackagingTool is installed if requested
+	// The Packaging Tool is opt-in; MakeAppx is the default.
 	if options.UseMsixPackagingTool {
-		cmd := exec.Command("powershell", "-Command", "Get-AppxPackage -Name Microsoft.MsixPackagingTool")
-		if err := cmd.Run(); err != nil {
-			return fmt.Errorf("Microsoft MSIX Packaging Tool is not installed. Please install it from the Microsoft Store")
+		if _, err := exec.LookPath("MsixPackagingTool.exe"); err != nil {
+			return fmt.Errorf("Microsoft MSIX Packaging Tool is not found in PATH: %w", err)
 		}
+	} else if _, err := findWindowsSDKTool("MakeAppx.exe"); err != nil {
+		return err
 	}
-
-	// Check if MakeAppx is available if requested
-	if options.UseMakeAppx {
-		cmd := exec.Command("where", "MakeAppx.exe")
-		if err := cmd.Run(); err != nil {
-			return fmt.Errorf("MakeAppx.exe is not found in PATH. Please install the Windows SDK")
-		}
-	}
-
-	// If neither is specified, check for MakeAppx as the default
-	if !options.UseMsixPackagingTool && !options.UseMakeAppx {
-		cmd := exec.Command("where", "MakeAppx.exe")
-		if err := cmd.Run(); err != nil {
-			return fmt.Errorf("MakeAppx.exe is not found in PATH. Please install the Windows SDK")
-		}
-	}
-
-	// Check if signtool is available for signing
-	if options.CertificatePath != "" {
-		cmd := exec.Command("where", "signtool.exe")
-		if err := cmd.Run(); err != nil {
-			return fmt.Errorf("signtool.exe is not found in PATH. Please install the Windows SDK")
+	if options.CertificatePath != "" && !options.UseMsixPackagingTool {
+		if _, err := findWindowsSDKTool("signtool.exe"); err != nil {
+			return err
 		}
 	}
 
 	return nil
+}
+
+// findWindowsSDKTool prefers PATH, then the Windows SDK's host-architecture tools.
+func findWindowsSDKTool(name string) (string, error) {
+	if path, err := exec.LookPath(name); err == nil {
+		return path, nil
+	}
+	root := os.Getenv("ProgramFiles(x86)")
+	if root == "" {
+		root = `C:\Program Files (x86)`
+	}
+	bin := filepath.Join(root, "Windows Kits", "10", "bin")
+	arch := archToMSIX(runtime.GOARCH)
+	matches, _ := filepath.Glob(filepath.Join(bin, "10.*"))
+	sort.Sort(sort.Reverse(sort.StringSlice(matches)))
+	matches = append(matches, bin)
+	for _, dir := range matches {
+		path := filepath.Join(dir, arch, name)
+		if info, err := os.Stat(path); err == nil && !info.IsDir() {
+			return path, nil
+		}
+	}
+	return "", fmt.Errorf("%s was not found in PATH or the Windows SDK; install the Windows SDK", name)
 }
 
 // validateMSIXOptions validates the MSIX options
@@ -204,6 +174,8 @@ func validateMSIXOptions(options *MSIXOptions) error {
 	if options.ProcessorArchitecture == "" {
 		options.ProcessorArchitecture = archToMSIX(runtime.GOARCH)
 	}
+
+	options.ProcessorArchitecture = archToMSIX(options.ProcessorArchitecture)
 
 	// Set default publisher if not provided
 	if options.Publisher == "" {
@@ -269,7 +241,11 @@ func createMSIXWithMakeAppx(options *MSIXOptions) error {
 
 	// Create the MSIX package
 	fmt.Println("Creating MSIX package using MakeAppx.exe...")
-	cmd := exec.Command("MakeAppx.exe", "pack", "/d", tempDir, "/p", options.OutputPath)
+	makeAppx, err := findWindowsSDKTool("MakeAppx.exe")
+	if err != nil {
+		return err
+	}
+	cmd := exec.Command(makeAppx, "pack", "/o", "/d", tempDir, "/p", options.OutputPath)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	if err := cmd.Run(); err != nil {
@@ -288,7 +264,11 @@ func createMSIXWithMakeAppx(options *MSIXOptions) error {
 
 		signArgs = append(signArgs, options.OutputPath)
 
-		cmd = exec.Command("signtool.exe", signArgs...)
+		signTool, err := findWindowsSDKTool("signtool.exe")
+		if err != nil {
+			return err
+		}
+		cmd = exec.Command(signTool, signArgs...)
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr
 		if err := cmd.Run(); err != nil {
@@ -298,6 +278,28 @@ func createMSIXWithMakeAppx(options *MSIXOptions) error {
 
 	fmt.Printf("MSIX package created successfully: %s\n", options.OutputPath)
 	return nil
+}
+
+// msixBuildConfig uses the same data contract as project build-asset generation.
+func msixBuildConfig(options *MSIXOptions) BuildConfig {
+	return BuildConfig{
+		BuildAssetsOptions: BuildAssetsOptions{
+			ProductName:           options.Info.ProductName,
+			ProductIdentifier:     options.Info.ProductIdentifier,
+			ProductVersion:        options.Info.Version,
+			ProductCompany:        options.Info.CompanyName,
+			ProductDescription:    options.Info.Description,
+			Publisher:             options.Publisher,
+			ProcessorArchitecture: options.ProcessorArchitecture,
+			BinaryName:            filepath.Base(options.ExecutableName),
+			ExecutableName:        filepath.Base(options.ExecutableName),
+			ExecutablePath:        options.ExecutablePath,
+			OutputPath:            options.OutputPath,
+			CertificatePath:       options.CertificatePath,
+		},
+		FileAssociations: options.FileAssociations,
+		Protocols:        options.Protocols,
+	}
 }
 
 // generateMSIXTemplate generates the MSIX template file for the Microsoft MSIX Packaging Tool
@@ -322,7 +324,7 @@ func generateMSIXTemplate(options *MSIXOptions, outputPath string) error {
 	defer file.Close()
 
 	// Execute the template
-	if err := tmpl.Execute(file, options); err != nil {
+	if err := tmpl.Execute(file, msixBuildConfig(options)); err != nil {
 		return fmt.Errorf("error executing template: %w", err)
 	}
 
@@ -344,7 +346,7 @@ func createMSIXPackageStructure(options *MSIXOptions, outputDir string) error {
 	}
 
 	// Copy the executable
-	executableDest := filepath.Join(outputDir, filepath.Base(options.ExecutablePath))
+	executableDest := filepath.Join(outputDir, filepath.Base(options.ExecutableName))
 	if err := copyFile(options.ExecutablePath, executableDest); err != nil {
 		return fmt.Errorf("error copying executable: %w", err)
 	}
@@ -400,7 +402,7 @@ func generateAppxManifest(options *MSIXOptions, outputPath string) error {
 	defer file.Close()
 
 	// Execute the template
-	if err := tmpl.Execute(file, options); err != nil {
+	if err := tmpl.Execute(file, msixBuildConfig(options)); err != nil {
 		return fmt.Errorf("error executing template: %w", err)
 	}
 
@@ -409,20 +411,24 @@ func generateAppxManifest(options *MSIXOptions, outputPath string) error {
 
 // generatePlaceholderImage generates a placeholder image file
 func generatePlaceholderImage(outputPath string) error {
-	// For now, we'll create a simple 1x1 transparent PNG
-	// In a real implementation, we would generate proper icons based on the application icon
-
-	// Create a minimal valid PNG file (1x1 transparent pixel)
-	pngData := []byte{
-		0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0x00, 0x00, 0x0D,
-		0x49, 0x48, 0x44, 0x52, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01,
-		0x08, 0x06, 0x00, 0x00, 0x00, 0x1F, 0x15, 0xC4, 0x89, 0x00, 0x00, 0x00,
-		0x0A, 0x49, 0x44, 0x41, 0x54, 0x78, 0x9C, 0x63, 0x00, 0x01, 0x00, 0x00,
-		0x05, 0x00, 0x01, 0x0D, 0x0A, 0x2D, 0xB4, 0x00, 0x00, 0x00, 0x00, 0x49,
-		0x45, 0x4E, 0x44, 0xAE, 0x42, 0x60, 0x82,
+	// MakeAppx validates the dimensions of each manifest asset.
+	sizes := map[string]image.Point{
+		"Square150x150Logo.png": {150, 150},
+		"Square44x44Logo.png":   {44, 44},
+		"Wide310x150Logo.png":   {310, 150},
+		"SplashScreen.png":      {620, 300},
+		"StoreLogo.png":         {50, 50},
+		"FileIcon.png":          {44, 44},
 	}
-
-	return os.WriteFile(outputPath, pngData, 0644)
+	size, ok := sizes[filepath.Base(outputPath)]
+	if !ok {
+		return fmt.Errorf("unknown MSIX asset: %s", outputPath)
+	}
+	var data bytes.Buffer
+	if err := png.Encode(&data, image.NewNRGBA(image.Rect(0, 0, size.X, size.Y))); err != nil {
+		return err
+	}
+	return os.WriteFile(outputPath, data.Bytes(), 0644)
 }
 
 // copyFile copies a file from src to dst
@@ -456,8 +462,7 @@ func InstallMSIXTools() error {
 	// Check if Windows SDK is installed
 	fmt.Println("Checking for Windows SDK...")
 	sdkInstalled := false
-	cmd = exec.Command("where", "MakeAppx.exe")
-	if err := cmd.Run(); err == nil {
+	if _, err := findWindowsSDKTool("MakeAppx.exe"); err == nil {
 		sdkInstalled = true
 		fmt.Println("Windows SDK is already installed.")
 	}
@@ -476,10 +481,4 @@ func InstallMSIXTools() error {
 
 	fmt.Println("MSIX packaging tools installation initiated. Please complete the installation process in the opened windows.")
 	return nil
-}
-
-// init registers the MSIX command
-func init() {
-	// Register the MSIX command in the CLI
-	// This will be called by the CLI framework
 }

--- a/v3/internal/commands/msix_test.go
+++ b/v3/internal/commands/msix_test.go
@@ -133,3 +133,101 @@ func TestMSIXPackagingToolDoesNotRequireSDK(t *testing.T) {
 		t.Fatal("MakeAppx should require the SDK")
 	}
 }
+
+// TestMSIXArchitectureValidation covers native MSIX names, Go aliases and invalid targets.
+func TestMSIXArchitectureValidation(t *testing.T) {
+	for _, tt := range []struct{ input, want string }{
+		{"", archToMSIX(runtime.GOARCH)},
+		{"amd64", "x64"}, {"x64", "x64"}, {"386", "x86"}, {"x86", "x86"}, {"arm64", "arm64"},
+		{"arm", "arm"}, {"neutral", "neutral"}, {"x86a64", "x86a64"},
+		{"riscv64", ""}, {"invalid", ""}, {"AMD64", ""},
+	} {
+		t.Run(tt.input, func(t *testing.T) {
+			options := validMSIXTestOptions(t)
+			options.ProcessorArchitecture = tt.input
+			err := validateMSIXOptions(&options)
+			if tt.want == "" {
+				if err == nil || !strings.Contains(err.Error(), "unsupported MSIX processor architecture") {
+					t.Fatalf("architecture %q: expected validation error, got %v", tt.input, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			if options.ProcessorArchitecture != tt.want {
+				t.Fatalf("architecture = %q, want %q", options.ProcessorArchitecture, tt.want)
+			}
+		})
+	}
+}
+
+// TestMSIXPackagingTemplatePublisher preserves explicit subjects and the company default.
+func TestMSIXPackagingTemplatePublisher(t *testing.T) {
+	for _, tt := range []struct{ name, publisher, want string }{
+		{"explicit", "CN=Custom Publisher, O=Example, C=GB", "CN=Custom Publisher, O=Example, C=GB"},
+		{"default", "", "CN=Example"},
+		{"xml escaping", `CN="Example & Sons"`, `CN="Example & Sons"`},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			options := validMSIXTestOptions(t)
+			options.Publisher = tt.publisher
+			if err := validateMSIXOptions(&options); err != nil {
+				t.Fatal(err)
+			}
+			path := filepath.Join(t.TempDir(), "template.xml")
+			if err := generateMSIXTemplate(&options, path); err != nil {
+				t.Fatal(err)
+			}
+			data, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			var template struct {
+				PackageInformation struct {
+					Publisher string `xml:"PublisherName,attr"`
+				} `xml:"PackageInformation"`
+			}
+			if err := xml.Unmarshal(data, &template); err != nil {
+				t.Fatal(err)
+			}
+			if template.PackageInformation.Publisher != tt.want {
+				t.Fatalf("publisher = %q, want %q", template.PackageInformation.Publisher, tt.want)
+			}
+			if err := generateAppxManifest(&options, path); err != nil {
+				t.Fatal(err)
+			}
+			data, err = os.ReadFile(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			var manifest struct {
+				Identity struct {
+					Publisher string `xml:"Publisher,attr"`
+				} `xml:"Identity"`
+			}
+			if err := xml.Unmarshal(data, &manifest); err != nil {
+				t.Fatal(err)
+			}
+			if manifest.Identity.Publisher != tt.want {
+				t.Fatalf("manifest publisher = %q, want %q", manifest.Identity.Publisher, tt.want)
+			}
+
+		})
+	}
+}
+
+// validMSIXTestOptions supplies an executable and metadata for focused validation tests.
+func validMSIXTestOptions(t *testing.T) MSIXOptions {
+	t.Helper()
+	options := MSIXOptions{ExecutableName: "example.exe", ExecutablePath: filepath.Join(t.TempDir(), "example.exe")}
+	options.Info.CompanyName = "Example"
+	options.Info.ProductName = "Example App"
+	options.Info.ProductIdentifier = "com.example.app"
+	options.Info.Version = "1.2.3"
+	options.Info.Description = "Example description"
+	if err := os.WriteFile(options.ExecutablePath, []byte("executable payload"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	return options
+}

--- a/v3/internal/commands/msix_test.go
+++ b/v3/internal/commands/msix_test.go
@@ -1,0 +1,135 @@
+package commands
+
+import (
+	"encoding/xml"
+	"image/png"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/wailsapp/wails/v3/internal/flags"
+	"gopkg.in/yaml.v3"
+)
+
+func TestMSIXPackageStructure(t *testing.T) {
+	for _, config := range []string{
+		"info:\n  companyName: Example\n  productName: Example App\n  productIdentifier: com.example.app\n  version: 1.2.3\n  description: Example description\n",
+		`{"info":{"companyName":"Example","productName":"Example App","productIdentifier":"com.example.app","version":"1.2.3","description":"Example description"}}`,
+	} {
+		for _, arch := range []string{"amd64", "arm64"} {
+			t.Run(arch+"/"+config[:1], func(t *testing.T) {
+				var options MSIXOptions
+				if err := yaml.Unmarshal([]byte(config), &options.WailsConfig); err != nil {
+					t.Fatal(err)
+				}
+				options.ExecutablePath = filepath.Join(t.TempDir(), "source.exe")
+				options.ExecutableName = "example.exe"
+				options.ProcessorArchitecture = arch
+				if err := os.WriteFile(options.ExecutablePath, []byte("executable payload"), 0600); err != nil {
+					t.Fatal(err)
+				}
+				if err := validateMSIXOptions(&options); err != nil {
+					t.Fatal(err)
+				}
+				dir := t.TempDir()
+				if err := createMSIXPackageStructure(&options, dir); err != nil {
+					t.Fatal(err)
+				}
+				data, err := os.ReadFile(filepath.Join(dir, "AppxManifest.xml"))
+				if err != nil {
+					t.Fatal(err)
+				}
+				var manifest struct {
+					Identity struct {
+						Name      string `xml:"Name,attr"`
+						Version   string `xml:"Version,attr"`
+						Arch      string `xml:"ProcessorArchitecture,attr"`
+						Publisher string `xml:"Publisher,attr"`
+					} `xml:"Identity"`
+					Application struct {
+						Executable string `xml:"Executable,attr"`
+					} `xml:"Applications>Application"`
+				}
+				if err := xml.Unmarshal(data, &manifest); err != nil {
+					t.Fatal(err)
+				}
+				if manifest.Identity.Name != "com.example.app" || manifest.Identity.Version != "1.2.3.0" || manifest.Identity.Arch != archToMSIX(arch) || manifest.Identity.Publisher != "CN=Example" || manifest.Application.Executable != "example.exe" {
+					t.Fatalf("incorrect manifest: %+v", manifest)
+				}
+				payload, err := os.ReadFile(filepath.Join(dir, manifest.Application.Executable))
+				if err != nil || string(payload) != "executable payload" {
+					t.Fatalf("packaged executable: %q, %v", payload, err)
+				}
+				for name, size := range map[string][2]int{"Square150x150Logo.png": {150, 150}, "Square44x44Logo.png": {44, 44}, "Wide310x150Logo.png": {310, 150}, "SplashScreen.png": {620, 300}, "StoreLogo.png": {50, 50}} {
+					f, err := os.Open(filepath.Join(dir, "Assets", name))
+					if err != nil {
+						t.Fatal(err)
+					}
+					img, err := png.Decode(f)
+					f.Close()
+					if err != nil {
+						t.Fatal(err)
+					}
+					if img.Bounds().Dx() != size[0] || img.Bounds().Dy() != size[1] {
+						t.Fatalf("wrong dimensions for %s: %v", name, img.Bounds())
+					}
+				}
+			})
+		}
+	}
+}
+
+func TestFindWindowsSDKTool(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("Windows SDK discovery")
+	}
+	root := t.TempDir()
+	t.Setenv("ProgramFiles(x86)", root)
+	t.Setenv("PATH", t.TempDir())
+	// The SDK uses a lowercase filename; discovery must be case-insensitive.
+	dir := filepath.Join(root, "Windows Kits", "10", "bin", "10.0.26100.0", archToMSIX(runtime.GOARCH))
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, "makeappx.exe")
+	if err := os.WriteFile(path, nil, 0600); err != nil {
+		t.Fatal(err)
+	}
+	got, err := findWindowsSDKTool("MakeAppx.exe")
+	if err != nil || !strings.EqualFold(got, path) {
+		t.Fatalf("SDK lookup = %q, %v; want %q", got, err, path)
+	}
+	pathDir := t.TempDir()
+	pathTool := filepath.Join(pathDir, "makeappx.exe")
+	if err := os.WriteFile(pathTool, nil, 0600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", pathDir)
+	got, err = findWindowsSDKTool("MakeAppx.exe")
+	if err != nil || !strings.EqualFold(got, pathTool) {
+		t.Fatalf("PATH precedence = %q, %v", got, err)
+	}
+	if _, err := findWindowsSDKTool("missing-sdk-tool.exe"); err == nil {
+		t.Fatal("missing SDK tool should fail")
+	}
+}
+
+func TestMSIXPackagingToolDoesNotRequireSDK(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("Windows packaging tools")
+	}
+	dir := t.TempDir()
+	t.Setenv("PATH", dir)
+	t.Setenv("ProgramFiles(x86)", t.TempDir())
+	if err := os.WriteFile(filepath.Join(dir, "MsixPackagingTool.exe"), nil, 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := checkMSIXTools(&flags.ToolMSIX{UseMsixPackagingTool: true, CertificatePath: "certificate.pfx"}); err != nil {
+		t.Fatalf("Packaging Tool should not require the SDK: %v", err)
+	}
+	if err := checkMSIXTools(&flags.ToolMSIX{UseMakeAppx: true, CertificatePath: "certificate.pfx"}); err == nil {
+		t.Fatal("MakeAppx should require the SDK")
+	}
+}

--- a/v3/internal/flags/msix.go
+++ b/v3/internal/flags/msix.go
@@ -5,22 +5,22 @@ type ToolMSIX struct {
 	Common
 
 	// Project configuration
-	ConfigPath string `name:"config" description:"Path to the project configuration file" default:"wails.json"`
+	ConfigPath string `name:"config" description:"Path to the project configuration file" default:"build/config.yml"`
 
 	// MSIX package information
 	Publisher string `name:"publisher" description:"Publisher name for the MSIX package (e.g., CN=CompanyName)" default:""`
-	
+
 	// Certificate for signing
 	CertificatePath     string `name:"cert" description:"Path to the certificate file for signing the MSIX package" default:""`
 	CertificatePassword string `name:"cert-password" description:"Password for the certificate file" default:""`
-	
+
 	// Build options
 	Arch           string `name:"arch" description:"Architecture of the package (x64, x86, arm64)" default:"x64"`
 	ExecutableName string `name:"name" description:"Name of the executable in the package" default:""`
 	ExecutablePath string `name:"executable" description:"Path to the executable file to package" default:""`
 	OutputPath     string `name:"out" description:"Path where the MSIX package will be saved" default:""`
-	
+
 	// Tool selection
 	UseMsixPackagingTool bool `name:"use-msix-tool" description:"Use the Microsoft MSIX Packaging Tool for packaging" default:"false"`
-	UseMakeAppx         bool `name:"use-makeappx" description:"Use MakeAppx.exe for packaging" default:"true"`
+	UseMakeAppx          bool `name:"use-makeappx" description:"Use MakeAppx.exe for packaging" default:"true"`
 }

--- a/v3/internal/flags/msix.go
+++ b/v3/internal/flags/msix.go
@@ -15,7 +15,7 @@ type ToolMSIX struct {
 	CertificatePassword string `name:"cert-password" description:"Password for the certificate file" default:""`
 
 	// Build options
-	Arch           string `name:"arch" description:"Architecture of the package (x64, x86, arm64)" default:"x64"`
+	Arch           string `name:"arch" description:"Architecture of the package (x64, x86, arm, arm64, x86a64, neutral; Go aliases amd64 and 386 are accepted)" default:"x64"`
 	ExecutableName string `name:"name" description:"Name of the executable in the package" default:""`
 	ExecutablePath string `name:"executable" description:"Path to the executable file to package" default:""`
 	OutputPath     string `name:"out" description:"Path where the MSIX package will be saved" default:""`

--- a/v3/internal/templates/_common/Taskfile.tmpl.yml
+++ b/v3/internal/templates/_common/Taskfile.tmpl.yml
@@ -39,6 +39,11 @@ tasks:
     cmds:
       - wails3 dev -config ./build/config.yml -port {{.Opn}}.VITE_PORT{{.Cls}}
 
+  install:msix:tools:
+    summary: Installs tools required for Windows MSIX packaging
+    cmds:
+      - task: windows:install:msix:tools
+
   setup:docker:
     summary: Builds Docker image for cross-compilation (~800MB download)
     cmds:

--- a/v3/scripts/test-msix.ps1
+++ b/v3/scripts/test-msix.ps1
@@ -1,0 +1,63 @@
+# End-to-end regression for #6114. Requires Go, Node.js and the Windows SDK.
+param(
+    [ValidateSet('amd64', 'arm64')][string]$Arch = 'amd64',
+    [string]$WorkDir = (Join-Path ([IO.Path]::GetTempPath()) ('wails-msix-smoke-' + [guid]::NewGuid()))
+)
+$ErrorActionPreference = 'Stop'
+$repo = (Resolve-Path (Join-Path $PSScriptRoot '../..')).Path
+New-Item -ItemType Directory -Force $WorkDir | Out-Null
+$WorkDir = (Resolve-Path $WorkDir).Path
+$oldPath = $env:PATH
+Push-Location (Join-Path $repo 'v3')
+try {
+    go build -o (Join-Path $WorkDir 'wails3.exe') ./cmd/wails3
+    if ($LASTEXITCODE -ne 0) { throw 'CLI build failed' }
+    # Deliberately do not add the SDK to PATH: exercise SDK discovery too.
+    $env:PATH = "$WorkDir;$oldPath"
+    Set-Location $WorkDir
+    wails3 init -n msix-smoke -t vanilla -skipgomodtidy
+    if ($LASTEXITCODE -ne 0) { throw 'Project initialization failed' }
+    Set-Location msix-smoke
+    go mod edit "-replace=github.com/wailsapp/wails/v3=$repo/v3"
+    if ($LASTEXITCODE -ne 0) { throw 'Local module replacement failed' }
+    # Repeat to ensure replacing an existing output never prompts in CI.
+    foreach ($attempt in 1..2) {
+        # Windows PowerShell 5 treats redirected native stderr as error records.
+        # Task logs to stderr on success; use its exit code as the failure signal.
+        $ErrorActionPreference = 'Continue'
+        wails3 task package FORMAT=msix "ARCH=$Arch"
+        $packageExit = $LASTEXITCODE
+        $ErrorActionPreference = 'Stop'
+        if ($packageExit -ne 0) { throw "MSIX packaging failed on attempt $attempt" }
+    }
+    Add-Type -AssemblyName System.IO.Compression.FileSystem
+    $package = Join-Path (Get-Location) "bin/msix-smoke-$Arch.msix"
+    $zip = [IO.Compression.ZipFile]::OpenRead($package)
+    try {
+        $reader = [IO.StreamReader]::new($zip.GetEntry('AppxManifest.xml').Open())
+        try { [xml]$manifest = $reader.ReadToEnd() } finally { $reader.Dispose() }
+        $expectedArch = if ($Arch -eq 'amd64') { 'x64' } else { 'arm64' }
+        if ($manifest.Package.Identity.ProcessorArchitecture -ne $expectedArch) { throw 'Wrong package architecture' }
+        $exe = $manifest.Package.Applications.Application.Executable
+        $entry = $zip.GetEntry($exe)
+        if (!$entry -or $entry.Length -eq 0) { throw 'Manifest executable missing from package' }
+        # Verify the PE machine type, not just the manifest's architecture label.
+        $stream = $entry.Open()
+        $memory = [IO.MemoryStream]::new()
+        try {
+            $stream.CopyTo($memory)
+            $bytes = $memory.ToArray()
+            $pe = [BitConverter]::ToInt32($bytes, 0x3c)
+            $machine = [BitConverter]::ToUInt16($bytes, $pe + 4)
+            $expectedMachine = if ($Arch -eq 'amd64') { 0x8664 } else { 0xaa64 }
+            if ($machine -ne $expectedMachine) { throw 'Wrong executable architecture' }
+        } finally { $stream.Dispose(); $memory.Dispose() }
+        foreach ($asset in 'StoreLogo', 'Square150x150Logo', 'Square44x44Logo', 'Wide310x150Logo', 'SplashScreen') {
+            if (!$zip.GetEntry("Assets/$asset.png")) { throw "Missing asset: $asset" }
+        }
+    } finally { $zip.Dispose() }
+    Write-Host "MSIX smoke test passed: $package"
+} finally {
+    $env:PATH = $oldPath
+    Pop-Location
+}


### PR DESCRIPTION
Fresh Wails v3 projects fail at `wails3 task package FORMAT=msix` because the MSIX CLI commands are not registered. After registration, the generated task also selects the wrong tool, references a nonexistent JSON config, passes Go architecture names, and renders the manifest with incompatible template data.

This change registers the packaging and tool-install commands, uses `build/config.yml` while retaining explicit JSON-config support, selects MakeAppx by default, maps architectures, discovers SDK tools outside PATH, and supplies the shared build-template data. It also honors and XML-escapes explicit publishers in both templates, validates architecture names against the MSIX Identity schema, honors an explicit packaged executable name, only requires signing tools for the selected backend, generates valid PNG assets at the required sizes, and allows repeat packaging without overwrite prompts.

Validation on win-node1:
- Fresh vanilla projects packaged successfully for amd64 and arm64 with MakeAppx validation enabled, using directories containing spaces.
- Both projects packaged twice; the smoke test checked manifest architecture, executable presence and PE machine type, and required assets.
- `go test ./internal/commands ./cmd/wails3 ./internal/flags -count=1` passed.
- CodeRabbit review findings were corrected. Follow-up tests cover publisher defaults/overrides/XML escaping and valid/invalid architecture inputs.
- Added unit regressions and a Windows CI smoke-test matrix for both architectures.

Architecture validation follows the [MSIX Identity schema](https://learn.microsoft.com/en-us/uwp/schemas/appxpackage/uapmanifestschema/element-identity), including its valid legacy and neutral values, while accepting Go aliases.

The smoke tests produce unsigned packages; certificate signing and the optional Microsoft MSIX Packaging Tool path were not exercised.

Fixes #6114.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added MSIX packaging through the `wails3 tool` command.
  * Added commands and build tasks for installing Windows MSIX tools.
  * Added YAML project configuration support and architecture options including amd64 and arm64.
  * Added automatic Windows SDK tool discovery and optional Microsoft Packaging Tool support.

* **Bug Fixes**
  * MSIX packages can now be overwritten reliably during repeated builds.
  * Generated package assets use the correct image dimensions.
  * Improved manifest, executable architecture, asset, and publisher validation.
  * Added automated end-to-end MSIX packaging checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->