### PR TITLE
ci: build changelog helper before running it

### DIFF
--- a/.github/workflows/auto-changelog-v3.yml
+++ b/.github/workflows/auto-changelog-v3.yml
@@ -65,10 +65,12 @@ jobs:
       with:
         go-version: '1.25'
 
-    - name: Test changelog URL generation
+    - name: Test and build changelog helper
       if: steps.check.outputs.skip == 'false'
       working-directory: v3
-      run: go test scripts/auto-changelog.go scripts/auto-changelog_test.go
+      run: |
+        go test scripts/auto-changelog.go scripts/auto-changelog_test.go
+        go build -o "$RUNNER_TEMP/wails-auto-changelog" scripts/auto-changelog.go
 
     - name: Test changelog publication
       run: python3 -m unittest discover -s v3/scripts -p 'test_publish_changelog.py'
@@ -80,7 +82,7 @@ jobs:
         OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
         GITHUB_REPOSITORY: ${{ github.repository }}
         PR_NUMBER: ${{ steps.pr.outputs.number }}
-      run: go run v3/scripts/auto-changelog.go
+      run: '"$RUNNER_TEMP/wails-auto-changelog"'
 
     - name: Commit and push
       if: steps.check.outputs.skip == 'false'

--- a/.github/workflows/docs-mpress.yml
+++ b/.github/workflows/docs-mpress.yml
@@ -2,9 +2,9 @@ name: Wails v3 documentation
 
 on:
   pull_request:
-    paths: ['docs/mpress/**', 'mpress.yaml', '.github/workflows/docs-mpress.yml', 'v3/scripts/*changelog*', 'v3/tasks/release/**']
+    paths: ['docs/mpress/**', 'mpress.yaml', '.github/workflows/docs-mpress.yml', '.github/workflows/auto-changelog-v3.yml', 'v3/scripts/*changelog*', 'v3/tasks/release/**']
   push:
-    paths: ['docs/mpress/**', 'mpress.yaml', '.github/workflows/docs-mpress.yml', 'v3/scripts/*changelog*', 'v3/tasks/release/**']
+    paths: ['docs/mpress/**', 'mpress.yaml', '.github/workflows/docs-mpress.yml', '.github/workflows/auto-changelog-v3.yml', 'v3/scripts/*changelog*', 'v3/tasks/release/**']
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
The post-merge changelog job failed after #6116 because `go run v3/scripts/auto-changelog.go` executes outside the v3 module with GOWORK disabled. The helper now imports the existing TOML parser to read MPD metadata.

Build the helper in the v3 module alongside its tests, then execute the compiled binary from the repository root so its repository-relative changelog and documentation paths remain correct. Changes to this workflow also trigger the documentation automation checks.

Validation: helper tests pass, the binary builds in the v3 module, and invoking it from the repository root reaches its expected environment validation. Both workflow files parse successfully.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved automated changelog generation by building and reusing a helper tool during CI checks.
  * Updated documentation workflow triggers to include changelog automation and release-task changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->