### PR TITLE
docs: repair credits embeds and changelog links

### DIFF
--- a/docs/mpress/content/credits.mpd
+++ b/docs/mpress/content/credits.mpd
@@ -17,17 +17,8 @@ sourcePath = "credits.mpd"
 ## Sponsors
 
 @rawHTML
-<object
-@end
-  type="image/svg+xml"\
-  data="https://wails.io/img/sponsors.svg"\
-  aria-label="Sponsors"\
-  style="margin: auto; width: 100%; max-width: 800px"
->
-  @rawHTML
+<object type="image/svg+xml" data="https://wails.io/img/sponsors.svg" aria-label="Sponsors" style="margin: auto; width: 100%; max-width: 800px" >
   <img src="https://wails.io/img/sponsors.svg" alt="Sponsors" style="width: 100%" />
-  @end
-@rawHTML
 </object>
 @end
 Special thanks:
@@ -47,17 +38,8 @@ Special thanks:
 ## Contributors
 
 @rawHTML
-<object
-@end
-  type="image/svg+xml"\
-  data="https://wails.io/img/contributors.svg"\
-  aria-label="Wails contributors"\
-  style="margin: auto; width: 100%; max-width: 800px"
->
-  @rawHTML
+<object type="image/svg+xml" data="https://wails.io/img/contributors.svg" aria-label="Wails contributors" style="margin: auto; width: 100%; max-width: 800px" >
   <img src="https://wails.io/img/contributors.svg" alt="Wails contributors" style="width: 100%" />
-  @end
-@rawHTML
 </object>
 @end
 

--- a/docs/mpress/content/de/credits.mpd
+++ b/docs/mpress/content/de/credits.mpd
@@ -17,17 +17,8 @@ sourcePath = "de/credits.mpd"
 ## Sponsoren
 
 @rawHTML
-<object
-@end
-  type="image/svg+xml"\
-  data="https://wails.io/img/sponsors.svg"\
-  aria-label="Sponsoren"\
-  style="margin: auto; width: 100%; max-width: 800px"
->
-  @rawHTML
+<object type="image/svg+xml" data="https://wails.io/img/sponsors.svg" aria-label="Sponsoren" style="margin: auto; width: 100%; max-width: 800px" >
   <img src="https://wails.io/img/sponsors.svg" alt="Sponsoren" style="width: 100%" />
-  @end
-@rawHTML
 </object>
 @end
 Besonderer Dank:
@@ -47,17 +38,8 @@ Besonderer Dank:
 ## Mitwirkende
 
 @rawHTML
-<object
-@end
-  type="image/svg+xml"\
-  data="https://wails.io/img/contributors.svg"\
-  aria-label="Wails contributors"\
-  style="margin: auto; width: 100%; max-width: 800px"
->
-  @rawHTML
+<object type="image/svg+xml" data="https://wails.io/img/contributors.svg" aria-label="Wails contributors" style="margin: auto; width: 100%; max-width: 800px" >
   <img src="https://wails.io/img/contributors.svg" alt="Wails contributors" style="width: 100%" />
-  @end
-@rawHTML
 </object>
 @end
 

--- a/docs/mpress/content/fr/credits.mpd
+++ b/docs/mpress/content/fr/credits.mpd
@@ -17,17 +17,8 @@ sourcePath = "fr/credits.mpd"
 ## Sponsors
 
 @rawHTML
-<object
-@end
-  type="image/svg+xml"\
-  data="https://wails.io/img/sponsors.svg"\
-  aria-label="Sponsors"\
-  style="margin: auto; width: 100%; max-width: 800px"
->
-  @rawHTML
+<object type="image/svg+xml" data="https://wails.io/img/sponsors.svg" aria-label="Sponsors" style="margin: auto; width: 100%; max-width: 800px" >
   <img src="https://wails.io/img/sponsors.svg" alt="Sponsors" style="width: 100%" />
-  @end
-@rawHTML
 </object>
 @end
 Remerciements spéciaux :
@@ -47,17 +38,8 @@ Remerciements spéciaux :
 ## Contributeurs
 
 @rawHTML
-<object
-@end
-  type="image/svg+xml"\
-  data="https://wails.io/img/contributors.svg"\
-  aria-label="Wails contributors"\
-  style="margin: auto; width: 100%; max-width: 800px"
->
-  @rawHTML
+<object type="image/svg+xml" data="https://wails.io/img/contributors.svg" aria-label="Wails contributors" style="margin: auto; width: 100%; max-width: 800px" >
   <img src="https://wails.io/img/contributors.svg" alt="Wails contributors" style="width: 100%" />
-  @end
-@rawHTML
 </object>
 @end
 

--- a/docs/mpress/content/id/credits.mpd
+++ b/docs/mpress/content/id/credits.mpd
@@ -17,17 +17,8 @@ sourcePath = "id/credits.mpd"
 ## Sponsor
 
 @rawHTML
-<object
-@end
-  type="image/svg+xml"\
-  data="https://wails.io/img/sponsors.svg"\
-  aria-label="Sponsors"\
-  style="margin: auto; width: 100%; max-width: 800px"
->
-  @rawHTML
+<object type="image/svg+xml" data="https://wails.io/img/sponsors.svg" aria-label="Sponsors" style="margin: auto; width: 100%; max-width: 800px" >
   <img src="https://wails.io/img/sponsors.svg" alt="Sponsors" style="width: 100%" />
-  @end
-@rawHTML
 </object>
 @end
 Ucapan terima kasih khusus:
@@ -47,17 +38,8 @@ Ucapan terima kasih khusus:
 ## Kontributor
 
 @rawHTML
-<object
-@end
-  type="image/svg+xml"\
-  data="https://wails.io/img/contributors.svg"\
-  aria-label="Wails contributors"\
-  style="margin: auto; width: 100%; max-width: 800px"
->
-  @rawHTML
+<object type="image/svg+xml" data="https://wails.io/img/contributors.svg" aria-label="Wails contributors" style="margin: auto; width: 100%; max-width: 800px" >
   <img src="https://wails.io/img/contributors.svg" alt="Wails contributors" style="width: 100%" />
-  @end
-@rawHTML
 </object>
 @end
 

--- a/docs/mpress/content/ja/credits.mpd
+++ b/docs/mpress/content/ja/credits.mpd
@@ -17,17 +17,8 @@ sourcePath = "ja/credits.mpd"
 ## スポンサー
 
 @rawHTML
-<object
-@end
-  type="image/svg+xml"\
-  data="https://wails.io/img/sponsors.svg"\
-  aria-label="Sponsors"\
-  style="margin: auto; width: 100%; max-width: 800px"
->
-  @rawHTML
+<object type="image/svg+xml" data="https://wails.io/img/sponsors.svg" aria-label="Sponsors" style="margin: auto; width: 100%; max-width: 800px" >
   <img src="https://wails.io/img/sponsors.svg" alt="Sponsors" style="width: 100%" />
-  @end
-@rawHTML
 </object>
 @end
 特別感謝:
@@ -47,17 +38,8 @@ sourcePath = "ja/credits.mpd"
 ## 貢献者
 
 @rawHTML
-<object
-@end
-  type="image/svg+xml"\
-  data="https://wails.io/img/contributors.svg"\
-  aria-label="Wails contributors"\
-  style="margin: auto; width: 100%; max-width: 800px"
->
-  @rawHTML
+<object type="image/svg+xml" data="https://wails.io/img/contributors.svg" aria-label="Wails contributors" style="margin: auto; width: 100%; max-width: 800px" >
   <img src="https://wails.io/img/contributors.svg" alt="Wails contributors" style="width: 100%" />
-  @end
-@rawHTML
 </object>
 @end
 

--- a/docs/mpress/content/ko/credits.mpd
+++ b/docs/mpress/content/ko/credits.mpd
@@ -17,17 +17,8 @@ sourcePath = "ko/credits.mpd"
 ## 스폰서
 
 @rawHTML
-<object
-@end
-  type="image/svg+xml"\
-  data="https://wails.io/img/sponsors.svg"\
-  aria-label="Sponsors"\
-  style="margin: auto; width: 100%; max-width: 800px"
->
-  @rawHTML
+<object type="image/svg+xml" data="https://wails.io/img/sponsors.svg" aria-label="Sponsors" style="margin: auto; width: 100%; max-width: 800px" >
   <img src="https://wails.io/img/sponsors.svg" alt="Sponsors" style="width: 100%" />
-  @end
-@rawHTML
 </object>
 @end
 특별 감사:
@@ -47,17 +38,8 @@ sourcePath = "ko/credits.mpd"
 ## 기여자
 
 @rawHTML
-<object
-@end
-  type="image/svg+xml"\
-  data="https://wails.io/img/contributors.svg"\
-  aria-label="Wails contributors"\
-  style="margin: auto; width: 100%; max-width: 800px"
->
-  @rawHTML
+<object type="image/svg+xml" data="https://wails.io/img/contributors.svg" aria-label="Wails contributors" style="margin: auto; width: 100%; max-width: 800px" >
   <img src="https://wails.io/img/contributors.svg" alt="Wails contributors" style="width: 100%" />
-  @end
-@rawHTML
 </object>
 @end
 

--- a/docs/mpress/content/pt/credits.mpd
+++ b/docs/mpress/content/pt/credits.mpd
@@ -17,17 +17,8 @@ sourcePath = "pt/credits.mpd"
 ## Patrocinadores
 
 @rawHTML
-<object
-@end
-  type="image/svg+xml"\
-  data="https://wails.io/img/sponsors.svg"\
-  aria-label="Sponsors"\
-  style="margin: auto; width: 100%; max-width: 800px"
->
-  @rawHTML
+<object type="image/svg+xml" data="https://wails.io/img/sponsors.svg" aria-label="Sponsors" style="margin: auto; width: 100%; max-width: 800px" >
   <img src="https://wails.io/img/sponsors.svg" alt="Sponsors" style="width: 100%" />
-  @end
-@rawHTML
 </object>
 @end
 Agradecimentos especiais:
@@ -47,17 +38,8 @@ Agradecimentos especiais:
 ## Contribuidores
 
 @rawHTML
-<object
-@end
-  type="image/svg+xml"\
-  data="https://wails.io/img/contributors.svg"\
-  aria-label="Wails contributors"\
-  style="margin: auto; width: 100%; max-width: 800px"
->
-  @rawHTML
+<object type="image/svg+xml" data="https://wails.io/img/contributors.svg" aria-label="Wails contributors" style="margin: auto; width: 100%; max-width: 800px" >
   <img src="https://wails.io/img/contributors.svg" alt="Wails contributors" style="width: 100%" />
-  @end
-@rawHTML
 </object>
 @end
 

--- a/docs/mpress/content/ru/credits.mpd
+++ b/docs/mpress/content/ru/credits.mpd
@@ -17,17 +17,8 @@ sourcePath = "ru/credits.mpd"
 ## Спонсоры
 
 @rawHTML
-<object
-@end
-  type="image/svg+xml"\
-  data="https://wails.io/img/sponsors.svg"\
-  aria-label="Sponsors"\
-  style="margin: auto; width: 100%; max-width: 800px"
->
-  @rawHTML
+<object type="image/svg+xml" data="https://wails.io/img/sponsors.svg" aria-label="Sponsors" style="margin: auto; width: 100%; max-width: 800px" >
   <img src="https://wails.io/img/sponsors.svg" alt="Sponsors" style="width: 100%" />
-  @end
-@rawHTML
 </object>
 @end
 Особая благодарность:
@@ -47,17 +38,8 @@ sourcePath = "ru/credits.mpd"
 ## Участники
 
 @rawHTML
-<object
-@end
-  type="image/svg+xml"\
-  data="https://wails.io/img/contributors.svg"\
-  aria-label="Wails contributors"\
-  style="margin: auto; width: 100%; max-width: 800px"
->
-  @rawHTML
+<object type="image/svg+xml" data="https://wails.io/img/contributors.svg" aria-label="Wails contributors" style="margin: auto; width: 100%; max-width: 800px" >
   <img src="https://wails.io/img/contributors.svg" alt="Wails contributors" style="width: 100%" />
-  @end
-@rawHTML
 </object>
 @end
 

--- a/docs/mpress/content/zh-cn/credits.mpd
+++ b/docs/mpress/content/zh-cn/credits.mpd
@@ -17,17 +17,8 @@ sourcePath = "zh-cn/credits.mpd"
 ## 赞助商
 
 @rawHTML
-<object
-@end
-  type="image/svg+xml"\
-  data="https://wails.io/img/sponsors.svg"\
-  aria-label="Sponsors"\
-  style="margin: auto; width: 100%; max-width: 800px"
->
-  @rawHTML
+<object type="image/svg+xml" data="https://wails.io/img/sponsors.svg" aria-label="Sponsors" style="margin: auto; width: 100%; max-width: 800px" >
   <img src="https://wails.io/img/sponsors.svg" alt="Sponsors" style="width: 100%" />
-  @end
-@rawHTML
 </object>
 @end
 特别感谢：
@@ -47,17 +38,8 @@ sourcePath = "zh-cn/credits.mpd"
 ## 贡献者
 
 @rawHTML
-<object
-@end
-  type="image/svg+xml"\
-  data="https://wails.io/img/contributors.svg"\
-  aria-label="Wails contributors"\
-  style="margin: auto; width: 100%; max-width: 800px"
->
-  @rawHTML
+<object type="image/svg+xml" data="https://wails.io/img/contributors.svg" aria-label="Wails contributors" style="margin: auto; width: 100%; max-width: 800px" >
   <img src="https://wails.io/img/contributors.svg" alt="Wails contributors" style="width: 100%" />
-  @end
-@rawHTML
 </object>
 @end
 

--- a/docs/mpress/content/zh-tw/credits.mpd
+++ b/docs/mpress/content/zh-tw/credits.mpd
@@ -17,17 +17,8 @@ sourcePath = "zh-tw/credits.mpd"
 ## 贊助商
 
 @rawHTML
-<object
-@end
-  type="image/svg+xml"\
-  data="https://wails.io/img/sponsors.svg"\
-  aria-label="Sponsors"\
-  style="margin: auto; width: 100%; max-width: 800px"
->
-  @rawHTML
+<object type="image/svg+xml" data="https://wails.io/img/sponsors.svg" aria-label="Sponsors" style="margin: auto; width: 100%; max-width: 800px" >
   <img src="https://wails.io/img/sponsors.svg" alt="Sponsors" style="width: 100%" />
-  @end
-@rawHTML
 </object>
 @end
 特別感謝：
@@ -47,17 +38,8 @@ sourcePath = "zh-tw/credits.mpd"
 ## 貢獻者
 
 @rawHTML
-<object
-@end
-  type="image/svg+xml"\
-  data="https://wails.io/img/contributors.svg"\
-  aria-label="Wails contributors"\
-  style="margin: auto; width: 100%; max-width: 800px"
->
-  @rawHTML
+<object type="image/svg+xml" data="https://wails.io/img/contributors.svg" aria-label="Wails contributors" style="margin: auto; width: 100%; max-width: 800px" >
   <img src="https://wails.io/img/contributors.svg" alt="Wails contributors" style="width: 100%" />
-  @end
-@rawHTML
 </object>
 @end
 

--- a/v3/scripts/auto-changelog.go
+++ b/v3/scripts/auto-changelog.go
@@ -16,8 +16,6 @@ import (
 	"regexp"
 	"strings"
 	"time"
-
-	"github.com/BurntSushi/toml"
 )
 
 const changelogPath = "v3/UNRELEASED_CHANGELOG.md"
@@ -309,6 +307,8 @@ func documentationURLFromPath(file, slug string) (string, error) {
 	return (&url.URL{Scheme: "https", Host: strings.TrimPrefix(docsSiteURL, "https://"), Path: relative}).String(), nil
 }
 
+var mpdSlugField = regexp.MustCompile(`(?m)^[\t ]*slug[\t ]*=[\t ]*(.*)$`)
+
 func readFrontmatterSlug(file string) (string, error) {
 	data, err := os.ReadFile(file)
 	if err != nil {
@@ -323,13 +323,17 @@ func readFrontmatterSlug(file string) (string, error) {
 		return "", nil
 	}
 	frontmatter := content[3 : end+3]
-	var metadata struct {
-		Slug string `toml:"slug"`
+	// MPD uses key = JSON-value fields, including nested objects that are not
+	// TOML. Only the slug field affects the public route.
+	field := mpdSlugField.FindStringSubmatch(frontmatter)
+	if field == nil {
+		return "", nil
 	}
-	if _, err := toml.Decode(frontmatter, &metadata); err != nil {
+	var slug string
+	if err := json.Unmarshal([]byte(field[1]), &slug); err != nil {
 		return "", fmt.Errorf("parse MPD metadata in %s: %w", file, err)
 	}
-	return metadata.Slug, nil
+	return slug, nil
 }
 
 func appendDocumentationLinks(entry string, docURLs []string) string {

--- a/v3/scripts/auto-changelog_test.go
+++ b/v3/scripts/auto-changelog_test.go
@@ -5,6 +5,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"io/fs"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -171,14 +172,52 @@ func TestDocumentationURLForMissingFile(t *testing.T) {
 }
 
 func TestMPDFrontmatterSlug(t *testing.T) {
-	file := filepath.Join(t.TempDir(), "page.mpd")
-	if err := os.WriteFile(file, []byte("---\nschema = 1\nslug = \"guides/custom-route\" # route override\n---\nBody"), 0600); err != nil {
+	tests := []struct {
+		name, fields, want string
+		wantError          bool
+	}{
+		{name: "JSON objects", fields: `banner = {"content":"Welcome"}
+slug = "guides/custom-route"
+hero = {"actions":[{"text":"Start"}]}`, want: "guides/custom-route"},
+		{name: "no override", fields: `hero = {"slug":"not-a-page-route"}`},
+		{name: "JSON escaping", fields: `slug = "guides\u002fcustom-route"`, want: "guides/custom-route"},
+		{name: "invalid type", fields: `slug = {"path":"guide"}`, wantError: true},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			file := filepath.Join(t.TempDir(), "page.mpd")
+			source := "---\nschema = 1\n" + test.fields + "\n---\nBody"
+			if err := os.WriteFile(file, []byte(source), 0600); err != nil {
+				t.Fatal(err)
+			}
+			slug, err := readFrontmatterSlug(file)
+			if (err != nil) != test.wantError || slug != test.want {
+				t.Fatalf("slug = %q, err = %v; want %q, error %v", slug, err, test.want, test.wantError)
+			}
+		})
+	}
+}
+
+func TestDocumentationMetadataCorpus(t *testing.T) {
+	count := 0
+	err := filepath.WalkDir("../../docs/mpress/content", func(file string, entry fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if entry.IsDir() || filepath.Ext(file) != ".mpd" {
+			return nil
+		}
+		count++
+		_, err = readFrontmatterSlug(file)
+		return err
+	})
+	if err != nil {
 		t.Fatal(err)
 	}
-	slug, err := readFrontmatterSlug(file)
-	if err != nil || slug != "guides/custom-route" {
-		t.Fatalf("slug = %q, err = %v", slug, err)
+	if count == 0 {
+		t.Fatal("no documentation pages checked")
 	}
+	t.Logf("checked metadata in %d documentation pages", count)
 }
 
 func TestLocalizedMPDSlug(t *testing.T) {


### PR DESCRIPTION
Fix two migration defects found while verifying the production documentation:

- Credits pages contained split raw HTML blocks that displayed sponsor and contributor object markup as text. Keep each SVG object in one raw HTML block with a complete opening tag, preserving the interactive SVGs in all ten languages.
- Changelog automation parsed M-Press metadata as TOML, which rejected valid JSON banner and hero objects and omitted documentation links. Read the slug field using the standard JSON decoder.

Validation: strict M-Press v1.0.3 build, link/asset check and six site-validator tests pass. All 20 SVG embeds are object elements in the rendered credits pages. Go regression tests cover nested objects, missing overrides, escaped strings, invalid slug types, and all 527 documentation source files. Ripwire reports an unchanged function contract and no regressions in existing symbols.

CodeRabbit CLI was attempted as required but its free OSS review quota is exhausted; GitHub review and CI run on this PR. Follow-up to #6116 and #6117.
